### PR TITLE
Sketch out Skeleton loading placeholders

### DIFF
--- a/src/components/BalanceSheet/BalanceSheet.tsx
+++ b/src/components/BalanceSheet/BalanceSheet.tsx
@@ -3,6 +3,7 @@ import { useBalanceSheet } from '../../hooks/useBalanceSheet'
 import DownloadCloud from '../../icons/DownloadCloud'
 import { BalanceSheetDatePicker } from '../BalanceSheetDatePicker'
 import { BalanceSheetRow } from '../BalanceSheetRow'
+import { SkeletonBalanceSheetRow } from '../SkeletonBalanceSheetRow'
 import { format, parseISO } from 'date-fns'
 
 export const BalanceSheet = () => {
@@ -38,7 +39,18 @@ export const BalanceSheet = () => {
         </button>
       </div>
       {!data || isLoading ? (
-        <div>Loading</div>
+        <div className="Layer__balance-sheet__table">
+          <SkeletonBalanceSheetRow>
+            <SkeletonBalanceSheetRow />
+            <SkeletonBalanceSheetRow>
+              <SkeletonBalanceSheetRow />
+              <SkeletonBalanceSheetRow />
+            </SkeletonBalanceSheetRow>
+          </SkeletonBalanceSheetRow>
+          <SkeletonBalanceSheetRow>
+            <SkeletonBalanceSheetRow />
+          </SkeletonBalanceSheetRow>
+        </div>
       ) : (
         <div className="Layer__balance-sheet__table">
           <BalanceSheetRow

--- a/src/components/SkeletonBalanceSheetRow/SkeletonBalanceSheetRow.tsx
+++ b/src/components/SkeletonBalanceSheetRow/SkeletonBalanceSheetRow.tsx
@@ -1,0 +1,43 @@
+import React, { PropsWithChildren } from 'react'
+import ChevronDown from '../../icons/ChevronDown'
+
+type Props = PropsWithChildren
+
+export const SkeletonBalanceSheetRow = ({ children }: Props) => {
+  const labelClasses = [
+    'Layer__balance-sheet-row',
+    'Layer__balance-sheet-row__label',
+    'Layer__balance-sheet-row__label--skeleton',
+  ]
+  const valueClasses = [
+    'Layer__balance-sheet-row',
+    'Layer__balance-sheet-row__value',
+    'Layer__balance-sheet-row__value--skeleton',
+  ]
+  return (
+    <>
+      <div className={labelClasses.join(' ')}>
+        {children && <ChevronDown size={16} />}
+        <div
+          style={{ width: '20rem' }}
+          className="Layer__balance-sheet-row__skeleton-text"
+        >
+          {' '}
+        </div>
+      </div>
+      <div className={valueClasses.join(' ')}>
+        <div
+          style={{ width: '4rem' }}
+          className="Layer__balance-sheet-row__skeleton-text"
+        >
+          {' '}
+        </div>
+      </div>
+      {children && (
+        <div className="Layer__balance-sheet-row__children Layer__balance-sheet-row__children--expanded Layer__balance-sheet-row__children--skeleton">
+          {children}
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/SkeletonBalanceSheetRow/index.tsx
+++ b/src/components/SkeletonBalanceSheetRow/index.tsx
@@ -1,0 +1,1 @@
+export { SkeletonBalanceSheetRow } from './SkeletonBalanceSheetRow'

--- a/src/styles/balance_sheet.scss
+++ b/src/styles/balance_sheet.scss
@@ -238,3 +238,32 @@
   color: transparent;
   user-select: none;
 }
+
+@keyframes pulse {
+  from {
+    opacity: 100%;
+  }
+  to {
+    opacity: 20%;
+  }
+}
+
+.Layer__balance-sheet-row__skeleton-text {
+  width: 4rem;
+  background-color: var(--text-skeleton-color);
+  height: 1rem;
+  border-radius: var(--corner-radius);
+}
+
+.Layer__balance-sheet-row__children--skeleton {
+  background-color: var(--background-color);
+  padding-left: 1rem;
+}
+
+.Layer__balance-sheet-row__value--skeleton,
+.Layer__balance-sheet-row__label--skeleton {
+  animation: 1s pulse ease-in-out alternate infinite;
+  & svg {
+    stroke: var(--text-skeleton-color);
+  }
+}

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -2,6 +2,7 @@
   --color-alabaster: #f9f9f9;
   --color-athens-gray: #eaecf0;
   --color-blue-ribbon: #0c48e5;
+  --color-comet: #57627a;
   --color-cornflower-blue: #6d8ee7;
   --color-ebony: #101828;
   --color-fiord: #475467;
@@ -27,6 +28,7 @@
   --text-color-transaction-credit: var(--color-green-haze);
   --text-color-varying-amount: var(--color-fiord);
   --text-color: var(--color-ebony);
+  --text-skeleton-color: var(--color-comet);
   --transition-speed: 0.33s;
 
   border: 0;


### PR DESCRIPTION
BalanceSheet may not have been the best place to sketch out this pattern since it currently loads with static data, but this works fairly well. It just draws in some placeholder rows that use "pill" formatting instead of text, and it animates them a bit as a loading indicator.