### PR TITLE
fix: toggle thumb not updated when options disabled

### DIFF
--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -79,9 +79,19 @@ export const Toggle = ({
       return
     }
 
-    const optionsNodes = [...toggleRef.current.children].filter(c =>
-      c.className.includes('Layer__toggle-option'),
-    )
+    const optionsNodes = [...toggleRef.current.children]
+      .map(x => {
+        if (
+          x.className.includes('Layer__tooltip-trigger') &&
+          x.children &&
+          x.children.length > 0
+        ) {
+          return x.children[0]
+        }
+
+        return x
+      })
+      .filter(c => c.className.includes('Layer__toggle-option'))
 
     let shift = 0
     let width = thumbPos.width


### PR DESCRIPTION
## Description

Toggle thumb size and position was not updated when all options are disabled.

![image](https://github.com/user-attachments/assets/96002ad7-0adf-4b99-bac3-dc7c5856afae)


## How this has been tested?

![image](https://github.com/user-attachments/assets/6b9a21d3-e386-48d4-923a-3592fb779f4a)
