### PR TITLE
fix: missing badge hover color in variables

### DIFF
--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -164,6 +164,7 @@
   --btn-secondary-bg-color: var(--color-white);
 
   --badge-color: var(--color-base-900);
+  --badge-fg-color: var(--color-base-900);
   --badge-bg-color: var(--color-base-400);
 
   --badge-color-success: var(--color-info-success);


### PR DESCRIPTION
## Description

Add missing `--badge-fg-color` to variables.

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/44795f26-0af9-4358-b717-3277bfc41ad5)
