### PR TITLE
Make components look better in demo app

### DIFF
--- a/src/styles/balance_sheet.scss
+++ b/src/styles/balance_sheet.scss
@@ -1,7 +1,7 @@
 .Layer__balance-sheet {
-  width: 60rem;
-  background-color: white;
-  padding: 0.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--corner-radius);
+  background-color: var(--background-color);
 
   * {
     color: var(--text-color);
@@ -13,19 +13,19 @@
 }
 
 .Layer__balance-sheet__table {
-  border: 1px solid var(--border-color);
-  border-radius: var(--corner-radius);
-  background-color: var(--border-color);
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 1px 0;
   font-size: 1rem;
+  background-color: var(--border-color);
 }
 
 .Layer__balance-sheet__header {
   display: flex;
   flex: 1;
   flex-direction: row;
+  background-color: var(--background-color);
+  padding: 0 1rem;
 }
 
 .Layer__balance-sheet__title {

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -1,10 +1,8 @@
 .Layer__bank-transactions {
-  margin: 3rem;
   border-radius: var(--corner-radius);
   border: 1px solid var(--border-color);
   background-color: var(--background-color);
   overflow: hidden;
-  width: 100rem;
 }
 
 .Layer__bank-transactions * {

--- a/src/styles/chart_of_accounts.scss
+++ b/src/styles/chart_of_accounts.scss
@@ -1,7 +1,7 @@
 .Layer__chart-of-accounts {
-  width: 60rem;
   background-color: var(--background-color);
-  padding: 0.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--corner-radius);
 
   * {
     color: var(--text-color);
@@ -13,8 +13,6 @@
 }
 
 .Layer__chart-of-accounts__table {
-  border: 1px solid var(--border-color);
-  border-radius: var(--corner-radius);
   background-color: var(--border-color);
   display: grid;
   grid-template-columns: 2fr 1fr 1fr 1fr auto;
@@ -26,6 +24,9 @@
   display: flex;
   flex: 1;
   flex-direction: row;
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-color);
+  align-items: center;
 }
 
 .Layer__chart-of-accounts__title {
@@ -33,9 +34,7 @@
   flex: 1;
   font-size: 1.5rem;
   font-weight: 600;
-  margin-bottom: 1.5rem;
-  margin-left: 1.5rem;
-  margin-right: 1.5rem;
+  margin: 0;
 }
 
 .Layer__chart-of-accounts__actions {

--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -1,5 +1,4 @@
 .Layer__profit-and-loss {
-  width: 60rem;
   background-color: white;
   padding: 0.25rem;
 


### PR DESCRIPTION
These changes are to make the components look more like they're supposed to in the demo app, wrapped in rounded-rectangle boxes with properly-aligned titles. Since the P&L can be moved around, that's more up in the air.
<img width="1838" alt="Screenshot 2023-12-29 at 1 19 55 PM" src="https://github.com/Layer-Fi/layer-react/assets/4632/fa3fccbc-772b-4b55-802d-3b3697054b5d">
<img width="1838" alt="Screenshot 2023-12-29 at 1 19 52 PM" src="https://github.com/Layer-Fi/layer-react/assets/4632/eb008bff-3cca-452c-b0a1-829287c19bba">
<img width="1827" alt="Screenshot 2023-12-29 at 1 23 00 PM" src="https://github.com/Layer-Fi/layer-react/assets/4632/e588cf03-18c2-46d9-a826-3fd9fe13d5b9">
<img width="1838" alt="Screenshot 2023-12-29 at 1 19 44 PM" src="https://github.com/Layer-Fi/layer-react/assets/4632/65fd228f-c385-40c6-938d-b8c57567cf4d">
