### PR TITLE
Tasks navigation

### DIFF
--- a/src/components/TasksList/TasksList.tsx
+++ b/src/components/TasksList/TasksList.tsx
@@ -1,10 +1,19 @@
-import React, { useContext, useMemo, useState } from 'react'
+import React, { useContext, useEffect, useMemo, useState } from 'react'
 import { TasksContext } from '../../contexts/TasksContext'
 import SmileIcon from '../../icons/SmileIcon'
-import { isComplete } from '../../types/tasks'
+import { isComplete, TaskTypes } from '../../types/tasks'
 import { Pagination } from '../Pagination'
 import { TasksListItem } from '../TasksListItem'
 import { ErrorText, Text, TextSize } from '../Typography'
+
+function paginateArray<T>(array: T[], chunkSize: number = 10): T[][] {
+  const result: T[][] = []
+  for (let i = 0; i < array.length; i += chunkSize) {
+    const chunk = array.slice(i, i + chunkSize)
+    result.push(chunk)
+  }
+  return result
+}
 
 const TasksEmptyState = () => (
   <div className='Layer__tasks-empty-state'>
@@ -19,23 +28,51 @@ const TasksEmptyState = () => (
 )
 
 export const TasksList = ({ pageSize = 10 }: { pageSize?: number }) => {
-  const [currentPage, setCurrentPage] = useState(1)
   const { data: tasks, error } = useContext(TasksContext)
+
+  const firstPageWithIincompleteTasks = paginateArray(
+    tasks || [],
+    pageSize,
+  ).findIndex(page => page.some(task => !isComplete(task.status)))
+
+  const [currentPage, setCurrentPage] = useState(
+    firstPageWithIincompleteTasks === -1
+      ? 1
+      : firstPageWithIincompleteTasks + 1,
+  )
 
   const sortedTasks = useMemo(() => {
     const firstPageIndex = (currentPage - 1) * pageSize
     const lastPageIndex = firstPageIndex + pageSize
-    return tasks
-      ?.sort(a => (isComplete(a.status) ? 1 : -1))
-      ?.slice(firstPageIndex, lastPageIndex)
+    return tasks?.slice(firstPageIndex, lastPageIndex)
   }, [tasks, currentPage])
+
+  const indexFirstIncomplete = sortedTasks?.findIndex(
+    task => !isComplete(task.status),
+  )
+
+  const goToNextPage = (task: TaskTypes) => {
+    const allComplete = sortedTasks
+      ?.filter(taskInList => taskInList.id !== task.id)
+      .every(task => isComplete(task.status))
+    if (allComplete) {
+      setCurrentPage(currentPage + 1)
+    }
+  }
+
+  console.log('TasksList', { tasks, sortedTasks, currentPage })
 
   return (
     <div className='Layer__tasks-list'>
       {sortedTasks && sortedTasks.length > 0 ? (
         <>
           {sortedTasks.map((task, index) => (
-            <TasksListItem key={task.id} task={task} index={index} />
+            <TasksListItem
+              key={task.id}
+              task={task}
+              goToNextPageIfAllComplete={goToNextPage}
+              defaultOpen={index === indexFirstIncomplete}
+            />
           ))}
           {tasks && tasks.length >= 10 && (
             <div className='Layer__tasks__pagination'>

--- a/src/components/TasksListItem/TasksListItem.tsx
+++ b/src/components/TasksListItem/TasksListItem.tsx
@@ -12,14 +12,14 @@ import { set } from 'date-fns'
 
 export const TasksListItem = ({
   task,
-  index,
+  goToNextPageIfAllComplete,
+  defaultOpen,
 }: {
   task: TaskTypes
-  index: number
+  goToNextPageIfAllComplete: (task: TaskTypes) => void
+  defaultOpen: boolean
 }) => {
-  const [isOpen, setIsOpen] = useState(
-    index === 0 && !isComplete(task.status) ? true : false,
-  )
+  const [isOpen, setIsOpen] = useState(defaultOpen)
   const [userResponse, setUserResponse] = useState(task.user_response || '')
 
   const { submitResponseToTask } = useContext(TasksContext)
@@ -41,6 +41,10 @@ export const TasksListItem = ({
     'Layer__tasks-list-item',
     isOpen && 'Layer__tasks-list-item__expanded',
   )
+
+  useEffect(() => {
+    setIsOpen(defaultOpen)
+  }, [defaultOpen])
 
   return (
     <div className='Layer__tasks-list-item-wrapper'>
@@ -86,6 +90,7 @@ export const TasksListItem = ({
                 onClick={() => {
                   submitResponseToTask(task.id, userResponse)
                   setIsOpen(false)
+                  goToNextPageIfAllComplete(task)
                 }}
               >
                 {userResponse && userResponse.length === 0 ? 'Update' : 'Save'}


### PR DESCRIPTION
Three changes
1. Don't re-order tasks after completion: completed ones don't go to the bottom. This has nasty UX side effects where you can "complete" all your tasks and not realize there are multiple pages (it's not super obvious), so two additional changes...
2. Upon page open, we go to the first page with incomplete tasks.
3. Upon completing all the tasks on a page, automatically change to the next page.