### PR TITLE
idea: table skeleton loader

### DIFF
--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useBankTransactions } from '../../hooks/useBankTransactions'
 import { BankTransaction, CategorizationStatus } from '../../types'
 import { BankTransactionRow } from '../BankTransactionRow'
@@ -37,8 +37,11 @@ const filterVisibility =
   }
 
 export const BankTransactions = () => {
+  const componentRef = useRef<HTMLDivElement>(null)
+  const [skeletonRows, setSkeletonRows] = useState(0)
+
   const [display, setDisplay] = useState<DisplayState>(DisplayState.review)
-  const { data } = useBankTransactions()
+  const { data, isLoading } = useBankTransactions()
   const bankTransactions = data.filter(filterVisibility(display))
   const onCategorizationDisplayChange = (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -51,8 +54,30 @@ export const BankTransactions = () => {
   const [openRows, setOpenRows] = useState<Record<string, boolean>>({})
   const toggleOpen = (id: string) =>
     setOpenRows({ ...openRows, [id]: !openRows[id] })
+
+  useEffect(() => {
+    if (componentRef.current) {
+      const rows = Math.floor(componentRef.current.offsetHeight / 70) - 2
+      console.log(componentRef.current.offsetHeight, rows)
+      setSkeletonRows(rows)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (componentRef.current && isLoading) {
+      const rows = Math.floor(componentRef.current.offsetHeight / 70) - 2
+      console.log(componentRef.current.offsetHeight, rows)
+      setSkeletonRows(rows)
+    }
+  }, [isLoading])
+
+  console.log('bankTransactions', bankTransactions)
+
   return (
-    <div className='Layer__component Layer__bank-transactions'>
+    <div
+      className='Layer__component Layer__bank-transactions'
+      ref={componentRef}
+    >
       <header className='Layer__bank-transactions__header'>
         <h2 className='Layer__bank-transactions__title'>Transactions</h2>
         <RadioButtonGroup
@@ -86,17 +111,42 @@ export const BankTransactions = () => {
             Actions
           </div>
         </div>
-        {bankTransactions.map((bankTransaction: BankTransaction) => (
-          <BankTransactionRow
-            key={bankTransaction.id}
-            dateFormat={dateFormat}
-            bankTransaction={bankTransaction}
-            isOpen={openRows[bankTransaction.id]}
-            toggleOpen={toggleOpen}
-            editable={display === DisplayState.review}
-          />
-        ))}
+
+        {!isLoading && bankTransactions?.length > 0
+          ? bankTransactions.map((bankTransaction: BankTransaction) => (
+              <BankTransactionRow
+                key={bankTransaction.id}
+                dateFormat={dateFormat}
+                bankTransaction={bankTransaction}
+                isOpen={openRows[bankTransaction.id]}
+                toggleOpen={toggleOpen}
+                editable={display === DisplayState.review}
+              />
+            ))
+          : null}
       </div>
+
+      {isLoading || !bankTransactions || bankTransactions?.length === 0 ? (
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            overflow: 'hidden',
+            maxHeight: '100%',
+            position: 'relative',
+          }}
+        >
+          {[...Array(skeletonRows)].map((i, idx) => (
+            <div key={idx} style={{ padding: 25, background: '#fff' }}>
+              <div
+                className='Layer__table-row__skeleton'
+                style={{ width: '100%' }}
+              />
+            </div>
+          ))}
+          <div className='Layer__table-row__skeleton-overflow' />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -3,6 +3,7 @@
   border: 1px solid var(--border-color);
   background-color: var(--background-color);
   overflow: hidden;
+  min-height: 100%;
 }
 
 .Layer__bank-transactions * {
@@ -270,4 +271,30 @@
   font-weight: bold;
   color: var(--error-color);
   border: 2.5px dotted var(--error-color);
+}
+
+@keyframes pulse {
+  from {
+    opacity: 100%;
+  }
+  to {
+    opacity: 20%;
+  }
+}
+
+.Layer__table-row__skeleton {
+  width: 4rem;
+  background-color: var(--text-skeleton-color);
+  height: 1rem;
+  border-radius: var(--corner-radius);
+  animation: 1s pulse ease-in-out alternate infinite;
+}
+
+.Layer__table-row__skeleton-overflow {
+  height: 20%;
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -34,4 +34,5 @@
   border: 0;
   padding: 0;
   margin: 0;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
## Description

Draft of the skeleton loader for Bank Transactions table.

There is related issue with grids and animating grid rows when we use `display: contents` (fix for Safari).
To overcome all this, we probably will need to convert grid into regular table so it works on Safari and we can have animations. Therefore, we will need to adjust this Skeleton loader into table.

https://github.com/Layer-Fi/layer-react/assets/11715931/e5fea330-9dee-47db-ab47-b6d9706badcb


