### PR TITLE
fix: responsive sizing of detailed pnl charts

### DIFF
--- a/src/styles/accounting_overview.scss
+++ b/src/styles/accounting_overview.scss
@@ -20,6 +20,12 @@
   display: none;
 }
 
+@container (max-width: 1023px) {
+  .Layer__accounting-overview-profit-and-loss .recharts-legend-wrapper {
+    margin-top: -40px;
+  }
+}
+
 @container (max-width: 796px) {
   .Layer__accounting-overview__summaries-row {
     flex-direction: column;

--- a/src/styles/profit_and_loss_detailed_charts.scss
+++ b/src/styles/profit_and_loss_detailed_charts.scss
@@ -51,11 +51,15 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
 }
 
 .Layer__profit-and-loss-detailed-charts {
-  width: 480px;
+  width: 100%;
   background: var(--color-base-0);
 
+  .chart-field {
+    width: 100%;
+  }
+
   .chart-container {
-    width: 480px;
+    width: 100%;
     height: 280px;
     padding-top: var(--spacing-2xl);
     padding-bottom: var(--spacing-lg);
@@ -290,6 +294,10 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
       display: flex;
       flex-direction: row;
       justify-content: space-between;
+
+      .chart-field {
+        max-width: 300px;
+      }
 
       .chart-container {
         max-width: 300px;


### PR DESCRIPTION
## Description

1. Fix alignment of the PnL chart legend on small screens
2. Fix sizing of detailed charts

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/9ee3b5f3-3fec-4cbe-8125-152ccb3e7242)

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/45cf50b7-b7d8-4d2d-81b8-7a0eab0c1257)

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/456491c6-3e0e-49ae-b5f1-5fc48359095a)

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/d1cbd1d4-96e8-4fb3-bee7-90ba97c67904)
