### PR TITLE
fix confirm account dropdown

### DIFF
--- a/src/components/LinkedAccounts/LinkedAccountsContent.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountsContent.tsx
@@ -49,7 +49,7 @@ export const LinkedAccountsContent = ({
             text: 'Confirm account',
             config: [
               {
-                name: 'Oops... this is a duplicate account!',
+                name: 'Mark as a duplicate account',
                 action: async () => {
                   // TODO: trigger some sort of loading spinner here
                   await denyAccount(account.external_account_source, account.id)
@@ -57,7 +57,7 @@ export const LinkedAccountsContent = ({
                 },
               },
               {
-                name: 'This is not a duplicate account',
+                name: 'Mark as not a duplicate account',
                 action: async () => {
                   // TODO: trigger some sort of loading spinner here
                   await confirmAccount(

--- a/src/styles/linked_accounts.scss
+++ b/src/styles/linked_accounts.scss
@@ -2,6 +2,7 @@
   min-height: 150px;
   box-sizing: border-box;
   overflow: visible;
+  z-index: 1;
 
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
Just in time for this to no longer matter (since it is no longer possible to get an account marked as needing confirmation), I have fixed the hover menu that is shown on linked accounts.

<img width="622" alt="Screenshot 2024-06-27 at 4 22 52 PM" src="https://github.com/Layer-Fi/layer-react/assets/38053792/c3b39276-9fd5-4d5c-b021-e6c7a57ea67d">
