### PR TITLE
feat: add bell icon to the onboarding step

### DIFF
--- a/src/components/Onboarding/ConnectAccount.tsx
+++ b/src/components/Onboarding/ConnectAccount.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useMemo } from 'react'
 import { LinkedAccountsContext } from '../../contexts/LinkedAccountsContext'
 import { useBankTransactions } from '../../hooks/useBankTransactions'
+import BellIcon from '../../icons/Bell'
 import CreditCardIcon from '../../icons/CreditCard'
 import FolderIcon from '../../icons/Folder'
 import LinkIcon from '../../icons/Link'
@@ -76,7 +77,11 @@ export const ConnectAccount = ({
           title={
             <Text>
               Categorise transactions{' '}
-              <Badge variant={BadgeVariant.WARNING} size={BadgeSize.SMALL}>
+              <Badge
+                variant={BadgeVariant.WARNING}
+                size={BadgeSize.SMALL}
+                icon={<BellIcon size={12} />}
+              >
                 {transactionsToReview} pending
               </Badge>
             </Text>

--- a/src/views/AccountingOverview/AccountingOverview.tsx
+++ b/src/views/AccountingOverview/AccountingOverview.tsx
@@ -26,7 +26,11 @@ export const AccountingOverview = ({
   return (
     <ProfitAndLoss asContainer={false}>
       <View title={title} headerControls={<ProfitAndLoss.DatePicker />}>
-        {enableOnboarding && <Onboarding />}
+        {enableOnboarding && (
+          <Onboarding
+            onTransactionsToReviewClick={onTransactionsToReviewClick}
+          />
+        )}
         <div className='Layer__accounting-overview__summaries-row'>
           <ProfitAndLoss.Summaries actionable={false} />
           <TransactionToReviewCard onClick={onTransactionsToReviewClick} />
@@ -61,7 +65,7 @@ export const AccountingOverview = ({
             name={classNames(
               'accounting-overview-profit-and-loss-chart',
               pnlToggle !== 'revenue' &&
-              'accounting-overview-profit-and-loss-chart--hidden',
+                'accounting-overview-profit-and-loss-chart--hidden',
             )}
           >
             <ProfitAndLoss.DetailedCharts scope='revenue' hideClose={true} />
@@ -70,7 +74,7 @@ export const AccountingOverview = ({
             name={classNames(
               'accounting-overview-profit-and-loss-chart',
               pnlToggle !== 'expenses' &&
-              'accounting-overview-profit-and-loss-chart--hidden',
+                'accounting-overview-profit-and-loss-chart--hidden',
             )}
           >
             <ProfitAndLoss.DetailedCharts scope='expenses' hideClose={true} />


### PR DESCRIPTION
## Description

1. Add missing "Bell" icon the pending transactions badge.
2. Enable showing transactions to categorise in onboarding.

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/80660630-2216-4afd-9756-449b46bf26c1)
