### PR TITLE
fix: profit and loss url datetime encoding

### DIFF
--- a/src/api/layer/profit_and_loss.ts
+++ b/src/api/layer/profit_and_loss.ts
@@ -6,5 +6,7 @@ export const getProfitAndLoss = get<{
   error?: unknown
 }>(
   ({ businessId, startDate, endDate }) =>
-    `/v1/businesses/${businessId}/reports/profit-and-loss?start_date=${startDate}&end_date=${endDate}`,
+    `/v1/businesses/${businessId}/reports/profit-and-loss?start_date=${
+      startDate ? encodeURIComponent(startDate) : ''
+    }&end_date=${endDate ? encodeURIComponent(endDate) : ''}`,
 )


### PR DESCRIPTION
## Description

Fix encoding datetimes in API requests for "Profit & Loss".

## How this has been tested?

Before:

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/65528775-911b-40ac-829d-bd6529c5490c)


<br/>
<br/>

After:


![image](https://github.com/Layer-Fi/layer-react/assets/11715931/20cfc5de-3dd7-4fc6-9d6c-e193e86a21b7)
