### PR TITLE
fix: inputs size in bank transactions form

### DIFF
--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -223,6 +223,7 @@
   display: flex;
   gap: var(--spacing-sm);
   flex: 1;
+  align-items: center;
 }
 
 .Layer__expanded-bank-transaction-row__table-cell--split-entry__merge-btn {

--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -577,6 +577,13 @@
     .Layer__select__control,
     .Layer__input {
       font-size: 16px;
+      min-height: 39px;
+    }
+
+    .Layer__bank-transaction-list-item__expanded-row
+      .Layer__select
+      .Layer__select__control {
+      min-height: 39px;
     }
   }
 }


### PR DESCRIPTION
## Description

Fix inputs' sizes in Bank Transaction form.

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/b34143e1-cc12-4a7f-9f3a-afd98947dc36)
