### PR TITLE
Add Duplicate Account and Repair Connection UIs

### DIFF
--- a/src/api/layer.ts
+++ b/src/api/layer.ts
@@ -24,6 +24,7 @@ import {
   unlinkAccount,
   confirmConnection,
   denyConnection,
+  breakPlaidItemConnection,
 } from './layer/linked_accounts'
 import { getProfitAndLoss } from './layer/profit_and_loss'
 import { getTasks, submitResponseToTask } from './layer/tasks'
@@ -54,4 +55,5 @@ export const Layer = {
   denyConnection,
   getTasks,
   submitResponseToTask,
+  breakPlaidItemConnection,
 }

--- a/src/api/layer.ts
+++ b/src/api/layer.ts
@@ -25,6 +25,7 @@ import {
   confirmConnection,
   denyConnection,
   breakPlaidItemConnection,
+  syncConnection,
 } from './layer/linked_accounts'
 import { getProfitAndLoss } from './layer/profit_and_loss'
 import { getTasks, submitResponseToTask } from './layer/tasks'
@@ -56,4 +57,5 @@ export const Layer = {
   getTasks,
   submitResponseToTask,
   breakPlaidItemConnection,
+  syncConnection,
 }

--- a/src/api/layer/linked_accounts.ts
+++ b/src/api/layer/linked_accounts.ts
@@ -6,9 +6,7 @@ export const getLinkedAccounts = get<
   {
     businessId: string
   }
->(
-  ({ businessId }) => `/v1/businesses/${businessId}/external-accounts`,
-)
+>(({ businessId }) => `/v1/businesses/${businessId}/external-accounts`)
 
 export const confirmConnection = post<
   Record<string, unknown>,
@@ -18,7 +16,8 @@ export const confirmConnection = post<
     accountId: string
   }
 >(
-  ({businessId, accountId}) => `/v1/businesses/${businessId}/external-accounts/${accountId}/confirm`
+  ({ businessId, accountId }) =>
+    `/v1/businesses/${businessId}/external-accounts/${accountId}/confirm`,
 )
 
 export const denyConnection = post<
@@ -29,11 +28,12 @@ export const denyConnection = post<
     accountId: string
   }
 >(
-  ({businessId, accountId}) => `/v1/businesses/${businessId}/external-accounts/${accountId}/confirm`
+  ({ businessId, accountId }) =>
+    `/v1/businesses/${businessId}/external-accounts/${accountId}/deny`,
 )
 
 // TODO: not implemented yet in backend
-export const unlinkConnection = deleteRequest<
+export const unlinkConnection = post<
   Record<string, unknown>,
   Record<string, unknown>,
   {
@@ -54,7 +54,6 @@ export const unlinkAccount = post<
     `/v1/businesses/${businessId}/external-accounts/${accountId}/archive`,
 )
 
-
 /**********************
  * Plaid Specific API *
  **********************/
@@ -64,7 +63,7 @@ export const getPlaidLinkToken = post<
     data: {
       type: 'Link_Token'
       link_token: string
-    },
+    }
   },
   Record<string, unknown>,
   {
@@ -77,7 +76,7 @@ export const getPlaidUpdateModeLinkToken = post<
     data: {
       type: 'Link_Token'
       link_token: string
-    },
+    }
   },
   Record<string, unknown>,
   {
@@ -93,17 +92,31 @@ export const exchangePlaidPublicToken = post<
   }
 >(({ businessId }) => `/v1/businesses/${businessId}/plaid/link/exchange`)
 
-// TODO: Delete once "unlinkConnection" is online
-export const unlinkPlaidItem = deleteRequest<
+// TODO: Delete once "unlinkConnection" is online. unlinkConnection is broader and would be able
+// to handle other providers like Stripe as well as Plaid
+export const unlinkPlaidItem = post<
   Record<string, unknown>,
   Record<string, unknown>,
   {
     businessId: string
-    plaidItemId: string
+    plaidItemPlaidId: string
   }
 >(
-  ({ businessId, plaidItemId }) =>
-    `/v1/businesses/${businessId}/plaid/items/${plaidItemId}`,
+  ({ businessId, plaidItemPlaidId }) =>
+    `/v1/businesses/${businessId}/plaid/items/${plaidItemPlaidId}/unlink`,
+)
+
+// Only works in non-production environments
+export const breakPlaidItemConnection = post<
+  Record<string, unknown>,
+  Record<string, unknown>,
+  {
+    businessId: string
+    plaidItemPlaidId: string
+  }
+>(
+  ({ businessId, plaidItemPlaidId }) =>
+    `/v1/businesses/${businessId}/plaid/items/${plaidItemPlaidId}/sandbox-reset-item-login`,
 )
 
 // export const createAccount = post<{ data: LinkedAccount }, NewAccount>(

--- a/src/api/layer/linked_accounts.ts
+++ b/src/api/layer/linked_accounts.ts
@@ -1,5 +1,13 @@
 import { LinkedAccounts, PublicToken } from '../../types/linked_accounts'
-import { get, post, deleteRequest } from './authenticated_http'
+import { get, post } from './authenticated_http'
+
+export const syncConnection = post<
+  Record<string, unknown>,
+  Record<string, unknown>,
+  {
+    businessId: string
+  }
+>(({ businessId }) => `/v1/businesses/${businessId}/sync`)
 
 export const getLinkedAccounts = get<
   { data: LinkedAccounts },

--- a/src/components/HoverMenu/HoverMenu.tsx
+++ b/src/components/HoverMenu/HoverMenu.tsx
@@ -1,25 +1,15 @@
 import React, { ReactNode, useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
-import { Source } from '../../types/linked_accounts'
 
 export interface HoverMenuProps {
   children: ReactNode
   config: {
     name: string
-    action: (source: Source, sourceId: string, accountId: string) => void
+    action: () => void
   }[]
-  connectionId: string
-  accountId: string
-  source: Source
 }
 
-export const HoverMenu = ({
-  children,
-  config,
-  connectionId,
-  accountId,
-  source,
-}: HoverMenuProps) => {
+export const HoverMenu = ({ children, config }: HoverMenuProps) => {
   const [openMenu, setOpenMenu] = useState(false)
   const hoverMenuRef = useRef<HTMLDivElement>(null)
 
@@ -69,7 +59,7 @@ export const HoverMenu = ({
               >
                 <button
                   className='Layer__hover-menu__list-item-button'
-                  onClick={() => item.action(source, connectionId, accountId)}
+                  onClick={item.action}
                 >
                   {item.name}
                 </button>

--- a/src/components/LinkedAccountOptions/LinkedAccountOptions.tsx
+++ b/src/components/LinkedAccountOptions/LinkedAccountOptions.tsx
@@ -10,9 +10,6 @@ interface LinkedAccountOptionsProps extends HoverMenuProps {
 export const LinkedAccountOptions = ({
   children,
   config,
-  accountId,
-  connectionId,
-  source,
   showLedgerBalance,
 }: LinkedAccountOptionsProps) => {
   const linkedAccountOptionsClassName = classNames(
@@ -23,12 +20,7 @@ export const LinkedAccountOptions = ({
     <div className={linkedAccountOptionsClassName}>
       <div className='Layer__linked-accounts__options-overlay'>
         <div className='Layer__linked-accounts__options-overlay-button'>
-          <HoverMenu
-            config={config}
-            accountId={accountId}
-            connectionId={connectionId}
-            source={source}
-          >
+          <HoverMenu config={config}>
             <MoreVertical size={16} />
           </HoverMenu>
         </div>

--- a/src/components/LinkedAccountPill/LinkedAccountPill.tsx
+++ b/src/components/LinkedAccountPill/LinkedAccountPill.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import AlertCircle from '../../icons/AlertCircle'
+import MoreVertical from '../../icons/MoreVertical'
+import { HoverMenu } from '../HoverMenu'
+import { Pill } from '../Pill/Pill'
+
+type Props = {
+  text: string
+  config: { name: string; action: () => void }[]
+}
+
+export const LinkedAccountPill = ({ text, config }: Props) => {
+  return (
+    <>
+      <Pill kind='error'>
+        <AlertCircle size={14} /> {text}
+        <div className='Layer__linked-accounts-pill__options-overlay'>
+          <HoverMenu config={config}>
+            <div className={'Layer__linked-accounts-pill__invisible-spacer'} />
+          </HoverMenu>
+        </div>
+      </Pill>
+    </>
+  )
+}

--- a/src/components/LinkedAccountPill/index.tsx
+++ b/src/components/LinkedAccountPill/index.tsx
@@ -1,0 +1,1 @@
+export { LinkedAccountPill } from './LinkedAccountPill'

--- a/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
+++ b/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import InstitutionIcon from '../../icons/InstitutionIcon'
 import { centsToDollars as formatMoney } from '../../models/Money'
 import { LinkedAccount } from '../../types/linked_accounts'
+import { LinkedAccountPill } from '../LinkedAccountPill'
 import { Text, TextSize } from '../Typography'
 import classNames from 'classnames'
 
@@ -9,6 +10,10 @@ export interface LinkedAccountThumbProps {
   account: LinkedAccount
   asWidget?: boolean
   showLedgerBalance?: boolean
+  pillConfig?: {
+    text: string
+    config: { name: string; action: () => void }[]
+  }
 }
 
 const AccountNumber = ({ accountNumber }: { accountNumber: string }) => (
@@ -21,11 +26,25 @@ export const LinkedAccountThumb = ({
   account,
   asWidget,
   showLedgerBalance,
+  pillConfig,
 }: LinkedAccountThumbProps) => {
   const linkedAccountThumbClassName = classNames(
     'Layer__linked-account-thumb',
     asWidget && '--as-widget',
   )
+
+  let balance: React.ReactNode
+  if (pillConfig) {
+    balance = (
+      <LinkedAccountPill text={pillConfig.text} config={pillConfig.config} />
+    )
+  } else {
+    balance = (
+      <Text as='span' className='account-balance'>
+        ${formatMoney(account.latest_balance_timestamp?.balance)}
+      </Text>
+    )
+  }
 
   return (
     <div className={linkedAccountThumbClassName}>
@@ -67,9 +86,7 @@ export const LinkedAccountThumb = ({
           >
             Bank balance
           </Text>
-          <Text as='span' className='account-balance'>
-            ${formatMoney(account.latest_balance_timestamp?.balance)}
-          </Text>
+          {balance}
         </div>
       )}
       {showLedgerBalance && (

--- a/src/components/LinkedAccounts/LinkedAccountsContent.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountsContent.tsx
@@ -24,7 +24,6 @@ export const LinkedAccountsContent = ({
     repairConnection,
     confirmAccount,
     denyAccount,
-    refetchAccounts,
     breakConnection,
   } = useContext(LinkedAccountsContext)
   const { environment } = useLayerContext()
@@ -48,7 +47,6 @@ export const LinkedAccountsContent = ({
                   // TODO: trigger some sort of loading spinner here
                   await denyAccount(account.external_account_source, account.id)
                   // TODO: turn off loading spinner
-                  refetchAccounts()
                 },
               },
               {
@@ -60,7 +58,6 @@ export const LinkedAccountsContent = ({
                     account.id,
                   )
                   // TODO: turn off loading spinner
-                  refetchAccounts()
                 },
               },
             ],
@@ -72,13 +69,14 @@ export const LinkedAccountsContent = ({
               {
                 name: 'Repair connection',
                 action: async () => {
-                  if (account.connection_id)
+                  if (account.connection_external_id)
+                    // TODO: trigger some sort of loading spinner here
                     // An account is "broken" when its connection is broken
                     await repairConnection(
                       account.external_account_source,
-                      account.connection_id,
+                      account.connection_external_id,
                     )
-                  refetchAccounts()
+                  // TODO: turn off loading spinner
                 },
               },
             ],
@@ -106,7 +104,6 @@ export const LinkedAccountsContent = ({
                     account.id,
                   )
                   // TODO: turn off loading spinner
-                  refetchAccounts()
                 },
               },
               {
@@ -129,11 +126,11 @@ export const LinkedAccountsContent = ({
                     account.connection_external_id,
                   )
                   // TODO: turn off loading spinner
-                  refetchAccounts()
                 },
               },
               ...(pillConfig ? pillConfig.config : []),
-              ...(environment === 'staging'
+              ...(environment === 'staging' &&
+              !account.connection_needs_repair_as_of
                 ? [
                     {
                       name: 'Break connection (test utility)',
@@ -143,7 +140,6 @@ export const LinkedAccountsContent = ({
                             account.external_account_source,
                             account.connection_external_id,
                           )
-                          refetchAccounts()
                         } else {
                           console.warn(
                             "Account doesn't have defined connection_external_id",

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -1,5 +1,14 @@
 import React, { PropsWithChildren } from 'react'
 
-export const Pill = ({ children }: PropsWithChildren) => (
-  <span className='Layer__pill'>{children}</span>
+type PillKind = 'default' | 'info' | 'success' | 'warning' | 'error'
+
+type Props = PropsWithChildren & { kind?: PillKind; onHover?: () => void }
+
+export const Pill = ({ children, kind = 'default', onHover }: Props) => (
+  <span
+    onMouseOver={onHover}
+    className={`Layer__pill ${kind === 'error' ? 'Layer__pill--error' : ''}`}
+  >
+    {children}
+  </span>
 )

--- a/src/contexts/LayerContext/LayerContext.tsx
+++ b/src/contexts/LayerContext/LayerContext.tsx
@@ -28,4 +28,5 @@ export const LayerContext = createContext<
   setColors: () => undefined,
   onboardingStep: undefined,
   setOnboardingStep: () => undefined,
+  environment: '',
 })

--- a/src/contexts/LinkedAccountsContext/LinkedAccountsContext.ts
+++ b/src/contexts/LinkedAccountsContext/LinkedAccountsContext.ts
@@ -13,4 +13,7 @@ export const LinkedAccountsContext = createContext<LinkedAccountsContextType>({
   repairConnection: () => {},
   refetchAccounts: () => {},
   unlinkAccount: () => {},
+  denyAccount: () => {},
+  confirmAccount: () => {},
+  breakConnection: () => {},
 })

--- a/src/hooks/useLinkedAccounts/mockData.ts
+++ b/src/hooks/useLinkedAccounts/mockData.ts
@@ -2,11 +2,11 @@ import { LinkedAccount } from '../../types/linked_accounts'
 
 export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
   {
-    id: '1',
+    id: 'd800ada8-8075-4436-a712-08efabcbd51a',
     external_account_external_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
     external_account_source: 'PLAID',
     external_account_name: 'Citi Double Cash® Card',
-    mask: "1234",
+    mask: '1234',
     latest_balance_timestamp: {
       external_account_external_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
       external_account_source: 'PLAID',
@@ -20,15 +20,16 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
       logo: '',
     },
     connection_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
+    connection_external_id: '11111',
     connection_needs_repair_as_of: null,
     requires_user_confirmation_as_of: null,
   },
   {
-    id: '2',
+    id: 'f98ec50a-c370-484d-a35b-d00207436075',
     external_account_external_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
     external_account_source: 'PLAID',
     external_account_name: 'Citi Double Cash® Card',
-    mask: "1234",
+    mask: '1234',
     latest_balance_timestamp: {
       external_account_external_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
       external_account_source: 'PLAID',
@@ -42,15 +43,16 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
       logo: '',
     },
     connection_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
+    connection_external_id: '11111',
     connection_needs_repair_as_of: null,
     requires_user_confirmation_as_of: null,
   },
   {
-    id: '3',
+    id: '843f1748-fdaa-422d-a73d-2489a40c8dc7',
     external_account_external_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
     external_account_source: 'PLAID',
     external_account_name: 'Citi Double Cash® Card',
-    mask: "1234",
+    mask: '1234',
     latest_balance_timestamp: {
       external_account_external_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
       external_account_source: 'PLAID',
@@ -64,15 +66,16 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
       logo: '',
     },
     connection_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
+    connection_external_id: '11111',
     connection_needs_repair_as_of: '2024-03-06T16:44:35.715458Z',
     requires_user_confirmation_as_of: null,
   },
   {
-    id: '4',
+    id: '8f430e29-e339-4d71-a08a-fce469c7a7c1',
     external_account_external_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
     external_account_source: 'PLAID',
     external_account_name: 'Citi Double Cash® Card',
-    mask: "1234",
+    mask: '1234',
     latest_balance_timestamp: {
       external_account_external_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
       external_account_source: 'PLAID',
@@ -86,6 +89,7 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
       logo: '',
     },
     connection_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
+    connection_external_id: '11111',
     connection_needs_repair_as_of: null,
     requires_user_confirmation_as_of: '2024-03-06T16:44:35.715458Z',
   },

--- a/src/providers/LayerProvider/LayerProvider.tsx
+++ b/src/providers/LayerProvider/LayerProvider.tsx
@@ -100,6 +100,7 @@ export const LayerProvider = ({
     colors,
     usePlaidSandbox,
     onboardingStep: undefined,
+    environment,
   })
 
   const { data: auth } =

--- a/src/styles/hover-menu.scss
+++ b/src/styles/hover-menu.scss
@@ -1,6 +1,7 @@
 .Layer__hover-menu {
   position: relative;
   display: flex;
+  width: 100%;
 
   &.Layer__hover-menu--open {
     .Layer__hover-menu__list-wrapper {
@@ -17,6 +18,7 @@
     align-items: center;
     justify-content: center;
     cursor: pointer;
+    width: 100%;
   }
 
   .Layer__hover-menu__list-wrapper {
@@ -25,7 +27,7 @@
     top: 80%;
     right: -8px;
     padding-top: var(--spacing-xs);
-    min-width: 108px;
+    min-width: 160px;
     touch-action: none;
     pointer-events: none;
     opacity: 0;
@@ -59,6 +61,7 @@
         align-items: center;
 
         .Layer__hover-menu__list-item-button {
+          text-align: start;
           background: none;
           border: none;
           outline: none;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -28,6 +28,7 @@
 @import './data_state.scss';
 @import './icons.scss';
 @import './linked_accounts.scss';
+@import './linked_account_pill.scss';
 @import './loader.scss';
 @import './tasks.scss';
 @import './pagination.scss';

--- a/src/styles/linked_account_pill.scss
+++ b/src/styles/linked_account_pill.scss
@@ -1,0 +1,13 @@
+.Layer__linked-accounts-pill__options-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  cursor: pointer;
+}
+
+.Layer__linked-accounts-pill__invisible-spacer {
+  width: 100%;
+  height: 24px;
+}

--- a/src/styles/linked_accounts.scss
+++ b/src/styles/linked_accounts.scss
@@ -1,6 +1,7 @@
 .Layer__linked-accounts {
   min-height: 150px;
   box-sizing: border-box;
+  overflow: visible;
 
   &::-webkit-scrollbar {
     display: none;
@@ -259,5 +260,9 @@
       transform: translate3d(5px, -5px, 0);
       transition: 0.15s all ease-out;
     }
+  }
+
+  .Layer__linked-accounts__options-overlay--transparent {
+    background: none;
   }
 }

--- a/src/styles/pill.scss
+++ b/src/styles/pill.scss
@@ -1,4 +1,5 @@
 .Layer__pill {
+  position: relative;
   background-color: var(--badge-bg-color);
   color: var(--badge-color);
   border-radius: var(--badge-border-radius);
@@ -8,8 +9,14 @@
   flex-direction: row;
   align-items: center;
   white-space: nowrap;
+  user-select: none;
 
   & svg {
     margin-right: 0.25rem;
   }
+}
+
+.Layer__pill--error {
+  background-color: var(--color-info-error-bg);
+  color: var(--color-info-error-fg);
 }

--- a/src/styles/tasks.scss
+++ b/src/styles/tasks.scss
@@ -43,7 +43,7 @@
   .Layer__tasks-header {
     display: flex;
     align-items: center;
-    justify-content: start;
+    justify-content: flex-start;
     gap: var(--spacing-md);
   }
 
@@ -156,7 +156,7 @@
     display: flex;
     gap: var(--spacing-xs);
     align-items: center;
-    justify-content: end;
+    justify-content: flex-end;
   }
 
   .Layer__tasks-icon {
@@ -172,7 +172,7 @@
 
   .Layer__tasks__pagination {
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
     padding: var(--spacing-md) var(--spacing-sm);
     margin: 0 var(--spacing-xs);
 

--- a/src/types/layer_context.ts
+++ b/src/types/layer_context.ts
@@ -10,6 +10,7 @@ export type LayerContextValues = {
   colors: ColorsPalette
   usePlaidSandbox?: boolean
   onboardingStep?: OnboardingStep
+  environment: string
 }
 
 export type LayerContextHelpers = {

--- a/src/types/linked_accounts.ts
+++ b/src/types/linked_accounts.ts
@@ -23,7 +23,8 @@ export interface LinkedAccount {
     logo: string | null
   }
   mask?: string
-  connection_id: string
+  connection_id?: string
+  connection_external_id?: string
   connection_needs_repair_as_of: string | null
   requires_user_confirmation_as_of: string | null
 }


### PR DESCRIPTION
Adds support for
1. In staging environments, breaking a connection
2. Unlinking connections
3. Displaying account status pills (connection broken / needs duplication confirmation)
4. Duplication confirmation/denial
5. Link repair flow

