### PR TITLE
Get rid of most of the TypeScript errors

### DIFF
--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -41,7 +41,12 @@ export const BankTransactions = () => {
   const bankTransactions = (data?.data || []).filter(filterVisibility(display))
   const onCategorizationDisplayChange = (
     event: React.ChangeEvent<HTMLInputElement>,
-  ) => setDisplay(event.target.value)
+  ) =>
+    setDisplay(
+      event.target.value === DisplayState.categorized
+        ? DisplayState.categorized
+        : DisplayState.review,
+    )
   const [openRows, setOpenRows] = useState<Record<string, boolean>>({})
   const toggleOpen = (id: string) =>
     setOpenRows({ ...openRows, [id]: !openRows[id] })
@@ -70,7 +75,7 @@ export const BankTransactions = () => {
         <div className="header">Category</div>
         <div className="header">Action</div>
         <div className="header"></div>
-        {bankTransactions.map(bankTransaction => (
+        {bankTransactions.map((bankTransaction: BankTransaction) => (
           <BankTransactionRow
             key={bankTransaction.id}
             dateFormat={dateFormat}

--- a/src/components/CategoryMenu/CategoryMenu.tsx
+++ b/src/components/CategoryMenu/CategoryMenu.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useLayerContext } from '../../hooks/useLayerContext'
+import { Category } from '../../types'
 import { CategoryMenuItem } from './CategoryMenuItem'
 
 type Props = {
@@ -10,7 +11,7 @@ export const CategoryMenu = ({ selectedCategory }: Props) => {
   const { categories } = useLayerContext()
   return (
     <select defaultValue={selectedCategory}>
-      {categories.map(category => (
+      {categories.map((category: Category) => (
         <CategoryMenuItem key={category.category} category={category} />
       ))}
     </select>

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -25,8 +25,13 @@ type RowState = {
   file: unknown
 }
 
+enum Purpose {
+  categorize = 'categorize',
+  match = 'match',
+}
+
 export const ExpandedBankTransactionRow = ({ bankTransaction }: Props) => {
-  const [purpose, setPurpose] = useState<'categorize' | 'match'>('categorize')
+  const [purpose, setPurpose] = useState<Purpose>(Purpose.categorize)
   const [rowState, updateRowState] = useState<RowState>({
     splits: [
       {
@@ -80,7 +85,9 @@ export const ExpandedBankTransactionRow = ({ bankTransaction }: Props) => {
   }
 
   const onChangePurpose = (event: React.ChangeEvent<HTMLInputElement>) =>
-    setPurpose(event.target.value)
+    setPurpose(
+      event.target.value === Purpose.match ? Purpose.match : Purpose.categorize,
+    )
   return (
     <div className="expand-area">
       <div className="purpose">

--- a/src/components/Hello/Hello.tsx
+++ b/src/components/Hello/Hello.tsx
@@ -5,7 +5,7 @@ type Props = {
   user?: string | undefined
 }
 
-const fetcher = url => fetch(url).then(res => res.json())
+const fetcher = (url: string) => fetch(url).then(res => res.json())
 
 export const Hello = ({ user }: Props) => {
   const { data, isLoading } = useSWR(

--- a/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -11,7 +11,7 @@ type Props = {
   name: string
   size?: 'small' | 'large'
   buttons: RadioButtonLabel[]
-  selected?: Pick<RadioButtonLabel, 'value'>
+  selected?: RadioButtonLabel['value']
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
 }
 

--- a/src/contexts/LayerContext/LayerContext.tsx
+++ b/src/contexts/LayerContext/LayerContext.tsx
@@ -1,7 +1,7 @@
 import { createContext } from 'react'
-import { LayerConfig } from '../../types'
+import { LayerContextValues } from '../../types'
 
-export const LayerContext = createContext<LayerConfig>({
+export const LayerContext = createContext<LayerContextValues>({
   auth: undefined,
   businessId: '',
   categories: [],

--- a/src/test/mockFetch.ts
+++ b/src/test/mockFetch.ts
@@ -1,2 +1,2 @@
-export default (url, config) =>
-  Promise.resolve({ json: () => Promise.resolve() })
+export default (url: string, config: Record<string, string>) =>
+  Promise.resolve({ json: () => Promise.resolve({ url, config }) })

--- a/src/test/setupAfterEnv.ts
+++ b/src/test/setupAfterEnv.ts
@@ -1,7 +1,8 @@
-import mockFetch from './mockFetch.ts'
+import mockFetch from './mockFetch'
 
 beforeAll(() => (global.fetch = jest.fn()))
 beforeEach(() => {
+  global.fetch = jest.fn()
   global.fetch.mockReset()
   global.fetch.mockImplementation(mockFetch)
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,8 +34,6 @@ export enum CategorizationStatus {
   JOURNALING = 'JOURNALING',
 }
 
-export type ISODateString = string
-export type UUID = string
 export type Direction = 'CREDIT' | 'DEBIT'
 
 export interface Category {
@@ -45,7 +43,8 @@ export interface Category {
 }
 
 export interface BankTransaction {
-  date: ISODateString
+  id: string
+  date: string
   amount: number
   direction: Direction
   counterparty_name: string

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,7 +57,7 @@
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    "noEmit": true /* Disable emitting files from a compilation. */,
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */


### PR DESCRIPTION
This was done with a plain old `npx tsc` and fixing the issues. Some were left as they don't appear trivial and we, unfortunately, don't have the time to fix them right now. As of this writing they are:

```
src/components/Hello/Hello.test.tsx:7:16 - error TS2339: Property 'mockResolvedValue' does not exist on type '{ (input: RequestInfo | URL, init?: RequestInit | undefined): Promise<Response>; (input: RequestInfo, init?: RequestInit | undefined): Promise<...>; }'.
src/test/setupAfterEnv.ts:6:16 - error TS2339: Property 'mockReset' does not exist on type '{ (input: RequestInfo | URL, init?: RequestInit | undefined): Promise<Response>; (input: RequestInfo, init?: RequestInit | undefined): Promise<...>; }'.
src/test/setupAfterEnv.ts:7:16 - error TS2339: Property 'mockImplementation' does not exist on type '{ (input: RequestInfo | URL, init?: RequestInit | undefined): Promise<Response>; (input: RequestInfo, init?: RequestInit | undefined): Promise<...>; }'.
```