### PR TITLE
Center the Legend vertically

### DIFF
--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -162,6 +162,11 @@
   font-size: 1rem;
 }
 
+.Layer__profit-and-loss-chart .recharts-legend-item {
+  fill: var(--income-bar-color);
+  vertical-align: middle;
+}
+
 .Layer__profit-and-loss-chart .legend-item-0 {
   fill: var(--income-bar-color);
 }


### PR DESCRIPTION
Ensure thst the Dots that indicate bar color are centered vertically against the legend labels.

Normal size:
<img width="216" alt="Screenshot 2023-12-18 at 9 44 10 AM" src="https://github.com/Layer-Fi/layer-react/assets/4632/5de942d5-ac3c-4451-93b2-723db03e3753">


Increased font size:

<img width="285" alt="Screenshot 2023-12-18 at 9 43 59 AM" src="https://github.com/Layer-Fi/layer-react/assets/4632/0143fa04-b2f4-4fd6-b606-a3c873ad500e">