### PR TITLE
Handle null categorization_flow + account institution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.43",
+  "version": "0.1.45",
   "description": "Layer React Components",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
+++ b/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
@@ -71,7 +71,9 @@ export const LinkedAccountThumb = ({
             className='account-institution'
             size={'sm' as TextSize}
           >
-            {account.institution?.name}
+            {account.institution?.name
+              ? account.institution?.name
+              : account.external_account_name}
           </Text>
         </div>
         <div className='topbar-logo'>
@@ -80,7 +82,11 @@ export const LinkedAccountThumb = ({
               width={28}
               height={28}
               src={`data:image/png;base64,${account.institution.logo}`}
-              alt={account.institution?.name}
+              alt={
+                account.institution?.name
+                  ? account.institution?.name
+                  : account.external_account_name
+              }
             />
           ) : (
             <InstitutionIcon />

--- a/src/types/bank_transactions.ts
+++ b/src/types/bank_transactions.ts
@@ -1,5 +1,5 @@
 import { Categorization, CategorizationStatus, Category } from './categories'
-import {S3PresignedUrl} from "./general";
+import { S3PresignedUrl } from './general'
 
 export enum Direction {
   CREDIT = 'CREDIT',
@@ -34,7 +34,7 @@ export interface BankTransaction extends Record<string, unknown> {
   counterparty_name: string
   category: Category
   categorization_status: CategorizationStatus
-  categorization_flow: Categorization
+  categorization_flow: Categorization | null
   categorization_method: string
   error?: string
   processing?: boolean

--- a/src/types/categories.ts
+++ b/src/types/categories.ts
@@ -67,9 +67,10 @@ export type SplitCategoryUpdate = {
 export type CategoryUpdate = SingleCategoryUpdate | SplitCategoryUpdate
 
 export function hasSuggestions(
-  categorization: Categorization,
+  categorization: Categorization | null,
 ): categorization is SuggestedCategorization {
   return (
+    categorization != null &&
     (categorization as SuggestedCategorization).suggestions !== undefined &&
     (categorization as SuggestedCategorization).suggestions.length > 0
   )


### PR DESCRIPTION
<img width="955" alt="Screenshot 2024-08-06 at 12 16 32 PM" src="https://github.com/user-attachments/assets/3288dad5-1408-4072-8904-0c7f620f6b9f">
<img width="776" alt="Screenshot 2024-08-06 at 12 16 24 PM" src="https://github.com/user-attachments/assets/bb4a3a0f-b46e-4197-af90-d7de0993055c">

Was getting an unhandled error for a business with transactions with null categorization flows and realized that this was not accounted for on the front-end.

Also included in this PR: falling back to the linked bank account name when the institution is null
