### PR TITLE
fix: Profit and Loss - chart colors - use similar colors for same categories

### DIFF
--- a/src/components/ProfitAndLossDetailedCharts/DetailedChart.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedChart.tsx
@@ -1,8 +1,4 @@
 import React, { useMemo } from 'react'
-import {
-  INACTIVE_OPACITY_LEVELS,
-  DEFAULT_CHART_COLORS,
-} from '../../config/charts'
 import { SidebarScope } from '../../hooks/useProfitAndLoss/useProfitAndLoss'
 import { centsToDollars as formatMoney } from '../../models/Money'
 import { LineBaseItem } from '../../types/line_item'
@@ -20,6 +16,7 @@ import {
   Text as ChartText,
 } from 'recharts'
 import { PolarViewBox } from 'recharts/types/util/types'
+import { mapColorsToTypes } from './DetailedTable'
 
 interface DetailedChartProps {
   filteredData: LineBaseItem[]
@@ -46,21 +43,26 @@ export const DetailedChart = ({
     if (!filteredData) {
       return []
     }
-    return filteredData.map(x => {
+    return filteredData.map((x) => {
       if (x.hidden) {
         return {
           name: x.display_name,
           value: 0,
+          type: x.type,
         }
       }
       return {
         name: x.display_name,
         value: x.value,
+        type: x.type,
       }
     })
   }, [filteredData, isLoading])
 
-  const noValue = chartData.length === 0 || !chartData.find(x => x.value !== 0)
+  const noValue =
+    chartData.length === 0 || !chartData.find((x) => x.value !== 0)
+
+  const typeColorMapping = mapColorsToTypes(chartData)
 
   return (
     <div className='chart-field'>
@@ -86,18 +88,11 @@ export const DetailedChart = ({
                 animationEasing='ease-in-out'
               >
                 {chartData.map((entry, index) => {
-                  const colorConfig =
-                    DEFAULT_CHART_COLORS[index % DEFAULT_CHART_COLORS.length]
-                  let fill: string | undefined = colorConfig.color
-                  let opacity = colorConfig.opacity
+                  let fill: string | undefined = typeColorMapping[index].color
                   let active = true
                   if (hoveredItem && entry.name !== hoveredItem) {
                     active = false
                     fill = undefined
-                    opacity =
-                      INACTIVE_OPACITY_LEVELS[
-                        index % INACTIVE_OPACITY_LEVELS.length
-                      ]
                   }
 
                   return (
@@ -107,7 +102,7 @@ export const DetailedChart = ({
                         hoveredItem && active ? 'active' : 'inactive'
                       }`}
                       style={{ fill }}
-                      opacity={opacity}
+                      opacity={typeColorMapping[index].opacity}
                       onMouseEnter={() => setHoveredItem(entry.name)}
                       onMouseLeave={() => setHoveredItem(undefined)}
                     />
@@ -117,7 +112,7 @@ export const DetailedChart = ({
                   position='center'
                   value='Total'
                   className='pie-center-label-title'
-                  content={props => {
+                  content={(props) => {
                     const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
                       cx: 0,
                       cy: 0,
@@ -154,7 +149,7 @@ export const DetailedChart = ({
                   position='center'
                   value='Total'
                   className='pie-center-label-title'
-                  content={props => {
+                  content={(props) => {
                     const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
                       cx: 0,
                       cy: 0,
@@ -173,7 +168,7 @@ export const DetailedChart = ({
                     let value = filteredTotal
                     if (hoveredItem) {
                       value = filteredData.find(
-                        x => x.display_name === hoveredItem,
+                        (x) => x.display_name === hoveredItem
                       )?.value
                     }
 
@@ -192,7 +187,7 @@ export const DetailedChart = ({
                   position='center'
                   value='Total'
                   className='pie-center-label-title'
-                  content={props => {
+                  content={(props) => {
                     const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
                       cx: 0,
                       cy: 0,
@@ -217,8 +212,8 @@ export const DetailedChart = ({
                         >
                           {`${formatPercent(
                             filteredData.find(
-                              x => x.display_name === hoveredItem,
-                            )?.share,
+                              (x) => x.display_name === hoveredItem
+                            )?.share
                           )}%`}
                         </ChartText>
                       )
@@ -248,7 +243,7 @@ export const DetailedChart = ({
                   position='center'
                   value='Total'
                   className='pie-center-label-title'
-                  content={props => {
+                  content={(props) => {
                     const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
                       cx: 0,
                       cy: 0,
@@ -285,7 +280,7 @@ export const DetailedChart = ({
                   position='center'
                   value='Total'
                   className='pie-center-label-title'
-                  content={props => {
+                  content={(props) => {
                     const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
                       cx: 0,
                       cy: 0,
@@ -304,7 +299,7 @@ export const DetailedChart = ({
                     let value = filteredTotal
                     if (hoveredItem) {
                       value = filteredData.find(
-                        x => x.display_name === hoveredItem,
+                        (x) => x.display_name === hoveredItem
                       )?.value
                     }
 

--- a/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { DEFAULT_CHART_COLORS } from '../../config/charts'
+import { DEFAULT_CHART_COLOR_TYPE } from '../../config/charts'
 import {
   Scope,
   SidebarScope,
@@ -21,6 +21,32 @@ export interface DetailedTableProps {
   sortBy: (scope: Scope, field: string, direction?: SortDirection) => void
 }
 
+export const mapColorsToTypes = (data: any[]) => {
+  const typeToColor: any = {}
+  const typeToLastOpacity: any = {}
+  let colorIndex = 0
+
+  return data.map((obj) => {
+    const type = obj.type
+
+    if (!typeToColor[type]) {
+      typeToColor[type] =
+        DEFAULT_CHART_COLOR_TYPE[colorIndex % DEFAULT_CHART_COLOR_TYPE.length]
+      colorIndex++
+      typeToLastOpacity[type] = 1
+    } else {
+      typeToLastOpacity[type] -= 0.1
+    }
+
+    const opacity = typeToLastOpacity[type]
+
+    return {
+      color: typeToColor[type],
+      opacity: opacity,
+    }
+  })
+}
+
 export const DetailedTable = ({
   filteredData,
   sidebarScope,
@@ -36,9 +62,14 @@ export const DetailedTable = ({
         ? `sort--${
             (sidebarScope && filters[sidebarScope]?.sortDirection) ?? 'desc'
           }`
-        : '',
+        : ''
     )
   }
+
+  const typeColorMapping: any = mapColorsToTypes(filteredData)
+
+  // Index to keep track of the next color to assign
+  let colorIndex = 0
 
   return (
     <div className='details-container'>
@@ -69,10 +100,8 @@ export const DetailedTable = ({
           </thead>
           <tbody>
             {filteredData
-              .filter(x => !x.hidden)
+              .filter((x) => !x.hidden)
               .map((item, idx) => {
-                const colorConfig =
-                  DEFAULT_CHART_COLORS[idx % DEFAULT_CHART_COLORS.length]
                 return (
                   <tr
                     key={`pl-side-table-item-${idx}`}
@@ -80,7 +109,7 @@ export const DetailedTable = ({
                       'Layer__profit-and-loss-detailed-table__row',
                       hoveredItem && hoveredItem === item.display_name
                         ? 'active'
-                        : '',
+                        : ''
                     )}
                     onMouseEnter={() => setHoveredItem(item.display_name)}
                     onMouseLeave={() => setHoveredItem(undefined)}
@@ -94,8 +123,8 @@ export const DetailedTable = ({
                         <div
                           className='share-icon'
                           style={{
-                            background: colorConfig.color,
-                            opacity: colorConfig.opacity,
+                            background: typeColorMapping[idx].color,
+                            opacity: typeColorMapping[idx].opacity,
                           }}
                         />
                       </span>

--- a/src/config/charts.ts
+++ b/src/config/charts.ts
@@ -1,5 +1,29 @@
 export const INACTIVE_OPACITY_LEVELS = [
-  0.85, 0.7, 0.66, 0.55, 0.4, 0.33, 0.25, 0.15,
+  0.85,
+  0.7,
+  0.66,
+  0.55,
+  0.4,
+  0.33,
+  0.25,
+  0.15,
+]
+
+export const DEFAULT_CHART_OPACITY = [1, 0.8, 0.6, 0.4, 0.2, 0.1]
+
+export const DEFAULT_CHART_COLOR_TYPE = [
+  '#008028',
+  '#7417B3',
+  '#006A80',
+  '#8FB300',
+  '#3D87CC',
+  '#CC3DCC',
+  '#3DCCB2',
+  '#CCB129',
+  '#2949CC',
+  '#619900',
+  '#6A52CC',
+  '#71CC56',
 ]
 
 export const DEFAULT_CHART_COLORS = [


### PR DESCRIPTION
<img width="565" alt="Zrzut ekranu 2024-07-8 o 10 52 24" src="https://github.com/Layer-Fi/layer-react/assets/163312903/0f49d190-ebe8-448f-99ae-4b941bda83e6">
<img width="284" alt="Zrzut ekranu 2024-07-8 o 10 52 45" src="https://github.com/Layer-Fi/layer-react/assets/163312903/eb8e63f5-f2a2-40d1-a27e-1a0cc8de19d2">
<img width="562" alt="Zrzut ekranu 2024-07-8 o 10 53 06" src="https://github.com/Layer-Fi/layer-react/assets/163312903/9ce9fbcc-d22c-43e1-be27-8d4dfca8a1ee">
