### PR TITLE
feat: drawer for tablets

### DIFF
--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,5 +1,6 @@
-import React, { useContext } from 'react'
+import React, { RefObject, useContext, useRef } from 'react'
 import { DrawerContext } from '../../contexts/DrawerContext'
+import { useElementSize } from '../../hooks/useElementSize'
 
 const DrawerBackground = ({
   isOpen,

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,17 +1,54 @@
-import React from 'react';
+import React, { useContext } from 'react'
+import { DrawerContext } from '../../contexts/DrawerContext'
 
-const DrawerBackground = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => (
-  <div className={`Layer__drawer-background ${isOpen ? 'open' : ''}`} onClick={onClose}></div>
-);
+const DrawerBackground = ({
+  isOpen,
+  isClosing,
+  onClose,
+}: {
+  isOpen: boolean
+  isClosing: boolean
+  onClose: () => void
+}) => (
+  <div
+    className={`Layer__drawer-background ${isClosing ? 'closing' : ''} ${
+      isOpen ? 'open' : ''
+    }`}
+    onClick={onClose}
+  ></div>
+)
 
-export const Drawer = ({ isOpen, onClose, children }: { isOpen: boolean; onClose: () => void; children: React.ReactNode }) => {
+export const Drawer = ({
+  isOpen,
+  onClose,
+  children,
+}: {
+  isOpen: boolean
+  onClose: () => void
+  children: React.ReactNode
+}) => {
+  const { isClosing, finishClosing } = useContext(DrawerContext)
+
   return (
     <>
-      <DrawerBackground isOpen={isOpen} onClose={onClose} />
-      <div className={`Layer__drawer ${isOpen ? 'open' : ''}`} onClick={(e) => e.stopPropagation()}>
+      <DrawerBackground
+        isOpen={isOpen}
+        onClose={onClose}
+        isClosing={isClosing}
+      />
+      <div
+        className={`Layer__drawer ${isClosing ? 'closing' : ''} ${
+          isOpen ? 'open' : ''
+        }`}
+        onTransitionEnd={({ propertyName }) => {
+          if (propertyName === 'bottom' && isClosing) {
+            finishClosing()
+          }
+        }}
+        onClick={e => e.stopPropagation()}
+      >
         {children}
       </div>
     </>
-  );
-};
-
+  )
+}

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,6 +1,5 @@
-import React, { RefObject, useContext, useRef } from 'react'
+import React, { useContext } from 'react'
 import { DrawerContext } from '../../contexts/DrawerContext'
-import { useElementSize } from '../../hooks/useElementSize'
 
 const DrawerBackground = ({
   isOpen,

--- a/src/contexts/DrawerContext/DrawerContext.tsx
+++ b/src/contexts/DrawerContext/DrawerContext.tsx
@@ -6,4 +6,6 @@ export const DrawerContext = createContext<DrawerContextType>({
   content: undefined,
   setContent: () => undefined,
   close: () => undefined,
+  isClosing: false,
+  finishClosing: () => undefined,
 })

--- a/src/hooks/useDrawer/useDrawer.tsx
+++ b/src/hooks/useDrawer/useDrawer.tsx
@@ -3,17 +3,29 @@ import React, { ReactNode, useState } from 'react'
 type UseDrawer = () => {
   content?: ReactNode
   setContent: (content: ReactNode) => void
+  finishClosing: () => void
+  isClosing: boolean
   close: () => void
 }
 
 export const useDrawer: UseDrawer = () => {
   const [content, setContent] = useState<ReactNode>(undefined)
+  const [isClosing, setIsClosing] = useState(false)
 
-  const close = () => setContent(undefined)
+  const close = () => {
+    setIsClosing(true)
+  }
+
+  const finishClosing = () => {
+    setContent(undefined)
+    setIsClosing(false)
+  }
 
   return {
     content,
     setContent,
+    finishClosing,
+    isClosing,
     close,
   }
 }

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -22,6 +22,8 @@
 
 .Layer__bank-transactions__header.Layer__bank-transactions__header--mobile {
   background-color: transparent;
+  max-width: 414px;
+  margin: auto;
 }
 
 .Layer__bank-transactions__header.Layer__bank-transactions__header--mobile,

--- a/src/styles/bank_transactions_mobile_list.scss
+++ b/src/styles/bank_transactions_mobile_list.scss
@@ -223,3 +223,7 @@
   padding-bottom: var(--spacing-lg);
   font-size: 18px;
 }
+
+.Layer__bank-transaction-mobile-list-item__categories_list-container {
+  width: 100%;
+}

--- a/src/styles/bank_transactions_mobile_list.scss
+++ b/src/styles/bank_transactions_mobile_list.scss
@@ -6,6 +6,8 @@
   gap: var(--spacing-sm);
   list-style: none;
   overflow: hidden;
+  max-width: 414px;
+  margin: auto;
 }
 
 .Layer__bank-transaction-mobile-list-item {

--- a/src/styles/date_month_picker.scss
+++ b/src/styles/date_month_picker.scss
@@ -9,7 +9,7 @@
   }
 }
 
-@media screen and (min-width: 760px) {
+@container (min-width: 760px) {
   .Layer__date-month-picker__wrapper {
     &.Layer__date-month-picker__wrapper--current-date-option {
       .Layer__date-month-picker {
@@ -99,7 +99,7 @@
   z-index: 2;
 }
 
-@media screen and (max-width: 760px) {
+@container (max-width: 760px) {
   .Layer__date-month-picker__wrapper {
     .Layer__date-month-picker {
       border: none;

--- a/src/styles/drawer.scss
+++ b/src/styles/drawer.scss
@@ -24,6 +24,7 @@
 
 .Layer__drawer {
   position: fixed;
+  display: flex;
   bottom: -100%;
   left: 0;
   right: 0;
@@ -32,9 +33,13 @@
   width: 100%;
   max-height: 80%;
   overflow-y: auto;
-  padding: var(--spacing-xl) 28px 28px 28px;
+  padding: 0 14px;
   border-radius: var(--spacing-md) var(--spacing-md) 0px 0px;
   transition: bottom 0.2s ease-in-out;
+  border: 28px solid var(--color-base-0);
+  border-left: 14px solid var(--color-base-0);
+  border-right: 14px solid var(--color-base-0);
+  box-sizing: border-box;
 
   &::after {
     position: absolute;
@@ -44,11 +49,25 @@
     background-color: var(--color-base-50);
     left: 50%;
     transform: translateX(-50%);
-    top: 16px;
+    top: 0px;
     border-radius: 80px;
   }
 
   &.open:not(.closing) {
     bottom: 0;
+  }
+}
+
+@media (min-width: 414px) {
+  .Layer__drawer {
+    max-height: calc(82% - 32px);
+    max-width: 414px;
+    margin-left: auto;
+    margin-right: auto;
+    border-radius: var(--spacing-md);
+
+    &.open:not(.closing) {
+      bottom: 32px;
+    }
   }
 }

--- a/src/styles/drawer.scss
+++ b/src/styles/drawer.scss
@@ -5,8 +5,15 @@
   left: 0;
   right: 0;
   bottom: 0;
+  opacity: 0;
   z-index: 1000;
-  transition: background 0.3s ease-in-out;
+  transition:
+    background 0.2s ease-in-out,
+    opacity 0.2s ease-in-out;
+
+  &.open.closing {
+    opacity: 0;
+  }
 
   &.open {
     display: block;
@@ -41,7 +48,7 @@
     border-radius: 80px;
   }
 
-  &.open {
+  &.open:not(.closing) {
     bottom: 0;
   }
 }


### PR DESCRIPTION
## Description

1. Adjust sizing of drawer for "tablets"
2. improve drawer's closing animation
3. limit the width of mobile bank transactions list

## How this has been tested?

<img width="521" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/fdcc3b18-9c11-49ee-bc74-2d3302f7aa04">

<img width="521" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/da6e8f67-a911-40f0-8861-2d7064b38090">

<img width="378" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/92e2aac4-5139-43b5-a257-94e1722d9c84">

