### PR TITLE
fix: loading state in transactions to review after return

### DIFF
--- a/src/components/TransactionToReviewCard/TransactionToReviewCard.tsx
+++ b/src/components/TransactionToReviewCard/TransactionToReviewCard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { Badge } from '../../components/Badge'
 import { BadgeSize, BadgeVariant } from '../../components/Badge/Badge'
 import { Text, TextSize } from '../../components/Typography'
-import { useBankTransactions } from '../../hooks/useBankTransactions'
+import { useBankTransactionsContext } from '../../contexts/BankTransactionsContext'
 import BellIcon from '../../icons/Bell'
 import CheckIcon from '../../icons/Check'
 import RefreshCcw from '../../icons/RefreshCcw'
@@ -19,34 +19,18 @@ export const TransactionToReviewCard = ({
   onClick,
   currentMonthOnly = true,
 }: TransactionToReviewCardProps) => {
-  const [loaded, setLoaded] = useState('initiated')
   const {
     data,
     isLoading,
+    loadingStatus,
     error,
     refetch,
     activate: activateBankTransactions,
-  } = useBankTransactions()
+  } = useBankTransactionsContext()
 
   useEffect(() => {
     activateBankTransactions()
   }, [])
-
-  useEffect(() => {
-    if (!isLoading && data && data?.length > 0) {
-      setLoaded('complete')
-      return
-    }
-    if (isLoading && loaded === 'initiated') {
-      setLoaded('loading')
-      return
-    }
-
-    if (!isLoading && loaded !== 'initiated') {
-      setLoaded('complete')
-      return
-    }
-  }, [isLoading])
 
   const toReview = useMemo(
     () => countTransactionsToReview({ transactions: data, currentMonthOnly }),
@@ -59,23 +43,22 @@ export const TransactionToReviewCard = ({
       onClick={() => onClick && onClick()}
     >
       <Text size={TextSize.sm}>Transactions to review</Text>
-      {loaded === 'initiated' || loaded === 'loading' ? <BadgeLoader /> : null}
+      {loadingStatus === 'initial' || loadingStatus === 'loading' ? (
+        <BadgeLoader />
+      ) : null}
 
-      {loaded === 'complete' && error ? (
+      {loadingStatus === 'complete' && error ? (
         <Badge
           variant={BadgeVariant.ERROR}
           size={BadgeSize.SMALL}
           icon={<RefreshCcw size={12} />}
-          onClick={() => {
-            setLoaded('loading')
-            refetch()
-          }}
+          onClick={() => refetch()}
         >
           Refresh
         </Badge>
       ) : null}
 
-      {loaded === 'complete' && !error && toReview > 0 ? (
+      {loadingStatus === 'complete' && !error && toReview > 0 ? (
         <Badge
           variant={BadgeVariant.WARNING}
           size={BadgeSize.SMALL}
@@ -85,7 +68,7 @@ export const TransactionToReviewCard = ({
         </Badge>
       ) : null}
 
-      {loaded === 'complete' && !error && toReview === 0 ? (
+      {loadingStatus === 'complete' && !error && toReview === 0 ? (
         <Badge
           variant={BadgeVariant.SUCCESS}
           size={BadgeSize.SMALL}


### PR DESCRIPTION
## Description

Fix loading state of "Transactions to Review" card when user goes back to the view.

## How this has been tested?


https://github.com/Layer-Fi/layer-react/assets/11715931/d87000d7-fc36-4db1-838b-77f064cc115d

