### PR TITLE
feat: regular button instead of retry button in mobile bank transactions

### DIFF
--- a/src/components/BankTransactionMobileList/BusinessForm.tsx
+++ b/src/components/BankTransactionMobileList/BusinessForm.tsx
@@ -3,7 +3,7 @@ import { DrawerContext } from '../../contexts/DrawerContext'
 import { useBankTransactions } from '../../hooks/useBankTransactions'
 import { BankTransaction, CategorizationType } from '../../types'
 import { ActionableList } from '../ActionableList'
-import { Button, RetryButton } from '../Button'
+import { Button } from '../Button'
 import { ErrorText } from '../Typography'
 import { BusinessCategories } from './BusinessCategories'
 import { Option, mapCategoryToOption, getAssignedValue } from './utils'
@@ -116,7 +116,7 @@ export const BusinessForm = ({ bankTransaction }: BusinessFormProps) => {
           Select category
         </Button>
       ) : null}
-      {!showRetry && options.length > 0 ? (
+      {options.length > 0 ? (
         <Button
           onClick={save}
           disabled={
@@ -126,21 +126,6 @@ export const BusinessForm = ({ bankTransaction }: BusinessFormProps) => {
         >
           {isLoading || bankTransaction.processing ? 'Saving...' : 'Save'}
         </Button>
-      ) : null}
-      {showRetry && options.length > 0 ? (
-        <RetryButton
-          onClick={() => {
-            if (!bankTransaction.processing) {
-              save()
-            }
-          }}
-          fullWidth={true}
-          className='Layer__bank-transaction__retry-btn'
-          processing={bankTransaction.processing}
-          error={'Approval failed. Check connection and retry in few seconds.'}
-        >
-          Save
-        </RetryButton>
       ) : null}
       {bankTransaction.error && showRetry ? (
         <ErrorText>

--- a/src/components/BankTransactionMobileList/MatchForm.tsx
+++ b/src/components/BankTransactionMobileList/MatchForm.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useBankTransactions } from '../../hooks/useBankTransactions'
 import { BankTransaction } from '../../types'
 import { isAlreadyMatched } from '../../utils/bankTransactions'
-import { Button, RetryButton } from '../Button'
+import { Button } from '../Button'
 import { MatchFormMobile } from '../MatchForm'
 import { ErrorText, Text, TextSize, TextWeight } from '../Typography'
 
@@ -63,38 +63,20 @@ export const MatchForm = ({
           setSelectedMatchId(id)
         }}
       />
-      {!showRetry && (
-        <Button
-          fullWidth={true}
-          disabled={
-            !selectedMatchId ||
-            isLoading ||
-            bankTransaction.processing ||
-            selectedMatchId === isAlreadyMatched(bankTransaction)
-          }
-          onClick={save}
-        >
-          {isLoading || bankTransaction.processing
-            ? 'Saving...'
-            : 'Approve match'}
-        </Button>
-      )}
-      {showRetry ? (
-        <RetryButton
-          onClick={() => {
-            if (!bankTransaction.processing) {
-              save()
-            }
-          }}
-          fullWidth={true}
-          className='Layer__bank-transaction__retry-btn'
-          processing={bankTransaction.processing}
-          error={'Approval failed. Check connection and retry in few seconds.'}
-        >
-          Approve match
-        </RetryButton>
-      ) : null}
-
+      <Button
+        fullWidth={true}
+        disabled={
+          !selectedMatchId ||
+          isLoading ||
+          bankTransaction.processing ||
+          selectedMatchId === isAlreadyMatched(bankTransaction)
+        }
+        onClick={save}
+      >
+        {isLoading || bankTransaction.processing
+          ? 'Saving...'
+          : 'Approve match'}
+      </Button>
       {formError && <ErrorText>{formError}</ErrorText>}
       {bankTransaction.error && showRetry ? (
         <ErrorText>

--- a/src/components/BankTransactionMobileList/PersonalForm.tsx
+++ b/src/components/BankTransactionMobileList/PersonalForm.tsx
@@ -2,9 +2,8 @@ import React, { useEffect, useState } from 'react'
 import { useBankTransactions } from '../../hooks/useBankTransactions'
 import { BankTransaction, CategorizationStatus } from '../../types'
 import { isCredit } from '../../utils/bankTransactions'
-import { Button, RetryButton } from '../Button'
+import { Button } from '../Button'
 import { ErrorText } from '../Typography'
-import { Purpose } from './BankTransactionMobileListItem'
 import { PersonalCategories } from './constants'
 
 interface PersonalFormProps {
@@ -56,34 +55,17 @@ export const PersonalForm = ({ bankTransaction }: PersonalFormProps) => {
 
   return (
     <div className='Layer__bank-transaction-mobile-list-item__personal-form'>
-      {!showRetry && (
-        <Button
-          fullWidth={true}
-          disabled={alreadyAssigned || isLoading || bankTransaction.processing}
-          onClick={save}
-        >
-          {isLoading || bankTransaction.processing
-            ? 'Saving...'
-            : alreadyAssigned
-            ? 'Saved as Personal'
-            : 'Categorize as Personal'}
-        </Button>
-      )}
-      {showRetry ? (
-        <RetryButton
-          onClick={() => {
-            if (!bankTransaction.processing) {
-              save()
-            }
-          }}
-          fullWidth={true}
-          className='Layer__bank-transaction__retry-btn'
-          processing={bankTransaction.processing}
-          error={'Approval failed. Check connection and retry in few seconds.'}
-        >
-          Categorize as Personal
-        </RetryButton>
-      ) : null}
+      <Button
+        fullWidth={true}
+        disabled={alreadyAssigned || isLoading || bankTransaction.processing}
+        onClick={save}
+      >
+        {isLoading || bankTransaction.processing
+          ? 'Saving...'
+          : alreadyAssigned
+          ? 'Saved as Personal'
+          : 'Categorize as Personal'}
+      </Button>
       {bankTransaction.error && showRetry ? (
         <ErrorText>
           Approval failed. Check connection and retry in few seconds.

--- a/src/components/BankTransactionMobileList/SplitForm.tsx
+++ b/src/components/BankTransactionMobileList/SplitForm.tsx
@@ -12,7 +12,7 @@ import {
   hasSuggestions,
 } from '../../types/categories'
 import { getCategorizePayload } from '../../utils/bankTransactions'
-import { Button, ButtonVariant, RetryButton, TextButton } from '../Button'
+import { Button, ButtonVariant, TextButton } from '../Button'
 import { CategorySelect } from '../CategorySelect'
 import {
   CategoryOption,
@@ -252,30 +252,13 @@ export const SplitForm = ({
           Add new split
         </TextButton>
       </div>
-      {!showRetry && (
-        <Button
-          fullWidth={true}
-          onClick={save}
-          disabled={isLoading || bankTransaction.processing}
-        >
-          {isLoading || bankTransaction.processing ? 'Saving...' : 'Save'}
-        </Button>
-      )}
-      {showRetry ? (
-        <RetryButton
-          onClick={() => {
-            if (!bankTransaction.processing) {
-              save()
-            }
-          }}
-          fullWidth={true}
-          className='Layer__bank-transaction__retry-btn'
-          processing={bankTransaction.processing}
-          error={'Approval failed. Check connection and retry in few seconds.'}
-        >
-          Save
-        </RetryButton>
-      ) : null}
+      <Button
+        fullWidth={true}
+        onClick={save}
+        disabled={isLoading || bankTransaction.processing}
+      >
+        {isLoading || bankTransaction.processing ? 'Saving...' : 'Save'}
+      </Button>
       {formError && <ErrorText>{formError}</ErrorText>}
       {bankTransaction.error && showRetry ? (
         <ErrorText>


### PR DESCRIPTION
## Description

Use regular button instead of Retry button, because it looks more logical and natural when combined with the error message displayed below the button.

## How this has been tested?

<img width="560" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/fe028b96-525c-43b2-961c-822a30e2b9df">

<img width="560" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/f8eb18be-35a7-4d71-87f3-6b6047a7cf83">

<img width="560" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/02896286-e969-42a1-8311-b0072409cd47">

