### PR TITLE
fix: bank transactions table column widths

### DIFF
--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -547,6 +547,7 @@
   min-width: 150px;
   box-sizing: border-box;
   z-index: 2;
+  text-align: right;
   box-shadow: -8px 0px 20px -2px rgb(255 255 255 / 64%);
 }
 
@@ -562,16 +563,13 @@
 }
 
 .Layer__bank-transactions__date-col {
-  min-width: 130px;
-  width: 130px;
-  max-width: 130px;
+  min-width: 140px;
+  width: 140px;
+  max-width: 140px;
   box-sizing: border-box;
 }
 
 .Layer__bank-transactions__tx-col {
-  min-width: 125px;
-  width: 180px;
-  max-width: 280px;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Description

In Bank transactions table, make column widths more fixed so it doesn't jump around when toggling "To review" and "Categorized"

## How this has been tested?


https://github.com/Layer-Fi/layer-react/assets/11715931/0c4025fd-d966-47a6-ae2a-32e1445a6117

