### PR TITLE
fix: filters label position

### DIFF
--- a/src/styles/profit_and_loss_detailed_charts.scss
+++ b/src/styles/profit_and_loss_detailed_charts.scss
@@ -84,6 +84,7 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
 
   .filters {
     display: flex;
+    align-items: center;
     margin: 0 var(--spacing-md);
     padding: var(--spacing-2xs) var(--spacing-xs);
     gap: var(--spacing-xs);


### PR DESCRIPTION
## Description

Fix "Filters" label position in Profit And Loss view.

## How this has been tested?

Before:

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/b66d011c-8c42-4db5-acfb-a0eb0abf0fed)


After:

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/34a3a4aa-f770-4491-af38-ce4faad8ee7c)
