### PR TITLE
Do not reauthenticte if the token has not expired

### DIFF
--- a/src/contexts/LayerContext/LayerContext.tsx
+++ b/src/contexts/LayerContext/LayerContext.tsx
@@ -2,7 +2,12 @@ import { createContext } from 'react'
 import { LayerContextValues } from '../../types'
 
 export const LayerContext = createContext<LayerContextValues>({
-  auth: { access_token: '', expires_in: -1, token_type: '' },
+  auth: {
+    access_token: '',
+    expires_at: new Date(2000, 1, 1),
+    expires_in: -1,
+    token_type: '',
+  },
   businessId: '',
   categories: [],
 })

--- a/src/types/authentication.ts
+++ b/src/types/authentication.ts
@@ -3,3 +3,7 @@ export type OAuthResponse = {
   token_type: string
   expires_in: number
 }
+
+export type ExpiringOAuthResponse = OAuthResponse & {
+  expires_at: Date
+}

--- a/src/types/layer_context.ts
+++ b/src/types/layer_context.ts
@@ -1,8 +1,8 @@
 import { Category } from '../types'
-import { OAuthResponse } from './authentication'
+import { ExpiringOAuthResponse } from './authentication'
 
 export type LayerContextValues = {
-  auth: OAuthResponse
+  auth: ExpiringOAuthResponse
   businessId: string
   categories: Category[]
 }


### PR DESCRIPTION
The aiuthentication request returns an `expires_in` value. That means the token is good for that long. We should not retrieve new tokens until that span of time is over.

This commit calculates the time when the token will expire and stores it in the OAuthResponse to make an ExpiringOAuthResponse. It then compares that time to the current time in order to determine if it should request authentication again.