### PR TITLE
Animate opening/closing ExpandedBankTransactionRow

### DIFF
--- a/src/components/BalanceSheet/BalanceSheet.tsx
+++ b/src/components/BalanceSheet/BalanceSheet.tsx
@@ -22,7 +22,7 @@ export const BalanceSheet = () => {
   }
   const dateString = format(effectiveDate, 'LLLL d, yyyy')
   return (
-    <div className="Layer__balance-sheet">
+    <div className="Layer__component Layer__balance-sheet">
       <div className="Layer__balance-sheet__header">
         <h2 className="Layer__balance-sheet__title">
           Balance Sheet

--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { useBankTransactions } from '../../hooks/useBankTransactions'
 import CheckedCircle from '../../icons/CheckedCircle'
 import ChevronDown from '../../icons/ChevronDown'
-import ChevronUp from '../../icons/ChevronUp'
 import { centsToDollars as formatMoney } from '../../models/Money'
 import { BankTransaction, CategorizationType, Direction } from '../../types'
 import { CategoryMenu } from '../CategoryMenu'
@@ -49,25 +48,27 @@ export const BankTransactionRow = ({
     })
 
   return (
-    <>
-      <div className={`${className} ${openClassName} ${className}--date`}>
-        {formatTime(parseISO(bankTransaction.date), dateFormat)}
-      </div>
-      <div className={`${className} ${openClassName}`}>
-        {bankTransaction.counterparty_name}
-      </div>
-      <div className={`${className} ${openClassName}`}>Business Checking</div>
-      <div
-        className={`${className} ${openClassName} ${className}--amount-${
-          isCredit(bankTransaction) ? 'credit' : 'debit'
-        }`}
-      >
-        {formatMoney(bankTransaction.amount)}
-      </div>
-      {isOpen ? (
-        <div className={`${className} ${openClassName}`}></div>
-      ) : (
+    <div className="Layer__bank-transaction-row__container">
+      <div className="Layer__bank-transaction-row__content">
+        <div className={`${className} ${openClassName} ${className}--date`}>
+          {formatTime(parseISO(bankTransaction.date), dateFormat)}
+        </div>
         <div className={`${className} ${openClassName}`}>
+          {bankTransaction.counterparty_name}
+        </div>
+        <div className={`${className} ${openClassName}`}>Business Checking</div>
+        <div
+          className={`${className} ${openClassName} ${className}--amount-${
+            isCredit(bankTransaction) ? 'credit' : 'debit'
+          }`}
+        >
+          {formatMoney(bankTransaction.amount)}
+        </div>
+        <div
+          className={`${className} ${openClassName} ${
+            isOpen && 'Layer__bank-transaction-row__table-cell--hide-contents'
+          }`}
+        >
           {editable ? (
             <CategoryMenu
               bankTransaction={bankTransaction}
@@ -79,33 +80,36 @@ export const BankTransactionRow = ({
             <Pill>{bankTransaction?.category?.display_name}</Pill>
           )}
         </div>
-      )}
-      <div className={`${className} ${openClassName} ${className}--actions`}>
-        <div
-          className="Layer__bank-transaction-row__save-button"
-          onClick={() => save()}
-        >
-          {editable && !isOpen && (
-            <CheckedCircle
-              size={28}
-              strokeColor="#0C48E5"
-              fillColor="#e0e9ff"
+        <div className={`${className} ${openClassName} ${className}--actions`}>
+          <div
+            className="Layer__bank-transaction-row__save-button"
+            onClick={() => save()}
+          >
+            {editable && !isOpen && (
+              <CheckedCircle
+                size={28}
+                strokeColor="#0C48E5"
+                fillColor="#e0e9ff"
+              />
+            )}
+          </div>
+          <div
+            onClick={() => toggleOpen(bankTransaction.id)}
+            className="Layer__bank-transaction-row__expand-button"
+          >
+            <ChevronDown
+              className={`Layer__chevron ${
+                isOpen ? 'Layer__chevron__up' : 'Layer__chevron__down'
+              }`}
             />
-          )}
+          </div>
         </div>
-        <div
-          onClick={() => toggleOpen(bankTransaction.id)}
-          className="Layer__bank-transaction-row__expand-button"
-        >
-          {isOpen ? <ChevronUp /> : <ChevronDown />}
-        </div>
-      </div>
-      {isOpen && (
         <ExpandedBankTransactionRow
           bankTransaction={bankTransaction}
           close={() => toggleOpen(bankTransaction.id)}
+          isOpen={isOpen}
         />
-      )}
-    </>
+      </div>
+    </div>
   )
 }

--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -51,7 +51,7 @@ export const BankTransactions = () => {
   const toggleOpen = (id: string) =>
     setOpenRows({ ...openRows, [id]: !openRows[id] })
   return (
-    <div className="Layer__bank-transactions" data-display={display}>
+    <div className="Layer__component Layer__bank-transactions">
       <header className="Layer__bank-transactions__header">
         <h2 className="Layer__bank-transactions__title">Transactions</h2>
         <RadioButtonGroup

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -19,6 +19,7 @@ import { RadioButtonGroup } from '../RadioButtonGroup'
 type Props = {
   bankTransaction: BankTransaction
   close?: () => void
+  isOpen?: boolean
 }
 
 type Split = {
@@ -41,6 +42,7 @@ enum Purpose {
 export const ExpandedBankTransactionRow = ({
   bankTransaction,
   close,
+  isOpen = false,
 }: Props) => {
   const { categorize: categorizeBankTransaction } = useBankTransactions()
   const [purpose, setPurpose] = useState<Purpose>(Purpose.categorize)
@@ -138,105 +140,111 @@ export const ExpandedBankTransactionRow = ({
 
   const className = 'Layer__expanded-bank-transaction-row'
   return (
-    <div className={className}>
-      <div className={`${className}__purpose-button`}>
-        <RadioButtonGroup
-          name={`purpose-${bankTransaction.id}`}
-          size="small"
-          buttons={[
-            { value: 'categorize', label: 'Categorize' },
-            { value: 'match', label: 'Match', disabled: true },
-          ]}
-          selected={purpose}
-          onChange={onChangePurpose}
-        />
-      </div>
-      <div
-        className={`${className}__content`}
-        id={`expanded-${bankTransaction.id}`}
-      >
-        <div
-          className={`${className}__table-cell ${className}__table-cell--header`}
-        ></div>
-        <div
-          className={`${className}__table-cell ${className}__table-cell--header`}
-        >
-          Category
+    <div
+      className={`${className} ${className}--${
+        isOpen ? 'expanded' : 'collapsed'
+      }`}
+    >
+      <div className={`${className}__wrapper`}>
+        <div className={`${className}__purpose-button`}>
+          <RadioButtonGroup
+            name={`purpose-${bankTransaction.id}`}
+            size="small"
+            buttons={[
+              { value: 'categorize', label: 'Categorize' },
+              { value: 'match', label: 'Match', disabled: true },
+            ]}
+            selected={purpose}
+            onChange={onChangePurpose}
+          />
         </div>
         <div
-          className={`${className}__table-cell ${className}__table-cell--header`}
+          className={`${className}__content`}
+          id={`expanded-${bankTransaction.id}`}
         >
-          Description
-        </div>
-        <div
-          className={`${className}__table-cell ${className}__table-cell--header`}
-        >
-          Receipt
-        </div>
-        <div
-          className={`${className}__table-cell ${className}__table-cell--header`}
-        ></div>
-        <div
-          className={`${className}__table-cell ${className}__table-cell--header`}
-        ></div>
+          <div
+            className={`${className}__table-cell ${className}__table-cell--header`}
+          ></div>
+          <div
+            className={`${className}__table-cell ${className}__table-cell--header`}
+          >
+            Category
+          </div>
+          <div
+            className={`${className}__table-cell ${className}__table-cell--header`}
+          >
+            Description
+          </div>
+          <div
+            className={`${className}__table-cell ${className}__table-cell--header`}
+          >
+            Receipt
+          </div>
+          <div
+            className={`${className}__table-cell ${className}__table-cell--header`}
+          ></div>
+          <div
+            className={`${className}__table-cell ${className}__table-cell--header`}
+          ></div>
 
-        <div className={`${className}__table-cell`}>
-          {rowState.splits.length === 1 ? (
-            <div className={`${className}__button--split`} onClick={addSplit}>
-              <Unlink className={`${className}__svg`} size={18} />
-              Split
-            </div>
-          ) : (
-            <div
-              className={`${className}__button--merge`}
-              onClick={removeSplit}
-            >
-              <Link className={`${className}__svg`} size={18} />
-              Merge
-            </div>
-          )}
-        </div>
-        <div className={`${className}__table-cell`}>
-          {rowState.splits.map((split, index) => (
-            <div
-              className={`${className}__table-cell--split-entry`}
-              key={`split-${index}`}
-            >
-              <CategoryMenu
-                bankTransaction={bankTransaction}
-                name={`category-${index}`}
-                value={split.category}
-                onChange={value => changeCategory(index, value)}
-              />
-              {rowState.splits.length > 1 && (
-                <input
-                  type="text"
-                  name={`split-${index}`}
-                  disabled={index + 1 === rowState.splits.length}
-                  onChange={updateAmounts(index)}
-                  value={split.inputValue}
-                  onBlur={onBlur}
-                  className={`${className}__split-amount${
-                    split.amount < 0 ? '--negative' : ''
-                  }`}
+          <div className={`${className}__table-cell`}>
+            {rowState.splits.length === 1 ? (
+              <div className={`${className}__button--split`} onClick={addSplit}>
+                <Unlink className={`${className}__svg`} size={18} />
+                Split
+              </div>
+            ) : (
+              <div
+                className={`${className}__button--merge`}
+                onClick={removeSplit}
+              >
+                <Link className={`${className}__svg`} size={18} />
+                Merge
+              </div>
+            )}
+          </div>
+          <div className={`${className}__table-cell`}>
+            {rowState.splits.map((split, index) => (
+              <div
+                className={`${className}__table-cell--split-entry`}
+                key={`split-${index}`}
+              >
+                <CategoryMenu
+                  bankTransaction={bankTransaction}
+                  name={`category-${index}`}
+                  value={split.category}
+                  onChange={value => changeCategory(index, value)}
                 />
-              )}
-            </div>
-          ))}
-        </div>
-        <div
-          className={`${className}__table-cell ${className}__table-cell--description`}
-        >
-          <textarea></textarea>
-        </div>
-        <div className={`${className}__table-cell`}>
-          <input type="file" />
-        </div>
-        <div className={`${className}__table-cell`}></div>
-        <div className={`${className}__table-cell`}>
-          <button onClick={save} className={`${className}__button--save`}>
-            Save
-          </button>
+                {rowState.splits.length > 1 && (
+                  <input
+                    type="text"
+                    name={`split-${index}`}
+                    disabled={index + 1 === rowState.splits.length}
+                    onChange={updateAmounts(index)}
+                    value={split.inputValue}
+                    onBlur={onBlur}
+                    className={`${className}__split-amount${
+                      split.amount < 0 ? '--negative' : ''
+                    }`}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+          <div
+            className={`${className}__table-cell ${className}__table-cell--description`}
+          >
+            <textarea></textarea>
+          </div>
+          <div className={`${className}__table-cell`}>
+            <input type="file" />
+          </div>
+          <div className={`${className}__table-cell`}></div>
+          <div className={`${className}__table-cell`}>
+            <button onClick={save} className={`${className}__button--save`}>
+              Save
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/ProfitAndLoss/ProfitAndLoss.tsx
+++ b/src/components/ProfitAndLoss/ProfitAndLoss.tsx
@@ -22,7 +22,7 @@ const ProfitAndLoss = ({ children }: PropsWithChildren) => {
   const contextData = useProfitAndLoss()
   return (
     <PNLContext.Provider value={contextData}>
-      <div className="Layer__profit-and-loss">
+      <div className="Layer__component Layer__profit-and-loss">
         <h2 className="Layer__profit-and-loss__title">Profit & Loss</h2>
         {children}
       </div>

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -8,6 +8,7 @@
   --positive-amount-text-color: #039855;
   --variable-amount-text-color: #475467;
   --error-color: red;
+  --transition-speed: 0.33s;
 
   margin: 3rem;
   border-radius: 0.6rem;
@@ -43,7 +44,7 @@
 
 .Layer__bank-transactions__table {
   display: grid;
-  grid-template-columns: repeat(3, 1fr) repeat(3, auto);
+  grid-template-columns: 1fr 1fr 1fr auto auto auto;
   gap: 1px 0px;
   background-color: var(--table-border-color);
   border-top: 1px solid var(--table-border-color);
@@ -53,7 +54,7 @@
 .Layer__bank-transactions__table-cell--header {
   display: flex;
   align-items: center;
-  background-color: white;
+  background-color: var(--table-background-color);
   font-size: 16px;
   line-height: 20px;
   overflow: clip;
@@ -66,10 +67,31 @@
   justify-content: flex-end;
 }
 
+.Layer__bank-transaction-row__container {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  grid-template-rows: 1fr;
+  overflow: hidden;
+  transition: grid-template-rows var(--transition-speed);
+}
+
+.Layer__bank-transaction-row__container--removing {
+  grid-template-rows: 0fr;
+}
+
+.Layer__bank-transaction-row__content {
+  min-height: 0;
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+}
+
 .Layer__bank-transaction-row__table-cell {
   display: flex;
   align-items: center;
-  background-color: white;
+  background-color: var(--table-background-color);
+  transition: background-color var(--transition-speed);
   font-size: 16px;
   line-height: 20px;
   overflow: clip;
@@ -106,6 +128,10 @@
   }
 }
 
+.Layer__bank-transaction-row__table-cell--hide-contents * {
+  visibility: hidden;
+}
+
 .Layer__bank-transaction-row__save-button {
   cursor: pointer;
 }
@@ -117,6 +143,18 @@
 
 .Layer__expanded-bank-transaction-row {
   grid-column: 1 / -1;
+  display: grid;
+  grid-template-rows: 0fr;
+  background-color: var(--table-expanded-background-color);
+  transition: grid-template-rows var(--transition-speed);
+}
+
+.Layer__expanded-bank-transaction-row--expanded {
+  grid-template-rows: 1fr;
+}
+
+.Layer__expanded-bank-transaction-row__wrapper {
+  min-height: 0;
   display: flex;
   flex-direction: column;
   background-color: var(--table-expanded-background-color);

--- a/src/styles/icons.scss
+++ b/src/styles/icons.scss
@@ -1,0 +1,17 @@
+
+.Layer__chevron {
+  stroke: var(--font-color);
+  transition: transform 0.33s;
+}
+
+.Layer__chevron__down {
+  transform: rotate(0deg);
+}
+
+.Layer__chevron__up {
+  transform: rotate(180deg);
+}
+
+.Layer__chevron__up--counterclockwise {
+  transform: rotate(-180deg);
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,8 +1,10 @@
 @import 'https://fonts.googleapis.com/css2?family=Inter';
+@import './variables.scss';
 
 @import './balance_sheet.scss';
 @import './bank_transactions.scss';
 @import './category_menu.scss';
+@import './icons.scss';
 @import './pill.scss';
 @import './profit_and_loss.scss';
 @import './radio_button_group.scss';

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,0 +1,16 @@
+.Layer__component {
+  --font-color: #101828;
+  --buttons-border-color: #d0d5dd;
+  --buttons-selected-background-color: #e0e9ff;
+  --table-expanded-background-color: #f9f9f9;
+  --table-background-color: white;
+  --table-border-color: #eaecf0;
+  --table-text-color: #101828;
+  --positive-amount-text-color: #039855;
+  --variable-amount-text-color: #475467;
+  --error-color: red;
+  --transition-speed: 0.33s;
+  border: 0;
+  padding: 0;
+  margin: 0;
+}


### PR DESCRIPTION
![demo](https://github.com/Layer-Fi/layer-react/assets/4632/af13a5d5-18c1-4e5c-97ff-7f4a8ce6c475)

This uses the same technique that the BalanceSheetRows did: Enclose the animating portion in a single-celled grid and animate the free space in the grid's row from `0fr` to `1fr` (and vice versa). This requires pulling the grid's formatting down into the child components (where necessary) via `subgrid` but that does not appear to meaningfully impact the layout.