### PR TITLE
use auth from state

### DIFF
--- a/src/providers/LayerProvider/LayerProvider.tsx
+++ b/src/providers/LayerProvider/LayerProvider.tsx
@@ -145,8 +145,10 @@ export const LayerProvider = ({
   }, [businessAccessToken, auth?.access_token])
 
   useSWR(
-    businessId && auth?.access_token && `categories-${businessId}`,
-    Layer.getCategories(apiUrl, auth?.access_token, { params: { businessId } }),
+    businessId && state.auth?.access_token && `categories-${businessId}`,
+    Layer.getCategories(apiUrl, state.auth?.access_token, {
+      params: { businessId },
+    }),
     {
       ...defaultSWRConfig,
       onSuccess: response => {
@@ -161,8 +163,10 @@ export const LayerProvider = ({
   )
 
   useSWR(
-    businessId && auth?.access_token && `business-${businessId}`,
-    Layer.getBusiness(apiUrl, auth?.access_token, { params: { businessId } }),
+    businessId && state?.auth?.access_token && `business-${businessId}`,
+    Layer.getBusiness(apiUrl, state?.auth?.access_token, {
+      params: { businessId },
+    }),
     {
       ...defaultSWRConfig,
       onSuccess: response => {


### PR DESCRIPTION
We were using the `auth` local variable instead of using the reduced `state.auth`. This was fine for cases where we just refreshed the auth token, but this doesn't work when using a `businessAuthToken`, as there's no manual refreshing of credentials.