### PR TITLE
fix: hide back button in detailed charts

### DIFF
--- a/src/components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts.tsx
@@ -65,7 +65,7 @@ export const ProfitAndLossDetailedCharts = ({
       </header>
 
       <header className='Layer__profit-and-loss-detailed-charts__header--tablet'>
-        <BackButton onClick={() => setSidebarScope(undefined)} />
+        {!hideClose && <BackButton onClick={() => setSidebarScope(undefined)} />}
         <div className='Layer__profit-and-loss-detailed-charts__head'>
           <Text size={TextSize.lg} weight={TextWeight.bold} className='title'>
             {humanizeTitle(theScope)}


### PR DESCRIPTION
## Description

Hide Back button from PnL detailed charts on overview views.

![image](https://github.com/user-attachments/assets/d32ca093-af64-4634-bb51-ddf312e1d9c7)

<br/>
<br/>

## How this has been tested?

![image](https://github.com/user-attachments/assets/54c81232-a5e0-492d-be4f-5780f4db2d90)
