### PR TITLE
Implement the Balance Sheet Date Picker Button

### DIFF
--- a/src/components/BalanceSheet/BalanceSheet.tsx
+++ b/src/components/BalanceSheet/BalanceSheet.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react'
 import { useBalanceSheet } from '../../hooks/useBalanceSheet'
+import DownloadCloud from '../../icons/DownloadCloud'
 import { BalanceSheetDatePicker } from '../BalanceSheetDatePicker'
 import { BalanceSheetRow } from '../BalanceSheetRow'
-import { format } from 'date-fns'
+import { format, parseISO } from 'date-fns'
 
 export const BalanceSheet = () => {
   const [effectiveDate, setEffectiveDate] = useState(new Date())
-  const { data, isLoading } = useBalanceSheet()
+  const { data, isLoading } = useBalanceSheet(effectiveDate)
   const assets = {
     name: 'Assets',
     display_name: 'Assets',
@@ -19,15 +20,20 @@ export const BalanceSheet = () => {
     line_items: data?.liabilities_and_equity || [],
     value: undefined,
   }
-  const dateString = format(effectiveDate, 'LLL d, yyyy')
+  const dateString = format(effectiveDate, 'LLLL d, yyyy')
   return (
     <div className="Layer__balance-sheet">
       <div className="Layer__balance-sheet__header">
         <h2 className="Layer__balance-sheet__title">
-          Balance Sheet - as of {dateString}
+          Balance Sheet
+          <span className="Layer__balance-sheet__date">{dateString}</span>
         </h2>
-        <BalanceSheetDatePicker onChange={setEffectiveDate} />
+        <BalanceSheetDatePicker
+          value={effectiveDate}
+          onChange={event => setEffectiveDate(parseISO(event.target.value))}
+        />
         <button className="Layer__balance-sheet__download-button">
+          <DownloadCloud />
           Download
         </button>
       </div>

--- a/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
+++ b/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
@@ -1,1 +1,27 @@
-export const BalanceSheetDatePicker = () => null
+import React, { useRef } from 'react'
+import CalendarIcon from '../../icons/Calendar'
+import { format } from 'date-fns'
+
+type Props = {
+  value: Date
+  onChange: React.ChangeEventHandler<HTMLInputElement>
+}
+
+export const BalanceSheetDatePicker = ({ value, onChange }: Props) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const showPicker = () => inputRef.current && inputRef.current.showPicker()
+  return (
+    <span className="Layer__balance-sheet-date-picker">
+      <button onClick={showPicker}>
+        <CalendarIcon />
+        {format(value, 'LLLL dd, yyyy')}
+        <input
+          type="date"
+          ref={inputRef}
+          value={format(value, 'yyyy-MM-dd')}
+          onChange={onChange}
+        />
+      </button>
+    </span>
+  )
+}

--- a/src/hooks/useBalanceSheet/useBalanceSheet.tsx
+++ b/src/hooks/useBalanceSheet/useBalanceSheet.tsx
@@ -1,6 +1,7 @@
 import { Layer } from '../../api/layer'
 import { BalanceSheet } from '../../types'
 import { useLayerContext } from '../useLayerContext'
+import { format, startOfDay } from 'date-fns'
 import useSWR from 'swr'
 
 type UseBalanceSheet = {
@@ -9,12 +10,18 @@ type UseBalanceSheet = {
   error: unknown
 }
 
-export const useBalanceSheet = (): UseBalanceSheet => {
+export const useBalanceSheet = (date?: Date): UseBalanceSheet => {
   const { auth, businessId } = useLayerContext()
+  const dateString = format(startOfDay(date), 'yyyy-mm-dd')
 
   const { data, isLoading, error } = useSWR(
-    businessId && auth?.access_token && `balance-sheet-${businessId}`,
-    Layer.getBalanceSheet(auth?.access_token, { params: { businessId } }),
+    businessId &&
+      dateString &&
+      auth?.access_token &&
+      `balance-sheet-${businessId}-${dateString}`,
+    Layer.getBalanceSheet(auth?.access_token, {
+      params: { businessId, date: dateString },
+    }),
   )
 
   return { data, isLoading, error }

--- a/src/icons/Calendar.tsx
+++ b/src/icons/Calendar.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { SVGProps } from 'react'
+
+const Calendar = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={20}
+    height={22}
+    fill="none"
+    {...props}
+  >
+    <path
+      stroke="#000"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M19 9H1m13-8v4M6 1v4m-.2 16h8.4c1.68 0 2.52 0 3.162-.327a3 3 0 0 0 1.311-1.311C19 18.72 19 17.88 19 16.2V7.8c0-1.68 0-2.52-.327-3.162a3 3 0 0 0-1.311-1.311C16.72 3 15.88 3 14.2 3H5.8c-1.68 0-2.52 0-3.162.327a3 3 0 0 0-1.311 1.311C1 5.28 1 6.12 1 7.8v8.4c0 1.68 0 2.52.327 3.162a3 3 0 0 0 1.311 1.311C3.28 21 4.12 21 5.8 21Z"
+    />
+  </svg>
+)
+export default Calendar

--- a/src/icons/DownloadCloud.tsx
+++ b/src/icons/DownloadCloud.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { SVGProps } from 'react'
+
+const DownloadCloud = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={24}
+    height={24}
+    fill="none"
+    {...props}
+  >
+    <path
+      stroke="#000"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M4 16.242A4.5 4.5 0 0 1 6.08 8.02a6.002 6.002 0 0 1 11.84 0A4.5 4.5 0 0 1 20 16.242M8 17l4 4m0 0 4-4m-4 4v-9"
+    />
+  </svg>
+)
+export default DownloadCloud

--- a/src/styles/balance_sheet.scss
+++ b/src/styles/balance_sheet.scss
@@ -46,8 +46,67 @@
   margin-right: 1.5rem;
 }
 
+.Layer__balance-sheet__date {
+  font-size: 0.75em;
+  &::before {
+    content: ' - as of ';
+  }
+}
+
 .Layer__balance-sheet__download-button {
   align-self: center;
+  border: 2px solid var(--border-color);
+  background-color: var(--background-color);
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  margin-left: 0.5rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+
+  &:active {
+    background-color: var(--active);
+  }
+
+  & svg {
+    margin-right: 0.5rem;
+  }
+}
+
+.Layer__balance-sheet-date-picker {
+  align-items: center;
+  justify-content: center;
+  display: flex;
+
+  & button {
+    position: relative;
+    border: 2px solid var(--border-color);
+    background-color: var(--background-color);
+    padding: 0.5rem;
+    border-radius: 0.5rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+
+    &:active {
+      background-color: var(--active);
+    }
+
+    & svg {
+      margin-right: 0.5rem;
+    }
+
+    & input {
+      position: absolute;
+      z-index: -1;
+      bottom: 0;
+      left: 0;
+      width: 1px;
+      height: 100%;
+    }
+  }
 }
 
 .Layer__balance-sheet-row {
@@ -140,44 +199,4 @@
   svg {
     display: none;
   }
-}
-
-.Layer__balance-sheet-date-picker {
-  width: 20rem;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding: 0.25rem;
-  margin: 0.5rem;
-  border: 1px solid var(--border-color);
-  border-radius: 0.5rem;
-}
-
-.Layer__balance-sheet-date-picker__button {
-  padding: 0.25rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  background-color: var(--background-color);
-  border: 0;
-  border-radius: 0.5rem;
-
-  &:active {
-    background-color: var(--active);
-  }
-}
-
-.Layer__balance-sheet-date-picker__button-icon path {
-  stroke: var(--font-color);
-}
-
-.Layer__balance-sheet-date-picker__label {
-  flex: 1;
-  font-size: 1rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
 }


### PR DESCRIPTION
The date picker we're using is just the standard `input type="date"` picker as supplied by the browser. But since the input element itself has variations between browsers and because we want it to appear like a button, we're doing a bit of trckery to get it to look right. We're keeping the element visible in case screen readers care (and also beause we want the picker portion of it), but we're hiding it behind an actual button element. This will remove variation while keeping usability and accessibility high (as both elements are still visible and usable).

Also, despite the availability of `valueAsDate` on the element itself, as presented by the HTML standard, the date appears as a local Date object once parsed as UTC, which means if we select 1/1/2024, we recieve an object that is 12/31/2023T19:00-0500, which does not work for our purposes. Parsing the date with `date-fns` returns a date that is 1/1/2024T00:00-0500. The difference is one parsed in UTC and the translated to local time versus one parsed already in local time. While it's arguable which one is "correct", the latter is the one that is usable for our purposes without futher modification.

Normal operation.
<img width="970" alt="Screenshot 2023-12-08 at 8 08 24 AM" src="https://github.com/Layer-Fi/layer-react/assets/4632/f7940c38-8cf6-4cf7-ae91-65e517d0c680">

When the element is too close to the bottom to draw below it.
<img width="957" alt="Screenshot 2023-12-08 at 8 08 54 AM" src="https://github.com/Layer-Fi/layer-react/assets/4632/f634e393-6eba-4276-a035-f7831765d34e">
