### PR TITLE
feat: add layer__variables class

### DIFF
--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -4,6 +4,7 @@
 .Layer__tooltip,
 .Layer__toasts-container,
 .Layer__drawer,
+.Layer__variables,
 #Layer__datepicker__portal {
   // 1. BASE VARIABLES:
   --color-black: #1a1a1a;
@@ -21,7 +22,6 @@
   --color-info-error: hsl(0 76% 50%);
   --color-info-error-bg: hsl(0 83% 86%);
   --color-info-error-fg: hsl(0 88% 32%);
-
 
   --color-dark-h: 0;
   --color-dark-s: 0%;


### PR DESCRIPTION
## Description

Add `.Layer__variables` to allow use CSS variables without using `.Layer__component`.

## How this has been tested?

Without  `.Layer__variables`:

![image](https://github.com/user-attachments/assets/4d962a08-5e23-42f7-8084-d7b1bcb8deb7)

With `.Layer__variables`:

![image](https://github.com/user-attachments/assets/97ff6510-00c7-4a25-b23b-dfbe429dbd14)
