### PR TITLE
Allow the direction of Line Items to show properly

### DIFF
--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -4,7 +4,7 @@ import CheckedCircle from '../../icons/CheckedCircle'
 import ChevronDown from '../../icons/ChevronDown'
 import ChevronUp from '../../icons/ChevronUp'
 import { centsToDollars as formatMoney } from '../../models/Money'
-import { BankTransaction, SingleCategoryUpdate } from '../../types'
+import { BankTransaction, Direction, SingleCategoryUpdate } from '../../types'
 import { CategoryMenu } from '../CategoryMenu'
 import { ExpandedBankTransactionRow } from '../ExpandedBankTransactionRow'
 import { Pill } from '../Pill'
@@ -19,7 +19,7 @@ type Props = {
 }
 
 const isCredit = ({ direction }: Pick<BankTransaction, 'direction'>) =>
-  direction === 'CREDIT'
+  direction === Direction.CREDIT
 
 export const BankTransactionRow = ({
   dateFormat,

--- a/src/components/ProfitAndLossRow/ProfitAndLossRow.test.tsx
+++ b/src/components/ProfitAndLossRow/ProfitAndLossRow.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import { Direction } from '../../types'
+import { ProfitAndLossRow } from './ProfitAndLossRow'
+import { render, screen } from '@testing-library/react'
+
+describe(ProfitAndLossRow, () => {
+  it('renders a key and value field for a LineItem', async () => {
+    const lineItem = {
+      display_name: 'Bob',
+      value: 100123,
+    }
+
+    render(<ProfitAndLossRow lineItem={lineItem} />)
+
+    const label = await screen.findByText('Bob')
+    const value = await screen.findByText('1001.23')
+    expect(label).toHaveClass('Layer__profit-and-loss-row__label')
+    expect(value).toHaveClass('Layer__profit-and-loss-row__value')
+  })
+
+  it('renders positive money direction', async () => {
+    const lineItem = {
+      display_name: 'Bob',
+      value: 100123,
+    }
+
+    render(
+      <ProfitAndLossRow lineItem={lineItem} direction={Direction.CREDIT} />,
+    )
+
+    const label = await screen.findByText('Bob')
+    const value = await screen.findByText('1001.23')
+    expect(label).not.toHaveClass(
+      'Layer__profit-and-loss-row__label--amount-positive',
+    )
+    expect(value).toHaveClass(
+      'Layer__profit-and-loss-row__value',
+      'Layer__profit-and-loss-row__value--amount-positive',
+    )
+  })
+
+  it('renders negative money direction', async () => {
+    const lineItem = {
+      display_name: 'Bob',
+      value: 100123,
+    }
+
+    render(<ProfitAndLossRow lineItem={lineItem} direction={Direction.DEBIT} />)
+
+    const label = await screen.findByText('Bob')
+    const value = await screen.findByText('1001.23')
+    expect(label).not.toHaveClass(
+      'Layer__profit-and-loss-row__label--amount-negative',
+    )
+    expect(value).toHaveClass(
+      'Layer__profit-and-loss-row__value',
+      'Layer__profit-and-loss-row__value--amount-negative',
+    )
+  })
+
+  it('renders nested LineItems up to maxDepth', async () => {
+    const lineItem = {
+      display_name: 'Bob',
+      value: 1001,
+      line_items: [
+        {
+          display_name: 'Jan',
+          value: 1002,
+          line_items: [
+            {
+              display_name: 'Dave',
+              value: 1003,
+            },
+          ],
+        },
+        {
+          display_name: 'Sue',
+          value: 1004,
+        },
+      ],
+    }
+
+    render(<ProfitAndLossRow lineItem={lineItem} maxDepth={1} />)
+
+    expect(await screen.findByText('Bob')).toHaveClass(
+      'Layer__profit-and-loss-row__label',
+    )
+    expect(await screen.findByText('10.01')).toHaveClass(
+      'Layer__profit-and-loss-row__value',
+    )
+    expect(await screen.findByText('Jan')).toHaveClass(
+      'Layer__profit-and-loss-row__label',
+      'Layer__profit-and-loss-row__label--depth-1',
+    )
+    expect(await screen.findByText('10.02')).toHaveClass(
+      'Layer__profit-and-loss-row__value',
+      'Layer__profit-and-loss-row__value--depth-1',
+    )
+    expect(screen.queryByText('Dave')).not.toBeInTheDocument()
+    expect(screen.queryByText('10.03')).not.toBeInTheDocument()
+    expect(await screen.findByText('Sue')).toHaveClass(
+      'Layer__profit-and-loss-row__label',
+      'Layer__profit-and-loss-row__label--depth-1',
+    )
+    expect(await screen.findByText('10.04')).toHaveClass(
+      'Layer__profit-and-loss-row__value',
+      'Layer__profit-and-loss-row__value--depth-1',
+    )
+  })
+})

--- a/src/components/ProfitAndLossRow/ProfitAndLossRow.tsx
+++ b/src/components/ProfitAndLossRow/ProfitAndLossRow.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import { centsToDollars } from '../../models/Money'
+import { Direction } from '../../types'
 import { LineItem } from '../../types/profit_and_loss'
-import { ProfitAndLossRow } from '../ProfitAndLossRow'
 
 type Props = {
   variant?: string
   depth?: number
   maxDepth?: number
   lineItem: LineItem
+  direction?: Direction
 }
 
 export const ProfitAndLossRow = ({
@@ -15,6 +16,7 @@ export const ProfitAndLossRow = ({
   lineItem,
   depth = 0,
   maxDepth = 1,
+  direction = Direction.DEBIT,
 }: Props) => {
   if (!lineItem) {
     return null
@@ -32,7 +34,7 @@ export const ProfitAndLossRow = ({
     'Layer__profit-and-loss-row__value',
   ]
   valueClasses.push(
-    amount >= 0
+    direction === Direction.CREDIT
       ? 'Layer__profit-and-loss-row__value--amount-positive'
       : 'Layer__profit-and-loss-row__value--amount-negative',
   )
@@ -55,14 +57,13 @@ export const ProfitAndLossRow = ({
       {depth < maxDepth &&
         (line_items || []).map(line_item => (
           <ProfitAndLossRow
-            key={line_item.name}
+            key={line_item.display_name}
             lineItem={line_item}
             depth={depth + 1}
             maxDepth={maxDepth}
+            direction={direction}
           />
         ))}
     </>
   )
 }
-
-

--- a/src/components/ProfitAndLossTable/ProfitAndLossTable.tsx
+++ b/src/components/ProfitAndLossTable/ProfitAndLossTable.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react'
+import { Direction } from '../../types'
 import { ProfitAndLoss } from '../ProfitAndLoss'
 import { ProfitAndLossRow } from '../ProfitAndLossRow'
 
@@ -10,33 +11,51 @@ export const ProfitAndLossTable = () => {
         <div>Loading</div>
       ) : (
         <>
-          <ProfitAndLossRow lineItem={data.income} />
-          <ProfitAndLossRow lineItem={data.cost_of_goods_sold} />
+          <ProfitAndLossRow
+            lineItem={data.income}
+            direction={Direction.CREDIT}
+          />
+          <ProfitAndLossRow
+            lineItem={data.cost_of_goods_sold}
+            direction={Direction.DEBIT}
+          />
           <ProfitAndLossRow
             lineItem={{
               value: data.gross_profit,
               display_name: 'Gross Profit',
             }}
             variant="GROSS"
+            direction={Direction.CREDIT}
           />
-          <ProfitAndLossRow lineItem={data.expenses} />
+          <ProfitAndLossRow
+            lineItem={data.expenses}
+            direction={Direction.DEBIT}
+          />
           <ProfitAndLossRow
             lineItem={{
               value: data.profit_before_taxes,
               display_name: 'Profit Before Taxes',
             }}
             variant="BEFORETAX"
+            direction={Direction.CREDIT}
           />
-          <ProfitAndLossRow lineItem={data.taxes} />
+          <ProfitAndLossRow lineItem={data.taxes} direction={Direction.DEBIT} />
           <ProfitAndLossRow
             lineItem={{
               value: data.net_profit,
               display_name: 'Net Profit',
             }}
             variant="NETPROFIT"
+            direction={Direction.CREDIT}
           />
-          <ProfitAndLossRow lineItem={data.other_outflows} />
-          <ProfitAndLossRow lineItem={data.personal_expenses} />
+          <ProfitAndLossRow
+            lineItem={data.other_outflows}
+            direction={Direction.DEBIT}
+          />
+          <ProfitAndLossRow
+            lineItem={data.personal_expenses}
+            direction={Direction.DEBIT}
+          />
         </>
       )}
     </div>

--- a/src/test/factories/bankTransaction.ts
+++ b/src/test/factories/bankTransaction.ts
@@ -1,4 +1,4 @@
-import { BankTransaction } from '../../types'
+import { BankTransaction, Direction } from '../../types'
 
 export const makeBankTransaction = (
   options: Partial<BankTransaction> = {},
@@ -11,7 +11,7 @@ export const makeBankTransaction = (
   source_account_id: '9311880',
   imported_at: '2023-10-04T20:05:10.853973Z',
   date: '2023-09-28T20:04:45Z',
-  direction: 'CREDIT',
+  direction: Direction.DEBIT,
   amount: 20090,
   counterparty_name: 'AMERICAN TRANSPORT LLC ',
   description: null,

--- a/src/test/factories/profitAndLoss.ts
+++ b/src/test/factories/profitAndLoss.ts
@@ -1,0 +1,150 @@
+import { ProfitAndLoss } from '../../types'
+import { LineItem } from '../../types/profit_and_loss'
+
+export const makeProfitAndLoss = (
+  options: Partial<ProfitAndLoss>,
+): ProfitAndLoss => ({
+  type: 'Profit_And_Loss',
+  business_id: '9bf9c71c-ebbb-4fd1-bccb-756267aad447',
+  start_date: '2023-01-01T06:00:00Z',
+  end_date: '2023-12-31T17:59:00Z',
+  income: {
+    name: 'REVENUE',
+    display_name: 'Revenue',
+    value: 677136,
+    line_items: [
+      makeLineItem({
+        name: 'SERVICE_REVENUE',
+        display_name: 'Service Revenue',
+        value: 626881,
+        line_items: null,
+      }),
+      makeLineItem({
+        name: 'MERCHANDISE_SALES_REVENUE',
+        display_name: 'Merchandise Sales Revenue',
+        value: 50255,
+        line_items: null,
+      }),
+    ],
+  },
+  cost_of_goods_sold: {
+    name: 'COGS',
+    display_name: 'Cost of Goods Sold',
+    value: 64312,
+    line_items: [
+      makeLineItem({
+        name: 'SUPPLIES_EXPENSE',
+        display_name: 'Supplies',
+        value: 38903,
+        line_items: [
+          makeLineItem({
+            name: 'SUPPLIES_GENERAL_ELECTRIC',
+            display_name: 'Supplies from General Electric',
+            value: 20281,
+            line_items: null,
+          }),
+          makeLineItem({
+            name: 'SUPPLIES_OTHER',
+            display_name: 'Supplies from other vendors',
+            value: 18622,
+            line_items: null,
+          }),
+        ],
+      }),
+      makeLineItem({
+        name: 'LABOR_EXPENSE',
+        display_name: 'Labor',
+        value: 25000,
+        line_items: null,
+      }),
+      makeLineItem({
+        name: 'OTHER_COST_OF_SALES',
+        display_name: 'Other cost of sales',
+        value: 409,
+        line_items: null,
+      }),
+    ],
+  },
+  gross_profit: 612824,
+  expenses: {
+    name: 'OPERATING_EXPENSES',
+    display_name: 'Operating Expenses',
+    value: 27839,
+    line_items: [
+      makeLineItem({
+        name: 'RENT_EXPENSE',
+        display_name: 'Rent',
+        value: 0,
+        line_items: null,
+      }),
+      makeLineItem({
+        name: 'UTILITIES',
+        display_name: 'Utilities',
+        value: 0,
+        line_items: null,
+      }),
+      makeLineItem({
+        name: 'PHONE',
+        display_name: 'Cell phone plans',
+        value: 21131,
+        line_items: null,
+      }),
+      makeLineItem({
+        name: 'ADVERTISING',
+        display_name: 'Advertising',
+        value: 3779,
+        line_items: null,
+      }),
+      makeLineItem({
+        name: 'INSURANCE',
+        display_name: 'Insurance',
+        value: 0,
+        line_items: null,
+      }),
+      makeLineItem({
+        name: 'OTHER_BUSINESS',
+        display_name: 'Other business expenses',
+        value: 2929,
+        line_items: null,
+      }),
+    ],
+  },
+  profit_before_taxes: 584985,
+  taxes: makeLineItem({
+    name: 'TAXES',
+    display_name: 'Taxes',
+    value: 3921,
+    line_items: null,
+  }),
+  net_profit: 581064,
+  other_outflows: null,
+  personal_expenses: makeLineItem({
+    name: 'PERSONAL',
+    display_name: 'Personal expenses',
+    value: 5599,
+    line_items: null,
+  }),
+  fully_categorized: false,
+  ...options,
+})
+
+export const makeLineItem = (options: Partial<LineItem>): LineItem => ({
+  name: 'REVENUE',
+  display_name: 'Revenue',
+  value: 677136,
+  line_items: [
+    {
+      name: 'SERVICE_REVENUE',
+      display_name: 'Service Revenue',
+      value: 626881,
+      line_items: null,
+    },
+    {
+      name: 'MERCHANDISE_SALES_REVENUE',
+      display_name: 'Merchandise Sales Revenue',
+      value: 50255,
+      line_items: null,
+    },
+  ],
+  ...options,
+})

--- a/src/test/setupAfterEnv.ts
+++ b/src/test/setupAfterEnv.ts
@@ -1,4 +1,5 @@
 import mockFetch from './mockFetch'
+import '@testing-library/jest-dom'
 
 beforeAll(() => (global.fetch = jest.fn()))
 beforeEach(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,10 @@ export enum CategorizationStatus {
   JOURNALING = 'JOURNALING',
 }
 
-export type Direction = 'CREDIT' | 'DEBIT'
+export enum Direction {
+  CREDIT = 'CREDIT',
+  DEBIT = 'DEBIT',
+}
 
 export interface Category {
   display_name: string

--- a/src/types/profit_and_loss.ts
+++ b/src/types/profit_and_loss.ts
@@ -18,5 +18,5 @@ export interface LineItem {
   name?: String
   display_name: string
   value: number
-  line_items?: LineItem[]
+  line_items?: LineItem[] | null
 }


### PR DESCRIPTION
Since all the line items in a P&L report come through to the consumer (Us) as positive values, we should supply the direction of money flow (debit or credit), so the value looks right on the sheet.