### PR TITLE
Normalize all CSS variables so they're all defined

### DIFF
--- a/src/styles/balance_sheet.scss
+++ b/src/styles/balance_sheet.scss
@@ -1,20 +1,11 @@
 .Layer__balance-sheet {
-  --border-color: #eaecf0;
-  --font-color: #101828;
-  --indicator-bar-color: #3c3c3c;
-  --background-color: white;
-  --active: #e0e9ff;
-  --income-bar-color: #0c48e5;
-  --expenses-bar-color: #6d8ee7;
-  --transition-speed: 0.25s;
-
   width: 60rem;
   background-color: white;
   padding: 0.25rem;
 
   * {
-    color: var(--font-color);
-    stroke: var(--font-color);
+    color: var(--text-color);
+    stroke: var(--text-color);
     font-family: Inter;
     font-weight: 500;
     font-style: normal;
@@ -145,7 +136,7 @@
   justify-content: flex-start;
   align-items: center;
   svg {
-    stroke: var(--font-color);
+    stroke: var(--text-color);
     width: 1.25rem;
     height: 1.25rem;
     margin-right: 0.25rem;
@@ -165,7 +156,7 @@
   justify-content: flex-end;
   align-items: center;
   svg {
-    stroke: var(--font-color);
+    stroke: var(--text-color);
     width: 1.25rem;
     height: 1.25rem;
     margin-right: 0.25rem;

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -1,26 +1,15 @@
 .Layer__bank-transactions {
-  --buttons-border-color: #d0d5dd;
-  --buttons-selected-background-color: #e0e9ff;
-  --table-expanded-background-color: #f9f9f9;
-  --table-background-color: white;
-  --table-border-color: #eaecf0;
-  --table-text-color: #101828;
-  --positive-amount-text-color: #039855;
-  --variable-amount-text-color: #475467;
-  --error-color: red;
-  --transition-speed: 0.33s;
-
   margin: 3rem;
   border-radius: 0.6rem;
-  border: 1px solid var(--table-border-color);
-  background-color: var(--table-background-color);
+  border: 1px solid var(--border-color);
+  background-color: var(--background-color);
   overflow: hidden;
   width: 100rem;
 }
 
 .Layer__bank-transactions * {
   font-family: Inter;
-  color: var(--table-text-color);
+  color: var(--text-color);
   font-style: normal;
   font-weight: 500;
 }
@@ -54,7 +43,7 @@
 .Layer__bank-transactions__table-cell--header {
   display: flex;
   align-items: center;
-  background-color: var(--table-background-color);
+  background-color: var(--background-color);
   font-size: 16px;
   line-height: 20px;
   overflow: clip;
@@ -68,7 +57,7 @@
 }
 
 .Layer__bank-transaction-row__container {
-  background-color: var(--table-background-color);
+  background-color: var(--background-color);
   display: grid;
   grid-column: 1 / -1;
   grid-template-columns: subgrid;
@@ -111,12 +100,12 @@
 }
 
 .Layer__bank-transaction-row__table-cell--date {
-  color: var(--variable-amount-text-color);
+  color: var(--text-color-varying-amount);
 }
 
 .Layer__bank-transaction-row__table-cell--amount-credit {
   justify-content: flex-end;
-  color: var(--positive-amount-text-color);
+  color: var(--text-color-transaction-credit);
 
   &::before {
     content: '+$';
@@ -125,7 +114,7 @@
 
 .Layer__bank-transaction-row__table-cell--amount-debit {
   justify-content: flex-end;
-  color: var(--variable-amount-text-color);
+  color: var(--text-color-varying-amount);
 
   &::before {
     content: ' $';
@@ -206,7 +195,7 @@
 
 .Layer__expanded-bank-transaction-row__table-cell--description textarea {
   resize: none;
-  border: 1px solid var(--buttons-border-color);
+  border: 1px solid var(--border-color);
   border-radius: 0.5rem;
 }
 
@@ -230,10 +219,10 @@
 }
 
 .Layer__expanded-bank-transaction-row__button--save {
-  border: 1px solid var(--buttons-border-color);
+  border: 1px solid var(--border-color);
   border-radius: 0.5rem;
   padding: 0.625rem 1rem;
-  background-color: var(--buttons-selected-background-color);
+  background-color: var(--active);
   font-weight: 600;
 }
 
@@ -249,7 +238,7 @@
   & input {
     justify-content: stretch;
     margin-left: 0.5rem;
-    border: 1px solid var(--buttons-border-color);
+    border: 1px solid var(--border-color);
     border-radius: 0.5rem;
     padding: 0.25rem;
     width: 5rem;

--- a/src/styles/icons.scss
+++ b/src/styles/icons.scss
@@ -1,6 +1,6 @@
 
 .Layer__chevron {
-  stroke: var(--font-color);
+  stroke: var(--text-color);
   transition: transform 0.33s;
 }
 

--- a/src/styles/pill.scss
+++ b/src/styles/pill.scss
@@ -1,6 +1,6 @@
 .Layer__pill {
-  background-color: var(--bank-transaction-buttons-selected-background-color);
-  color: var(--bank-transaction-table-text-color);
+  background-color: var(--active);
+  color: var(--text-color);
   border-radius: 1rem;
   padding: 0.25rem 0.5rem;
   display: flex;

--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -1,18 +1,10 @@
 .Layer__profit-and-loss {
-  --border-color: #eaecf0;
-  --font-color: #101828;
-  --indicator-bar-color: #3c3c3c;
-  --background-color: white;
-  --active: #e0e9ff;
-  --income-bar-color: #0c48e5;
-  --expenses-bar-color: #6d8ee7;
-
   width: 60rem;
   background-color: white;
   padding: 0.25rem;
 
   * {
-    color: var(--font-color);
+    color: var(--text-color);
     font-family: Inter;
     font-weight: 500;
     font-style: normal;
@@ -130,7 +122,7 @@
 }
 
 .Layer__profit-and-loss-date-picker__button-icon path {
-  stroke: var(--font-color);
+  stroke: var(--text-color);
 }
 
 .Layer__profit-and-loss-date-picker__label {
@@ -143,11 +135,11 @@
 }
 
 .Layer__profit-and-loss-chart__bar--income {
-  fill: var(--income-bar-color);
+  fill: var(--bar-color-income);
 }
 
 .Layer__profit-and-loss-chart__bar--expenses {
-  fill: var(--expenses-bar-color);
+  fill: var(--bar-color-expenses);
 }
 
 .Layer__profit-and-loss-chart .recharts-cartesian-axis-tick-value tspan {
@@ -163,21 +155,21 @@
 }
 
 .Layer__profit-and-loss-chart .recharts-legend-item {
-  fill: var(--income-bar-color);
+  fill: var(--bar-color-income);
   vertical-align: middle;
 }
 
 .Layer__profit-and-loss-chart .legend-item-0 {
-  fill: var(--income-bar-color);
+  fill: var(--bar-color-income);
 }
 
 .Layer__profit-and-loss-chart .legend-item-1 {
-  fill: var(--expenses-bar-color);
+  fill: var(--bar-color-expenses);
 }
 
 .Layer__profit-and-loss-chart__selection-indicator {
   height: 0.25rem;
-  fill: var(--indicator-bar-color);
+  fill: var(--indicator-color);
   transition: x 0.5s;
 }
 

--- a/src/styles/radio_button_group.scss
+++ b/src/styles/radio_button_group.scss
@@ -1,7 +1,4 @@
 .Layer__radio-button-group {
-
-  --buttons-border-color: #d0d5dd;
-
   display: flex;
   font-size: 1rem;
   align-items: center;
@@ -51,6 +48,6 @@
 }
 
 .Layer__radio-button-group__radio-button input:checked + div {
-  background: var(--transaction-buttons-selected-background-color);
+  background: var(--active);
 }
 

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,15 +1,32 @@
 .Layer__component {
-  --font-color: #101828;
-  --buttons-border-color: #d0d5dd;
-  --buttons-selected-background-color: #e0e9ff;
-  --table-expanded-background-color: #f9f9f9;
-  --table-background-color: white;
-  --table-border-color: #eaecf0;
-  --table-text-color: #101828;
-  --positive-amount-text-color: #039855;
-  --variable-amount-text-color: #475467;
-  --error-color: red;
+  --color-alabaster: #f9f9f9;
+  --color-athens-gray: #eaecf0;
+  --color-blue-ribbon: #0c48e5;
+  --color-cornflower-blue: #6d8ee7;
+  --color-ebony: #101828;
+  --color-fiord: #475467;
+  --color-green-haze: #039855;
+  --color-mine-shaft: #3c3c3c;
+  --color-mischke: #d0d5dd;
+  --color-red: red;
+  --color-white: white;
+  --color-zumthor: #e0e9ff;
+
+  --active: var(--color-zumthor);
+  --background-color: var(--color-white);
+  --bar-color-expenses: var(--color-cornflower-blue);
+  --bar-color-income: var(--color-blue-ribbon);
+  --border-color: var(--color-athens-gray);
+  --buttons-border-color: var(--color-mischke);
+  --error-color: var(--color-red);
+  --indicator-color: var(--color-mine-shaft);
+  --table-border-color: var(--color-athens-gray);
+  --table-expanded-background-color: var(--color-alabaster);
+  --text-color-transaction-credit: var(--color-green-haze);
+  --text-color-varying-amount: var(--color-fiord);
+  --text-color: var(--color-ebony);
   --transition-speed: 0.33s;
+
   border: 0;
   padding: 0;
   margin: 0;


### PR DESCRIPTION
CSS variables were still spread out, and some went undefined. This waa causing some unexpected visuals. This commit fixes all that.

Also, we can use this command to find all CSS variables being used, so we can compare them to the ones being defined. This is more manual than is preferred at the moment, but it works for now:

```
ag "var\\(" src/styles/ | perl -pe "s/.*?var\(([^)]*)\).*/\\1/" | \
 sort | uniq | pbcopy
```