### PR TITLE
fix: fixed debit and credit columns width in ledger account details

### DIFF
--- a/src/styles/ledger_account.scss
+++ b/src/styles/ledger_account.scss
@@ -71,8 +71,19 @@
 }
 
 .Layer__table.Layer__ledger-account__entry-details__table th,
-.Layer__ledger-account__entry-details__table__total-row td {
-  padding: var(--spacing-lm) var(--spacing-md);
+.Layer__ledger-account__entry-details__table__total-row td,
+.Layer__table.Layer__ledger-account__entry-details__table
+  tr
+  th:last-child.Layer__table-header,
+.Layer__table.Layer__ledger-account__entry-details__table
+  tr
+  th:first-child.Layer__table-header {
+  padding: var(--spacing-md);
+}
+
+.Layer__ledger-account__entry-details__table .Layer__table-cell--amount {
+  width: 128px;
+  box-sizing: border-box;
 }
 
 .Layer__ledger-account__pagination {


### PR DESCRIPTION
## Description

Set "static" widths to Debit and Credit columns in the Line items table to prevent layout shifting when user changes selected row main table

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/7d171317-864e-4aa3-a247-d4c54371d0d3)
