### PR TITLE
feat: add linked accounts options and hover menu components

### DIFF
--- a/src/components/HoverMenu/HoverMenu.tsx
+++ b/src/components/HoverMenu/HoverMenu.tsx
@@ -1,0 +1,69 @@
+import React, { ReactNode, useEffect, useRef, useState } from 'react'
+import classNames from 'classnames'
+
+export interface HoverMenuProps {
+  children: ReactNode
+  config: { name: string; action: () => void }[]
+}
+
+export const HoverMenu = ({ children, config }: HoverMenuProps) => {
+  const [openMenu, setOpenMenu] = useState(false)
+  const hoverMenuRef = useRef<HTMLDivElement>(null)
+
+  const hoverMenuClassName = classNames(
+    'Layer__hover-menu',
+    openMenu && '--open',
+  )
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        hoverMenuRef.current &&
+        !hoverMenuRef.current.contains(event.target as Node)
+      ) {
+        setOpenMenu(false)
+      }
+    }
+
+    document.addEventListener('click', handleClickOutside)
+    return () => {
+      document.removeEventListener('click', handleClickOutside)
+    }
+  }, [])
+
+  return (
+    <div
+      className={hoverMenuClassName}
+      ref={hoverMenuRef}
+      onMouseLeave={() => setOpenMenu(false)}
+    >
+      <div
+        className='Layer__hover-menu__children'
+        role='button'
+        onMouseEnter={() => setOpenMenu(true)}
+        onClick={() => setOpenMenu(true)}
+      >
+        {children}
+      </div>
+      <div className='Layer__hover-menu__list-wrapper'>
+        <ul className='Layer__hover-menu__list'>
+          {config &&
+            config.length > 0 &&
+            config.map(item => (
+              <li
+                key={`hover-menu-${item.name}`}
+                className='Layer__hover-menu__list-item'
+              >
+                <button
+                  className='Layer__hover-menu__list-item-button'
+                  onClick={() => item.action()}
+                >
+                  {item.name}
+                </button>
+              </li>
+            ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/HoverMenu/index.tsx
+++ b/src/components/HoverMenu/index.tsx
@@ -1,0 +1,1 @@
+export { HoverMenu, HoverMenuProps } from './HoverMenu'

--- a/src/components/LinkedAccountOptions/LinkedAccountOptions.tsx
+++ b/src/components/LinkedAccountOptions/LinkedAccountOptions.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode } from 'react'
+import MoreVertical from '../../icons/MoreVertical'
+import { HoverMenu, HoverMenuProps } from '../HoverMenu'
+
+interface LinkedAccountOptionsProps extends HoverMenuProps {}
+
+export const LinkedAccountOptions = ({
+  children,
+  config,
+}: LinkedAccountOptionsProps) => {
+  return (
+    <div className='Layer__linked-accounts__options'>
+      <div className='Layer__linked-accounts__options-overlay'>
+        <div className='Layer__linked-accounts__options-overlay-button'>
+          <HoverMenu config={config}>
+            <MoreVertical size={16} />
+          </HoverMenu>
+        </div>
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/src/components/LinkedAccountOptions/index.tsx
+++ b/src/components/LinkedAccountOptions/index.tsx
@@ -1,0 +1,1 @@
+export { LinkedAccountOptions } from './LinkedAccountOptions'

--- a/src/components/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/components/LinkedAccounts/LinkedAccounts.tsx
@@ -3,6 +3,7 @@ import { useLinkedAccounts } from '../../hooks/useLinkedAccounts'
 import PlusIcon from '../../icons/PlusIcon'
 import { Container, Header } from '../Container'
 import { DataState, DataStateStatus } from '../DataState'
+import { LinkedAccountOptions } from '../LinkedAccountOptions'
 import { LinkedAccountThumb } from '../LinkedAccountThumb'
 import { Loader } from '../Loader'
 import { Heading, HeadingSize, Text, TextSize } from '../Typography'
@@ -11,8 +12,21 @@ import classNames from 'classnames'
 const COMPONENT_NAME = 'linked-accounts'
 
 export const LinkedAccounts = ({ asWidget }: { asWidget?: boolean }) => {
-  const { data, isLoading, error, isValidating, refetch, addAccount } =
-    useLinkedAccounts()
+  const {
+    data,
+    isLoading,
+    error,
+    isValidating,
+    refetch,
+    addAccount,
+    unlinkAccount,
+    relinkAccount,
+  } = useLinkedAccounts()
+
+  const linkedAccountOptionsConfig = [
+    { name: 'Unlink', action: unlinkAccount },
+    { name: 'Relink', action: relinkAccount },
+  ]
 
   const linkedAccountsNewAccountClassName = classNames(
     'Layer__linked-accounts__new-account',
@@ -46,11 +60,12 @@ export const LinkedAccounts = ({ asWidget }: { asWidget?: boolean }) => {
       {!error && !isLoading ? (
         <div className='Layer__linked-accounts__list'>
           {data?.map((account, index) => (
-            <LinkedAccountThumb
-              account={account}
-              asWidget={asWidget}
+            <LinkedAccountOptions
               key={`linked-acc-${index}`}
-            />
+              config={linkedAccountOptionsConfig}
+            >
+              <LinkedAccountThumb account={account} asWidget={asWidget} />
+            </LinkedAccountOptions>
           ))}
           <div
             role='button'

--- a/src/hooks/useLinkedAccounts/useLinkedAccounts.ts
+++ b/src/hooks/useLinkedAccounts/useLinkedAccounts.ts
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { Layer } from '../../api/layer'
 import { LinkedAccount } from '../../types/linked_accounts'
 import { useLayerContext } from '../useLayerContext'
@@ -74,6 +73,8 @@ type UseLinkedAccounts = () => {
   error: unknown
   refetch: () => void
   addAccount: () => void
+  unlinkAccount: () => void
+  relinkAccount: () => void
 }
 
 export const useLinkedAccounts: UseLinkedAccounts = () => {
@@ -99,6 +100,14 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     console.log('add account...')
   }
 
+  const unlinkAccount = () => {
+    console.log('unlink account...')
+  }
+
+  const relinkAccount = () => {
+    console.log('relink account...')
+  }
+
   const refetch = () => {
     console.log('refetch...')
   }
@@ -111,5 +120,7 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     error: responseError,
     refetch,
     addAccount,
+    unlinkAccount,
+    relinkAccount,
   }
 }

--- a/src/icons/MoreVertical.tsx
+++ b/src/icons/MoreVertical.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { IconSvgProps } from './types'
+
+const MoreVertical = ({ size = 18, ...props }: IconSvgProps) => {
+  return (
+    <svg
+      viewBox='0 0 16 14'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      {...props}
+      width={size}
+      height={size}
+    >
+      <path
+        d='M8.66659 8C8.66659 7.63181 8.36811 7.33333 7.99992 7.33333C7.63173 7.33333 7.33325 7.63181 7.33325 8C7.33325 8.36819 7.63173 8.66667 7.99992 8.66667C8.36811 8.66667 8.66659 8.36819 8.66659 8Z'
+        fill='currentColor'
+        stroke='currentColor'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path
+        d='M8.66659 3.33333C8.66659 2.96514 8.36811 2.66667 7.99992 2.66667C7.63173 2.66667 7.33325 2.96514 7.33325 3.33333C7.33325 3.70152 7.63173 4 7.99992 4C8.36811 4 8.66659 3.70152 8.66659 3.33333Z'
+        fill='currentColor'
+        stroke='currentColor'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path
+        d='M8.66659 12.6667C8.66659 12.2985 8.36811 12 7.99992 12C7.63173 12 7.33325 12.2985 7.33325 12.6667C7.33325 13.0349 7.63173 13.3333 7.99992 13.3333C8.36811 13.3333 8.66659 13.0349 8.66659 12.6667Z'
+        fill='currentColor'
+        stroke='currentColor'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  )
+}
+
+export default MoreVertical

--- a/src/styles/hover-menu.scss
+++ b/src/styles/hover-menu.scss
@@ -1,0 +1,76 @@
+.Layer__hover-menu {
+  position: relative;
+  display: flex;
+
+  &.--open {
+    .Layer__hover-menu__list-wrapper {
+      top: 100%;
+      opacity: 1;
+      touch-action: auto;
+      pointer-events: auto;
+    }
+  }
+
+  .Layer__hover-menu__children {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+  }
+
+  .Layer__hover-menu__list-wrapper {
+    position: absolute;
+    top: 120%;
+    right: 0;
+    padding-top: var(--spacing-xs);
+    min-width: 108px;
+    touch-action: none;
+    pointer-events: none;
+    opacity: 0;
+    display: flex;
+    justify-content: stretch;
+    transition: all 0.15s ease;
+
+    .Layer__hover-menu__list {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing-3xs);
+      background: var(--color-base-0);
+      border: 1px solid var(--color-base-100);
+      border-radius: var(--spacing-xs);
+      box-shadow:
+        0px 0px 0px 1px rgba(25, 25, 25, 0.06),
+        0px 4px 12px 0px var(--base-transparent-1, rgba(16, 24, 40, 0.01)),
+        0px 2px 4px 0px rgba(25, 25, 25, 0.06);
+      box-sizing: border-box;
+      margin: 0;
+      padding: var(--spacing-3xs);
+      list-style: none;
+
+      .Layer__hover-menu__list-item {
+        padding: var(--spacing-3xs);
+        padding-left: var(--spacing-xs);
+        border-radius: var(--spacing-2xs);
+        color: var(--color-base-500);
+        transition: all 0.2s ease-in-out;
+
+        .Layer__hover-menu__list-item-button {
+          background: none;
+          border: none;
+          outline: none;
+          color: inherit;
+          font-size: var(--text-sm);
+          font-weight: 540;
+          letter-spacing: -0.06px;
+          cursor: pointer;
+        }
+
+        &:hover {
+          background: var(--color-base-50);
+          color: var(--color-base-800);
+        }
+      }
+    }
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -5,6 +5,7 @@
 @import './badge.scss';
 @import './button.scss';
 @import './charts.scss';
+@import './hover-menu.scss';
 @import './component.scss';
 @import './inputs.scss';
 @import './table.scss';

--- a/src/styles/linked_accounts.scss
+++ b/src/styles/linked_accounts.scss
@@ -1,5 +1,8 @@
 .Layer__linked-accounts {
   min-height: 151px;
+  box-shadow:
+    0px 2px 4px 0px var(--base-transparent-6),
+    0px 0px 0px 1px var(--base-transparent-4);
   box-sizing: border-box;
 
   &::-webkit-scrollbar {
@@ -56,15 +59,12 @@
   align-items: center;
   justify-content: center;
   flex: 1;
-  max-width: 284px;
+  max-width: 272px;
   min-height: 152px;
   padding: var(--spacing-2xs);
+  border: 1px solid var(--color-base-100);
   border-radius: var(--border-radius-sm);
   background: var(--base-transparent-1);
-  box-shadow:
-    0px 2px 4px 0px var(--base-transparent-6),
-    0px 0px 0px 1px var(--base-transparent-4);
-  box-sizing: border-box;
 
   &.--as-widget {
     min-height: 100px;
@@ -92,9 +92,7 @@
   padding: var(--spacing-2xs);
   border-radius: var(--border-radius-sm);
   background: var(--color-base-0);
-  box-shadow:
-    0px 2px 4px 0px var(--base-transparent-6),
-    0px 0px 0px 1px var(--base-transparent-4);
+  border: 1px solid var(--color-base-100);
   box-sizing: border-box;
 
   .topbar {
@@ -189,6 +187,53 @@
 
     .bottombar {
       padding: 0 var(--spacing-xs) 0 0;
+    }
+  }
+}
+
+.Layer__linked-accounts__options {
+  position: relative;
+  display: flex;
+
+  &:hover .Layer__linked-accounts__options-overlay {
+    opacity: 1;
+    touch-action: auto;
+
+    .Layer__linked-accounts__options-overlay-button {
+      transform: translate3d(0, 0, 0);
+    }
+  }
+
+  .Layer__linked-accounts__options-overlay {
+    opacity: 0;
+    touch-action: none;
+    position: absolute;
+    top: var(--spacing-2xs);
+    right: var(--spacing-2xs);
+    width: 74px;
+    height: 54px;
+    display: flex;
+    justify-content: flex-end;
+    background: linear-gradient(
+      270deg,
+      #f8f8fa 1.52%,
+      rgba(248, 248, 250, 0) 99.75%
+    );
+    transition: 0.2s all ease-in-out;
+
+    .Layer__linked-accounts__options-overlay-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+      margin: var(--spacing-xs);
+      background: var(--color-base-0);
+      border: none;
+      border-radius: var(--spacing-2xs);
+      cursor: pointer;
+      transform: translate3d(5px, -5px, 0);
+      transition: 0.2s all ease-in-out;
     }
   }
 }


### PR DESCRIPTION
## Description

- [x] Add hover menu component (to any element)
- [x] Add linked account options component
- [x] Connect hover menu with linked account
- [x] Add styles and motion 

## Context

[LAY-536](https://linear.app/layerfi/issue/LAY-536/unlink-account-options)

## How this has been tested?

https://github.com/Layer-Fi/layer-react/assets/32065451/652e5f81-d3c8-464a-b3b3-08574c8b8fbd
