### PR TITLE
Add configuration options

### DIFF
--- a/src/components/ProfitAndLoss/ProfitAndLoss.tsx
+++ b/src/components/ProfitAndLoss/ProfitAndLoss.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, createContext } from 'react'
 import { useProfitAndLoss } from '../../hooks/useProfitAndLoss'
-import { ReportingBasis } from '../../types'
+import { DateRange, ReportingBasis } from '../../types'
 import { ProfitAndLossChart } from '../ProfitAndLossChart'
 import { ProfitAndLossDatePicker } from '../ProfitAndLossDatePicker'
 import { ProfitAndLossSummaries } from '../ProfitAndLossSummaries'
@@ -25,16 +25,38 @@ type Props = PropsWithChildren & {
     values: string[]
   }
   reportingBasis?: ReportingBasis
+  hideWrapper?: boolean
+  dateRange?: DateRange
+  businessId?: string
 }
 
-const ProfitAndLoss = ({ children, tagFilter, reportingBasis }: Props) => {
-  const contextData = useProfitAndLoss({ tagFilter, reportingBasis })
+const ProfitAndLoss = ({
+  children,
+  tagFilter,
+  reportingBasis,
+  hideWrapper,
+  dateRange,
+  businessId,
+}: Props) => {
+  const contextData = useProfitAndLoss({
+    tagFilter,
+    reportingBasis,
+    startDate: dateRange?.startDate,
+    endDate: dateRange?.endDate,
+    businessId,
+  })
   return (
     <PNLContext.Provider value={contextData}>
-      <div className='Layer__component Layer__profit-and-loss'>
-        <h2 className='Layer__profit-and-loss__title'>Profit & Loss</h2>
-        {children}
-      </div>
+      {hideWrapper ? (
+        <div className='Layer__component Layer__profit-and-loss--no-wrapper'>
+          {children}
+        </div>
+      ) : (
+        <div className='Layer__component Layer__profit-and-loss'>
+          <h2 className='Layer__profit-and-loss__title'>Profit & Loss</h2>
+          {children}
+        </div>
+      )}
     </PNLContext.Provider>
   )
 }

--- a/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
+++ b/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
@@ -4,9 +4,13 @@ import { ProfitAndLoss as PNL } from '../ProfitAndLoss'
 
 type Props = {
   revenueLabel?: string
+  vertical?: boolean
 }
 
-export const ProfitAndLossSummaries = ({ revenueLabel = 'Revenue' }: Props) => {
+export const ProfitAndLossSummaries = ({
+  revenueLabel = 'Revenue',
+  vertical,
+}: Props) => {
   const { data: storedData } = useContext(PNL.Context)
   const data = storedData
     ? storedData
@@ -28,7 +32,13 @@ export const ProfitAndLossSummaries = ({ revenueLabel = 'Revenue' }: Props) => {
       : 'Layer__profit-and-loss-summaries__amount--pasitive'
 
   return (
-    <div className='Layer__profit-and-loss-summaries'>
+    <div
+      className={
+        vertical
+          ? 'Layer__profit-and-loss-summaries--vertical'
+          : 'Layer__profit-and-loss-summaries'
+      }
+    >
       <div className='Layer__profit-and-loss-summaries__summary Layer__profit-and-loss-summaries__summary--income'>
         <span className='Layer__profit-and-loss-summaries__title'>
           {revenueLabel}

--- a/src/hooks/useProfitAndLoss/useProfitAndLoss.tsx
+++ b/src/hooks/useProfitAndLoss/useProfitAndLoss.tsx
@@ -13,6 +13,7 @@ type Props = {
     values: string[]
   }
   reportingBasis?: ReportingBasis
+  businessId?: string
 }
 
 type UseProfitAndLoss = (props?: Props) => {
@@ -29,6 +30,7 @@ export const useProfitAndLoss: UseProfitAndLoss = (
     endDate: initialEndDate,
     tagFilter,
     reportingBasis,
+    businessId: overrideBusinessId,
   }: Props = {
     startDate: startOfMonth(new Date()),
     endDate: endOfMonth(new Date()),
@@ -51,7 +53,9 @@ export const useProfitAndLoss: UseProfitAndLoss = (
       startDate &&
       endDate &&
       auth?.access_token &&
-      `profit-and-loss-${businessId}-${startDate.valueOf()}-${endDate.valueOf()}-${tagFilter?.key}-${tagFilter?.values?.join(
+      `profit-and-loss-${
+        overrideBusinessId || businessId
+      }-${startDate.valueOf()}-${endDate.valueOf()}-${tagFilter?.key}-${tagFilter?.values?.join(
         ',',
       )}-${reportingBasis}`,
     Layer.getProfitAndLoss(apiUrl, auth?.access_token, {

--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -10,6 +10,15 @@
   }
 }
 
+.Layer__profit-and-loss--no-wrapper {
+  * {
+    color: var(--text-color);
+    font-family: Inter;
+    font-weight: 500;
+    font-style: normal;
+  }
+}
+
 .Layer__profit-and-loss__title {
   font-size: 1.5rem;
   font-weight: 600;
@@ -233,6 +242,20 @@
   flex: 1;
   flex-direction: row;
   justify-content: space-evenly;
+}
+
+.Layer__profit-and-loss-summaries--vertical {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: space-evenly;
+  gap: 1.5rem;
+
+  .Layer__profit-and-loss-summaries__summary {
+    &:first-child {
+      margin-left: 0;
+    }
+  }
 }
 
 .Layer__profit-and-loss-summaries__summary {


### PR DESCRIPTION
Four more config options:
1. Allow the ProfitAndLoss wrapper to be invisible. Right now it is a white wrapper with a header that says "Profit and Loss"
2. Allow the Summary to be in a vertical position
3. Allow a business id to be passed in to the ProfitAndLoss wrapper, instead of solely relying on an env variable to define the business
4. Allow ProfitAndLoss wrapper to accept a date range