### PR TITLE
Fix splits dollars to cents

### DIFF
--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -215,7 +215,8 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
     const updateAmounts =
       (rowNumber: number) => (event: React.ChangeEvent<HTMLInputElement>) => {
         const newDisplaying = sanitizeNumberInput(event.target.value)
-        const newAmount = Number(newDisplaying)
+
+        const newAmount = Number(newDisplaying) * 100 // cents
         const splitTotal = rowState.splits.reduce((sum, split, index) => {
           const amount =
             index === 0 ? 0 : index === rowNumber ? newAmount : split.amount


### PR DESCRIPTION
I replaced `parseMoney` with my own parsing function, not realizing that `parseMoney` also converted dollars to cents
<img width="950" alt="Screenshot 2024-07-31 at 2 01 07 PM" src="https://github.com/user-attachments/assets/097bf080-8b86-4b96-a9d0-9a23122477ee">
