### PR TITLE
Address TypeScript Errors

### DIFF
--- a/src/api/layer/balance_sheet.ts
+++ b/src/api/layer/balance_sheet.ts
@@ -1,5 +1,6 @@
 // import { BalanceSheet } from '../../types'
 // import { get } from './authenticated_http'
+import { BalanceSheet } from '../../types'
 import Data from './balance_sheet.json'
 
 // export const getBalanceSheet = get<{
@@ -10,4 +11,5 @@ import Data from './balance_sheet.json'
 //     `https://sandbox.layerfi.com/v1/businesses/${businessId}/balances`,
 // )
 
-export const getBalanceSheet = (_token: string, _params: any) => () => Data
+export const getBalanceSheet = (_token: string, _params: any) => () =>
+  Data as unknown as BalanceSheet

--- a/src/api/layer/bankTransactions.ts
+++ b/src/api/layer/bankTransactions.ts
@@ -25,7 +25,7 @@ export const getBankTransactions = get<
 
 export const categorizeBankTransaction = put<
   CategoryUpdate,
-  { data: BankTransaction; error: unknown }
+  { data: BankTransaction; errors: unknown }
 >(
   ({ businessId, bankTransactionId }) =>
     `https://sandbox.layerfi.com/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/categorize`,

--- a/src/components/BalanceSheetRow/BalanceSheetRow.tsx
+++ b/src/components/BalanceSheetRow/BalanceSheetRow.tsx
@@ -50,7 +50,7 @@ export const BalanceSheetRow = ({
 
   const toggleExpanded = () => setExpanded(!expanded)
   const canGoDeeper = depth < maxDepth
-  const hasChildren = line_items?.length > 0
+  const hasChildren = (line_items?.length ?? 0) > 0
   const displayChildren = hasChildren && canGoDeeper
   labelClasses.push(
     `Layer__balance-sheet-row__label--display-children-${displayChildren}`,

--- a/src/components/ProfitAndLossChart/Indicator.tsx
+++ b/src/components/ProfitAndLossChart/Indicator.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect } from 'react'
+import React, { useEffect } from 'react'
 import { Props as BaseProps } from 'recharts/types/component/Label'
 
 // This component does not always exist. It gets recreated each time the
@@ -46,6 +46,7 @@ export const Indicator = ({
       className="Layer__profit-and-loss-chart__selection-indicator"
       style={{
         width: `${boxWidth * multiplier}px`,
+        // @ts-ignore -- y is fine but x apparently isn't!
         x: actualX - xOffset,
         y: y + height,
       }}

--- a/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
+++ b/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
@@ -6,7 +6,7 @@ export const ProfitAndLossSummaries = () => {
   const { data: storedData } = useContext(PNL.Context)
   const data = !!storedData
     ? storedData
-    : { income: { value: NaN }, net_profit: { value: NaN } }
+    : { income: { value: NaN }, net_profit: NaN }
 
   return (
     <div className="Layer__profit-and-loss-summaries">
@@ -21,7 +21,7 @@ export const ProfitAndLossSummaries = () => {
           Expenses
         </span>
         <span className="Layer__profit-and-loss-summaries__amount">
-          {formatMoney(Math.abs(data.income.value - data.net_profit))}
+          {formatMoney(Math.abs((data.income.value ?? 0) - data.net_profit))}
         </span>
       </div>
       <div className="Layer__profit-and-loss-summaries__summary Layer__profit-and-loss-summaries__summary--net-profit">

--- a/src/hooks/useBalanceSheet/useBalanceSheet.tsx
+++ b/src/hooks/useBalanceSheet/useBalanceSheet.tsx
@@ -4,13 +4,13 @@ import { useLayerContext } from '../useLayerContext'
 import { format, startOfDay } from 'date-fns'
 import useSWR from 'swr'
 
-type UseBalanceSheetReturn = {
+type UseBalanceSheet = (date?: Date) => {
   data: BalanceSheet | undefined
   isLoading: boolean
   error: unknown
 }
 
-export const useBalanceSheet = (date?: Date): UseBalanceSheetReturn => {
+export const useBalanceSheet: UseBalanceSheet = (date: Date = new Date()) => {
   const { auth, businessId } = useLayerContext()
   const dateString = format(startOfDay(date), 'yyyy-mm-dd')
 

--- a/src/hooks/useBankTransactions/useBankTransactions.tsx
+++ b/src/hooks/useBankTransactions/useBankTransactions.tsx
@@ -3,7 +3,7 @@ import { BankTransaction, CategoryUpdate, Metadata } from '../../types'
 import { useLayerContext } from '../useLayerContext'
 import useSWR from 'swr'
 
-type UseBankTransactionsReturn = {
+type UseBankTransactions = () => {
   data: BankTransaction[]
   metadata: Metadata
   isLoading: boolean
@@ -12,9 +12,10 @@ type UseBankTransactionsReturn = {
     id: BankTransaction['id'],
     newCategory: CategoryUpdate,
   ) => Promise<void>
+  updateOneLocal: (bankTransaction: BankTransaction) => void
 }
 
-export const useBankTransactions = (): UseBankTransactionsReturn => {
+export const useBankTransactions: UseBankTransactions = () => {
   const { auth, businessId } = useLayerContext()
 
   const {
@@ -54,5 +55,12 @@ export const useBankTransactions = (): UseBankTransactionsReturn => {
     mutate({ data: updatedData }, { revalidate: false })
   }
 
-  return { data, metadata, isLoading, error, categorize, updateOneLocal }
+  return {
+    data,
+    metadata,
+    isLoading,
+    error: responseError || error,
+    categorize,
+    updateOneLocal,
+  }
 }

--- a/src/hooks/useChartOfAccounts/useChartOfAccounts.tsx
+++ b/src/hooks/useChartOfAccounts/useChartOfAccounts.tsx
@@ -3,13 +3,13 @@ import { ChartOfAccounts } from '../../types'
 import { useLayerContext } from '../useLayerContext'
 import useSWR from 'swr'
 
-type UseChartOfAccountsReturn = {
+type UseChartOfAccounts = () => {
   data: ChartOfAccounts | undefined
   isLoading: boolean
   error: unknown
 }
 
-export const useChartOfAccounts = (): UseChartOfAccountsReturn => {
+export const useChartOfAccounts: UseChartOfAccounts = () => {
   const { auth, businessId } = useLayerContext()
 
   const { data, isLoading, error } = useSWR(

--- a/src/hooks/useProfitAndLoss/useProfitAndLoss.tsx
+++ b/src/hooks/useProfitAndLoss/useProfitAndLoss.tsx
@@ -5,7 +5,9 @@ import { useLayerContext } from '../useLayerContext'
 import { startOfMonth, endOfMonth, formatISO } from 'date-fns'
 import useSWR from 'swr'
 
-type UseProfitAndLoss = {
+type Props = DateRange
+
+type UseProfitAndLoss = (props?: Props) => {
   data: ProfitAndLoss | undefined
   isLoading: boolean
   error: unknown
@@ -13,14 +15,12 @@ type UseProfitAndLoss = {
   changeDateRange: (dateRange: Partial<DateRange>) => void
 }
 
-type Props = DateRange
-
-export const useProfitAndLoss = (
+export const useProfitAndLoss: UseProfitAndLoss = (
   { startDate: initialStartDate, endDate: initialEndDate }: Props = {
     startDate: startOfMonth(new Date()),
     endDate: endOfMonth(new Date()),
   },
-): UseProfitAndLoss => {
+) => {
   const { auth, businessId } = useLayerContext()
   const [startDate, setStartDate] = useState(
     initialStartDate || startOfMonth(Date.now()),

--- a/src/icons/ChevronDown.tsx
+++ b/src/icons/ChevronDown.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { SVGProps } from 'react'
 
 type Props = SVGProps<SVGSVGElement> & {
-  size: SVGProps<SVGSVGElement>['width']
+  size?: SVGProps<SVGSVGElement>['width']
 }
 const ChevronDown = ({ size = 24, ...props }: Props) => (
   <svg

--- a/src/icons/ChevronRight.tsx
+++ b/src/icons/ChevronRight.tsx
@@ -5,7 +5,7 @@ type Props = SVGProps<SVGSVGElement> & {
   size: SVGProps<SVGSVGElement>['width']
 }
 
-const ChavronRight = ({ strokeColor, size, ...props }: Props) => (
+const ChavronRight = ({ size, ...props }: Props) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={size || 24}
@@ -15,7 +15,7 @@ const ChavronRight = ({ strokeColor, size, ...props }: Props) => (
     {...props}
   >
     <path
-      stroke={strokeColor ?? '#000'}
+      stroke={'#000'}
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth={2}

--- a/src/models/Money.ts
+++ b/src/models/Money.ts
@@ -4,10 +4,10 @@ const formatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 2,
 })
 
-export const centsToDollars = (cents: number): string =>
+export const centsToDollars = (cents: number = NaN): string =>
   isNaN(cents) ? '-.--' : formatter.format(cents / 100)
 
-export const dollarsToCents = (dollars: string): number =>
+export const dollarsToCents = (dollars: string = ''): number =>
   Math.round(parseFloat(dollars) * 100)
 
 export default {


### PR DESCRIPTION
There's only one we need to ignore, and that's the one in the Indicator about specifying the `x` coordinate. This apparently isn't allowed in thr style prop even though the `y` coordinate seems to be fine. And it works, so it's correct.