### PR TITLE
fix: chart of accounts indentation on mobile

### DIFF
--- a/src/components/ChartOfAccountsRow/ChartOfAccountsRow.tsx
+++ b/src/components/ChartOfAccountsRow/ChartOfAccountsRow.tsx
@@ -24,7 +24,7 @@ type ChartOfAccountsRowProps = {
 }
 
 const INDENTATION = 24
-const MOBILE_INDENTATION = 12
+const MOBILE_INDENTATION = 24
 
 const EXPANDED_STYLE = {
   height: 52,

--- a/src/components/ChartOfAccountsRow/ChartOfAccountsRow.tsx
+++ b/src/components/ChartOfAccountsRow/ChartOfAccountsRow.tsx
@@ -24,7 +24,6 @@ type ChartOfAccountsRowProps = {
 }
 
 const INDENTATION = 24
-const MOBILE_INDENTATION = 24
 
 const EXPANDED_STYLE = {
   height: 52,
@@ -210,7 +209,7 @@ export const ChartOfAccountsRow = ({
             <span
               className='Layer__table-cell-content Layer__table-cell-content-indentation'
               style={{
-                paddingLeft: MOBILE_INDENTATION * depth + 16,
+                paddingLeft: INDENTATION * depth + 16,
                 ...style,
               }}
             >


### PR DESCRIPTION
## Description

Improve indentations in Chart of accounts table on mobile.

## How this has been tested?

Before:

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/04f92395-0b1c-4e66-909c-6dd8c8e0afb4)


<br/>

<br/>

After:

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/8de7d52d-d9ec-425d-b5b5-fb60ddd9aba1)
