### PR TITLE
Parameterize auth configuration

### DIFF
--- a/src/api/layer/authenticate.test.ts
+++ b/src/api/layer/authenticate.test.ts
@@ -2,19 +2,20 @@ import { formStringFromObject } from '../util'
 import { authenticate } from './authenticate'
 
 describe(authenticate, () => {
-  it('passes params to the url-making function and uses accessToken', () => {
-    // These are repeated becauise they will be arguments later
-    // So they should act somewhat like them now.
+  it('passes params to the url-making function and uses accessToken', async () => {
     const appId = '1pskub33qd9qt19406hi4d1j6f'
     const appSecret = '1k7up1ia2m0ino8el6md2l1isq3t7fdj1eq6firmkui8757lk6r6'
-    const details = {
-      grant_type: 'client_credentials',
-      scope: 'https://sandbox.layerfi.com/sandbox',
-      client_id: 'canaryAppId',
-    }
+    const clientId = 'canaryAppId'
+    const scope = 'https://sandbox.layerfi.com/sandbox'
     const token = btoa(`${appId}:${appSecret}`)
 
-    authenticate()
+    await authenticate({
+      appId,
+      appSecret,
+      authenticationUrl: 'https://auth.layerfi.com/oauth2/token',
+      clientId,
+      scope,
+    })
 
     expect(fetch).toHaveBeenCalledWith(
       'https://auth.layerfi.com/oauth2/token',
@@ -24,7 +25,11 @@ describe(authenticate, () => {
           Authorization: `Basic ${token}`,
           'Content-Type': 'application/x-www-form-urlencoded',
         },
-        body: formStringFromObject(details),
+        body: formStringFromObject({
+          grant_type: 'client_credentials',
+          scope,
+          client_id: clientId,
+        }),
       },
     )
   })

--- a/src/api/layer/authenticate.ts
+++ b/src/api/layer/authenticate.ts
@@ -1,22 +1,29 @@
 import { OAuthResponse } from '../../types'
 import { formStringFromObject } from '../util'
 
-// These will be parameters or configurable per-environment in the future
-const appId = '1pskub33qd9qt19406hi4d1j6f'
-const appSecret = '1k7up1ia2m0ino8el6md2l1isq3t7fdj1eq6firmkui8757lk6r6'
-const url = 'https://auth.layerfi.com/oauth2/token'
-const details = {
-  grant_type: 'client_credentials',
-  scope: 'https://sandbox.layerfi.com/sandbox',
-  client_id: 'canaryAppId',
+type AuthenticationArguments = {
+  appId: string
+  appSecret: string
+  authenticationUrl?: string
+  clientId: string
+  scope: string
 }
-
-export const authenticate = (): Promise<OAuthResponse> =>
-  fetch(url, {
+export const authenticate = ({
+  appId,
+  appSecret,
+  authenticationUrl = 'https://auth.layerfi.com/oauth2/token',
+  clientId,
+  scope,
+}: AuthenticationArguments): Promise<OAuthResponse> =>
+  fetch(authenticationUrl, {
     method: 'POST',
     headers: {
       Authorization: 'Basic ' + btoa(appId + ':' + appSecret),
       'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: formStringFromObject(details),
+    body: formStringFromObject({
+      grant_type: 'client_credentials',
+      scope,
+      client_id: clientId,
+    }),
   }).then(res => res.json() as Promise<OAuthResponse>)

--- a/src/components/ProfitAndLossRow/ProfitAndLossRow.test.tsx
+++ b/src/components/ProfitAndLossRow/ProfitAndLossRow.test.tsx
@@ -13,7 +13,7 @@ describe(ProfitAndLossRow, () => {
     render(<ProfitAndLossRow lineItem={lineItem} />)
 
     const label = await screen.findByText('Bob')
-    const value = await screen.findByText('1001.23')
+    const value = await screen.findByText('1,001.23')
     expect(label).toHaveClass('Layer__profit-and-loss-row__label')
     expect(value).toHaveClass('Layer__profit-and-loss-row__value')
   })
@@ -29,7 +29,7 @@ describe(ProfitAndLossRow, () => {
     )
 
     const label = await screen.findByText('Bob')
-    const value = await screen.findByText('1001.23')
+    const value = await screen.findByText('1,001.23')
     expect(label).not.toHaveClass(
       'Layer__profit-and-loss-row__label--amount-positive',
     )
@@ -48,7 +48,7 @@ describe(ProfitAndLossRow, () => {
     render(<ProfitAndLossRow lineItem={lineItem} direction={Direction.DEBIT} />)
 
     const label = await screen.findByText('Bob')
-    const value = await screen.findByText('1001.23')
+    const value = await screen.findByText('1,001.23')
     expect(label).not.toHaveClass(
       'Layer__profit-and-loss-row__label--amount-negative',
     )

--- a/src/providers/LayerProvider/LayerProvider.tsx
+++ b/src/providers/LayerProvider/LayerProvider.tsx
@@ -21,13 +21,32 @@ const reducer: Reducer<LayerContextValues, LayerContextAction> = (
   }
 }
 
+type LayerEnvironmentConfig = {
+  url: string
+  scope: string
+}
+export const LayerEnvironment: Record<string, LayerEnvironmentConfig> = {
+  staging: {
+    url: 'https://auth.layerfi.com/oauth2/token',
+    scope: 'https://sandbox.layerfi.com/sandbox',
+  },
+}
+
 type Props = {
   businessId: string
+  appId: string
+  appSecret: string
+  clientId: string
+  environment: keyof typeof LayerEnvironment
 }
 
 export const LayerProvider = ({
+  appId,
+  appSecret,
   businessId,
   children,
+  clientId,
+  environment,
 }: PropsWithChildren<Props>) => {
   const defaultSWRConfig = {
     revalidateInterval: 0,
@@ -36,6 +55,7 @@ export const LayerProvider = ({
     revalidateIfStale: false,
   }
 
+  const { url, scope } = LayerEnvironment[environment]
   const [state, dispatch] = useReducer(reducer, {
     auth: { access_token: '', token_type: '', expires_in: 0 },
     businessId,
@@ -44,7 +64,13 @@ export const LayerProvider = ({
 
   const { data: auth } = useSWR(
     'authenticate',
-    Layer.authenticate,
+    Layer.authenticate({
+      appId,
+      appSecret,
+      authenticationUrl: url,
+      scope,
+      clientId,
+    }),
     defaultSWRConfig,
   )
   useEffect(() => {

--- a/src/test/mockFetch.ts
+++ b/src/test/mockFetch.ts
@@ -1,2 +1,7 @@
-export default (url: string, config: Record<string, string>) =>
-  Promise.resolve({ json: () => Promise.resolve({ url, config }) })
+const mockFetch = jest
+  .fn()
+  .mockImplementation((url: string, config: Record<string, string>) =>
+    Promise.resolve({ json: () => Promise.resolve({ url, config }) }),
+  )
+
+export default mockFetch

--- a/src/test/setupAfterEnv.ts
+++ b/src/test/setupAfterEnv.ts
@@ -1,1 +1,4 @@
+import mockFetch from './mockFetch'
 import '@testing-library/jest-dom'
+
+global.fetch = mockFetch


### PR DESCRIPTION
This commit moves the `appId`, etc from being defined as constants in `src/api/layer/authenticate.ts` and moves it to being defined as a prop on the LayerProvider. This is a step toward making the module publishable, since having static auth config wouldn't be terribly useful to people.

Also, it shifts around some of the code involving mocking `fetch` since that wasn't working for some reason.