### PR TITLE
fix: radio button position

### DIFF
--- a/src/styles/radio_button_group.scss
+++ b/src/styles/radio_button_group.scss
@@ -11,6 +11,7 @@
 .Layer__radio-button-group__radio-button {
   display: flex;
   flex-direction: row;
+  position: relative;
 }
 
 .Layer__radio-button-group__radio-button input {


### PR DESCRIPTION
## Description

Add `position: relative` to `RadioButton` to fix the issue of expanding window height.

## Context

When I tried to embed the `BankTransaction` component as a card on the Dashboard-like page, the list of Categorized transaction expanded the window height even if the card used `overflow: hidden`:


https://github.com/Layer-Fi/layer-react/assets/11715931/a5e13025-45dc-4b9a-b9fd-b10d6935a3c1

The issue was with the `RadioButton` and missing `relative` rule on the outer element.

## How this has been tested?

https://github.com/Layer-Fi/layer-react/assets/11715931/2cca20ab-8c51-4836-94e2-e08c4878870d


