### PR TITLE
fix: handle undefined categorization flow in bank txs

### DIFF
--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -31,7 +31,7 @@ export const BankTransactionRow = ({
   const { categorize: categorizeBankTransaction, updateOneLocal } =
     useBankTransactions()
   const [selectedCategory, setSelectedCategory] = useState(
-    bankTransaction.categorization_flow.type ===
+    bankTransaction.categorization_flow?.type ===
       CategorizationType.ASK_FROM_SUGGESTIONS
       ? bankTransaction.categorization_flow.suggestions[0]
       : undefined,


### PR DESCRIPTION
## Description

Fix issue in `BankTransactionRow` component when records from API have empty `transaction_flow`.

## Context

<img width="1532" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/86095f92-1e38-4094-8fff-5c1110295d5f">

## How this has been tested?

<img width="1532" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/0acc9f5c-68e0-4527-a722-e4d1671aaf7e">
