### PR TITLE
feat: restyle download button on bank transactions

### DIFF
--- a/src/components/BankTransactions/BankTransactionsHeader.tsx
+++ b/src/components/BankTransactions/BankTransactionsHeader.tsx
@@ -10,6 +10,7 @@ import { DatePicker } from '../DatePicker'
 import { SyncingComponent } from '../SyncingComponent'
 import { Tabs } from '../Tabs'
 import { Toggle } from '../Toggle'
+import { ToggleSize } from '../Toggle/Toggle'
 import { Heading, HeadingSize } from '../Typography'
 import { MobileComponentType } from './constants'
 import classNames from 'classnames'
@@ -39,12 +40,16 @@ export interface BankTransactionsHeaderStringOverrides {
 
 const DownloadButton = ({
   downloadButtonTextOverride,
+  iconOnly,
 }: {
   downloadButtonTextOverride?: string
+  iconOnly?: boolean
 }) => {
   const { auth, businessId, apiUrl } = useLayerContext()
   const [requestFailed, setRequestFailed] = useState(false)
+  const [isDownloading, setIsDownloading] = useState(false)
   const handleClick = async () => {
+    setIsDownloading(true)
     const currentYear = new Date().getFullYear().toString()
     const getBankTransactionsCsv = Layer.getBankTransactionsCsv(
       apiUrl,
@@ -66,6 +71,8 @@ const DownloadButton = ({
       }
     } catch (e) {
       setRequestFailed(true)
+    } finally {
+      setIsDownloading(false)
     }
   }
 
@@ -74,6 +81,8 @@ const DownloadButton = ({
       onClick={handleClick}
       className='Layer__download-retry-btn'
       error={'Approval failed. Check connection and retry in few seconds.'}
+      disabled={isDownloading}
+      iconOnly={iconOnly}
     >
       Retry
     </RetryButton>
@@ -82,6 +91,9 @@ const DownloadButton = ({
       variant={ButtonVariant.secondary}
       rightIcon={<DownloadCloud size={12} />}
       onClick={handleClick}
+      disabled={isDownloading}
+      iconAsPrimary={iconOnly}
+      iconOnly={iconOnly}
     >
       {downloadButtonTextOverride || 'Download'}
     </Button>
@@ -149,31 +161,15 @@ export const BankTransactionsHeader = ({
         ) : null}
       </div>
       <div className='Layer__header__actions-wrapper'>
-        <div className='Layer__header__actions'>
-          <DownloadButton
-            downloadButtonTextOverride={stringOverrides?.downloadButton}
-          />
-          {!categorizedOnly &&
-            !(mobileComponent == 'mobileList' && listView) &&
-            categorizeView && (
-              <Toggle
-                name='bank-transaction-display'
-                options={[
-                  { label: 'To Review', value: DisplayState.review },
-                  { label: 'Categorized', value: DisplayState.categorized },
-                ]}
-                selected={display}
-                onChange={onCategorizationDisplayChange}
-              />
-            )}
-        </div>
-
-        {!categorizedOnly &&
-          mobileComponent === 'mobileList' &&
-          listView &&
-          categorizeView && (
-            <Tabs
+        <div className='Layer__header__actions Layer__justify--space-between'>
+          {!categorizedOnly && categorizeView && (
+            <Toggle
               name='bank-transaction-display'
+              size={
+                mobileComponent === 'mobileList'
+                  ? ToggleSize.small
+                  : ToggleSize.medium
+              }
               options={[
                 { label: 'To Review', value: DisplayState.review },
                 { label: 'Categorized', value: DisplayState.categorized },
@@ -182,6 +178,12 @@ export const BankTransactionsHeader = ({
               onChange={onCategorizationDisplayChange}
             />
           )}
+
+          <DownloadButton
+            downloadButtonTextOverride={stringOverrides?.downloadButton}
+            iconOnly={listView}
+          />
+        </div>
       </div>
     </Header>
   )

--- a/src/components/Button/RetryButton.tsx
+++ b/src/components/Button/RetryButton.tsx
@@ -10,6 +10,7 @@ export interface RetryButtonProps
   disabled?: boolean
   error: string
   fullWidth?: boolean
+  iconOnly?: boolean
 }
 
 export const RetryButton = ({

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -65,6 +65,14 @@
   align-items: center;
 }
 
+.Layer__header__actions-wrapper {
+  width: 100%;
+}
+
+.Layer__header__actions {
+  width: 100%;
+}
+
 .Layer__bank-transactions__list-loader {
   padding: var(--spacing-lg) var(--spacing-md);
 }
@@ -108,6 +116,11 @@
     width: 100%;
     padding-left: var(--spacing-3xs);
   }
+}
+
+.Layer__bank-transactions__header--with-date-picker.Layer__bank-transactions__header--mobile
+  .Layer__datepicker__wrapper {
+  margin-right: 4px;
 }
 
 .Layer__bank-transaction-row {

--- a/src/styles/bank_transactions_mobile_list.scss
+++ b/src/styles/bank_transactions_mobile_list.scss
@@ -11,7 +11,7 @@
 
 .Layer__bank-transaction-mobile-list-item {
   padding: 0;
-  margin: var(--spacing-2xs);
+  margin: var(--spacing-2xs) var(--spacing-md);
   background: var(--color-base-0);
   box-shadow:
     0px 2px 2px 0px var(--color-base-200),
@@ -37,7 +37,9 @@
 
   &.show.Layer__bank-transaction-row--removing {
     opacity: 0;
-    transition: all 500ms ease-in-out, opacity 80ms ease-out;
+    transition:
+      all 500ms ease-in-out,
+      opacity 80ms ease-out;
     overflow: hidden;
     margin-top: 0;
     margin-bottom: 0;

--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -155,6 +155,10 @@
   width: 122px;
 }
 
+.Layer__download-retry-btn.Layer__btn--icon-only {
+  width: 36px;
+}
+
 .Layer__btn--primary {
   color: var(--btn-color-primary);
   background: var(--btn-bg-color-primary);


### PR DESCRIPTION
## Description

Restyle bank transactions header including download button.

Further improvement can/will be done with other PRs:
1. Show spinner on download button
2. Reorganize buttons into two rows

## How this has been tested?

![image](https://github.com/user-attachments/assets/fb34a41a-b001-46e5-90f4-c12c3624eb02)

![image](https://github.com/user-attachments/assets/c11e5852-3fd9-475c-9992-3ff0d0657874)

![image](https://github.com/user-attachments/assets/d2ac8ebb-624f-4519-8860-17341a30cea2)

https://github.com/user-attachments/assets/415da0ee-f311-494a-b2f5-041cc73611e6


https://github.com/user-attachments/assets/8a1302f0-e159-454e-bc54-c957db0a96a7

https://github.com/user-attachments/assets/cdafa1ba-fb42-43f0-bddc-6daf8635fed7



https://github.com/user-attachments/assets/1d50301b-cefd-4a22-9028-d2568da8e2e7




