### PR TITLE
fix: missing spacing in table data state component

### DIFF
--- a/src/styles/table.scss
+++ b/src/styles/table.scss
@@ -128,6 +128,8 @@
 }
 
 .Layer__table-state-container {
+  padding: var(--spacing-2xl) var(--spacing-sm);
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Description

Fix missing spacing in Data State component:

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/d44e18a2-f158-4918-9e14-38277abcce72)


## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/0a6286d8-52e1-4329-9af3-64014410ebe1)
