### PR TITLE
fix: add profil and loss provider to export

### DIFF
--- a/src/components/ProfitAndLossTable/ProfitAndLossTableComponent.tsx
+++ b/src/components/ProfitAndLossTable/ProfitAndLossTableComponent.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect } from 'react'
+import { TableProvider } from '../../contexts/TableContext'
 import { SidebarScope } from '../../hooks/useProfitAndLoss/useProfitAndLoss'
 import { useTableExpandRow } from '../../hooks/useTableExpandRow'
 import PieChart from '../../icons/PieChart'
@@ -15,13 +16,16 @@ export interface ProfitAndLossTableStringOverrides {
   netProfitLabel?: string
 }
 
-type Props = {
+export type ProfilAndLostTableProps = {
   lockExpanded?: boolean
   asContainer?: boolean
   stringOverrides?: ProfitAndLossTableStringOverrides
 }
 
-export const ProfitAndLossTable = ({ asContainer, stringOverrides }: Props) => {
+export const ProfitAndLossTableComponent = ({
+  asContainer,
+  stringOverrides,
+}: ProfilAndLostTableProps) => {
   const {
     data: actualData,
     isLoading,

--- a/src/components/ProfitAndLossTable/ProfitAndLossTableWithProvider.tsx
+++ b/src/components/ProfitAndLossTable/ProfitAndLossTableWithProvider.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { TableProvider } from '../../contexts/TableContext'
+import {
+  ProfitAndLossTableComponent,
+  ProfilAndLostTableProps,
+} from './ProfitAndLossTableComponent'
+
+export const ProfitAndLossTableWithProvider = (
+  props: ProfilAndLostTableProps,
+) => {
+  return (
+    <TableProvider>
+      <ProfitAndLossTableComponent {...props} />
+    </TableProvider>
+  )
+}

--- a/src/components/ProfitAndLossTable/index.tsx
+++ b/src/components/ProfitAndLossTable/index.tsx
@@ -1,1 +1,2 @@
-export { ProfitAndLossTable } from './ProfitAndLossTable'
+export { ProfitAndLossTableWithProvider as ProfitAndLossTable } from './ProfitAndLossTableWithProvider'
+export { ProfitAndLossTableStringOverrides } from './ProfitAndLossTableComponent'

--- a/src/components/ProfitAndLossView/ProfitAndLossView.tsx
+++ b/src/components/ProfitAndLossView/ProfitAndLossView.tsx
@@ -7,7 +7,7 @@ import { ProfitAndLoss } from '../ProfitAndLoss'
 import { ProfitAndLossDetailedCharts } from '../ProfitAndLossDetailedCharts'
 import { ProfitAndLossDetailedChartsStringOverrides } from '../ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts'
 import { ProfitAndLossSummariesStringOverrides } from '../ProfitAndLossSummaries/ProfitAndLossSummaries'
-import { ProfitAndLossTableStringOverrides } from '../ProfitAndLossTable/ProfitAndLossTable'
+import { ProfitAndLossTableStringOverrides } from '../ProfitAndLossTable/ProfitAndLossTableComponent'
 import { Heading } from '../Typography'
 
 const COMPONENT_NAME = 'profit-and-loss'
@@ -113,11 +113,9 @@ const Components = ({
         </div>
       )}
       {!hideTable && (
-        <TableProvider>
-          <ProfitAndLoss.Table
-            stringOverrides={stringOverrides?.profitAndLossTable}
-          />
-        </TableProvider>
+        <ProfitAndLoss.Table
+          stringOverrides={stringOverrides?.profitAndLossTable}
+        />
       )}
     </>
   )

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -7,13 +7,12 @@ import { Container } from '../../components/Container'
 import { Panel } from '../../components/Panel'
 import { ProfitAndLoss } from '../../components/ProfitAndLoss'
 import { ProfitAndLossDetailedChartsStringOverrides } from '../../components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts'
-import { ProfitAndLossTableStringOverrides } from '../../components/ProfitAndLossTable/ProfitAndLossTable'
+import { ProfitAndLossTableStringOverrides } from '../../components/ProfitAndLossTable'
 import { StatementOfCashFlow } from '../../components/StatementOfCashFlow'
 import { StatementOfCashFlowStringOverrides } from '../../components/StatementOfCashFlow/StatementOfCashFlow'
 import { Toggle } from '../../components/Toggle'
 import { View } from '../../components/View'
 import { useLayerContext } from '../../contexts/LayerContext'
-import { TableProvider } from '../../contexts/TableContext'
 import DownloadCloud from '../../icons/DownloadCloud'
 
 interface ReportsStringOverrides {
@@ -172,37 +171,33 @@ const ReportsPanel = ({
   return (
     <>
       {openReport === 'profitAndLoss' && (
-        <TableProvider>
-          <View
-            type='panel'
-            headerControls={
-              <>
-                <ProfitAndLoss.DatePicker />
-                <DownloadButton
-                  stringOverrides={stringOverrides?.downloadButton}
-                />
-              </>
-            }
-          >
-            <Panel
-              sidebar={
-                <ProfitAndLoss.DetailedCharts
-                  showDatePicker={false}
-                  stringOverrides={
-                    stringOverrides?.profitAndLoss?.detailedCharts
-                  }
-                />
-              }
-              sidebarIsOpen={Boolean(sidebarScope)}
-              parentRef={containerRef}
-            >
-              <ProfitAndLoss.Table
-                asContainer={false}
-                stringOverrides={stringOverrides?.profitAndLoss?.table}
+        <View
+          type='panel'
+          headerControls={
+            <>
+              <ProfitAndLoss.DatePicker />
+              <DownloadButton
+                stringOverrides={stringOverrides?.downloadButton}
               />
-            </Panel>
-          </View>
-        </TableProvider>
+            </>
+          }
+        >
+          <Panel
+            sidebar={
+              <ProfitAndLoss.DetailedCharts
+                showDatePicker={false}
+                stringOverrides={stringOverrides?.profitAndLoss?.detailedCharts}
+              />
+            }
+            sidebarIsOpen={Boolean(sidebarScope)}
+            parentRef={containerRef}
+          >
+            <ProfitAndLoss.Table
+              asContainer={false}
+              stringOverrides={stringOverrides?.profitAndLoss?.table}
+            />
+          </Panel>
+        </View>
       )}
       {openReport === 'balanceSheet' && (
         <BalanceSheet stringOverrides={stringOverrides?.balanceSheet} />


### PR DESCRIPTION
## Log

Previously, it was necessary to have a `TableProvider` before using the profit and loss table. This requirement has now been removed. Instead, the `ProfitAndLoss.Table` is directly exported and can be used without needing a separate `TableProvider`.