### PR TITLE
feat: count only transactions to review from current month

### DIFF
--- a/src/components/Onboarding/ConnectAccount.tsx
+++ b/src/components/Onboarding/ConnectAccount.tsx
@@ -7,6 +7,7 @@ import LinkIcon from '../../icons/Link'
 import PlaidIcon from '../../icons/PlaidIcon'
 import SunriseIcon from '../../icons/Sunrise'
 import { OnboardingStep } from '../../types/layer_context'
+import { countTransactionsToReview } from '../../utils/bankTransactions'
 import { ActionableRow } from '../ActionableRow'
 import { Badge, BadgeVariant } from '../Badge'
 import { BadgeSize } from '../Badge/Badge'
@@ -19,22 +20,21 @@ import { Text } from '../Typography'
 export interface ConnectAccountProps {
   onboardingStep: OnboardingStep
   onTransactionsToReviewClick?: () => void
+  currentMonthOnly?: boolean
 }
 
 export const ConnectAccount = ({
   onboardingStep,
   onTransactionsToReviewClick,
+  currentMonthOnly = true,
 }: ConnectAccountProps) => {
   const { addConnection } = useContext(LinkedAccountsContext)
   const { data, isLoading } = useBankTransactions()
 
-  const transactionsToReview = useMemo(() => {
-    if (data && data.length > 0) {
-      return data.filter(tx => filterVisibility(DisplayState.review, tx)).length
-    }
-
-    return 0
-  }, [data, isLoading])
+  const transactionsToReview = useMemo(
+    () => countTransactionsToReview({ transactions: data, currentMonthOnly }),
+    [data, isLoading],
+  )
 
   if (onboardingStep === 'connectAccount') {
     return (

--- a/src/components/TransactionToReviewCard/TransactionToReviewCard.tsx
+++ b/src/components/TransactionToReviewCard/TransactionToReviewCard.tsx
@@ -6,17 +6,18 @@ import { useBankTransactions } from '../../hooks/useBankTransactions'
 import BellIcon from '../../icons/Bell'
 import CheckIcon from '../../icons/Check'
 import RefreshCcw from '../../icons/RefreshCcw'
+import { countTransactionsToReview } from '../../utils/bankTransactions'
 import { BadgeLoader } from '../BadgeLoader'
-import { DisplayState } from '../BankTransactions/constants'
-import { filterVisibility } from '../BankTransactions/utils'
 import { NotificationCard } from '../NotificationCard'
 
 export interface TransactionToReviewCardProps {
   onClick?: () => void
+  currentMonthOnly?: true
 }
 
 export const TransactionToReviewCard = ({
   onClick,
+  currentMonthOnly = true,
 }: TransactionToReviewCardProps) => {
   const [loaded, setLoaded] = useState('initiated')
   const { data, isLoading, error, refetch } = useBankTransactions()
@@ -37,13 +38,10 @@ export const TransactionToReviewCard = ({
     }
   }, [isLoading])
 
-  const toReview = useMemo(() => {
-    if (data && data.length > 0) {
-      return data.filter(tx => filterVisibility(DisplayState.review, tx)).length
-    }
-
-    return 0
-  }, [data, isLoading])
+  const toReview = useMemo(
+    () => countTransactionsToReview({ transactions: data, currentMonthOnly }),
+    [data, isLoading],
+  )
 
   return (
     <NotificationCard

--- a/src/utils/bankTransactions.ts
+++ b/src/utils/bankTransactions.ts
@@ -1,4 +1,7 @@
+import { DisplayState } from '../components/BankTransactions/constants'
+import { filterVisibility } from '../components/BankTransactions/utils'
 import { BankTransaction, Direction } from '../types'
+import { endOfMonth, isWithinInterval, parseISO, startOfMonth } from 'date-fns'
 
 export const hasMatch = (bankTransaction?: BankTransaction) => {
   return Boolean(
@@ -20,4 +23,35 @@ export const isAlreadyMatched = (bankTransaction?: BankTransaction) => {
   }
 
   return undefined
+}
+
+export const countTransactionsToReview = ({
+  transactions,
+  currentMonthOnly,
+}: {
+  transactions?: BankTransaction[]
+  currentMonthOnly?: boolean
+}) => {
+  if (transactions && transactions.length > 0) {
+    if (currentMonthOnly) {
+      const currentMonth = {
+        start: startOfMonth(new Date()),
+        end: endOfMonth(new Date()),
+      }
+      return transactions.filter(tx => {
+        try {
+          return (
+            filterVisibility(DisplayState.review, tx) &&
+            isWithinInterval(parseISO(tx.date), currentMonth)
+          )
+        } catch (_err) {
+          return false
+        }
+      }).length
+    }
+    return transactions.filter(tx => filterVisibility(DisplayState.review, tx))
+      .length
+  }
+
+  return 0
 }

--- a/src/views/AccountingOverview/AccountingOverview.tsx
+++ b/src/views/AccountingOverview/AccountingOverview.tsx
@@ -26,7 +26,11 @@ export const AccountingOverview = ({
   return (
     <ProfitAndLoss asContainer={false}>
       <View title={title} headerControls={<ProfitAndLoss.DatePicker />}>
-        {enableOnboarding && <Onboarding />}
+        {enableOnboarding && (
+          <Onboarding
+            onTransactionsToReviewClick={onTransactionsToReviewClick}
+          />
+        )}
         <div className='Layer__accounting-overview__summaries-row'>
           <ProfitAndLoss.Summaries actionable={false} />
           <TransactionToReviewCard onClick={onTransactionsToReviewClick} />
@@ -61,7 +65,7 @@ export const AccountingOverview = ({
             name={classNames(
               'accounting-overview-profit-and-loss-chart',
               pnlToggle !== 'revenue' &&
-              'accounting-overview-profit-and-loss-chart--hidden',
+                'accounting-overview-profit-and-loss-chart--hidden',
             )}
           >
             <ProfitAndLoss.DetailedCharts scope='revenue' hideClose={true} />
@@ -70,7 +74,7 @@ export const AccountingOverview = ({
             name={classNames(
               'accounting-overview-profit-and-loss-chart',
               pnlToggle !== 'expenses' &&
-              'accounting-overview-profit-and-loss-chart--hidden',
+                'accounting-overview-profit-and-loss-chart--hidden',
             )}
           >
             <ProfitAndLoss.DetailedCharts scope='expenses' hideClose={true} />


### PR DESCRIPTION
## Description

Use only current month to count number of transactions to review.

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/96e637c2-5b70-463f-b16b-2db052ccf68a)

<br/>
<br/>

7 transactions to review in overall, but only 2 in June:

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/b2886036-66ac-4d1f-a946-39972d2d2ed1)
