### PR TITLE
fix: chevron clickable area

### DIFF
--- a/src/components/JournalRow/JournalRow.tsx
+++ b/src/components/JournalRow/JournalRow.tsx
@@ -130,7 +130,7 @@ export const JournalRow = ({
                     size={16}
                     className='Layer__table__expand-icon'
                     style={{
-                      transform: isOpen ? 'rotate(0deg)' : 'rotate(180deg)',
+                      transform: isOpen ? 'rotate(0deg)' : 'rotate(-90deg)',
                     }}
                   />
                 )}

--- a/src/styles/chart_of_accounts.scss
+++ b/src/styles/chart_of_accounts.scss
@@ -124,8 +124,8 @@
 .Layer__table__expand-icon {
   transition: transform 150ms ease-out;
   color: var(--color-base-600);
-  margin-left: -3px;
-  margin-right: var(--spacing-sm);
+  margin-left: -15px;
+  padding: var(--spacing-sm);
 }
 
 .Layer__chart-of-accounts__table

--- a/src/styles/journal.scss
+++ b/src/styles/journal.scss
@@ -155,17 +155,6 @@
   background-color: var(--bg-element-focus);
 }
 
-.Layer__table__expand-icon {
-  transition: transform 150ms ease-out;
-  color: var(--color-base-600);
-  margin-left: -3px;
-  margin-right: var(--spacing-sm);
-}
-
-.Layer__journal__table .Layer__table-row--collapsed .Layer__table__expand-icon {
-  transform: rotate(-90deg);
-}
-
 .Layer__journal__form {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Description

Make chevron area larger so it's easier to click and expand the row.
Use same chevron rotation in Journal as in Chart of Accounts

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/7ebbe1bb-fc95-4a46-beb2-4233c962ddf2)

New clickable area includes new padding:

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/51986f03-519f-4558-8cd3-85b745e1c2e6)
