### PR TITLE
Fix missing currying with authentication function

### DIFF
--- a/src/api/layer/authenticate.ts
+++ b/src/api/layer/authenticate.ts
@@ -8,22 +8,24 @@ type AuthenticationArguments = {
   clientId: string
   scope: string
 }
-export const authenticate = ({
-  appId,
-  appSecret,
-  authenticationUrl = 'https://auth.layerfi.com/oauth2/token',
-  clientId,
-  scope,
-}: AuthenticationArguments): Promise<OAuthResponse> =>
-  fetch(authenticationUrl, {
-    method: 'POST',
-    headers: {
-      Authorization: 'Basic ' + btoa(appId + ':' + appSecret),
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: formStringFromObject({
-      grant_type: 'client_credentials',
-      scope,
-      client_id: clientId,
-    }),
-  }).then(res => res.json() as Promise<OAuthResponse>)
+export const authenticate =
+  ({
+    appId,
+    appSecret,
+    authenticationUrl = 'https://auth.layerfi.com/oauth2/token',
+    clientId,
+    scope,
+  }: AuthenticationArguments) =>
+  (): Promise<OAuthResponse> =>
+    fetch(authenticationUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Basic ' + btoa(appId + ':' + appSecret),
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: formStringFromObject({
+        grant_type: 'client_credentials',
+        scope,
+        client_id: clientId,
+      }),
+    }).then(res => res.json() as Promise<OAuthResponse>)


### PR DESCRIPTION
There was an oversight in the authentication config abstraction commit. The `authenticate` function should have been returning a function that `useSWR` would tirgger. For some reason it wasn't ans it wasn't being a problem -- until now. But this fixes the problem!