### PR TITLE
fix: fix align items css rule in linked accounts

### DIFF
--- a/src/styles/linked_accounts.scss
+++ b/src/styles/linked_accounts.scss
@@ -110,7 +110,7 @@
   .topbar {
     min-width: 272px;
     display: flex;
-    align-items: start;
+    align-items: flex-start;
     justify-content: space-between;
     background: var(--color-base-50);
     color: var(--color-base-900);


### PR DESCRIPTION
## Description

Having following warning:

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/73728751-d347-4ffa-af12-338ecd1b1584)


## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/20c246c2-5c36-489c-b010-2d87d9fe7dc7)
