### PR TITLE
fix: export types

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -4,7 +4,7 @@ const { Generator } = require('npm-dts')
 const { sassPlugin } = require('esbuild-sass-plugin')
 
 new Generator({
-  entry: 'src/index.tsx',
+  entry: 'index.tsx',
   output: 'dist/index.d.ts',
   tsc: '-p ./tsconfig.json',
 }).generate()

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "Layer React Components",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest",
     "typecheck": "tsc --noEmit",
@@ -13,7 +14,11 @@
     "type": "git",
     "url": "git+https://github.com/Layer-Fi/layer-react.git"
   },
-  "keywords": ["layerfi", "accounting", "react"],
+  "keywords": [
+    "layerfi",
+    "accounting",
+    "react"
+  ],
   "author": "Layer Financial",
   "license": "UNLICENSED",
   "bugs": {
@@ -57,7 +62,9 @@
     "semi": false,
     "singleQuote": true,
     "arrowParens": "avoid",
-    "plugins": ["@trivago/prettier-plugin-sort-imports"],
+    "plugins": [
+      "@trivago/prettier-plugin-sort-imports"
+    ],
     "importOrder": [
       "^react.*",
       "<THIRD_PARTY_MODULES>",
@@ -75,7 +82,9 @@
         }
       ]
     },
-    "setupFilesAfterEnv": ["<rootDir>/src/test/setupAfterEnv.ts"],
+    "setupFilesAfterEnv": [
+      "<rootDir>/src/test/setupAfterEnv.ts"
+    ],
     "moduleNameMapper": {
       "\\.(css|scss)$": "<rootDir>/test/mocks/styleMock.js"
     }

--- a/src/api/layer/bankTransactions.ts
+++ b/src/api/layer/bankTransactions.ts
@@ -1,12 +1,12 @@
 import { CategoryUpdate, BankTransaction, Metadata } from '../../types'
 import { get, put } from './authenticated_http'
 
-type GetBankTransactionsReturn = {
+export type GetBankTransactionsReturn = {
   data?: BankTransaction[]
   meta?: Metadata
   error?: unknown
 }
-interface GetBankTransactionsParams extends Record<string, string | undefined> {
+export interface GetBankTransactionsParams extends Record<string, string | undefined> {
   businessId: string
   sortOrder?: 'ASC' | 'DESC'
   sortBy?: string


### PR DESCRIPTION
## Description

The problem was that `index.d.ts` was not added to the `dist` folder on `npm run build`. The file was not created because `npm-dts` failing due to missing `export` for `interface GetBankTransactionsParams`.

Secondly, the `declare module` in `index.d.ts` was pointing wrongly to the `@layerfi/components/src/index` instead of `@layerfi/components/index` - fixed by changing `entry` in `bin/build.js`.

## How this has been tested?

Types/interfaces of `@layerfi/components` are visible in the demo app:

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/da1cee43-4a1d-4ad5-8413-430f740e787b)
