### PR TITLE
feat: add uncategorized to detailed charts

### DIFF
--- a/src/components/ProfitAndLossDetailedCharts/DetailedChart.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedChart.tsx
@@ -7,6 +7,7 @@ import { humanizeTitle } from '../../utils/profitAndLossUtils'
 import { ProfitAndLossDatePicker } from '../ProfitAndLossDatePicker'
 import { Text, TextSize, TextWeight } from '../Typography'
 import { mapTypesToColors } from './DetailedTable'
+import classNames from 'classnames'
 import { format } from 'date-fns'
 import {
   PieChart,
@@ -87,6 +88,17 @@ export const DetailedChart = ({
                 <rect width='4' height='4' opacity={0.16} />
                 <line x1='0' y='0' x2='0' y2='4' strokeWidth='2' />
               </pattern>
+              <pattern
+                id='layer-pie-dots-pattern'
+                x='0'
+                y='0'
+                width='3'
+                height='3'
+                patternUnits='userSpaceOnUse'
+              >
+                <rect width='3' height='3' opacity={0.46} className='bg' />
+                <rect width='1' height='1' opacity={0.56} />
+              </pattern>
             </defs>
             {!isLoading && !noValue ? (
               <Pie
@@ -113,13 +125,16 @@ export const DetailedChart = ({
                   return (
                     <Cell
                       key={`cell-${index}`}
-                      className={`Layer__profit-and-loss-detailed-charts__pie ${
-                        hoveredItem && active ? 'active' : 'inactive'
-                      }`}
+                      className={classNames(
+                        'Layer__profit-and-loss-detailed-charts__pie',
+                        hoveredItem && active ? 'active' : 'inactive',
+                        entry.type === 'Uncategorized' &&
+                          'Layer__profit-and-loss-detailed-charts__pie--border',
+                      )}
                       style={{
                         fill:
                           entry.type === 'Uncategorized' && fill
-                            ? 'url(#layer-pie-stripe-pattern)'
+                            ? 'url(#layer-pie-dots-pattern)'
                             : fill,
                       }}
                       opacity={typeColorMapping[index].opacity}

--- a/src/components/ProfitAndLossDetailedCharts/DetailedChart.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedChart.tsx
@@ -74,6 +74,20 @@ export const DetailedChart = ({
       <div className='chart-container'>
         <ResponsiveContainer>
           <PieChart>
+            <defs>
+              <pattern
+                id='layer-pie-stripe-pattern'
+                x='0'
+                y='0'
+                width='4'
+                height='4'
+                patternTransform='rotate(45)'
+                patternUnits='userSpaceOnUse'
+              >
+                <rect width='4' height='4' opacity={0.16} />
+                <line x1='0' y='0' x2='0' y2='4' strokeWidth='2' />
+              </pattern>
+            </defs>
             {!isLoading && !noValue ? (
               <Pie
                 data={chartData}
@@ -102,7 +116,12 @@ export const DetailedChart = ({
                       className={`Layer__profit-and-loss-detailed-charts__pie ${
                         hoveredItem && active ? 'active' : 'inactive'
                       }`}
-                      style={{ fill }}
+                      style={{
+                        fill:
+                          entry.type === 'Uncategorized' && fill
+                            ? 'url(#layer-pie-stripe-pattern)'
+                            : fill,
+                      }}
                       opacity={typeColorMapping[index].opacity}
                       onMouseEnter={() => setHoveredItem(entry.name)}
                       onMouseLeave={() => setHoveredItem(undefined)}

--- a/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
@@ -40,6 +40,13 @@ export const mapTypesToColors = (
   return data.map(obj => {
     const type = obj.type
 
+    if (type === 'Uncategorized') {
+      return {
+        color: '#EEEEF0',
+        opacity: 1,
+      }
+    }
+
     if (!typeToColor[type]) {
       typeToColor[type] = colorList[colorIndex % colorList.length]
       colorIndex++
@@ -55,6 +62,30 @@ export const mapTypesToColors = (
       opacity: opacity,
     }
   })
+}
+
+const ValueIcon = ({
+  item,
+  typeColorMapping,
+  idx,
+}: {
+  item: LineBaseItem
+  typeColorMapping: any
+  idx: number
+}) => {
+  if (item.type === 'Uncategorized') {
+    return <div className='share-icon Layer__value-icon--uncategorized' />
+  }
+
+  return (
+    <div
+      className='share-icon'
+      style={{
+        background: typeColorMapping[idx].color,
+        opacity: typeColorMapping[idx].opacity,
+      }}
+    />
+  )
 }
 
 export const DetailedTable = ({
@@ -135,12 +166,10 @@ export const DetailedTable = ({
                     <td className='share-col'>
                       <span className='share-cell-content'>
                         {formatPercent(item.share)}%
-                        <div
-                          className='share-icon'
-                          style={{
-                            background: typeColorMapping[idx].color,
-                            opacity: typeColorMapping[idx].opacity,
-                          }}
+                        <ValueIcon
+                          item={item}
+                          typeColorMapping={typeColorMapping}
+                          idx={idx}
                         />
                       </span>
                     </td>

--- a/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
@@ -74,7 +74,36 @@ const ValueIcon = ({
   idx: number
 }) => {
   if (item.type === 'Uncategorized') {
-    return <div className='share-icon Layer__value-icon--uncategorized' />
+    return (
+      <svg
+        viewBox='0 0 12 12'
+        fill='none'
+        xmlns='http://www.w3.org/2000/svg'
+        width='12'
+        height='12'
+      >
+        <defs>
+          <pattern
+            id='layer-pie-dots-pattern-legend'
+            x='0'
+            y='0'
+            width='3'
+            height='3'
+            patternUnits='userSpaceOnUse'
+          >
+            <rect width='1' height='1' opacity={0.76} />
+          </pattern>
+        </defs>
+        <rect width='12' height='12' id='layer-pie-dots-pattern-bg' rx='2' />
+        <rect
+          x='1'
+          y='1'
+          width='10'
+          height='10'
+          fill='url(#layer-pie-dots-pattern-legend)'
+        />
+      </svg>
+    )
   }
 
   return (

--- a/src/hooks/useProfitAndLoss/useProfitAndLoss.tsx
+++ b/src/hooks/useProfitAndLoss/useProfitAndLoss.tsx
@@ -11,6 +11,7 @@ import {
   collectRevenueItems,
   applyShare,
 } from '../../utils/profitAndLossUtils'
+import { useProfitAndLossLTM } from './useProfitAndLossLTM'
 import { useProfitAndLossQuery } from './useProfitAndLossQuery'
 import { startOfMonth, endOfMonth } from 'date-fns'
 
@@ -90,6 +91,10 @@ export const useProfitAndLoss: UseProfitAndLoss = (
       reportingBasis,
     })
 
+  const { data: summaryData } = useProfitAndLossLTM({
+    currentDate: startDate ? startDate : startOfMonth(new Date()),
+  })
+
   const changeDateRange = ({
     startDate: newStartDate,
     endDate: newEndDate,
@@ -142,6 +147,20 @@ export const useProfitAndLoss: UseProfitAndLoss = (
       return x
     })
 
+    const month = startDate.getMonth() + 1
+    const year = startDate.getFullYear()
+    const found = summaryData.find(x => x.month === month && x.year === year)
+    if (found && (found.uncategorizedInflows ?? 0) > 0) {
+      filtered.push({
+        name: 'uncategorized',
+        display_name: 'Uncategorized',
+        value: found.uncategorizedInflows,
+        type: 'Uncategorized',
+        share: 0,
+        hidden: false,
+      })
+    }
+
     const sorted = filtered.sort((a, b) => {
       switch (filters['revenue']?.sortBy) {
         case 'category':
@@ -169,7 +188,7 @@ export const useProfitAndLoss: UseProfitAndLoss = (
     const withShare = applyShare(sorted, total)
 
     return { filteredDataRevenue: withShare, filteredTotalRevenue: total }
-  }, [data, startDate, filters, sidebarScope])
+  }, [data, startDate, filters, sidebarScope, summaryData])
 
   const { filteredDataExpenses, filteredTotalExpenses } = useMemo(() => {
     if (!data) {
@@ -190,6 +209,21 @@ export const useProfitAndLoss: UseProfitAndLoss = (
 
       return x
     })
+
+    const month = startDate.getMonth() + 1
+    const year = startDate.getFullYear()
+    const found = summaryData.find(x => x.month === month && x.year === year)
+    if (found && (found.uncategorizedOutflows ?? 0) > 0) {
+      filtered.push({
+        name: 'uncategorized',
+        display_name: 'Uncategorized',
+        value: found.uncategorizedOutflows,
+        type: 'Uncategorized',
+        share: 0,
+        hidden: false,
+      })
+    }
+
     const sorted = filtered.sort((a, b) => {
       switch (filters['expenses']?.sortBy) {
         case 'category':
@@ -217,7 +251,7 @@ export const useProfitAndLoss: UseProfitAndLoss = (
     const withShare = applyShare(sorted, total)
 
     return { filteredDataExpenses: withShare, filteredTotalExpenses: total }
-  }, [data, startDate, filters, sidebarScope])
+  }, [data, startDate, filters, sidebarScope, summaryData])
 
   return {
     data,

--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -429,6 +429,14 @@
   stroke: var(--color-base-900);
 }
 
+#layer-pie-stripe-pattern rect {
+  fill: var(--color-base-200);
+}
+
+#layer-pie-stripe-pattern line {
+  stroke: var(--color-base-500);
+}
+
 @container (min-width: 1024px) {
   .Layer__profit-and-loss-row__label--depth-0 {
     padding-left: var(--spacing-xl);

--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -413,6 +413,10 @@
   padding-left: 22px;
 }
 
+.Layer__profit-and-loss-detailed-charts__pie--border {
+  stroke: var(--color-base-200);
+}
+
 #layer-bar-stripe-pattern rect {
   fill: var(--color-base-400);
 }
@@ -430,11 +434,27 @@
 }
 
 #layer-pie-stripe-pattern rect {
-  fill: var(--color-base-200);
+  fill: var(--color-base-300);
 }
 
-#layer-pie-stripe-pattern line {
-  stroke: var(--color-base-500);
+#layer-dots-stripe-pattern rect {
+  fill: var(--color-base-500);
+}
+
+#layer-pie-dots-pattern rect {
+  fill: var(--color-base-500);
+}
+
+#layer-pie-dots-pattern rect.bg {
+  fill: var(--color-base-100);
+}
+
+#layer-pie-dots-pattern-legend rect {
+  fill: var(--color-base-500);
+}
+
+#layer-pie-dots-pattern-bg {
+  fill: var(--color-base-100);
 }
 
 @container (min-width: 1024px) {

--- a/src/styles/profit_and_loss_detailed_charts.scss
+++ b/src/styles/profit_and_loss_detailed_charts.scss
@@ -228,6 +228,18 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
         height: 12px;
         border-radius: 2px;
       }
+
+      .Layer__value-icon--uncategorized {
+        background-image: repeating-linear-gradient(
+          -45deg,
+          var(--color-base-200) 0px,
+          var(--color-base-200) 2px,
+          var(--color-base-500) 2px,
+          var(--color-base-500) 3.5px,
+          var(--color-base-200) 3.5px,
+          var(--color-base-200) 4px
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Add "Uncategorized" to P&L detailed charts.

## How this has been tested?


https://github.com/user-attachments/assets/b7e2595b-16c4-4818-b158-6d6997fa063e


EDIT:

Detailed charts are using "dots" in a background pattern of the pie:

![image](https://github.com/user-attachments/assets/0b19de6f-c385-490e-861f-17a88aa87ca3)

