### PR TITLE
fix max width on reports header actions

### DIFF
--- a/src/styles/component.scss
+++ b/src/styles/component.scss
@@ -72,7 +72,6 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-sm);
-  max-width: 1406px;
 }
 
 .Layer__header__actions-col {

--- a/src/styles/component.scss
+++ b/src/styles/component.scss
@@ -72,6 +72,7 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-sm);
+  max-width: 1406px;
 }
 
 .Layer__header__actions-col {

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -74,7 +74,7 @@ export const Reports = ({ title = 'Reports' }: ReportsProps) => {
   return (
     <ProfitAndLoss asContainer={false}>
       <View title={title} headerControls={<ProfitAndLoss.DatePicker />}>
-        <div className='Layer__header__actions'>
+        <div className='Layer__component Layer__header__actions'>
           <Toggle
             name='reports-tabs'
             options={[


### PR DESCRIPTION
<img width="1256" alt="Screenshot 2024-06-07 at 12 40 19 PM" src="https://github.com/Layer-Fi/layer-react/assets/38053792/00a63204-5b11-4571-b1f1-5d04edaf4815">
Prevents this ^ from happening when screen enlarged enough or zoomed out