### PR TITLE
fix: rename expense/sale into category

### DIFF
--- a/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
@@ -50,7 +50,7 @@ export const DetailedTable = ({
                 className={buildColClass('category')}
                 onClick={() => sortBy(sidebarScope ?? 'expenses', 'category')}
               >
-                Expense/Sale <SortArrows className='Layer__sort-arrows' />
+                Category <SortArrows className='Layer__sort-arrows' />
               </th>
               <th
                 className={buildColClass('type')}


### PR DESCRIPTION
## Description

Rename "Expense/Sale" into "Category" in P&L.

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/da58c98c-d0fc-4f4f-b3d8-fb76c5a67afb)
