### PR TITLE
feat: drop bank transaction loaders when data loaded

### DIFF
--- a/src/components/BankTransactionsLoader/BankTransactionsLoader.tsx
+++ b/src/components/BankTransactionsLoader/BankTransactionsLoader.tsx
@@ -40,10 +40,13 @@ export const BankTransactionsLoader = ({
   )
   return (
     <SkeletonTableLoader
-      rows={4}
+      rows={6}
       cols={
         isLoading
-          ? [{ colSpan: 4 }, { colSpan: 1 }]
+          ? [
+              { colSpan: 4, trimLastXRows: 3 },
+              { colSpan: 1, parts: 2 },
+            ]
           : [
               { colSpan: 4 },
               { colSpan: 1, colComponent: inactiveBankTransactionsActions },

--- a/src/components/BankTransactionsTable/BankTransactionsTable.tsx
+++ b/src/components/BankTransactionsTable/BankTransactionsTable.tsx
@@ -93,9 +93,6 @@ export const BankTransactionsTable = ({
       {isLoading && page && page === 1 ? (
         <BankTransactionsLoader isLoading={true} />
       ) : null}
-      {!isLoading && isSyncing && page && page === 1 ? (
-        <BankTransactionsLoader isLoading={false} />
-      ) : null}
       <tbody>
         {!isLoading &&
           bankTransactions?.map(

--- a/src/components/SkeletonTableLoader/SkeletonTableLoader.tsx
+++ b/src/components/SkeletonTableLoader/SkeletonTableLoader.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
 import { SkeletonLoader } from '../SkeletonLoader'
-import classNames from 'classnames'
 
 interface SkeletonTableLoaderProps {
   rows: number
-  cols: Array<{ colSpan: number; colComponent?: React.ReactNode }>
+  cols: Array<{
+    colSpan: number
+    colComponent?: React.ReactNode
+    trimLastXRows?: number
+    parts?: number
+  }>
   height?: number
   width?: number
 }
@@ -19,19 +23,38 @@ export const SkeletonTableLoader = ({
     <tbody className={'Layer__skeleton-table-body__loader'}>
       {Array.from({ length: rows }).map((_, rowIndex) => (
         <tr key={rowIndex}>
-          {cols.map((col, colIndex) => (
-            <td
-              key={colIndex}
-              colSpan={col.colSpan}
-              className='Layer__skeleton-loader__row'
-            >
-              {col.colComponent ? (
-                col.colComponent
-              ) : (
-                <SkeletonLoader width={`${width}%`} height={`${height}px`} />
-              )}
-            </td>
-          ))}
+          {cols.map((col, colIndex) => {
+            const trim: number =
+              col.trimLastXRows && rowIndex >= col.trimLastXRows - 1
+                ? (rowIndex - col.trimLastXRows + 1) * 10
+                : 0
+            return (
+              <td
+                key={colIndex}
+                colSpan={col.colSpan}
+                className='Layer__skeleton-loader__row'
+              >
+                {col.colComponent ? (
+                  col.colComponent
+                ) : col.parts && col.parts > 1 ? (
+                  <span className='Layer__skeleton-loader__row__group'>
+                    {[...Array(col.parts)].map((_part, partIndex) => (
+                      <SkeletonLoader
+                        key={`part-${partIndex}`}
+                        width='100%'
+                        height={`${height}px`}
+                      />
+                    ))}
+                  </span>
+                ) : (
+                  <SkeletonLoader
+                    width={`${width - trim}%`}
+                    height={`${height}px`}
+                  />
+                )}
+              </td>
+            )
+          })}
         </tr>
       ))}
     </tbody>

--- a/src/styles/loader.scss
+++ b/src/styles/loader.scss
@@ -31,6 +31,12 @@
   height: 63px;
 }
 
+.Layer__skeleton-loader__row__group {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
 .Layer__skeleton-loader {
   width: 100%;
   height: 12px;


### PR DESCRIPTION
## Description

1. Drop skeleton loaders from bank transaction table when any data is loaded
2. improve structure of loaders

## How this has been tested?

https://github.com/user-attachments/assets/81fc6a4a-9918-4647-801a-9cc5375c0314


https://github.com/user-attachments/assets/76b4aac2-6313-4392-92f6-8acb52848956


 

https://github.com/user-attachments/assets/c59ce0a8-3d62-4bf7-b158-a8f0e2709dc5

