### PR TITLE
fix: reset bank transactions page on filters change

### DIFF
--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -160,6 +160,10 @@ const BankTransactionsContent = ({
   }, [inputFilters, categorizeView, mode])
 
   useEffect(() => {
+    setCurrentPage(1)
+  }, [filters])
+
+  useEffect(() => {
     if (loadingStatus === 'complete') {
       const timeoutLoad = setTimeout(() => {
         setInitialLoad(false)


### PR DESCRIPTION
## Description

Bank transactions: Set page number to `1` when filters change.

## How this has been tested?


https://github.com/user-attachments/assets/cf345b32-f7d0-4844-b299-fcb153117a7d

