### PR TITLE
Show loading status on linked accounts / fix linked account tile size

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -154,6 +154,7 @@ export const DatePicker = ({
         showTimeSelect={mode === 'timePicker'}
         showTimeSelectOnly={mode === 'timePicker'}
         minDate={minDate}
+        maxDate={new Date()}
         {...props}
       >
         {mode === 'dayRangePicker' && (

--- a/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
+++ b/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
@@ -33,15 +33,17 @@ export const LinkedAccountThumb = ({
     asWidget && '--as-widget',
   )
 
-  let balance: React.ReactNode
+  let bankBalance: React.ReactNode
   if (pillConfig) {
-    balance = (
+    bankBalance = (
       <LinkedAccountPill text={pillConfig.text} config={pillConfig.config} />
     )
   } else {
-    balance = (
+    bankBalance = (
       <Text as='span' className='account-balance'>
-        ${formatMoney(account.latest_balance_timestamp?.balance)}
+        {isLessThanFiveMinutesOld(account.created_at)
+          ? 'Syncing...'
+          : `${formatMoney(account.latest_balance_timestamp?.balance)}`}
       </Text>
     )
   }
@@ -86,7 +88,7 @@ export const LinkedAccountThumb = ({
           >
             Bank balance
           </Text>
-          {balance}
+          {bankBalance}
         </div>
       )}
       {showLedgerBalance && (
@@ -103,10 +105,15 @@ export const LinkedAccountThumb = ({
             </Text>
           )}
           <Text as='span' className='account-balance'>
-            ${formatMoney(account.current_ledger_balance)}
+            {isLessThanFiveMinutesOld(account.created_at)
+              ? 'Syncing...'
+              : `${formatMoney(account.current_ledger_balance)}`}
           </Text>
         </div>
       )}
     </div>
   )
 }
+
+const isLessThanFiveMinutesOld = (dateString: string) =>
+  Number(new Date()) - Number(new Date(dateString)) < 5 * 60 * 1000

--- a/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
+++ b/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
@@ -41,7 +41,7 @@ export const LinkedAccountThumb = ({
   } else {
     bankBalance = (
       <Text as='span' className='account-balance'>
-        {isLessThanFiveMinutesOld(account.created_at)
+        {account.is_syncing
           ? 'Syncing...'
           : `${formatMoney(account.latest_balance_timestamp?.balance)}`}
       </Text>
@@ -105,7 +105,7 @@ export const LinkedAccountThumb = ({
             </Text>
           )}
           <Text as='span' className='account-balance'>
-            {isLessThanFiveMinutesOld(account.created_at)
+            {account.is_syncing
               ? 'Syncing...'
               : `${formatMoney(account.current_ledger_balance)}`}
           </Text>
@@ -114,6 +114,3 @@ export const LinkedAccountThumb = ({
     </div>
   )
 }
-
-const isLessThanFiveMinutesOld = (dateString: string) =>
-  Number(new Date()) - Number(new Date(dateString)) < 5 * 60 * 1000

--- a/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
+++ b/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
@@ -52,7 +52,7 @@ export const LinkedAccountThumb = ({
     <div className={linkedAccountThumbClassName}>
       <div className='topbar'>
         <div className='topbar-details'>
-          <Text as='span' className='account-name'>
+          <Text as='div' className='account-name'>
             {account.external_account_name}
           </Text>
           {!asWidget && account.mask && (

--- a/src/hooks/useLinkedAccounts/mockData.ts
+++ b/src/hooks/useLinkedAccounts/mockData.ts
@@ -23,7 +23,7 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
     connection_external_id: '11111',
     connection_needs_repair_as_of: null,
     requires_user_confirmation_as_of: null,
-    created_at: '2024-07-23T19:50:56.334Z',
+    is_syncing: true,
   },
   {
     id: 'f98ec50a-c370-484d-a35b-d00207436075',
@@ -47,7 +47,7 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
     connection_external_id: '11111',
     connection_needs_repair_as_of: null,
     requires_user_confirmation_as_of: null,
-    created_at: '2024-04-06T16:44:35.715458Z',
+    is_syncing: false,
   },
   {
     id: '843f1748-fdaa-422d-a73d-2489a40c8dc7',
@@ -71,7 +71,7 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
     connection_external_id: '11111',
     connection_needs_repair_as_of: '2024-03-06T16:44:35.715458Z',
     requires_user_confirmation_as_of: null,
-    created_at: '2024-04-06T16:44:35.715458Z',
+    is_syncing: false,
   },
   {
     id: '8f430e29-e339-4d71-a08a-fce469c7a7c1',
@@ -95,6 +95,6 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
     connection_external_id: '11111',
     connection_needs_repair_as_of: null,
     requires_user_confirmation_as_of: '2024-03-06T16:44:35.715458Z',
-    created_at: '2024-04-06T16:44:35.715458Z',
+    is_syncing: false,
   },
 ]

--- a/src/hooks/useLinkedAccounts/mockData.ts
+++ b/src/hooks/useLinkedAccounts/mockData.ts
@@ -12,7 +12,7 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
       external_account_source: 'PLAID',
       balance: 435121,
       at: '2024-04-03T13:00:00Z',
-      created_at: '2024-04-06T16:44:35.715458Z',
+      created_at: '2024-04-06T22:47:59.715458Z',
     },
     current_ledger_balance: 373717,
     institution: {
@@ -23,6 +23,7 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
     connection_external_id: '11111',
     connection_needs_repair_as_of: null,
     requires_user_confirmation_as_of: null,
+    created_at: '2024-07-23T19:50:56.334Z',
   },
   {
     id: 'f98ec50a-c370-484d-a35b-d00207436075',
@@ -46,6 +47,7 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
     connection_external_id: '11111',
     connection_needs_repair_as_of: null,
     requires_user_confirmation_as_of: null,
+    created_at: '2024-04-06T16:44:35.715458Z',
   },
   {
     id: '843f1748-fdaa-422d-a73d-2489a40c8dc7',
@@ -69,6 +71,7 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
     connection_external_id: '11111',
     connection_needs_repair_as_of: '2024-03-06T16:44:35.715458Z',
     requires_user_confirmation_as_of: null,
+    created_at: '2024-04-06T16:44:35.715458Z',
   },
   {
     id: '8f430e29-e339-4d71-a08a-fce469c7a7c1',
@@ -92,5 +95,6 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
     connection_external_id: '11111',
     connection_needs_repair_as_of: null,
     requires_user_confirmation_as_of: '2024-03-06T16:44:35.715458Z',
+    created_at: '2024-04-06T16:44:35.715458Z',
   },
 ]

--- a/src/styles/linked_accounts.scss
+++ b/src/styles/linked_accounts.scss
@@ -87,9 +87,8 @@
     }
   }
 
-  @media screen and (max-width: 650px) {
-    min-width: 150px;
-  }
+  min-width: 286px;
+  box-sizing: border-box;
 
   .Layer__linked-accounts__new-account-label {
     display: flex;

--- a/src/styles/linked_accounts.scss
+++ b/src/styles/linked_accounts.scss
@@ -155,6 +155,10 @@
 
     .account-name {
       flex: 1;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      width: 200px;
+      overflow: hidden;
     }
   }
 

--- a/src/types/linked_accounts.ts
+++ b/src/types/linked_accounts.ts
@@ -27,7 +27,7 @@ export interface LinkedAccount {
   connection_external_id?: string
   connection_needs_repair_as_of: string | null
   requires_user_confirmation_as_of: string | null
-  created_at: string
+  is_syncing: boolean
 }
 
 export type PublicToken = {

--- a/src/types/linked_accounts.ts
+++ b/src/types/linked_accounts.ts
@@ -27,6 +27,7 @@ export interface LinkedAccount {
   connection_external_id?: string
   connection_needs_repair_as_of: string | null
   requires_user_confirmation_as_of: string | null
+  created_at: string
 }
 
 export type PublicToken = {


### PR DESCRIPTION
Requires this other PR to be merged first: https://github.com/Layer-Fi/api/pull/778

<img width="989" alt="Screenshot 2024-07-23 at 12 50 50 PM" src="https://github.com/user-attachments/assets/525f62a9-9e31-4e38-b3d7-83b81dfb0ca6">

<br /> <br />

Shorten long account names to prevent the name affecting the width of the card
<img width="606" alt="Screenshot 2024-07-23 at 1 15 51 PM" src="https://github.com/user-attachments/assets/a4e7ff19-379f-4e31-a50d-dedb3a46276e">

<br /> <br />

Prevent user from picking a date in the future using the date picker
<img width="321" alt="Screenshot 2024-07-23 at 4 38 24 PM" src="https://github.com/user-attachments/assets/78f22e47-44e6-48fa-a689-74c6e09803c2">

<br /> <br />

Prevent Add Account button from getting squished when 5+ account cards
<img width="962" alt="Screenshot 2024-07-23 at 4 47 43 PM" src="https://github.com/user-attachments/assets/e7e1e592-c452-4c46-b973-de1e710b910c">


