### PR TITLE
responsive bookkeeping overview

### DIFF
--- a/src/styles/bookkeeping_overview.scss
+++ b/src/styles/bookkeeping_overview.scss
@@ -37,9 +37,12 @@
   }
 }
 
+.Layer__bookkeeping-overview-profit-and-loss-chart {
+  width: calc(50% - var(--spacing-md) / 2);
+}
+
 .Layer__bookkeeping-overview-profit-and-loss-charts {
   display: flex;
-  flex-direction: column;
   gap: var(--spacing-md);
   max-width: 1406px;
 }
@@ -65,6 +68,10 @@
     .Layer__notification-card.Layer__txs-to-review {
       width: 100%;
     }
+  }
+
+  .Layer__bookkeeping-overview-profit-and-loss-chart {
+    width: 100%;
   }
 
   .Layer__bookkeeping-overview-profit-and-loss-charts {

--- a/src/styles/bookkeeping_overview.scss
+++ b/src/styles/bookkeeping_overview.scss
@@ -44,7 +44,7 @@
   max-width: 1406px;
 }
 
-.bookkeeping-overview-profit-and-loss-charts > .Layer__toggle {
+.Layer__bookkeeping-overview-profit-and-loss-charts > .Layer__toggle {
   display: none;
 }
 
@@ -52,9 +52,6 @@
   top: 16px !important;
 }
 
-.Layer__component.Layer__bookkeeping-overview-profit-and-loss-chart.bookkeeping-overview-profit-and-loss-chart--hidden {
-  display: none;
-}
 
 @container (max-width: 796px) {
   .Layer__bookkeeping-overview__summaries-row {
@@ -76,6 +73,10 @@
 
   .Layer__bookkeeping-overview-profit-and-loss-charts > .Layer__toggle {
     display: flex;
+  }
+
+  .Layer__component.Layer__bookkeeping-overview-profit-and-loss-chart.bookkeeping-overview-profit-and-loss-chart--hidden {
+    display: none;
   }
 }
 

--- a/src/views/AccountingOverview/AccountingOverview.tsx
+++ b/src/views/AccountingOverview/AccountingOverview.tsx
@@ -37,7 +37,7 @@ export const AccountingOverview = ({
   chartColorsList,
   stringOverrides,
 }: AccountingOverviewProps) => {
-  const [pnlToggle, setPnlToggle] = useState<PnlToggleOption>('revenue')
+  const [pnlToggle, setPnlToggle] = useState<PnlToggleOption>('expenses')
 
   return (
     <ProfitAndLoss asContainer={false}>

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -30,7 +30,7 @@ export const BookkeepingOverview = ({
   title, // deprecated
   stringOverrides,
 }: BookkeepingOverviewProps) => {
-  const [pnlToggle, setPnlToggle] = useState<PnlToggleOption>('revenue')
+  const [pnlToggle, setPnlToggle] = useState<PnlToggleOption>('expenses')
   const [width] = useWindowSize()
 
   return (


### PR DESCRIPTION
Wide screen:

<img width="1494" alt="Screenshot 2024-08-07 at 5 59 36 PM" src="https://github.com/user-attachments/assets/014f6fa4-39bb-49b8-9fe5-38ab721f0e61">


Narrow screen:

<img width="1195" alt="Screenshot 2024-08-07 at 5 59 55 PM" src="https://github.com/user-attachments/assets/a5c9f38c-328e-453a-8472-daa842db4dab">



Also included: Profit and Loss details charts toggle now defaults to Expenses instead of Revenue