### PR TITLE
feat: adjust usage of uncategorized in profit and loss

### DIFF
--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -350,6 +350,12 @@ export const ProfitAndLossChart = ({
         netProfit > 0 ? 'positive' : netProfit < 0 ? 'negative' : ''
       const revenue = payload.find(x => x.dataKey === 'revenue')?.value ?? 0
       const expenses = payload.find(x => x.dataKey === 'expenses')?.value ?? 0
+      const revenueUncategorized =
+        payload.find(x => x.dataKey === 'revenueUncategorized')?.value ?? 0
+      const expensesUncategorized =
+        payload.find(x => x.dataKey === 'expensesUncategorized')?.value ?? 0
+
+      console.log('payload', payload)
 
       return (
         <div className='Layer__chart__tooltip'>
@@ -363,10 +369,29 @@ export const ProfitAndLossChart = ({
                   ${centsToDollars(revenue)}
                 </span>
               </li>
+              <li style={{ marginBottom: 6 }}>
+                <label className='Layer__chart__tooltip-label'></label>
+                <span
+                  className='Layer__chart__tooltip-value'
+                  style={{ opacity: 0.5 }}
+                >
+                  ${centsToDollars(revenueUncategorized)}
+                </span>
+              </li>
               <li>
                 <label className='Layer__chart__tooltip-label'>Expenses</label>
                 <span className='Layer__chart__tooltip-value'>
                   ${centsToDollars(Math.abs(expenses))}
+                </span>
+              </li>
+              <li style={{ marginBottom: 6 }}>
+                <label className='Layer__chart__tooltip-label'></label>
+                <span
+                  className='Layer__chart__tooltip-value'
+                  style={{ opacity: 0.5 }}
+                >
+                  {expensesUncategorized &&
+                    `$${centsToDollars(expensesUncategorized * -1)}`}
                 </span>
               </li>
               <li>

--- a/src/components/ProfitAndLossDetailedCharts/DetailedChart.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedChart.tsx
@@ -3,12 +3,9 @@ import { SidebarScope } from '../../hooks/useProfitAndLoss/useProfitAndLoss'
 import { centsToDollars as formatMoney } from '../../models/Money'
 import { LineBaseItem } from '../../types/line_item'
 import { formatPercent } from '../../utils/format'
-import { humanizeTitle } from '../../utils/profitAndLossUtils'
 import { ProfitAndLossDatePicker } from '../ProfitAndLossDatePicker'
-import { Text, TextSize, TextWeight } from '../Typography'
 import { mapTypesToColors } from './DetailedTable'
 import classNames from 'classnames'
-import { format } from 'date-fns'
 import {
   PieChart,
   Pie,
@@ -240,16 +237,15 @@ export const DetailedChart = ({
                     }
 
                     if (hoveredItem) {
+                      const found = filteredData.find(
+                        x => x.display_name === hoveredItem,
+                      )?.share
                       return (
                         <ChartText
                           {...positioningProps}
                           className='pie-center-label__share'
                         >
-                          {`${formatPercent(
-                            filteredData.find(
-                              x => x.display_name === hoveredItem,
-                            )?.share,
-                          )}%`}
+                          {found ? `${formatPercent(found)}%` : ''}
                         </ChartText>
                       )
                     }

--- a/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
@@ -140,9 +140,6 @@ export const DetailedTable = ({
 
   const typeColorMapping: any = mapTypesToColors(filteredData, chartColorsList)
 
-  // Index to keep track of the next color to assign
-  const colorIndex = 0
-
   return (
     <div className='details-container'>
       <div className='table'>
@@ -194,7 +191,9 @@ export const DetailedTable = ({
                     <td className='value-col'>${formatMoney(item.value)}</td>
                     <td className='share-col'>
                       <span className='share-cell-content'>
-                        {formatPercent(item.share)}%
+                        {item.share !== undefined
+                          ? `${formatPercent(item.share)}%`
+                          : ''}
                         <ValueIcon
                           item={item}
                           typeColorMapping={typeColorMapping}

--- a/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
+++ b/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
@@ -69,6 +69,8 @@ export const ProfitAndLossSummaries = ({
 }: Props) => {
   const {
     data: storedData,
+    uncategorizedTotalExpenses,
+    uncategorizedTotalRevenue,
     isLoading,
     setSidebarScope,
     sidebarScope,
@@ -87,6 +89,8 @@ export const ProfitAndLossSummaries = ({
   }, [storedData])
 
   const data = dataItem ? dataItem : { income: { value: NaN }, net_profit: NaN }
+
+  console.log('data', data)
 
   const incomeDirectionClass =
     (data.income.value ?? NaN) < 0
@@ -130,11 +134,20 @@ export const ProfitAndLossSummaries = ({
               <SkeletonLoader />
             </div>
           ) : (
-            <span
-              className={`Layer__profit-and-loss-summaries__amount ${incomeDirectionClass}`}
-            >
-              {formatMoney(Math.abs(data?.income?.value ?? NaN))}
-            </span>
+            <div className='Layer__profit-and-loss-summaries__amount-wrapper'>
+              <span
+                className={`Layer__profit-and-loss-summaries__amount ${incomeDirectionClass}`}
+              >
+                {formatMoney(Math.abs(data?.income?.value ?? NaN))}
+              </span>
+              {uncategorizedTotalRevenue && (
+                <span
+                  className={`Layer__profit-and-loss-summaries__amount-uncategorized ${expensesDirectionClass}`}
+                >
+                  {formatMoney(uncategorizedTotalRevenue)}
+                </span>
+              )}
+            </div>
           )}
         </div>
       </div>
@@ -159,13 +172,22 @@ export const ProfitAndLossSummaries = ({
               <SkeletonLoader className='Layer__profit-and-loss-summaries__loader' />
             </div>
           ) : (
-            <span
-              className={`Layer__profit-and-loss-summaries__amount ${expensesDirectionClass}`}
-            >
-              {formatMoney(
-                Math.abs((data.income.value ?? 0) - data.net_profit),
+            <div className='Layer__profit-and-loss-summaries__amount-wrapper'>
+              <span
+                className={`Layer__profit-and-loss-summaries__amount ${expensesDirectionClass}`}
+              >
+                {formatMoney(
+                  Math.abs((data.income.value ?? 0) - data.net_profit),
+                )}
+              </span>
+              {uncategorizedTotalExpenses && (
+                <span
+                  className={`Layer__profit-and-loss-summaries__amount-uncategorized ${expensesDirectionClass}`}
+                >
+                  {formatMoney(uncategorizedTotalExpenses)}
+                </span>
               )}
-            </span>
+            </div>
           )}
         </div>
       </div>

--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -338,6 +338,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-4xs);
+  flex: 1;
 }
 
 .Layer__profit-and-loss-summaries__title {
@@ -358,6 +359,19 @@
   &::before {
     content: '$';
   }
+}
+
+.Layer__profit-and-loss-summaries__amount-wrapper {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: space-between;
+  padding-right: var(--spacing-2xs);
+}
+
+.Layer__profit-and-loss-summaries__amount-uncategorized {
+  font-size: var(--text-sm);
+  color: var(--text-color-secondary);
 }
 
 .Layer__profit-and-loss-summaries__amount--negative {

--- a/src/utils/profitAndLossUtils.ts
+++ b/src/utils/profitAndLossUtils.ts
@@ -63,10 +63,18 @@ export const humanizeTitle = (sidebarView: SidebarScope) => {
 export const applyShare = (
   items: LineBaseItem[],
   total: number,
+  exclude?: string[],
 ): LineBaseItem[] => {
   return items.map(item => {
     if (total === 0) {
       return item
+    }
+
+    if (exclude && exclude.includes(item.type)) {
+      return {
+        ...item,
+        share: undefined,
+      }
     }
 
     return {


### PR DESCRIPTION
## Description

1. Show uncategorized values in summary cards
2. Show uncategorized in the tooltip on Profit and Loss chart
3. don't sum up uncategorized to "Total" in detailed charts