### PR TITLE
feat: drawer for mobile splits

### DIFF
--- a/src/components/BankTransactionMobileList/SplitForm.tsx
+++ b/src/components/BankTransactionMobileList/SplitForm.tsx
@@ -62,12 +62,16 @@ export const SplitForm = ({
           {
             amount: bankTransaction.amount,
             inputValue: formatMoney(bankTransaction.amount),
-            category: mapCategoryToOption(defaultCategory),
+            category: defaultCategory
+              ? mapCategoryToOption(defaultCategory)
+              : undefined,
           },
           {
             amount: 0,
             inputValue: '0.00',
-            category: mapCategoryToOption(defaultCategory),
+            category: defaultCategory
+              ? mapCategoryToOption(defaultCategory)
+              : undefined,
           },
         ],
     description: '',
@@ -140,7 +144,9 @@ export const SplitForm = ({
         {
           amount: 0,
           inputValue: '0.00',
-          category: mapCategoryToOption(defaultCategory),
+          category: defaultCategory
+            ? mapCategoryToOption(defaultCategory)
+            : undefined,
         },
       ],
     })
@@ -217,6 +223,7 @@ export const SplitForm = ({
                 className='Layer__category-menu--full'
                 disabled={bankTransaction.processing}
                 excludeMatches
+                asDrawer
               />
             </div>
             <Input

--- a/src/components/CategorySelect/CategorySelect.tsx
+++ b/src/components/CategorySelect/CategorySelect.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import Select, {
   DropdownIndicatorProps,
   GroupHeadingProps,
@@ -17,6 +17,7 @@ import { SuggestedMatch } from '../../types/bank_transactions'
 import { CategoryEntry } from '../../types/categories'
 import { Badge } from '../Badge'
 import { BadgeSize } from '../Badge/Badge'
+import { CategorySelectDrawer } from './CategorySelectDrawer'
 import classNames from 'classnames'
 import { parseISO, format as formatTime } from 'date-fns'
 
@@ -28,6 +29,7 @@ type Props = {
   disabled?: boolean
   className?: string
   excludeMatches?: boolean
+  asDrawer?: boolean
 }
 
 export enum OptionActionType {
@@ -207,6 +209,7 @@ export const CategorySelect = ({
   disabled,
   className,
   excludeMatches = false,
+  asDrawer = false,
 }: Props) => {
   const { categories } = useLayerContext()
 
@@ -255,17 +258,20 @@ export const CategorySelect = ({
 
   const selected = value
     ? value
-    : matchOptions?.length === 1 && matchOptions[0].options.length === 1
+    : !excludeMatches &&
+      matchOptions?.length === 1 &&
+      matchOptions[0].options.length === 1
     ? matchOptions[0].options[0]
     : undefined
-
-  // @TODO ^ do this same for suggested options so user can just click approve
-  // However... parent component may handle this already - need some test data from API to verify
 
   const placeholder =
     matchOptions?.length === 1 && matchOptions[0].options.length > 1
       ? `${matchOptions[0].options.length} possible matches...`
       : 'Categorize or match...'
+
+  if (asDrawer) {
+    return <CategorySelectDrawer onSelect={onChange} selected={value} />
+  }
 
   // The menu does not show in all cases unless the
   // menuPortalTarget and styles lines exist

--- a/src/components/CategorySelect/CategorySelect.tsx
+++ b/src/components/CategorySelect/CategorySelect.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import Select, {
   DropdownIndicatorProps,
   GroupHeadingProps,

--- a/src/components/CategorySelect/CategorySelectDrawer.tsx
+++ b/src/components/CategorySelect/CategorySelectDrawer.tsx
@@ -47,18 +47,16 @@ const CategorySelectDrawerContent = ({
   onSelect,
 }: {
   onSelect: (value: CategoryOption) => void
-}) => {
-  return (
-    <BusinessCategories
-      select={option => {
-        option.value.payload &&
-          onSelect({
-            type: OptionActionType.CATEGORY,
-            payload: {
-              ...option.value.payload,
-            },
-          } satisfies CategoryOption)
-      }}
-    />
-  )
-}
+}) => (
+  <BusinessCategories
+    select={option => {
+      option.value.payload &&
+        onSelect({
+          type: OptionActionType.CATEGORY,
+          payload: {
+            ...option.value.payload,
+          },
+        } satisfies CategoryOption)
+    }}
+  />
+)

--- a/src/components/CategorySelect/CategorySelectDrawer.tsx
+++ b/src/components/CategorySelect/CategorySelectDrawer.tsx
@@ -1,0 +1,64 @@
+import React, { useContext } from 'react'
+import { DrawerContext } from '../../contexts/DrawerContext'
+import ChevronDown from '../../icons/ChevronDown'
+import { BusinessCategories } from '../BankTransactionMobileList/BusinessCategories'
+import { CategoryOption, OptionActionType } from './CategorySelect'
+import classNames from 'classnames'
+
+interface CategorySelectDrawerProps {
+  onSelect: (value: CategoryOption) => void
+  selected?: CategoryOption
+}
+
+export const CategorySelectDrawer = ({
+  onSelect,
+  selected,
+}: CategorySelectDrawerProps) => {
+  const { setContent, close } = useContext(DrawerContext)
+
+  const onDrawerCategorySelect = (value: CategoryOption) => {
+    close()
+    onSelect(value)
+  }
+
+  return (
+    <button
+      aria-label='Select category'
+      className={classNames(
+        'Layer__category-menu__drawer-btn',
+        selected && 'Layer__category-menu__drawer-btn--selected',
+      )}
+      onClick={() =>
+        setContent(
+          <CategorySelectDrawerContent onSelect={onDrawerCategorySelect} />,
+        )
+      }
+    >
+      {selected?.payload?.display_name ?? 'Select...'}
+      <ChevronDown
+        size={16}
+        className='Layer__category-menu__drawer-btn__arrow'
+      />
+    </button>
+  )
+}
+
+const CategorySelectDrawerContent = ({
+  onSelect,
+}: {
+  onSelect: (value: CategoryOption) => void
+}) => {
+  return (
+    <BusinessCategories
+      select={option => {
+        option.value.payload &&
+          onSelect({
+            type: OptionActionType.CATEGORY,
+            payload: {
+              ...option.value.payload,
+            },
+          } satisfies CategoryOption)
+      }}
+    />
+  )
+}

--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -514,6 +514,45 @@
   flex: 1;
 }
 
+.Layer__category-menu__drawer-btn {
+  display: flex;
+  flex: 1;
+  width: 100%;
+  color: var(--color-base-500);
+  padding: 8px;
+  box-sizing: border-box;
+  position: relative;
+  border: 1px solid var(--border-color);
+  border-radius: var(--input-border-radius);
+  border-width: 0px;
+  box-shadow:
+    0px 0px 0px 1px var(--input-border-color),
+    0px 0px 0px 2px rgba(0, 0, 0, 0);
+  margin: 1px;
+  font-family: var(--font-family);
+  font-size: var(--input-font-size);
+  line-height: 140%;
+  background-color: var(--color-base-0);
+  min-height: 39px;
+  align-items: center;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--text-color-primary);
+    background-color: var(--color-base-50);
+  }
+
+  &.Layer__category-menu__drawer-btn--selected {
+    color: var(--text-color-primary);
+  }
+
+  & .Layer__category-menu__drawer-btn__arrow {
+    position: absolute;
+    right: 12px;
+    top: 12px;
+  }
+}
+
 @media screen and (max-width: 400px) {
   .Layer__select__menu-portal .Layer__select__option {
     font-size: var(--text-sm) !important;


### PR DESCRIPTION
## Description

Use drawer to select split's category in the Split form.

## How this has been tested?

<img width="596" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/bef23b9c-9d69-4da0-9801-e56d9cd096b2">

<img width="596" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/aa164987-687b-4c08-88f4-90c1fbaa6b5f">
