### PR TITLE
fix: datepicker not calling onchange on every change

### DIFF
--- a/src/components/BalanceSheet/BalanceSheet.tsx
+++ b/src/components/BalanceSheet/BalanceSheet.tsx
@@ -5,12 +5,12 @@ import { useBalanceSheet } from '../../hooks/useBalanceSheet'
 import { BalanceSheetDatePicker } from '../BalanceSheetDatePicker'
 import { BalanceSheetExpandAllButton } from '../BalanceSheetExpandAllButton'
 import { BalanceSheetTable } from '../BalanceSheetTable'
+import { BalanceSheetTableStringOverrides } from '../BalanceSheetTable/BalanceSheetTable'
 import { Container } from '../Container'
 import { Loader } from '../Loader'
 import { View } from '../View'
 import { BALANCE_SHEET_ROWS } from './constants'
 import { format, parse, startOfDay } from 'date-fns'
-import { BalanceSheetTableStringOverrides } from '../BalanceSheetTable/BalanceSheetTable'
 
 export interface BalanceSheetStringOverrides {
   balanceSheetTable?: BalanceSheetTableStringOverrides
@@ -34,7 +34,11 @@ export const BalanceSheet = (props: BalanceSheetProps) => {
   const balanceSheetContextData = useBalanceSheet(props.effectiveDate)
   return (
     <BalanceSheetContext.Provider value={balanceSheetContextData}>
-      <BalanceSheetView asWidget={props.asWidget} stringOverrides={props.stringOverrides} {...props} />
+      <BalanceSheetView
+        asWidget={props.asWidget}
+        stringOverrides={props.stringOverrides}
+        {...props}
+      />
     </BalanceSheetContext.Provider>
   )
 }
@@ -86,7 +90,11 @@ const BalanceSheetView = ({
                 <Loader />
               </div>
             ) : (
-              <BalanceSheetTable data={data} config={BALANCE_SHEET_ROWS} stringOverrides={stringOverrides?.balanceSheetTable} />
+              <BalanceSheetTable
+                data={data}
+                config={BALANCE_SHEET_ROWS}
+                stringOverrides={stringOverrides?.balanceSheetTable}
+              />
             )}
           </View>
         </Container>
@@ -113,7 +121,11 @@ const BalanceSheetView = ({
             <Loader />
           </div>
         ) : (
-          <BalanceSheetTable data={data} config={BALANCE_SHEET_ROWS} stringOverrides={stringOverrides?.balanceSheetTable} />
+          <BalanceSheetTable
+            data={data}
+            config={BALANCE_SHEET_ROWS}
+            stringOverrides={stringOverrides?.balanceSheetTable}
+          />
         )}
       </View>
     </TableProvider>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -94,16 +94,20 @@ export const DatePicker = ({
   useEffect(() => {
     try {
       setPickerDate(true)
-      if (!isRangeMode(mode) && selected !== selectedDates) {
+      if (
+        !isRangeMode(mode) &&
+        (selected as Date | null)?.getTime() !==
+          (selectedDates as Date | null)?.getTime()
+      ) {
         setSelectedDates(selected)
         return
       }
 
       if (isRangeMode(mode) && Array.isArray(selected)) {
-        if (startDate !== selected[0]) {
+        if ((startDate as Date | null)?.getTime() !== selected[0]?.getTime()) {
           setStartDate(selected[0])
         }
-        if (endDate !== selected[1]) {
+        if ((endDate as Date | null)?.getTime() !== selected[1]?.getTime()) {
           setEndDate(selected[1])
         }
       }
@@ -113,7 +117,10 @@ export const DatePicker = ({
   }, [selected])
 
   useEffect(() => {
-    if (onChange && !updatePickerDate) {
+    if (
+      onChange &&
+      (!isRangeMode(mode) || (isRangeMode(mode) && !updatePickerDate))
+    ) {
       onChange(selectedDates as Date | [Date, Date])
     } else {
       setPickerDate(false)

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -775,6 +775,8 @@
     position: sticky;
     top: 0px;
     z-index: 2;
+    border-top-left-radius: var(--border-radius-sm);
+    border-top-right-radius: var(--border-radius-sm);
   }
 
   .Layer__bank-transactions__header.Layer__bank-transactions__header--mobile {


### PR DESCRIPTION
## Description

Data was not fetch on every date selection on BalanceSheet page, because DatePicker didn't call `onChange` on every date selection. The problem was with wrong dates comparison.

## How this has been tested?


https://github.com/user-attachments/assets/7b469429-afe6-4a79-9e7f-dc8a7158f9c2

