### PR TITLE
Account linking cleanup

### DIFF
--- a/src/api/layer.ts
+++ b/src/api/layer.ts
@@ -27,6 +27,7 @@ import {
   denyConnection,
   breakPlaidItemConnection,
   syncConnection,
+  updateConnectionStatus,
 } from './layer/linked_accounts'
 import {
   getProfitAndLoss,
@@ -64,4 +65,5 @@ export const Layer = {
   submitResponseToTask,
   breakPlaidItemConnection,
   syncConnection,
+  updateConnectionStatus,
 }

--- a/src/api/layer/linked_accounts.ts
+++ b/src/api/layer/linked_accounts.ts
@@ -9,6 +9,17 @@ export const syncConnection = post<
   }
 >(({ businessId }) => `/v1/businesses/${businessId}/sync`)
 
+export const updateConnectionStatus = post<
+  Record<string, unknown>,
+  Record<string, unknown>,
+  {
+    businessId: string
+  }
+>(
+  ({ businessId }) =>
+    `/v1/businesses/${businessId}/external-accounts/update-connection-status`,
+)
+
 export const getLinkedAccounts = get<
   { data: LinkedAccounts },
   {


### PR DESCRIPTION
- Remove out of date comments
- Remove calls to `syncAccounts` since this endpoint is now rate-limited. Either move sync trigger to backend or replace with `updateConnectionStatus` to refresh connection statuses if and only if there actually is a broken account connection