### PR TITLE
fix: open numeric keyboard on mobile for amount inputs

### DIFF
--- a/src/components/BankTransactionMobileList/SplitForm.tsx
+++ b/src/components/BankTransactionMobileList/SplitForm.tsx
@@ -232,6 +232,7 @@ export const SplitForm = ({
               onBlur={onBlur}
               isInvalid={split.amount < 0}
               errorMessage='Negative values are not allowed'
+              inputMode='numeric'
             />
             {index > 0 && (
               <Button

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -419,6 +419,7 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
                             value={split.inputValue}
                             onBlur={onBlur}
                             isInvalid={split.amount < 0}
+                            inputMode='numeric'
                             errorMessage='Negative values are not allowed'
                           />
                           <div
@@ -452,6 +453,7 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
                         <Input
                           disabled={true}
                           leftText='Total'
+                          inputMode='numeric'
                           value={`$${formatMoney(
                             rowState.splits.reduce(
                               (x, { amount }) => x + amount,


### PR DESCRIPTION
## Description 

Open numeric keyboard on mobile devices when user edits amount inputs.

## How this has been tested?

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/b79bf8e6-1e06-4c8c-af8f-b530d50012b2)

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/2b668bff-d97b-49c6-9ce9-e55810d4d1c9)

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/630360b0-87f2-4022-811e-607680fd9b3f)

![image](https://github.com/Layer-Fi/layer-react/assets/11715931/d23cf0cf-f6cf-4f1e-807e-1d21b392af8c)
