### PR TITLE
feat: pnl summaries cards not clickable by default

### DIFF
--- a/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
+++ b/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
@@ -57,7 +57,7 @@ const buildMiniChartData = (scope: Scope, data?: ProfitAndLoss) => {
 export const ProfitAndLossSummaries = ({
   vertical,
   revenueLabel = 'Revenue',
-  actionable = true,
+  actionable = false,
 }: Props) => {
   const {
     data: storedData,

--- a/src/components/ProfitAndLossView/ProfitAndLossView.tsx
+++ b/src/components/ProfitAndLossView/ProfitAndLossView.tsx
@@ -83,7 +83,7 @@ const Components = ({
             className={`Layer__${COMPONENT_NAME}__chart_with_summaries__summary-col`}
           >
             <ProfitAndLoss.DatePicker />
-            <ProfitAndLoss.Summaries vertical={true} />
+            <ProfitAndLoss.Summaries vertical={true} actionable />
           </div>
           <div
             className={`Layer__${COMPONENT_NAME}__chart_with_summaries__chart-col`}

--- a/src/views/AccountingOverview/AccountingOverview.tsx
+++ b/src/views/AccountingOverview/AccountingOverview.tsx
@@ -34,7 +34,7 @@ export const AccountingOverview = ({
           />
         )}
         <div className='Layer__accounting-overview__summaries-row'>
-          <ProfitAndLoss.Summaries actionable={false} />
+          <ProfitAndLoss.Summaries />
           <TransactionToReviewCard
             usePnlDateRange={true}
             onClick={onTransactionsToReviewClick}

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -46,7 +46,7 @@ export const BookkeepingOverview = ({
               <ProfitAndLoss.DatePicker />
             </Header>
             <div className='Layer__bookkeeping-overview__summaries-row'>
-              <ProfitAndLoss.Summaries actionable={false} />
+              <ProfitAndLoss.Summaries />
             </div>
             <ProfitAndLoss.Chart />
           </Container>


### PR DESCRIPTION
## Description

Make PnL summary cards not clickable by default.

## How this has been tested?


Using:

```
<ProfitAndLoss.Summaries />
```

![image](https://github.com/user-attachments/assets/ed4d2075-7a8a-471e-b346-6aa79602a5fa)


Using:

```
<ProfitAndLoss.Summaries actionable />
```

https://github.com/user-attachments/assets/aafc86d6-8159-47c9-ad4d-3bf7fc12555d



