### PR TITLE
fix: use actual value in account column of bank transactions

### DIFF
--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -72,7 +72,9 @@ export const BankTransactionRow = ({
         <div className={`${className} ${openClassName}`}>
           {bankTransaction.counterparty_name}
         </div>
-        <div className={`${className} ${openClassName}`}>Business Checking</div>
+        <div className={`${className} ${openClassName}`}>
+          {bankTransaction.account_name ?? ''}
+        </div>
         <div
           className={`${className} ${openClassName} ${className}--amount-${
             isCredit(bankTransaction) ? 'credit' : 'debit'

--- a/src/types/bank_transactions.ts
+++ b/src/types/bank_transactions.ts
@@ -9,6 +9,7 @@ export enum Direction {
 // more than we're using right now.
 export interface BankTransaction extends Record<string, unknown> {
   type: 'Bank_Transaction'
+  account_name?: string
   business_id: string
   recently_categorized?: boolean
   id: string


### PR DESCRIPTION
## Description

Replace hard-coded "Business checking" value in "Account" column with actual value.

## Context

LAY-347

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/6ead3c60-3fa8-4b43-84ca-bbb1edf22ab3)
