### PR TITLE
use returned SWR value always when it changes

### DIFF
--- a/src/providers/LayerProvider/LayerProvider.tsx
+++ b/src/providers/LayerProvider/LayerProvider.tsx
@@ -199,7 +199,7 @@ export const LayerProvider = ({
     }
   }, [businessAccessToken, auth?.access_token])
 
-  useSWR(
+  const { data: categoriesData } = useSWR(
     businessId && state.auth?.access_token && `categories-${businessId}`,
     Layer.getCategories(apiUrl, state.auth?.access_token, {
       params: { businessId },
@@ -216,8 +216,16 @@ export const LayerProvider = ({
       },
     },
   )
+  useEffect(() => {
+    if (categoriesData?.data?.categories?.length) {
+      dispatch({
+        type: Action.setCategories,
+        payload: { categories: categoriesData.data.categories || [] },
+      })
+    }
+  }, [categoriesData])
 
-  useSWR(
+  const { data: businessData } = useSWR(
     businessId && state?.auth?.access_token && `business-${businessId}`,
     Layer.getBusiness(apiUrl, state?.auth?.access_token, {
       params: { businessId },
@@ -234,6 +242,14 @@ export const LayerProvider = ({
       },
     },
   )
+  useEffect(() => {
+    if (businessData?.data) {
+      dispatch({
+        type: Action.setBusiness,
+        payload: { business: businessData.data || [] },
+      })
+    }
+  }, [businessData])
 
   const setTheme = (theme: LayerThemeConfig) => {
     dispatch({


### PR DESCRIPTION
1. I added console.logs and you can see that the `onSuccess` triggers only on page load, `useEffect` triggers immediately after that page load _and_ upon renavigating. This _is_ why it works.
2. I tried the `revalidateOnMount` param and that _also_ would have solved the issue by forcing a re-request to load the query again. Inferior for our use case, as we don't expect the values to have changed between navigating away and back, so no revalidation is necessary.