### PR TITLE
Daniel/lay 778 ship balance sheet in demo

### DIFF
--- a/src/components/BalanceSheet/BalanceSheet.tsx
+++ b/src/components/BalanceSheet/BalanceSheet.tsx
@@ -1,47 +1,54 @@
-import React, { useState } from 'react'
+import React, { PropsWithChildren, useState } from 'react'
 import { BalanceSheetContext } from '../../contexts/BalanceSheetContext'
 import { TableExpandProvider } from '../../contexts/TableExpandContext'
 import { useBalanceSheet } from '../../hooks/useBalanceSheet'
-import { BalanceSheetHeader } from '../BalanceSheetHeader'
+import { BalanceSheetDatePicker } from '../BalanceSheetDatePicker'
+import { BalanceSheetExpandAllButton } from '../BalanceSheetExpandAllButton'
 import { BalanceSheetTable } from '../BalanceSheetTable'
-import { Container } from '../Container'
 import { Loader } from '../Loader'
+import { PanelView } from '../PanelView'
 import { BALANCE_SHEET_ROWS } from './constants'
 import { startOfDay } from 'date-fns'
 
-export interface BalanceSheetProps {
-  withTitle?: boolean
-  effectiveDate?: Date
+export type BalanceSheetViewProps = PropsWithChildren & {
   withExpandAllButton?: boolean
+}
+
+export type BalanceSheetProps = PropsWithChildren & {
+  effectiveDate: Date
 }
 
 const COMPONENT_NAME = 'balance-sheet'
 
-export const BalanceSheet = (props: BalanceSheetProps) => {
+const BalanceSheet = (props: BalanceSheetProps) => {
   const balanceSheetContextData = useBalanceSheet(props.effectiveDate)
   return (
     <BalanceSheetContext.Provider value={balanceSheetContextData}>
-      <BalanceSheetContent {...props} />
+      {props.children}
     </BalanceSheetContext.Provider>
   )
 }
 
-export const BalanceSheetContent = ({
+const BalanceSheetView = ({
   withExpandAllButton = true,
-  withTitle = true,
-}: BalanceSheetProps) => {
+}: BalanceSheetViewProps) => {
   const [effectiveDate, setEffectiveDate] = useState(startOfDay(new Date()))
   const { data, isLoading } = useBalanceSheet(effectiveDate)
 
   return (
     <TableExpandProvider>
-      <Container name='balance-sheet'>
-        <BalanceSheetHeader
-          effectiveDate={effectiveDate}
-          setEffectiveDate={setEffectiveDate}
-          withExpandAllButton={withExpandAllButton}
-          withTitle={withTitle}
-        />
+      <PanelView
+        title='Balance Sheet'
+        headerControls={
+          <>
+            <BalanceSheetDatePicker
+              effectiveDate={effectiveDate}
+              setEffectiveDate={setEffectiveDate}
+            />
+            {withExpandAllButton && <BalanceSheetExpandAllButton />}
+          </>
+        }
+      >
         {!data || isLoading ? (
           <div className={`Layer__${COMPONENT_NAME}__loader-container`}>
             <Loader />
@@ -51,7 +58,10 @@ export const BalanceSheetContent = ({
             <BalanceSheetTable data={data} config={BALANCE_SHEET_ROWS} />
           </>
         )}
-      </Container>
+      </PanelView>
     </TableExpandProvider>
   )
 }
+
+BalanceSheet.View = BalanceSheetView
+export { BalanceSheet }

--- a/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
+++ b/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { DateDayPicker } from '../DateDayPicker'
+
+export type BalanceSheetDatePickerProps = {
+  effectiveDate: Date
+  setEffectiveDate: (date: Date) => void
+}
+
+export const BalanceSheetDatePicker = ({
+  effectiveDate,
+  setEffectiveDate,
+}: BalanceSheetDatePickerProps) => {
+  return (
+    <DateDayPicker
+      dateDay={effectiveDate}
+      changeDateDay={date => setEffectiveDate(date)}
+    />
+  )
+}

--- a/src/components/BalanceSheetDatePicker/index.tsx
+++ b/src/components/BalanceSheetDatePicker/index.tsx
@@ -1,0 +1,1 @@
+export { BalanceSheetDatePicker } from './BalanceSheetDatePicker'

--- a/src/components/BalanceSheetExpandAllButton/BalanceSheetExpandAllButton.tsx
+++ b/src/components/BalanceSheetExpandAllButton/BalanceSheetExpandAllButton.tsx
@@ -1,0 +1,13 @@
+import React, { useContext } from 'react'
+import { TableExpandContext } from '../../contexts/TableExpandContext'
+import { Button, ButtonVariant } from '../Button'
+
+export const BalanceSheetExpandAllButton = () => {
+  const { tableExpandState, toggleTableExpandState } =
+    useContext(TableExpandContext)
+  return (
+    <Button onClick={toggleTableExpandState} variant={ButtonVariant.secondary}>
+      {!tableExpandState ? 'Expand all rows' : 'Collapse all rows'}
+    </Button>
+  )
+}

--- a/src/components/BalanceSheetExpandAllButton/index.tsx
+++ b/src/components/BalanceSheetExpandAllButton/index.tsx
@@ -1,0 +1,1 @@
+export { BalanceSheetExpandAllButton } from './BalanceSheetExpandAllButton'

--- a/src/components/BalanceSheetHeader/BalanceSheetHeader.tsx
+++ b/src/components/BalanceSheetHeader/BalanceSheetHeader.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react'
 import { TableExpandContext } from '../../contexts/TableExpandContext'
-import DownloadCloud from '../../icons/DownloadCloud'
 import { Button, ButtonVariant } from '../Button'
 import { DateDayPicker } from '../DateDayPicker'
 import classNames from 'classnames'
@@ -41,6 +40,7 @@ export const BalanceSheetHeader = ({
             </Button>
           )}
         </div>
+        {/* Re-enable when we have balance sheet downloading available */}
         {/* <Button
           variant={ButtonVariant.secondary}
           rightIcon={<DownloadCloud size={12} />}

--- a/src/components/BalanceSheetHeader/BalanceSheetHeader.tsx
+++ b/src/components/BalanceSheetHeader/BalanceSheetHeader.tsx
@@ -41,12 +41,12 @@ export const BalanceSheetHeader = ({
             </Button>
           )}
         </div>
-        <Button
+        {/* <Button
           variant={ButtonVariant.secondary}
           rightIcon={<DownloadCloud size={12} />}
         >
           Download
-        </Button>
+        </Button> */}
       </div>
     </div>
   )

--- a/src/components/BalanceSheetRow/BalanceSheetRow.tsx
+++ b/src/components/BalanceSheetRow/BalanceSheetRow.tsx
@@ -25,7 +25,7 @@ export const BalanceSheetRow = ({
   }
 
   const { value, display_name, line_items } = lineItem
-  const { isOpen, setIsOpen } = useTableExpandRow(0, depth < 2)
+  const { isOpen, setIsOpen } = useTableExpandRow(0, false)
   const amount = value || 0
   const isPositive = amount >= 0
   const amountString = centsToDollars(Math.abs(amount))

--- a/src/components/BalanceSheetRow/BalanceSheetRow.tsx
+++ b/src/components/BalanceSheetRow/BalanceSheetRow.tsx
@@ -25,7 +25,7 @@ export const BalanceSheetRow = ({
   }
 
   const { value, display_name, line_items } = lineItem
-  const { isOpen, setIsOpen } = useTableExpandRow(0, false)
+  const { isOpen, setIsOpen } = useTableExpandRow(0, depth < 2)
   const amount = value || 0
   const isPositive = amount >= 0
   const amountString = centsToDollars(Math.abs(amount))

--- a/src/components/BalanceSheetTable/BalanceSheetTable.tsx
+++ b/src/components/BalanceSheetTable/BalanceSheetTable.tsx
@@ -31,7 +31,7 @@ export const BalanceSheetTable = ({
             <BalanceSheetRow
               key={'balance-sheet-row-' + idx + row.name}
               lineItem={data[row.lineItem as keyof BalanceSheet] as LineItem}
-              summarize={false}
+              summarize={true}
             />
           )
         })}

--- a/src/components/PanelView/PanelView.tsx
+++ b/src/components/PanelView/PanelView.tsx
@@ -1,0 +1,26 @@
+import React, { ReactNode } from 'react'
+import { useLayerContext } from '../../contexts/LayerContext'
+import { parseStylesFromThemeConfig } from '../../utils/colors'
+import { PanelViewHeader } from '../PanelViewHeader/PanelViewHeader'
+
+export interface PanelViewProps {
+  children: ReactNode
+  title?: string
+  headerControls?: ReactNode
+}
+
+export const PanelView = ({
+  title,
+  children,
+  headerControls,
+}: PanelViewProps) => {
+  const { theme } = useLayerContext()
+  const styles = parseStylesFromThemeConfig(theme)
+
+  return (
+    <div className='Layer__panel_view' style={{ ...styles }}>
+      <PanelViewHeader title={title} controls={headerControls} />
+      <div className='Layer__panel_view-main'>{children}</div>
+    </div>
+  )
+}

--- a/src/components/PanelView/index.tsx
+++ b/src/components/PanelView/index.tsx
@@ -1,0 +1,1 @@
+export { PanelView } from './PanelView'

--- a/src/components/PanelViewHeader/PanelViewHeader.tsx
+++ b/src/components/PanelViewHeader/PanelViewHeader.tsx
@@ -1,0 +1,20 @@
+import React, { ReactNode } from 'react'
+import { Heading } from '../Typography'
+
+export interface PanelViewHeaderProps {
+  title?: string
+  controls?: ReactNode
+}
+
+export const PanelViewHeader = ({ title, controls }: PanelViewHeaderProps) => {
+  return (
+    <div className='Layer__panel_view-header'>
+      <div className='Layer__panel_view-header__content'>
+        <Heading>{title}</Heading>
+        {controls && (
+          <div className='Layer__panel_view-header__controls'>{controls}</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/PanelViewHeader/index.tsx
+++ b/src/components/PanelViewHeader/index.tsx
@@ -1,0 +1,1 @@
+export { PanelViewHeader } from './PanelViewHeader'

--- a/src/contexts/TableExpandContext/TableExpandContext.tsx
+++ b/src/contexts/TableExpandContext/TableExpandContext.tsx
@@ -20,7 +20,7 @@ interface TableExpandProviderProps {
 export const TableExpandProvider: React.FC<TableExpandProviderProps> = ({
   children,
 }) => {
-  const [tableExpandState, setTableExpandState] = useState(false)
+  const [tableExpandState, setTableExpandState] = useState(true)
 
   const toggleTableExpandState = () => {
     setTableExpandState(prevState => !prevState)

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -21,6 +21,7 @@
 @import './typography.scss';
 @import './utils.scss';
 @import './view.scss';
+@import './panel_view.scss';
 
 @import './ledger_account.scss';
 @import './balance_sheet.scss';

--- a/src/styles/panel_view.scss
+++ b/src/styles/panel_view.scss
@@ -1,6 +1,5 @@
 
 .Layer__panel_view-main {
-  //padding: var(--spacing-md) var(--spacing-lg);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);

--- a/src/styles/panel_view.scss
+++ b/src/styles/panel_view.scss
@@ -1,0 +1,42 @@
+
+.Layer__panel_view-main {
+  //padding: var(--spacing-md) var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  container-type: inline-size;
+}
+
+.Layer__panel_view-header {
+  display: flex;
+  width: 100%;
+  border-bottom: 1px solid var(--color-base-200);
+  container-type: inline-size;
+}
+
+.Layer__panel_view-header__content {
+  padding: var(--spacing-lg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 1406px;
+}
+
+.Layer__panel_view-header__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+@container (max-width: 760px) {
+  .Layer__panel_view-header__content {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-sm);
+
+    .Layer__heading {
+      align-self: flex-start;
+    }
+  }
+}

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -4,11 +4,13 @@ import { BalanceSheet } from '../../components/BalanceSheet'
 import { Button, ButtonVariant, RetryButton } from '../../components/Button'
 import { Container } from '../../components/Container'
 import { Panel } from '../../components/Panel'
+import { PanelView } from '../../components/PanelView'
 import { ProfitAndLoss } from '../../components/ProfitAndLoss'
 import { Toggle } from '../../components/Toggle'
 import { View } from '../../components/View'
 import { useLayerContext } from '../../contexts/LayerContext'
 import DownloadCloud from '../../icons/DownloadCloud'
+import { startOfDay } from 'date-fns'
 
 export interface ReportsProps {
   title?: string
@@ -77,27 +79,25 @@ export const Reports = ({ title = 'Reports' }: ReportsProps) => {
   const [activeTab, setActiveTab] = useState<ReportType>('profitAndLoss')
 
   return (
-    <ProfitAndLoss asContainer={false}>
-      <View title={title} headerControls={<ProfitAndLoss.DatePicker />}>
-        <div className='Layer__component Layer__header__actions'>
-          <Toggle
-            name='reports-tabs'
-            options={
-              [
-                { value: 'profitAndLoss', label: 'Profit & Loss' },
-                { value: 'balanceSheet', label: 'Balance Sheet' },
-              ] as ReportOption[]
-            }
-            selected='profitAndLoss'
-            onChange={opt => setActiveTab(opt.target.value as ReportType)}
-          />
-          <DownloadButton />
-        </div>
-        <Container name='reports' ref={containerRef}>
-          <ReportsPanel containerRef={containerRef} openReport={activeTab} />
-        </Container>
-      </View>
-    </ProfitAndLoss>
+    <View title={'Reports'}>
+      <div className='Layer__component Layer__header__actions'>
+        <Toggle
+          name='reports-tabs'
+          options={
+            [
+              { value: 'profitAndLoss', label: 'Profit & Loss' },
+              { value: 'balanceSheet', label: 'Balance Sheet' },
+            ] as ReportOption[]
+          }
+          selected={activeTab}
+          onChange={opt => setActiveTab(opt.target.value as ReportType)}
+        />
+        <DownloadButton />
+      </div>
+      <Container name='reports' ref={containerRef}>
+        <ReportsPanel containerRef={containerRef} openReport={activeTab} />
+      </Container>
+    </View>
   )
 }
 
@@ -111,9 +111,18 @@ const ReportsPanel = ({ containerRef, openReport }: ReportsPanelProps) => {
       parentRef={containerRef}
     >
       {openReport === 'profitAndLoss' ? (
-        <ProfitAndLoss.Table asContainer={false} />
+        <ProfitAndLoss asContainer={false}>
+          <PanelView
+            title={'Profit & Loss'}
+            headerControls={<ProfitAndLoss.DatePicker />}
+          >
+            <ProfitAndLoss.Table asContainer={false} />
+          </PanelView>
+        </ProfitAndLoss>
       ) : (
-        <BalanceSheet />
+        <BalanceSheet effectiveDate={startOfDay(new Date())}>
+          <BalanceSheet.View />
+        </BalanceSheet>
       )}
     </Panel>
   )

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -1,5 +1,6 @@
 import React, { RefObject, useContext, useRef, useState } from 'react'
 import { Layer } from '../../api/layer'
+import { BalanceSheet } from '../../components/BalanceSheet'
 import { Button, ButtonVariant, RetryButton } from '../../components/Button'
 import { Container } from '../../components/Container'
 import { Panel } from '../../components/Panel'
@@ -13,8 +14,11 @@ export interface ReportsProps {
   title?: string
 }
 
+type ReportType = 'profitAndLoss' | 'balanceSheet'
+type ReportOption = { value: ReportType; label: string }
 export interface ReportsPanelProps {
   containerRef: RefObject<HTMLDivElement>
+  openReport: ReportType
 }
 
 const DownloadButton = () => {
@@ -70,6 +74,7 @@ const DownloadButton = () => {
 
 export const Reports = ({ title = 'Reports' }: ReportsProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
+  const [activeTab, setActiveTab] = useState<ReportType>('profitAndLoss')
 
   return (
     <ProfitAndLoss asContainer={false}>
@@ -77,24 +82,26 @@ export const Reports = ({ title = 'Reports' }: ReportsProps) => {
         <div className='Layer__component Layer__header__actions'>
           <Toggle
             name='reports-tabs'
-            options={[
-              { value: 'profitAndLoss', label: 'Profit & loss' },
-              { value: 'balanceSheet', label: 'Balance sheet', disabled: true },
-            ]}
+            options={
+              [
+                { value: 'profitAndLoss', label: 'Profit & Loss' },
+                { value: 'balanceSheet', label: 'Balance Sheet' },
+              ] as ReportOption[]
+            }
             selected='profitAndLoss'
-            onChange={() => null}
+            onChange={opt => setActiveTab(opt.target.value as ReportType)}
           />
           <DownloadButton />
         </div>
         <Container name='reports' ref={containerRef}>
-          <ReportsPanel containerRef={containerRef} />
+          <ReportsPanel containerRef={containerRef} openReport={activeTab} />
         </Container>
       </View>
     </ProfitAndLoss>
   )
 }
 
-const ReportsPanel = ({ containerRef }: ReportsPanelProps) => {
+const ReportsPanel = ({ containerRef, openReport }: ReportsPanelProps) => {
   const { sidebarScope } = useContext(ProfitAndLoss.Context)
 
   return (
@@ -103,7 +110,11 @@ const ReportsPanel = ({ containerRef }: ReportsPanelProps) => {
       sidebarIsOpen={Boolean(sidebarScope)}
       parentRef={containerRef}
     >
-      <ProfitAndLoss.Table asContainer={false} />
+      {openReport === 'profitAndLoss' ? (
+        <ProfitAndLoss.Table asContainer={false} />
+      ) : (
+        <BalanceSheet />
+      )}
     </Panel>
   )
 }

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -79,7 +79,7 @@ export const Reports = ({ title = 'Reports' }: ReportsProps) => {
   const [activeTab, setActiveTab] = useState<ReportType>('profitAndLoss')
 
   return (
-    <View title={'Reports'}>
+    <View title={title}>
       <div className='Layer__component Layer__header__actions'>
         <Toggle
           name='reports-tabs'

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -95,7 +95,11 @@ export const Reports = ({ title = 'Reports' }: ReportsProps) => {
         <DownloadButton />
       </div>
       <Container name='reports' ref={containerRef}>
-        <ReportsPanel containerRef={containerRef} openReport={activeTab} />
+        <ProfitAndLoss asContainer={false}>
+          <BalanceSheet effectiveDate={startOfDay(new Date())}>
+            <ReportsPanel containerRef={containerRef} openReport={activeTab} />
+          </BalanceSheet>
+        </ProfitAndLoss>
       </Container>
     </View>
   )
@@ -103,27 +107,24 @@ export const Reports = ({ title = 'Reports' }: ReportsProps) => {
 
 const ReportsPanel = ({ containerRef, openReport }: ReportsPanelProps) => {
   const { sidebarScope } = useContext(ProfitAndLoss.Context)
-
   return (
-    <Panel
-      sidebar={<ProfitAndLoss.DetailedCharts />}
-      sidebarIsOpen={Boolean(sidebarScope)}
-      parentRef={containerRef}
-    >
+    <>
       {openReport === 'profitAndLoss' ? (
-        <ProfitAndLoss asContainer={false}>
-          <PanelView
-            title={'Profit & Loss'}
-            headerControls={<ProfitAndLoss.DatePicker />}
+        <PanelView
+          title={'Profit & Loss'}
+          headerControls={<ProfitAndLoss.DatePicker />}
+        >
+          <Panel
+            sidebar={<ProfitAndLoss.DetailedCharts />}
+            sidebarIsOpen={Boolean(sidebarScope)}
+            parentRef={containerRef}
           >
             <ProfitAndLoss.Table asContainer={false} />
-          </PanelView>
-        </ProfitAndLoss>
+          </Panel>
+        </PanelView>
       ) : (
-        <BalanceSheet effectiveDate={startOfDay(new Date())}>
-          <BalanceSheet.View />
-        </BalanceSheet>
+        <BalanceSheet.View />
       )}
-    </Panel>
+    </>
   )
 }


### PR DESCRIPTION
### Changes in this PR

1. I broke out the date picker & `Expand all` buttons into their own components so I could re-use in a different layout.
2. I made the default 'view' component a reusable structure.
3. I made all rows expanded by default.
4. I *temporarily* made the `Asset` and `Liabilities and Equity` rows have `summarize={true}`. I would *prefer* to have the values in-line (like we discussed earlier), so I intend for us to undo my change when we've made the change to show the values in the same row.
5. Layout changes to the report tab that don't directly affect the Balance Sheet. (moving the date control out of the header & into a report-specific container)
