### PR TITLE
Prevent non-numeric-input in split amount fields / transaction empty state UX updates

### DIFF
--- a/src/components/BankTransactionMobileList/BusinessForm.tsx
+++ b/src/components/BankTransactionMobileList/BusinessForm.tsx
@@ -3,7 +3,7 @@ import { useBankTransactionsContext } from '../../contexts/BankTransactionsConte
 import { DrawerContext } from '../../contexts/DrawerContext'
 import { BankTransaction, CategorizationType } from '../../types'
 import { ActionableList } from '../ActionableList'
-import { Button } from '../Button'
+import { Button, ButtonVariant } from '../Button'
 import { ErrorText } from '../Typography'
 import { BusinessCategories } from './BusinessCategories'
 import { Option, mapCategoryToOption, getAssignedValue } from './utils'
@@ -112,7 +112,11 @@ export const BusinessForm = ({ bankTransaction }: BusinessFormProps) => {
         selected={selectedCategory}
       />
       {options.length === 0 ? (
-        <Button onClick={openDrawer} fullWidth={true}>
+        <Button
+          onClick={openDrawer}
+          fullWidth={true}
+          variant={ButtonVariant.secondary}
+        >
           Select category
         </Button>
       ) : null}

--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -5,6 +5,7 @@ import {
   BankTransactionFilters,
 } from '../../hooks/useBankTransactions/types'
 import { useElementSize } from '../../hooks/useElementSize'
+import { useLinkedAccounts } from '../../hooks/useLinkedAccounts'
 import { BankTransaction, DateRange, DisplayState } from '../../types'
 import { debounce } from '../../utils/helpers'
 import { BankTransactionList } from '../BankTransactionList'
@@ -20,6 +21,7 @@ import { MobileComponentType } from './constants'
 import { endOfMonth, parseISO, startOfMonth } from 'date-fns'
 
 const COMPONENT_NAME = 'bank-transactions'
+const TEST_EMPTY_STATE = false
 
 export interface BankTransactionsProps {
   asWidget?: boolean
@@ -83,6 +85,8 @@ const BankTransactionsContent = ({
     removeAfterCategorize,
   } = useBankTransactionsContext()
 
+  const { data: linkedAccounts } = useLinkedAccounts()
+
   useEffect(() => {
     activate()
   }, [])
@@ -124,14 +128,16 @@ const BankTransactionsContent = ({
     }
   }, [loadingStatus])
 
-  const bankTransactions = useMemo(() => {
-    if (monthlyView) {
-      return data?.filter(
-        x =>
-          parseISO(x.date) >= dateRange.startDate &&
-          parseISO(x.date) <= dateRange.endDate,
-      )
-    }
+  const bankTransactions = TEST_EMPTY_STATE
+    ? []
+    : useMemo(() => {
+        if (monthlyView) {
+          return data?.filter(
+            x =>
+              parseISO(x.date) >= dateRange.startDate &&
+              parseISO(x.date) <= dateRange.endDate,
+          )
+        }
 
     const firstPageIndex = (currentPage - 1) * pageSize
     const lastPageIndex = firstPageIndex + pageSize
@@ -249,6 +255,9 @@ const BankTransactionsContent = ({
       <DataStates
         bankTransactions={bankTransactions}
         isLoading={isLoading}
+        transactionsLoading={Boolean(
+          linkedAccounts?.some(item => item.is_syncing),
+        )}
         isValidating={isValidating}
         error={error}
         refetch={refetch}

--- a/src/components/BankTransactions/DataStates.tsx
+++ b/src/components/BankTransactions/DataStates.tsx
@@ -5,6 +5,7 @@ import { DataState, DataStateStatus } from '../DataState'
 
 interface DataStatesProps {
   bankTransactions?: BankTransaction[]
+  transactionsLoading: boolean
   isLoading?: boolean
   isValidating?: boolean
   error?: unknown
@@ -14,12 +15,29 @@ interface DataStatesProps {
 
 export const DataStates = ({
   bankTransactions,
+  transactionsLoading,
   isLoading,
   isValidating,
   error,
   refetch,
   editable,
 }: DataStatesProps) => {
+  let title: string
+  let description: string
+  if (transactionsLoading) {
+    title = 'Data sync in progress'
+    description = 'Check back later to review your transactions'
+  } else {
+    title = editable
+      ? 'You are up to date with transactions!'
+      : 'You have no categorized transactions'
+    description = editable
+      ? 'All uncategorized transaction will be displayed here'
+      : 'All transaction will be displayed here once reviewed'
+  }
+
+  const showRefreshButton = transactionsLoading || bankTransactions?.length
+
   return (
     <>
       {!isLoading &&
@@ -28,18 +46,14 @@ export const DataStates = ({
         (bankTransactions !== undefined && bankTransactions.length === 0)) ? (
         <div className='Layer__table-state-container'>
           <DataState
-            status={DataStateStatus.allDone}
-            title={
-              editable
-                ? 'You are up to date with transactions!'
-                : 'You have no categorized transactions'
+            status={
+              transactionsLoading
+                ? DataStateStatus.info
+                : DataStateStatus.allDone
             }
-            description={
-              editable
-                ? 'All uncategorized transaction will be displayed here'
-                : 'All transaction will be displayed here once reviewed'
-            }
-            onRefresh={() => refetch()}
+            title={title}
+            description={description}
+            onRefresh={showRefreshButton ? refetch : undefined}
             isLoading={isValidating}
             icon={!editable ? <InboxIcon /> : undefined}
           />
@@ -52,7 +66,7 @@ export const DataStates = ({
             status={DataStateStatus.failed}
             title='Something went wrong'
             description='We couldn’t load your data.'
-            onRefresh={() => refetch()}
+            onRefresh={refetch}
             isLoading={isValidating}
           />
         </div>

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -195,15 +195,33 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
       setSplitFormError(undefined)
     }
 
+    const sanitizeNumberInput = (input: string): string => {
+      let sanitized = input.replace(/[^0-9.]/g, '')
+
+      // Ensure there's at most one period
+      let parts = sanitized.split('.')
+      if (parts.length > 2) {
+        sanitized = parts[0] + '.' + parts.slice(1).join('')
+      }
+
+      // Limit to two digits after the decimal point
+      if (parts.length === 2) {
+        sanitized = parts[0] + '.' + parts[1].slice(0, 2)
+      }
+
+      return sanitized
+    }
+
     const updateAmounts =
       (rowNumber: number) => (event: React.ChangeEvent<HTMLInputElement>) => {
-        const newAmount = parseMoney(event.target.value) || 0
-        const newDisplaying = event.target.value
+        const newDisplaying = sanitizeNumberInput(event.target.value)
+        const newAmount = Number(newDisplaying)
         const splitTotal = rowState.splits.reduce((sum, split, index) => {
           const amount =
             index === 0 ? 0 : index === rowNumber ? newAmount : split.amount
           return sum + amount
         }, 0)
+
         const remaining = bankTransaction.amount - splitTotal
         rowState.splits[rowNumber].amount = newAmount
         rowState.splits[rowNumber].inputValue = newDisplaying

--- a/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
+++ b/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
@@ -5,6 +5,7 @@ import { LinkedAccount } from '../../types/linked_accounts'
 import { LinkedAccountPill } from '../LinkedAccountPill'
 import { Text, TextSize } from '../Typography'
 import classNames from 'classnames'
+import LoaderIcon from '../../icons/Loader'
 
 export interface LinkedAccountThumbProps {
   account: LinkedAccount
@@ -31,6 +32,13 @@ export const LinkedAccountThumb = ({
   const linkedAccountThumbClassName = classNames(
     'Layer__linked-account-thumb',
     asWidget && '--as-widget',
+    account.is_syncing && "--is-syncing",
+    account.is_syncing && "skeleton-loader"
+  )
+
+  const linkedAccountInfoClassName = classNames(
+    'topbar',
+    account.is_syncing && "--is-syncing",
   )
 
   let bankBalance: React.ReactNode
@@ -41,16 +49,14 @@ export const LinkedAccountThumb = ({
   } else {
     bankBalance = (
       <Text as='span' className='account-balance'>
-        {account.is_syncing
-          ? 'Syncing...'
-          : `${formatMoney(account.latest_balance_timestamp?.balance)}`}
+          {`${formatMoney(account.latest_balance_timestamp?.balance)}`}
       </Text>
     )
   }
 
   return (
     <div className={linkedAccountThumbClassName}>
-      <div className='topbar'>
+      <div className={linkedAccountInfoClassName}>
         <div className='topbar-details'>
           <Text as='div' className='account-name'>
             {account.external_account_name}
@@ -79,6 +85,18 @@ export const LinkedAccountThumb = ({
           )}
         </div>
       </div>
+      {account.is_syncing ? (
+        <div className="loadingbar">
+          <div className="loading-text Layer__text--sm">
+            <div>Syncing account data</div>
+            <div className="syncing-data-description">This may take up to 5 minutes</div>
+          </div>
+          <div className="loading-wrapper">
+      <LoaderIcon size={11} className='Layer__anim--rotating' />
+          </div>
+        </div>
+      ) :
+      <>
       {!asWidget && (
         <div className='middlebar'>
           <Text
@@ -105,12 +123,12 @@ export const LinkedAccountThumb = ({
             </Text>
           )}
           <Text as='span' className='account-balance'>
-            {account.is_syncing
-              ? 'Syncing...'
-              : `${formatMoney(account.current_ledger_balance)}`}
+            {`${formatMoney(account.current_ledger_balance)}`}
           </Text>
         </div>
       )}
+      </>
+      }
     </div>
   )
 }

--- a/src/styles/linked_accounts.scss
+++ b/src/styles/linked_accounts.scss
@@ -105,6 +105,35 @@
   }
 }
 
+
+@keyframes skeletonSweep {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.skeleton-loader {
+  position: relative;
+  padding: 1rem;
+  background: white;
+  border-radius: var(--border-radius-base);
+  overflow: hidden;
+}
+
+.skeleton-loader::after {
+  display: block;
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 1), transparent);
+  animation: skeletonSweep 1.5s infinite;
+}
+
+
 .Layer__linked-account-thumb {
   display: flex;
   flex-direction: column;
@@ -114,6 +143,8 @@
   background: var(--color-base-0);
   border: 1px solid var(--color-base-100);
   box-sizing: border-box;
+  min-width: 286px;
+  justify-content: space-between;
 
   .topbar {
     min-width: 272px;
@@ -128,6 +159,12 @@
     border-bottom-right-radius: 0;
     padding: var(--spacing-xs);
     box-sizing: border-box;
+
+    &.--is-syncing {
+      color: var(--color-base-500);
+      background: none;
+      z-index: 50;
+    }
 
     .account-institution {
       color: var(--color-base-500);
@@ -178,6 +215,35 @@
     }
   }
 
+  .loadingbar {
+    display: flex;
+    padding: var(--spacing-xs);
+    border-bottom-left-radius: var(--border-radius-xs);
+    border-bottom-right-radius: var(--border-radius-xs);
+    gap: var(--spacing-xs);
+    align-items: center;
+    z-index: 100;
+
+    .loading-text {
+      flex: 1;
+      line-height: 140%;
+    }
+
+    .loading-wrapper {
+      width: 28px;
+      height: 28px;
+      background: var(--color-blue);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .syncing-data-description {
+      color: var(--color-base-500);
+    }
+  }
+
   .bottombar {
     box-sizing: border-box;
     display: flex;
@@ -189,6 +255,10 @@
     .account-balance-text {
       color: var(--color-base-500);
     }
+  }
+
+  &.--is-syncing {
+      background: hsla(200 11% 96%);
   }
 
   &.--as-widget {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -7,6 +7,7 @@
   // 1. BASE VARIABLES:
   --color-black: #1a1a1a;
   --color-white: white;
+  --color-blue: hsl(217 100% 92%);
 
   --color-info-success: hsl(145, 45%, 42%);
   --color-info-success-bg: hsl(145, 59%, 86%);
@@ -19,6 +20,7 @@
   --color-info-error: hsl(0 76% 50%);
   --color-info-error-bg: hsl(0 83% 86%);
   --color-info-error-fg: hsl(0 88% 32%);
+
 
   --color-dark-h: 0;
   --color-dark-s: 0%;


### PR DESCRIPTION
1. Prevent non-numeric-input in split amount fields
![image (2)](https://github.com/user-attachments/assets/b5f9eedb-d181-4249-b080-24876676c498)
^^old picture from ticket
New Behavior: if the user tries to type a non-number or more than one period, their keypress does nothing
<br /> <br />
2. Hide refresh button on Transactions empty state
<img width="808" alt="Screenshot 2024-07-23 at 9 26 45 PM" src="https://github.com/user-attachments/assets/0c6a4aae-fcb3-434a-b845-f3599ae1674a">
<br /> <br />
3. Show loading message _and_ refresh button when at least one account is in the syncing state
<img width="1088" alt="Screenshot 2024-07-24 at 10 26 50 AM" src="https://github.com/user-attachments/assets/e0cdcefb-3f07-470b-a6a0-dc80b0b93738">
<br /> <br />
4. Change category button to "outline" style <br />
<img width="431" alt="Screenshot 2024-07-24 at 4 41 33 PM" src="https://github.com/user-attachments/assets/e4d4e424-e5c7-4d9b-a6d8-418fb59f3652">
<br /> <br />
5. New ui for account card in loading state
<img width="745" alt="Screenshot 2024-07-25 at 12 53 34 PM" src="https://github.com/user-attachments/assets/3d535483-b1ac-4acb-85c1-39421f243719">

