### PR TITLE
Return BankTransactions in reverse by default

### DIFF
--- a/src/api/layer/authenticated_http.ts
+++ b/src/api/layer/authenticated_http.ts
@@ -1,5 +1,11 @@
 export const get =
-  <Return = Record<string, string>, Params = Record<string, string>>(
+  <
+    Return extends Record<string, unknown> = Record<string, unknown>,
+    Params extends Record<string, string | undefined> = Record<
+      string,
+      string | undefined
+    >,
+  >(
     url: (params: Params) => string,
   ) =>
   (accessToken: string | undefined, options?: { params?: Params }) =>
@@ -14,9 +20,12 @@ export const get =
 
 export const put =
   <
-    Body = Record<string, string>,
-    Return = Record<string, string>,
-    Params = Record<string, string>,
+    Body extends Record<string, unknown> = Record<string, unknown>,
+    Return extends Record<string, unknown> = Record<string, unknown>,
+    Params extends Record<string, string | undefined> = Record<
+      string,
+      string | undefined
+    >,
   >(
     url: (params: Params) => string,
   ) =>

--- a/src/api/layer/bankTransactions.ts
+++ b/src/api/layer/bankTransactions.ts
@@ -1,13 +1,26 @@
 import { CategoryUpdate, BankTransaction, Metadata } from '../../types'
 import { get, put } from './authenticated_http'
 
-export const getBankTransactions = get<{
+type GetBankTransactionsReturn = {
   data?: BankTransaction[]
   meta?: Metadata
   error?: unknown
-}>(
-  ({ businessId }) =>
-    `https://sandbox.layerfi.com/v1/businesses/${businessId}/bank-transactions`,
+}
+interface GetBankTransactionsParams extends Record<string, string | undefined> {
+  businessId: string
+  sortOrder?: 'ASC' | 'DESC'
+  sortBy?: string
+}
+export const getBankTransactions = get<
+  GetBankTransactionsReturn,
+  GetBankTransactionsParams
+>(
+  ({
+    businessId,
+    sortBy = 'date',
+    sortOrder = 'DESC',
+  }: GetBankTransactionsParams) =>
+    `https://sandbox.layerfi.com/v1/businesses/${businessId}/bank-transactions?sort_by=${sortBy}&sort_order=${sortOrder}`,
 )
 
 export const categorizeBankTransaction = put<

--- a/src/components/ProfitAndLossChart/Indicator.tsx
+++ b/src/components/ProfitAndLossChart/Indicator.tsx
@@ -1,24 +1,18 @@
 import React from 'react'
+import { ContentType } from 'recharts/types/component/Label'
 
-type IndicatorProps = {
-  x: number
-  y: number
-  width: number
-  height: number
-  className: string
-}
-
-export const Indicator = ({
-  x,
-  y,
-  width,
-  height,
-  className,
-}: IndicatorProps) => {
-  const boxWidth = width * 2 + 4 // the bar gap
-  const multiplier = 1.5
-  const xOffset = (boxWidth * multiplier - boxWidth) / 2
-  if (className.match(/selected/)) {
+const emptyViewBox = { x: 0, y: 0, width: 0, height: 0 }
+export const Indicator: ContentType = ({ viewBox = {}, className }) => {
+  const {
+    x = 0,
+    y = 0,
+    width = 0,
+    height = 0,
+  } = 'x' in viewBox ? viewBox : emptyViewBox
+  if (className?.match(/selected/)) {
+    const boxWidth = width * 2 + 4 // the bar gap is 4
+    const multiplier = 1.5
+    const xOffset = (boxWidth * multiplier - boxWidth) / 2
     return (
       <rect
         className="Layer__profit-and-loss-chart__selection-indicator"

--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -127,13 +127,6 @@ export const ProfitAndLossChart = () => {
     }
   }
 
-  const incomeBar = useRef(null)
-  const incomeColor = useMemo(
-    () => incomeBar.current?.style?.getPropertyValue('fill'),
-    [!!incomeBar.current],
-  )
-  const expensesBar = useRef(null)
-
   // If net profit doesn't change, we're probably still the same.
   const data = useMemo(
     () => monthData.map(summarizePnL),
@@ -164,8 +157,6 @@ export const ProfitAndLossChart = () => {
         />
         <XAxis dataKey="name" tickLine={false} />
         <Bar
-          ref={incomeBar}
-          fill={incomeColor}
           dataKey="revenue"
           barSize={barSize}
           isAnimationActive={false}


### PR DESCRIPTION
BankTransactions should always be returned in reverse chronological order by default. We set up some parameters that default to sorting by `date` and order `DESC`. We also set up the types so this is apparent to users of the library.