### PR TITLE
dont call match endpoint for confirming existing matched transfers

### DIFF
--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -82,7 +82,8 @@ export type SaveHandle = {
 const isAlreadyMatched = (bankTransaction?: BankTransaction) => {
   if (bankTransaction?.match) {
     const foundMatch = bankTransaction.suggested_matches?.find(
-      x => x.details.id === bankTransaction?.match?.details.id,
+      x => x.details.id === bankTransaction?.match?.details.id
+        || x.details.id === bankTransaction?.match?.bank_transaction.id
     )
     return foundMatch?.id
   }
@@ -132,7 +133,7 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
         : Purpose.categorize,
     )
     const [selectedMatchId, setSelectedMatchId] = useState<string | undefined>(
-      isAlreadyMatched(bankTransaction),
+      isAlreadyMatched(bankTransaction) ?? bankTransaction?.suggested_matches?.[0]?.id,
     )
     const [matchFormError, setMatchFormError] = useState<string | undefined>()
     const [splitFormError, setSplitFormError] = useState<string | undefined>()

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -285,12 +285,15 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
       if (purpose === Purpose.match) {
         if (!selectedMatchId) {
           setMatchFormError('Select an option to match the transaction')
+          return
         } else if (
           selectedMatchId &&
           selectedMatchId !== isAlreadyMatched(bankTransaction)
         ) {
-          onMatchSubmit(selectedMatchId)
+          await onMatchSubmit(selectedMatchId)
+          return
         }
+        close()
         return
       }
 

--- a/src/hooks/useBankTransactions/useBankTransactions.tsx
+++ b/src/hooks/useBankTransactions/useBankTransactions.tsx
@@ -347,10 +347,7 @@ export const useBankTransactions: UseBankTransactions = params => {
   const shouldHideAfterCategorize = (
     bankTransaction: BankTransaction,
   ): boolean => {
-    return (
-      filters?.categorizationStatus === DisplayState.review &&
-      ReviewCategories.includes(bankTransaction.categorization_status)
-    )
+    return ( filters?.categorizationStatus === DisplayState.review )
   }
 
   const removeAfterCategorize = (bankTransaction: BankTransaction) => {


### PR DESCRIPTION
Fixes: LAY-947 (partially)- backend changes needed to make categorization & matching idempotent 