### PR TITLE
Keep displaying markup even if data isn't there

### DIFF
--- a/src/components/ProfitAndLossRow/ProfitAndLossRow.tsx
+++ b/src/components/ProfitAndLossRow/ProfitAndLossRow.tsx
@@ -22,7 +22,7 @@ export const ProfitAndLossRow = ({
   }
   const { value, display_name, line_items, name } = lineItem
   const variantName = variant || name
-  const amount = value || 0
+  const amount = value ?? NaN
   const amountString = centsToDollars(Math.abs(amount))
   const labelClasses = [
     'Layer__profit-and-loss-row',

--- a/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
+++ b/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
@@ -1,15 +1,12 @@
 import React, { useContext } from 'react'
 import { centsToDollars as formatMoney } from '../../models/Money'
 import { ProfitAndLoss as PNL } from '../ProfitAndLoss'
-import { format as formatDate, parseISO } from 'date-fns'
 
 export const ProfitAndLossSummaries = () => {
-  const { data } = useContext(PNL.Context)
-  if (!data) {
-    return null
-  }
-
-  const monthName = formatDate(parseISO(data?.start_date), 'LLLL')
+  const { data: storedData } = useContext(PNL.Context)
+  const data = !!storedData
+    ? storedData
+    : { income: { value: NaN }, net_profit: { value: NaN } }
 
   return (
     <div className="Layer__profit-and-loss-summaries">

--- a/src/components/ProfitAndLossTable/ProfitAndLossTable.tsx
+++ b/src/components/ProfitAndLossTable/ProfitAndLossTable.tsx
@@ -2,62 +2,52 @@ import React, { useContext } from 'react'
 import { Direction } from '../../types'
 import { ProfitAndLoss } from '../ProfitAndLoss'
 import { ProfitAndLossRow } from '../ProfitAndLossRow'
+import emptyPNL from './empty_profit_and_loss_report'
 
 export const ProfitAndLossTable = () => {
-  const { data, isLoading } = useContext(ProfitAndLoss.Context)
+  const { data: actualData, isLoading } = useContext(ProfitAndLoss.Context)
+  const data = !actualData || isLoading ? emptyPNL : actualData
   return (
     <div className="Layer__profit-and-loss-table">
-      {!data || isLoading ? (
-        <div>Loading</div>
-      ) : (
-        <>
-          <ProfitAndLossRow
-            lineItem={data.income}
-            direction={Direction.CREDIT}
-          />
-          <ProfitAndLossRow
-            lineItem={data.cost_of_goods_sold}
-            direction={Direction.DEBIT}
-          />
-          <ProfitAndLossRow
-            lineItem={{
-              value: data.gross_profit,
-              display_name: 'Gross Profit',
-            }}
-            variant="GROSS"
-            direction={Direction.CREDIT}
-          />
-          <ProfitAndLossRow
-            lineItem={data.expenses}
-            direction={Direction.DEBIT}
-          />
-          <ProfitAndLossRow
-            lineItem={{
-              value: data.profit_before_taxes,
-              display_name: 'Profit Before Taxes',
-            }}
-            variant="BEFORETAX"
-            direction={Direction.CREDIT}
-          />
-          <ProfitAndLossRow lineItem={data.taxes} direction={Direction.DEBIT} />
-          <ProfitAndLossRow
-            lineItem={{
-              value: data.net_profit,
-              display_name: 'Net Profit',
-            }}
-            variant="NETPROFIT"
-            direction={Direction.CREDIT}
-          />
-          <ProfitAndLossRow
-            lineItem={data.other_outflows}
-            direction={Direction.DEBIT}
-          />
-          <ProfitAndLossRow
-            lineItem={data.personal_expenses}
-            direction={Direction.DEBIT}
-          />
-        </>
-      )}
+      <ProfitAndLossRow lineItem={data.income} direction={Direction.CREDIT} />
+      <ProfitAndLossRow
+        lineItem={data.cost_of_goods_sold}
+        direction={Direction.DEBIT}
+      />
+      <ProfitAndLossRow
+        lineItem={{
+          value: data.gross_profit,
+          display_name: 'Gross Profit',
+        }}
+        variant="GROSS"
+        direction={Direction.CREDIT}
+      />
+      <ProfitAndLossRow lineItem={data.expenses} direction={Direction.DEBIT} />
+      <ProfitAndLossRow
+        lineItem={{
+          value: data.profit_before_taxes,
+          display_name: 'Profit Before Taxes',
+        }}
+        variant="BEFORETAX"
+        direction={Direction.CREDIT}
+      />
+      <ProfitAndLossRow lineItem={data.taxes} direction={Direction.DEBIT} />
+      <ProfitAndLossRow
+        lineItem={{
+          value: data.net_profit,
+          display_name: 'Net Profit',
+        }}
+        variant="NETPROFIT"
+        direction={Direction.CREDIT}
+      />
+      <ProfitAndLossRow
+        lineItem={data.other_outflows}
+        direction={Direction.DEBIT}
+      />
+      <ProfitAndLossRow
+        lineItem={data.personal_expenses}
+        direction={Direction.DEBIT}
+      />
     </div>
   )
 }

--- a/src/components/ProfitAndLossTable/empty_profit_and_loss_report.ts
+++ b/src/components/ProfitAndLossTable/empty_profit_and_loss_report.ts
@@ -1,0 +1,48 @@
+import { ProfitAndLoss } from '../../types'
+
+export default {
+  type: 'Profit_And_Loss',
+  business_id: '',
+  start_date: '',
+  end_date: '',
+  income: {
+    name: 'INCOME',
+    display_name: 'Income',
+    value: NaN,
+    line_items: null,
+  },
+  cost_of_goods_sold: {
+    display_name: 'Cost of Goods Sold',
+    name: 'COGS',
+    value: NaN,
+    line_items: null,
+  },
+  gross_profit: NaN,
+  expenses: {
+    name: 'EXPENSES',
+    display_name: 'Expenses',
+    value: NaN,
+    line_items: null,
+  },
+  profit_before_taxes: NaN,
+  taxes: {
+    name: 'TAXES',
+    display_name: 'Taxes',
+    value: NaN,
+    line_items: null,
+  },
+  net_profit: NaN,
+  other_outflows: {
+    name: 'OTHER_OUTFLOWS',
+    display_name: 'Other outflows',
+    value: NaN,
+    line_items: null,
+  },
+  personal_expenses: {
+    name: 'PERSONAL',
+    display_name: 'Personal expenses',
+    value: NaN,
+    line_items: null,
+  },
+  fully_categorized: false,
+} as ProfitAndLoss

--- a/src/models/Money.test.ts
+++ b/src/models/Money.test.ts
@@ -25,6 +25,11 @@ describe(Money.centsToDollars, () => {
     const output = Money.centsToDollars(1234567890)
     expect(output).toEqual('12,345,678.90')
   })
+
+  it('turns NaN into something useful', () => {
+    const output = Money.centsToDollars(NaN)
+    expect(output).toEqual('-.--')
+  })
 })
 
 describe(Money.dollarsToCents, () => {

--- a/src/models/Money.ts
+++ b/src/models/Money.ts
@@ -5,7 +5,7 @@ const formatter = new Intl.NumberFormat('en-US', {
 })
 
 export const centsToDollars = (cents: number): string =>
-  formatter.format(cents / 100)
+  isNaN(cents) ? '-.--' : formatter.format(cents / 100)
 
 export const dollarsToCents = (dollars: string): number =>
   Math.round(parseFloat(dollars) * 100)


### PR DESCRIPTION
The ProfitAndLossSummaries should stick around even if they don't have data. Seeing them blip in an out of existence is jarring. If there is no data for them to display, they should display `$-.--` so their structre sticks around.

This also applies to the ProfitAndLossTable. We need a "blank" document that replicates the things we need to show, but with `NaN` as values. We can use `NaN` to denote that dollar formatting should be `$-.--` instead of `$0.00`.

https://github.com/Layer-Fi/layer-react/assets/4632/ddfaa028-7cab-457d-bfc5-6b5db32d9b2d

