### PR TITLE
fix: mobile layout of summaries on accounting overview

### DIFF
--- a/src/styles/accounting_overview.scss
+++ b/src/styles/accounting_overview.scss
@@ -1,8 +1,9 @@
 .Layer__accounting-overview__summaries-row {
   display: flex;
   align-items: center;
-  column-gap: var(--spacing-md);
+  gap: var(--spacing-md);
   max-width: 1406px;
+  width: 100%;
 
   .Layer__notification-card {
     width: calc(25% - 12px);
@@ -13,4 +14,19 @@
 .Layer__component.Layer__accounting-overview-profit-and-loss
   .recharts-responsive-container {
   margin-top: -42px;
+}
+
+@container (max-width: 796px) {
+  .Layer__accounting-overview__summaries-row {
+    flex-direction: column;
+
+    .Layer__profit-and-loss-summaries {
+      width: 100%;
+      flex-direction: column;
+    }
+
+    .Layer__notification-card.Layer__txs-to-review {
+      width: 100%;
+    }
+  }
 }

--- a/src/styles/view.scss
+++ b/src/styles/view.scss
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+  container-type: inline-size;
 }
 
 .Layer__view-header {


### PR DESCRIPTION
## Description

Fix responsiveness of summaries on Accounting overview.

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/ed0c8a3c-96e2-4dc0-87bc-78791a3d2e4d)

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/07d0c324-55f7-401d-8d5e-99b9efd7e06c)

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/9cf6ca9e-7d4c-4444-a9d2-d1b93425e4fc)

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/f331a117-50ad-4dae-9e00-24d93bbaaf58)

