### PR TITLE
fix: styling for deeper levels in pnl table

### DIFF
--- a/src/components/ProfitAndLossRow/ProfitAndLossRow.tsx
+++ b/src/components/ProfitAndLossRow/ProfitAndLossRow.tsx
@@ -85,7 +85,9 @@ export const ProfitAndLossRow = ({
       <div
         className={labelClasses.join(' ')}
         onClick={() => !lockExpanded && toggleExpanded()}
-        style={{ paddingLeft: 16 * (depth + 1) }}
+        style={{
+          paddingLeft: depth === 0 && !hasChildren ? 28 : 16 * (depth + 1) + 2,
+        }}
       >
         <span className='Layer__profit-and-loss-row__label__title'>
           {!lockExpanded && variant !== 'summation' ? (

--- a/src/components/ProfitAndLossRow/ProfitAndLossRow.tsx
+++ b/src/components/ProfitAndLossRow/ProfitAndLossRow.tsx
@@ -14,6 +14,7 @@ type Props = {
   direction?: Direction
   scope?: SidebarScope
   setSidebarScope?: (name: SidebarScope) => void
+  defaultExpanded?: boolean
 
   /* This removes the expand toggle and leaves everything in the expanded state */
   lockExpanded?: boolean
@@ -23,17 +24,18 @@ export const ProfitAndLossRow = ({
   variant,
   lineItem,
   depth = 0,
-  maxDepth = 1,
+  maxDepth = 8,
   direction = Direction.DEBIT,
   lockExpanded = false,
   scope,
   setSidebarScope,
+  defaultExpanded = false,
 }: Props) => {
   if (!lineItem) {
     return null
   }
   const { value, display_name, line_items } = lineItem
-  const [expanded, setExpanded] = useState(true)
+  const [expanded, setExpanded] = useState(lockExpanded || defaultExpanded)
   const amount = value ?? 0
   const amountString = centsToDollars(Math.abs(amount))
   const labelClasses = [
@@ -83,6 +85,7 @@ export const ProfitAndLossRow = ({
       <div
         className={labelClasses.join(' ')}
         onClick={() => !lockExpanded && toggleExpanded()}
+        style={{ paddingLeft: 16 * (depth + 1) }}
       >
         <span className='Layer__profit-and-loss-row__label__title'>
           {!lockExpanded && variant !== 'summation' ? (

--- a/src/components/ProfitAndLossTable/ProfitAndLossTable.tsx
+++ b/src/components/ProfitAndLossTable/ProfitAndLossTable.tsx
@@ -18,7 +18,11 @@ type Props = {
   stringOverrides?: ProfitAndLossTableStringOverrides
 }
 
-export const ProfitAndLossTable = ({ lockExpanded, asContainer, stringOverrides }: Props) => {
+export const ProfitAndLossTable = ({
+  lockExpanded,
+  asContainer,
+  stringOverrides,
+}: Props) => {
   const {
     data: actualData,
     isLoading,
@@ -57,6 +61,7 @@ export const ProfitAndLossTable = ({ lockExpanded, asContainer, stringOverrides 
           lockExpanded={lockExpanded}
           scope='revenue'
           setSidebarScope={setSidebarScope}
+          defaultExpanded
         />
         <ProfitAndLossRow
           lineItem={data.cost_of_goods_sold}
@@ -64,6 +69,7 @@ export const ProfitAndLossTable = ({ lockExpanded, asContainer, stringOverrides 
           lockExpanded={lockExpanded}
           scope='expenses'
           setSidebarScope={setSidebarScope}
+          defaultExpanded
         />
         <ProfitAndLossRow
           lineItem={{
@@ -75,6 +81,7 @@ export const ProfitAndLossTable = ({ lockExpanded, asContainer, stringOverrides 
           lockExpanded={lockExpanded}
           scope='revenue'
           setSidebarScope={setSidebarScope}
+          defaultExpanded
         />
         <ProfitAndLossRow
           lineItem={data.expenses}
@@ -82,17 +89,20 @@ export const ProfitAndLossTable = ({ lockExpanded, asContainer, stringOverrides 
           lockExpanded={lockExpanded}
           scope='expenses'
           setSidebarScope={setSidebarScope}
+          defaultExpanded
         />
         <ProfitAndLossRow
           lineItem={{
             value: data.profit_before_taxes,
-            display_name: stringOverrides?.profitBeforeTaxesLabel || 'Profit Before Taxes',
+            display_name:
+              stringOverrides?.profitBeforeTaxesLabel || 'Profit Before Taxes',
           }}
           variant='summation'
           direction={Direction.CREDIT}
           lockExpanded={lockExpanded}
           scope='revenue'
           setSidebarScope={setSidebarScope}
+          defaultExpanded
         />
         <ProfitAndLossRow
           lineItem={data.taxes}
@@ -100,6 +110,7 @@ export const ProfitAndLossTable = ({ lockExpanded, asContainer, stringOverrides 
           lockExpanded={lockExpanded}
           scope='expenses'
           setSidebarScope={setSidebarScope}
+          defaultExpanded
         />
         <ProfitAndLossRow
           lineItem={{

--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -201,7 +201,7 @@
   }
 }
 
-.Layer__profit-and-loss-row__value--depth-1 {
+.Layer__profit-and-loss-row__label {
   .Layer__text {
     color: var(--color-base-700);
     font-variation-settings: 'wght' var(--font-weight-normal);

--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -173,15 +173,15 @@
   }
 }
 
-.Layer__profit-and-loss-row__label--depth-0 {
+.Layer__profit-and-loss-row__label {
   .Layer__text {
-    color: var(--color-base-800);
-    font-variation-settings: 'wght' var(--font-weight-bold);
+    color: var(--color-base-700);
+    font-variation-settings: 'wght' var(--font-weight-normal);
     margin: 0;
   }
 }
 
-.Layer__profit-and-loss-row__value--depth-0 {
+.Layer__profit-and-loss-row__label.Layer__profit-and-loss-row__label--depth-0 {
   .Layer__text {
     color: var(--color-base-800);
     font-variation-settings: 'wght' var(--font-weight-bold);
@@ -194,14 +194,6 @@
   padding-left: calc(var(--spacing-5xl) + var(--spacing-md));
   padding-top: var(--spacing-sm);
   padding-bottom: var(--spacing-sm);
-  .Layer__text {
-    color: var(--color-base-700);
-    font-variation-settings: 'wght' var(--font-weight-normal);
-    margin: 0;
-  }
-}
-
-.Layer__profit-and-loss-row__label {
   .Layer__text {
     color: var(--color-base-700);
     font-variation-settings: 'wght' var(--font-weight-normal);


### PR DESCRIPTION
## Description

Fix styling of row nested deeper than level `1` in Profit and Loss table.


Questions:
1. Do we want to support `maxDepth` through `ProfitAndLossTable` props?
2. only first level auto-expanded? or all auto-expanded?

## How this has been tested?


https://github.com/user-attachments/assets/e6fe5228-e3f9-4456-8d1c-709033bbf710

