### PR TITLE
fix: border roundings in profit and loss

### DIFF
--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -25,6 +25,7 @@
   display: grid;
   grid-template-columns: 1fr auto;
   font-size: 1rem;
+  overflow: hidden;
 }
 
 .Layer__profit-and-loss-table__outflows {


### PR DESCRIPTION
## Description

Fix table roundings in "Profit & Loss"

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/24a6068d-d4ea-45d6-8a62-a2edcc868bb0)


## Context

LAY-229

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/2a794a23-b53a-45fa-9214-f116610bc6d4)
