### PR TITLE
Display transaction data in Transaction component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "date-fns": "^2.30.0",
         "swr": "^2.2.4"
       },
       "devDependencies": {
@@ -183,6 +184,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -909,6 +921,21 @@
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
     },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1538,6 +1565,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/resolve-dir": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "date-fns": "^2.30.0",
     "swr": "^2.2.4"
   },
   "prettier": {

--- a/src/components/Transactions/Transactions.css
+++ b/src/components/Transactions/Transactions.css
@@ -1,0 +1,78 @@
+.transactions {
+  --transaction-buttons-border-color: #D0D5DD;
+  --transaction-buttons-selected-background-color: #E0E9FF;
+  --transaction-table-border-color: #EAECF0;
+  --transaction-table-text-color: #101828;
+}
+
+.transactions header {
+  display: flex;
+}
+
+.transactions header h1 {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  justify-content: flex-start;
+}
+
+.transactions header div {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  justify-content: flex-end;
+}
+
+.transactions .transaction-table {
+  display: grid;
+  grid-template-columns: auto repeat(5, 1fr) auto;
+  margin: 3rem;
+  grid-gap: 1px 0px;
+  background-color: var(--transaction-table-border-color);
+  border: 1px solid var(--transaction-table-border-color);
+}
+
+.transactions .transaction-table div {
+  padding: 1rem;
+  background-color: white;
+  color: var(--transaction-table-text-color);
+  font-family: sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+.transactions .transaction-table div.header {
+  font-weight: bold;
+}
+
+.transactions .radio-group {
+}
+
+.transactions .radio-group input {
+  position: absolute;
+  opacity: 0;
+}
+
+.transactions .radio-group div {
+  padding: 0.6rem 1rem;
+  border: 1px solid var(--transaction-buttons-border-color);
+  border-right: 0;
+  border-radius: 0;
+}
+
+.transactions .radio-group label:first-of-type div {
+  border-start-start-radius: 0.6rem;
+  border-end-start-radius: 0.6rem;
+}
+
+.transactions .radio-group label:last-of-type div {
+  border-right: 1px solid var(--transaction-buttons-border-color);
+  border-start-end-radius: 0.6rem;
+  border-end-end-radius: 0.6rem;
+}
+
+.transactions .radio-group input:checked + div {
+  background: var(--transaction-buttons-selected-background-color);
+}

--- a/src/components/Transactions/Transactions.tsx
+++ b/src/components/Transactions/Transactions.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react'
+import { useContext } from 'react'
+import { LayerContext } from '../../contexts/LayerContext'
+import fakeTransactions from '../../fake/transactions'
+import './Transactions.css'
+import { parseISO, format as formatTime } from 'date-fns'
+import useSWR from 'swr'
+
+const dateFormat = 'MM/dd/yyyy'
+
+const fetchTransactions = (accessToken: string) => (url: string) =>
+  fetch(url, {
+    headers: {
+      Authorization: 'Bearer ' + accessToken,
+      'Content-Type': 'application/json',
+    },
+    method: 'GET',
+  })
+
+const formatMoney = ({ amount, direction }) =>
+  (direction === 'CREDIT' ? '+' : '-') +
+  Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(
+    amount,
+  )
+
+type Props = {
+  businessId: string
+}
+
+export const Transactions = ({ businessId }: Props) => {
+  // const { access_token: accessToken } = useContext(LayerContext)
+  // const { data } = useSWR(
+  //   accessToken &&
+  //     `https://sandbox.layerfi.com/v1/businesses/${businessId}/bank-transactions`,
+  //   fetchTransactions(accessToken),
+  // )
+  // const transactions = data.data || []
+  const transactions = fakeTransactions.data
+  const transactionRow = transaction => (
+    <>
+      <div>
+        <input type="checkbox" />
+      </div>
+      <div>{formatTime(parseISO(transaction.date), dateFormat)}</div>
+      <div>{formatMoney(transaction)}</div>
+      <div>Business Checking</div>
+      <div>{transaction.counterparty_name}</div>
+      <div>{transaction?.category?.display_name || 'Uncategorized'}</div>
+      <div>&#x2304;</div>
+    </>
+  )
+  const [display, setDisplay] = useState<'review' | 'categorized'>('review')
+  const changeDisplay = (value: string) => () => setDisplay(value)
+  return (
+    <div className="transactions" data-display={display}>
+      <header>
+        <h1>Transactions</h1>
+        <div className="radio-group">
+          <label>
+            <input
+              type="radio"
+              name="transaction-display"
+              value="review"
+              {...(display === 'review' ? { checked: 'checked' } : {})}
+              onChange={changeDisplay('review')}
+            />
+            <div>To Review</div>
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="transaction-display"
+              value="categorized"
+              {...(display === 'categorized' ? { checked: 'checked' } : {})}
+              onChange={changeDisplay('categorized')}
+            />
+            <div>Categorized</div>
+          </label>
+        </div>
+      </header>
+      <div className="transaction-table">
+        <div className="header">
+          <input type="checkbox" />
+        </div>
+        <div className="header">Date</div>
+        <div className="header">Transaction</div>
+        <div className="header">Account</div>
+        <div className="header">Amount</div>
+        <div className="header">Category</div>
+        <div className="header">Action</div>
+        {transactions.map(transactionRow)}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
This commit makes the Transaction component display the data presented in the (as of this writing, fake) transaction response body. It uses the  `date-fns` module to display the date and the standard `Intl.NumberFormat` to display the money. The display of the toggle between To Review and Categorized is done primarily through CSS, since it's all style. The mechanics of it do not affect its display.