### PR TITLE
feat: use buttons below the form on mobile

### DIFF
--- a/src/components/ChartOfAccountsForm/ChartOfAccountsForm.tsx
+++ b/src/components/ChartOfAccountsForm/ChartOfAccountsForm.tsx
@@ -165,6 +165,37 @@ export const ChartOfAccountsForm = () => {
             disabled={sendingForm}
           />
         </InputGroup>
+
+        <div className='actions'>
+          <Button
+            type='button'
+            onClick={cancelForm}
+            variant={ButtonVariant.secondary}
+            disabled={sendingForm}
+          >
+            Cancel
+          </Button>
+          {apiError && (
+            <RetryButton
+              type='submit'
+              processing={sendingForm}
+              error={'Check connection and retry in few seconds.'}
+              disabled={sendingForm}
+            >
+              Retry
+            </RetryButton>
+          )}
+          {!apiError && (
+            <SubmitButton
+              type='submit'
+              noIcon={true}
+              active={true}
+              disabled={sendingForm}
+            >
+              Save
+            </SubmitButton>
+          )}
+        </div>
       </div>
     </form>
   )

--- a/src/components/JournalForm/JournalForm.tsx
+++ b/src/components/JournalForm/JournalForm.tsx
@@ -115,6 +115,36 @@ export const JournalForm = ({ config }: { config: JournalConfig }) => {
           />
         </InputGroup>
       </div>
+      <div className='Layer__journal__bottom-actions'>
+        <Button
+          type='button'
+          onClick={cancelForm}
+          variant={ButtonVariant.secondary}
+          disabled={sendingForm}
+        >
+          Cancel
+        </Button>
+        {apiError && (
+          <RetryButton
+            type='submit'
+            processing={sendingForm}
+            error={'Check connection and retry in few seconds.'}
+            disabled={sendingForm}
+          >
+            Retry
+          </RetryButton>
+        )}
+        {!apiError && (
+          <SubmitButton
+            type='submit'
+            noIcon={true}
+            active={true}
+            disabled={sendingForm}
+          >
+            Save
+          </SubmitButton>
+        )}
+      </div>
     </form>
   )
 }

--- a/src/styles/chart_of_accounts.scss
+++ b/src/styles/chart_of_accounts.scss
@@ -111,6 +111,14 @@
   }
 }
 
+.Layer__chart-of-accounts__form .actions {
+  display: none;
+  gap: var(--spacing-sm);
+  align-items: center;
+  justify-content: flex-end;
+  padding-top: var(--spacing-xl);
+}
+
 .Layer__chart-of-accounts__table .Layer__table-row {
   &:not(.Layer__table-row--header) {
     cursor: pointer;
@@ -264,6 +272,14 @@
 @container (max-width: 1024px) {
   .Layer__table-cell.Layer__coa__actions .Layer__table-cell-content {
     padding-right: var(--spacing-md);
+  }
+
+  .Layer__chart-of-accounts__sidebar__header .actions {
+    display: none;
+  }
+
+  .Layer__chart-of-accounts__form .actions {
+    display: flex;
   }
 }
 

--- a/src/styles/journal.scss
+++ b/src/styles/journal.scss
@@ -2,6 +2,21 @@
   display: flex;
   align-items: stretch;
   position: relative;
+  overflow: auto;
+}
+
+@container (min-width: 1025px) {
+  .Layer__component-container.Layer__journal {
+    overflow: unset;
+  }
+}
+
+.Layer__journal .Layer__journal__bottom-actions {
+  display: none;
+  gap: var(--spacing-sm);
+  align-items: center;
+  justify-content: flex-end;
+  padding: var(--spacing-xl);
 }
 
 .Layer__journal-table .Layer__table-cell-content::before {
@@ -273,6 +288,26 @@
 @container (max-width: 1024px) {
   .Layer__journal__panel .Layer__panel__sidebar .Layer__panel__sidebar-content {
     width: 100%;
+  }
+
+  .Layer__journal .Layer__journal__sidebar__header .actions {
+    display: none;
+  }
+
+  .Layer__journal .Layer__journal__sidebar__header .actions {
+    display: none;
+  }
+
+  .Layer__journal .Layer__journal__bottom-actions {
+    display: flex;
+  }
+
+  .Layer__journal .Layer__panel.Layer__panel--open {
+    overflow: hidden;
+  }
+
+  .Layer__journal__form__input-group.Layer__journal__form__input-group__textarea {
+    background: transparent;
   }
 }
 


### PR DESCRIPTION
## Description

Use Cancel/Submit buttons below the form on mobile screens so it's easier to reach by thumb and user doesn't have to scroll back up to see buttons on long forms.

## How this has been tested?

<img width="1122" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/0d81edbd-0fe6-4711-b9ee-e6f81f710d3c">

<img width="427" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/776033e3-2031-4e99-90a3-fe89e55c6f46">

<img width="1206" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/843a1f60-fe47-41b8-abf7-d0912089ec1e">

<img width="572" alt="image" src="https://github.com/Layer-Fi/layer-react/assets/11715931/2e77e7f5-81b4-4048-bb22-5f506679ef44">


