### PR TITLE
fix: date picker mixing styling on different breakpoints

### DIFF
--- a/src/components/DateDayPicker/DateDayPicker.tsx
+++ b/src/components/DateDayPicker/DateDayPicker.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import { useSizeClass } from '../../hooks/useWindowSize'
 import ChevronLeft from '../../icons/ChevronLeft'
 import ChevronRight from '../../icons/ChevronRight'
 import { Button, ButtonVariant } from '../Button'
@@ -21,7 +20,6 @@ export const DateDayPicker = ({
   enableFutureDates = false,
   currentDateOption = true,
 }: DateDayPickerProps) => {
-  const { isMobile, isTablet } = useSizeClass()
   const [isAnimating, setIsAnimating] = useState(false)
 
   const [localDate, setLocalDate] = useState(startOfDay(new Date()))
@@ -153,7 +151,7 @@ export const DateDayPicker = ({
         </button>
         <div className='Layer__date-month-picker__effect-blur'></div>
       </div>
-      {!isMobile && !isTablet && currentDateOption && (
+      {currentDateOption && (
         <Button
           className='Layer__date-month-picker__current-button'
           onClick={() => setCurrentDate()}

--- a/src/components/DateMonthPicker/DateMonthPicker.tsx
+++ b/src/components/DateMonthPicker/DateMonthPicker.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import { useSizeClass } from '../../hooks/useWindowSize'
 import ChevronLeft from '../../icons/ChevronLeft'
 import ChevronRight from '../../icons/ChevronRight'
 import { DateRange } from '../../types'
@@ -22,7 +21,6 @@ export const DateMonthPicker = ({
   minDate,
   currentDateOption = true,
 }: DateMonthPickerProps) => {
-  const { isMobile, isTablet } = useSizeClass()
   const [isAnimating, setIsAnimating] = useState(false)
 
   const [localDate, setLocalDate] = useState(dateRange.startDate)
@@ -172,7 +170,7 @@ export const DateMonthPicker = ({
         </button>
         <div className='Layer__date-month-picker__effect-blur'></div>
       </div>
-      {!isMobile && !isTablet && currentDateOption && (
+      {currentDateOption && (
         <Button
           className='Layer__date-month-picker__current-button'
           onClick={() => setCurrentDate()}

--- a/src/styles/date_month_picker.scss
+++ b/src/styles/date_month_picker.scss
@@ -99,7 +99,7 @@
   z-index: 2;
 }
 
-@container (max-width: 760px) {
+@container (max-width: 759px) {
   .Layer__date-month-picker__wrapper {
     .Layer__date-month-picker {
       border: none;
@@ -139,5 +139,9 @@
       justify-content: flex-end;
       font-size: 12px;
     }
+  }
+
+  .Layer__date-month-picker__current-button {
+    display: none;
   }
 }


### PR DESCRIPTION
## Description

Fix showing "Current" button in date pickers when component is small.

<img width="749" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/4984fedc-94d4-43ad-a940-02155aefed31">


## How this has been tested?

<img width="868" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/a62ea0dd-03fd-41c1-85cb-800a377628ff">

<img width="737" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/baf34826-efaf-47bb-a3a2-2f3b823b22b1">
