### PR TITLE
fix: rename income to revenue on pnl chart

### DIFF
--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -238,7 +238,7 @@ export const ProfitAndLossChart = () => {
           wrapperStyle={{ top: -24 }}
           payload={[
             {
-              value: 'Income',
+              value: 'Revenue',
               type: 'circle',
               id: 'IncomeLegend',
             },


### PR DESCRIPTION
## Description

Rename "Income" to "Revenue" on Profit and Loss chart to make it consistent with other elements.

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/2173b734-6a3a-409e-84ff-835e83243ffc)
