### PR TITLE
refactor: move breakpoints to config

### DIFF
--- a/src/components/ChartOfAccounts/ChartOfAccounts.tsx
+++ b/src/components/ChartOfAccounts/ChartOfAccounts.tsx
@@ -1,14 +1,11 @@
 import React, { createContext, useContext, useState } from 'react'
+import { BREAKPOINTS } from '../../config/general'
 import { useChartOfAccounts } from '../../hooks/useChartOfAccounts'
 import { useElementSize } from '../../hooks/useElementSize'
 import { useLedgerAccounts } from '../../hooks/useLedgerAccounts'
 import { ChartOfAccountsTable } from '../ChartOfAccountsTable'
 import { Container } from '../Container'
 import { LedgerAccount } from '../LedgerAccount'
-
-const TABLET_BREAKPOINT = 760
-
-const MOBILE_BREAKPOINT = 500
 
 export type View = 'mobile' | 'tablet' | 'desktop'
 
@@ -73,15 +70,15 @@ const ChartOfAccountsContent = ({ asWidget }: ChartOfAccountsProps) => {
 
   const containerRef = useElementSize<HTMLDivElement>((_a, _b, { width }) => {
     if (width) {
-      if (width >= TABLET_BREAKPOINT && view !== 'desktop') {
+      if (width >= BREAKPOINTS.TABLET && view !== 'desktop') {
         setView('desktop')
       } else if (
-        width <= TABLET_BREAKPOINT &&
-        width > MOBILE_BREAKPOINT &&
+        width <= BREAKPOINTS.TABLET &&
+        width > BREAKPOINTS.MOBILE &&
         view !== 'tablet'
       ) {
         setView('tablet')
-      } else if (width < MOBILE_BREAKPOINT && view !== 'mobile') {
+      } else if (width < BREAKPOINTS.MOBILE && view !== 'mobile') {
         setView('mobile')
       }
     }

--- a/src/config/general.ts
+++ b/src/config/general.ts
@@ -1,2 +1,7 @@
 export const DATE_FORMAT = 'LLL d, yyyy'
 export const TIME_FORMAT = 'p'
+
+export const BREAKPOINTS = {
+  TABLET: 760,
+  MOBILE: 500,
+}


### PR DESCRIPTION
## Description

Move breakpoints from `<ChartsOfAccounts />` component to the `config`.

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/e5934644-36f2-45d3-8bef-63d57e8f6a88)

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/2eb23b57-1145-45e3-a772-5d37acb35dd1)

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/f835cf56-982a-4c3c-a7be-4500490dcdd1)
