### PR TITLE
feat: mock tabs on reports view and add elevated prop to component

### DIFF
--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -7,14 +7,16 @@ export interface ContainerProps {
   name: string
   className?: string
   asWidget?: boolean
+  elevated?: boolean
   children: ReactNode
 }
 
 export const Container = forwardRef<HTMLDivElement, ContainerProps>(
-  ({ name, className, children, asWidget }, ref) => {
+  ({ name, className, children, asWidget, elevated = false }, ref) => {
     const baseClassName = classNames(
       'Layer__component Layer__component-container',
       `Layer__${name}`,
+      elevated && 'Layer__component--elevated',
       asWidget && 'Layer__component--as-widget',
       className,
     )

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -365,6 +365,7 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
                     value: 'match',
                     label: 'Match',
                     disabled: !hasMatch(bankTransaction),
+                    disabledMessage: 'We could not find matching transactions',
                   },
                 ]}
                 selected={purpose}

--- a/src/components/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/components/LinkedAccounts/LinkedAccounts.tsx
@@ -11,7 +11,12 @@ import classNames from 'classnames'
 
 const COMPONENT_NAME = 'linked-accounts'
 
-export const LinkedAccounts = ({ asWidget }: { asWidget?: boolean }) => {
+export interface LinkedAccountsProps {
+  asWidget?: boolean
+  elevated?: boolean
+}
+
+export const LinkedAccounts = ({ asWidget, elevated }: LinkedAccountsProps) => {
   const {
     data,
     isLoading,
@@ -34,7 +39,7 @@ export const LinkedAccounts = ({ asWidget }: { asWidget?: boolean }) => {
   )
 
   return (
-    <Container name={COMPONENT_NAME}>
+    <Container name={COMPONENT_NAME} elevated={elevated}>
       <Header className='Layer__linked-accounts__header'>
         <Heading
           className='Layer__linked-accounts__title'

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -13,6 +13,7 @@ export interface Option {
   label: string
   value: string
   disabled?: boolean
+  disabledMessage?: string
   leftIcon?: ReactNode
 }
 
@@ -37,6 +38,7 @@ interface ToggleOptionProps {
   onChange: (event: ChangeEvent<HTMLInputElement>) => void
   value: string
   disabled?: boolean
+  disabledMessage?: string
   leftIcon?: ReactNode
   index: number
 }
@@ -131,6 +133,7 @@ export const Toggle = ({
           checked={selectedValue === option.value}
           onChange={handleChange}
           disabled={option.disabled ?? false}
+          disabledMessage={option.disabledMessage}
           index={index}
         />
       ))}
@@ -148,6 +151,7 @@ const ToggleOption = ({
   size,
   leftIcon,
   disabled,
+  disabledMessage = 'Disabled',
   index,
 }: ToggleOptionProps) => {
   if (disabled) {
@@ -173,7 +177,7 @@ const ToggleOption = ({
           </label>
         </TooltipTrigger>
         <TooltipContent className='Layer__tooltip'>
-          We could not find matching transactions
+          {disabledMessage}
         </TooltipContent>
       </Tooltip>
     )

--- a/src/styles/component.scss
+++ b/src/styles/component.scss
@@ -30,6 +30,13 @@
   }
 }
 
+.Layer__component.Layer__component--elevated {
+  box-shadow:
+    0px 4px 12px 0px var(--base-transparent-8),
+    0px 2px 4px 0px var(--base-transparent-6),
+    0px 0px 0px 1px var(--base-transparent-4);
+}
+
 .Layer__component-header {
   padding: var(--spacing-md);
   display: flex;

--- a/src/styles/linked_accounts.scss
+++ b/src/styles/linked_accounts.scss
@@ -1,8 +1,5 @@
 .Layer__linked-accounts {
   min-height: 150px;
-  box-shadow:
-    0px 2px 4px 0px var(--base-transparent-6),
-    0px 0px 0px 1px var(--base-transparent-4);
   box-sizing: border-box;
 
   &::-webkit-scrollbar {

--- a/src/views/AccountingOverview/AccountingOverview.tsx
+++ b/src/views/AccountingOverview/AccountingOverview.tsx
@@ -15,7 +15,11 @@ export const AccountingOverview = ({
     <ProfitAndLoss asContainer={false}>
       <View title={title} headerControls={<ProfitAndLoss.DatePicker />}>
         <ProfitAndLoss.Summaries actionable={false} />
-        <Container name='accounting-overview-profit-and-loss' asWidget>
+        <Container
+          name='accounting-overview-profit-and-loss'
+          asWidget
+          elevated={true}
+        >
           <Header>
             <Heading size={HeadingSize.secondary}>Profit & Loss</Heading>
           </Header>

--- a/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
+++ b/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
@@ -12,7 +12,7 @@ export const BankTransactionsWithLinkedAccounts = ({
 }: BankTransactionsWithLinkedAccountsProps) => {
   return (
     <View title={title}>
-      <LinkedAccounts />
+      <LinkedAccounts elevated={true} />
       <BankTransactions asWidget />
     </View>
   )

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -2,6 +2,7 @@ import React, { RefObject, useContext, useRef } from 'react'
 import { Container } from '../../components/Container'
 import { Panel } from '../../components/Panel'
 import { ProfitAndLoss } from '../../components/ProfitAndLoss'
+import { Toggle } from '../../components/Toggle'
 import { View } from '../../components/View'
 
 export interface ReportsProps {
@@ -18,6 +19,22 @@ export const Reports = ({ title = 'Reports' }: ReportsProps) => {
   return (
     <ProfitAndLoss asContainer={false}>
       <View title={title} headerControls={<ProfitAndLoss.DatePicker />}>
+        <Toggle
+          name='reports-tabs'
+          options={[
+            {
+              value: 'profitAndLoss',
+              label: 'Profit & loss',
+            },
+            {
+              value: 'balanceSheet',
+              label: 'Balance sheet',
+              disabled: true,
+            },
+          ]}
+          selected='profitAndLoss'
+          onChange={() => null}
+        />
         <Container name='reports' ref={containerRef}>
           <ReportsPanel containerRef={containerRef} />
         </Container>


### PR DESCRIPTION
## Description

1. Add mocked (for now) toggle to the Reports view
2. Add `elevated` prop to the `<Component />` so we can promote components with a shadow

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/da83c94e-2f6a-47b0-9fba-2af33b65f397)

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/35e1e355-3709-46e5-941b-a21b32b08483)
