### PR TITLE
feat: profit and loss chart - sync and empty states

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -10,6 +10,7 @@ export enum BadgeSize {
 
 export enum BadgeVariant {
   DEFAULT = 'default',
+  INFO = 'info',
   SUCCESS = 'success',
   WARNING = 'warning',
   ERROR = 'error',

--- a/src/components/ProfitAndLoss/ProfitAndLoss.tsx
+++ b/src/components/ProfitAndLoss/ProfitAndLoss.tsx
@@ -5,6 +5,7 @@ import { Container } from '../Container'
 import { ProfitAndLossChart } from '../ProfitAndLossChart'
 import { ProfitAndLossDatePicker } from '../ProfitAndLossDatePicker'
 import { ProfitAndLossDetailedCharts } from '../ProfitAndLossDetailedCharts'
+import { ProfitAndLossHeader } from '../ProfitAndLossHeader'
 import { ProfitAndLossSummaries } from '../ProfitAndLossSummaries'
 import { ProfitAndLossTable } from '../ProfitAndLossTable'
 import { endOfMonth, startOfMonth } from 'date-fns'
@@ -69,4 +70,5 @@ ProfitAndLoss.DatePicker = ProfitAndLossDatePicker
 ProfitAndLoss.Summaries = ProfitAndLossSummaries
 ProfitAndLoss.Table = ProfitAndLossTable
 ProfitAndLoss.DetailedCharts = ProfitAndLossDetailedCharts
+ProfitAndLoss.Header = ProfitAndLossHeader
 export { ProfitAndLoss }

--- a/src/components/ProfitAndLossChart/ChartStateCard.tsx
+++ b/src/components/ProfitAndLossChart/ChartStateCard.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import BarChart2Icon from '../../icons/BarChart2'
+import { IconBox } from '../IconBox'
+import { Text, TextSize, TextWeight } from '../Typography'
+
+export const ChartStateCard = () => {
+  return (
+    <div className='Layer__profit-and-loss-chart__state-card'>
+      <IconBox>
+        <BarChart2Icon />
+      </IconBox>
+      <div className='Layer__profit-and-loss-chart__state-card__text'>
+        <Text weight={TextWeight.bold}>Data is syncing</Text>
+        <Text
+          size={TextSize.sm}
+          className='Layer__profit-and-loss-chart__state-card__description'
+        >
+          This may take up to few minutes
+        </Text>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -176,7 +176,6 @@ export const ProfitAndLossChart = ({
     currentDate: startOfMonth(Date.now()),
   })
 
-  // const anyData = true
   const anyData = useMemo(() => {
     return Boolean(
       data?.find(
@@ -194,11 +193,10 @@ export const ProfitAndLossChart = ({
 
   const { data: linkedAccounts } = useLinkedAccounts()
 
-  const isSyncing = true
-  // const isSyncing = useMemo(
-  //   () => Boolean(linkedAccounts?.some(item => item.is_syncing)),
-  //   [linkedAccounts],
-  // )
+  const isSyncing = useMemo(
+    () => Boolean(linkedAccounts?.some(item => item.is_syncing)),
+    [linkedAccounts],
+  )
 
   const loadingValue = useMemo(() => getLoadingValue(data), [data])
 

--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -531,7 +531,7 @@ export const ProfitAndLossChart = ({
   const [animateFrom, setAnimateFrom] = useState(-1)
 
   return (
-    <div className=''>
+    <div className='Layer__chart-wrapper'>
       <ResponsiveContainer
         key={forceRerenderOnDataChange ? JSON.stringify(theData) : 'pnl-chart'}
         className={classNames(

--- a/src/components/ProfitAndLossHeader/ProfitAndLossHeader.tsx
+++ b/src/components/ProfitAndLossHeader/ProfitAndLossHeader.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { Heading, HeadingSize } from '../../components/Typography'
+import { useLinkedAccounts } from '../../hooks/useLinkedAccounts'
+import { Header } from '../Container'
+import { ProfitAndLoss } from '../ProfitAndLoss'
+import { SyncingBadge } from '../SyncingBadge'
+
+export interface ProfitAndLossHeaderProps {
+  text?: string
+  className?: string
+  headingClassName?: string
+  withDatePicker?: boolean
+}
+
+export const ProfitAndLossHeader = ({
+  text,
+  className,
+  headingClassName,
+  withDatePicker,
+}: ProfitAndLossHeaderProps) => {
+  const { data: linkedAccounts } = useLinkedAccounts()
+
+  // @TODO - TOM
+  const isSyncing = true
+  // const isSyncing = useMemo(
+  //   () => Boolean(linkedAccounts?.some(item => item.is_syncing)),
+  //   [linkedAccounts],
+  // )
+  return (
+    <Header className={className}>
+      <span className='Layer__component-header__title-wrapper'>
+        <Heading size={HeadingSize.secondary} className={headingClassName}>
+          {text || 'Profit & Loss'}
+        </Heading>
+        {isSyncing && <SyncingBadge />}
+      </span>
+      {withDatePicker && <ProfitAndLoss.DatePicker />}
+    </Header>
+  )
+}

--- a/src/components/ProfitAndLossHeader/ProfitAndLossHeader.tsx
+++ b/src/components/ProfitAndLossHeader/ProfitAndLossHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Heading, HeadingSize } from '../../components/Typography'
 import { useLinkedAccounts } from '../../hooks/useLinkedAccounts'
 import { Header } from '../Container'
@@ -20,12 +20,11 @@ export const ProfitAndLossHeader = ({
 }: ProfitAndLossHeaderProps) => {
   const { data: linkedAccounts } = useLinkedAccounts()
 
-  // @TODO - TOM
-  const isSyncing = true
-  // const isSyncing = useMemo(
-  //   () => Boolean(linkedAccounts?.some(item => item.is_syncing)),
-  //   [linkedAccounts],
-  // )
+  const isSyncing = useMemo(
+    () => Boolean(linkedAccounts?.some(item => item.is_syncing)),
+    [linkedAccounts],
+  )
+
   return (
     <Header className={className}>
       <span className='Layer__component-header__title-wrapper'>

--- a/src/components/ProfitAndLossHeader/index.tsx
+++ b/src/components/ProfitAndLossHeader/index.tsx
@@ -1,0 +1,1 @@
+export { ProfitAndLossHeader } from './ProfitAndLossHeader'

--- a/src/components/ProfitAndLossView/ProfitAndLossView.tsx
+++ b/src/components/ProfitAndLossView/ProfitAndLossView.tsx
@@ -57,11 +57,11 @@ const ProfitAndLossPanel = ({
       sidebarIsOpen={Boolean(sidebarScope)}
       parentRef={containerRef}
     >
-      <Header className={`Layer__${COMPONENT_NAME}__header`}>
-        <Heading className='Layer__profit-and-loss__title'>
-          {stringOverrides?.header || 'Profit & Loss'}
-        </Heading>
-      </Header>
+      <ProfitAndLoss.Header
+        text={stringOverrides?.header || 'Profit & Loss'}
+        className={`Layer__${COMPONENT_NAME}__header`}
+        headingClassName='Layer__profit-and-loss__title'
+      />
 
       <Components stringOverrides={stringOverrides} {...props} />
     </Panel>

--- a/src/components/SyncingBadge/SyncingBadge.tsx
+++ b/src/components/SyncingBadge/SyncingBadge.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import Loader from '../../icons/Loader'
+import { Badge, BadgeVariant } from '../Badge'
+import { BadgeSize } from '../Badge/Badge'
+
+export const SyncingBadge = () => {
+  return (
+    <Badge
+      icon={<Loader className='Layer__anim--rotating' size={12} />}
+      size={BadgeSize.SMALL}
+      variant={BadgeVariant.INFO}
+    >
+      Syncing...
+    </Badge>
+  )
+}

--- a/src/components/SyncingBadge/index.tsx
+++ b/src/components/SyncingBadge/index.tsx
@@ -1,0 +1,1 @@
+export { SyncingBadge } from './SyncingBadge'

--- a/src/icons/BarChart2.tsx
+++ b/src/icons/BarChart2.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react'
+import { IconSvgProps } from './types'
+
+const BarChart2 = ({ size = 12, ...props }: IconSvgProps) => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    viewBox='0 0 12 12'
+    fill='none'
+    {...props}
+    width={size}
+    height={size}
+  >
+    <path
+      d='M9.5 10V5'
+      stroke='currentColor'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    />
+    <path
+      d='M6.5 10V2'
+      stroke='currentColor'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    />
+    <path
+      d='M3.5 10V7'
+      stroke='currentColor'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    />
+  </svg>
+)
+
+export default BarChart2

--- a/src/icons/Loader.tsx
+++ b/src/icons/Loader.tsx
@@ -12,49 +12,49 @@ const Loader = ({ size = 18, ...props }: IconSvgProps) => (
   >
     <path
       d='M9 1.5V4.5'
-      stroke='#3E4044'
+      stroke='currentColor'
       strokeLinecap='round'
       strokeLinejoin='round'
     />
     <path
       d='M9 13.5V16.5'
-      stroke='#818388'
+      stroke='currentColor'
       strokeLinecap='round'
       strokeLinejoin='round'
     />
     <path
-      d='M3.6975 3.6975L5.82 5.82'
-      stroke='#5F6166'
+      d='M3.69751 3.69751L5.82001 5.82001'
+      stroke='currentColor'
       strokeLinecap='round'
       strokeLinejoin='round'
     />
     <path
-      d='M12.18 12.18L14.3025 14.3025'
-      stroke='#2D2F33'
+      d='M12.1799 12.18L14.3024 14.3025'
+      stroke='currentColor'
       strokeLinecap='round'
       strokeLinejoin='round'
     />
     <path
       d='M1.5 9H4.5'
-      stroke='#5F6166'
+      stroke='currentColor'
       strokeLinecap='round'
       strokeLinejoin='round'
     />
     <path
       d='M13.5 9H16.5'
-      stroke='#2D2F33'
+      stroke='currentColor'
       strokeLinecap='round'
       strokeLinejoin='round'
     />
     <path
-      d='M3.6975 14.3025L5.82 12.18'
-      stroke='#818388'
+      d='M3.69751 14.3025L5.82001 12.18'
+      stroke='currentColor'
       strokeLinecap='round'
       strokeLinejoin='round'
     />
     <path
-      d='M12.18 5.82L14.3025 3.6975'
-      stroke='#3E4044'
+      d='M12.1799 5.82001L14.3024 3.69751'
+      stroke='currentColor'
       strokeLinecap='round'
       strokeLinejoin='round'
     />

--- a/src/styles/badge.scss
+++ b/src/styles/badge.scss
@@ -38,6 +38,11 @@
     color: var(--badge-fg-color);
   }
 
+  &.Layer__badge--info {
+    background-color: var(--badge-bg-color-info);
+    color: var(--badge-fg-color-info);
+  }
+
   &.Layer__badge--success {
     background-color: var(--badge-bg-color-success);
     color: var(--badge-fg-color-success);

--- a/src/styles/charts.scss
+++ b/src/styles/charts.scss
@@ -16,6 +16,10 @@
   padding-top: 42px;
 }
 
+.Layer__chart-wrapper {
+  position: relative;
+}
+
 .Layer__chart-container {
   min-height: 300px;
 }

--- a/src/styles/component.scss
+++ b/src/styles/component.scss
@@ -66,6 +66,12 @@
   }
 }
 
+.Layer__component-header__title-wrapper {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
 .Layer__header__actions {
   display: flex;
   align-items: center;

--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -376,6 +376,9 @@
 
 .Layer__profit-and-loss-chart__bar--loading {
   fill: var(--color-base-50);
+}
+
+.Layer__profit-and-loss-chart__bar--loading-anim {
   animation: layer_chart_bar_loading_anim 2s linear infinite;
 }
 
@@ -561,4 +564,40 @@
     background: var(--color-base-200);
     color: var(--color-base-900);
   }
+}
+
+.Layer__profit-and-loss-chart__state-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  background: #fff;
+  padding: var(--spacing-lg) var(--spacing-4xs);
+  width: 260px;
+  max-width: 70%;
+  height: 120px;
+  left: 50%;
+  bottom: 0;
+  transform: translate(-50%, -60px);
+  border-radius: var(--border-radius-sm);
+  box-shadow: 0px 0px 0px 1px var(--base-transparent-4);
+  gap: var(--spacing-md);
+
+  .Layer__icon-box {
+    background-color: var(--color-base-100);
+  }
+}
+
+.Layer__profit-and-loss-chart__state-card__text {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-4xs);
+}
+
+.Layer__profit-and-loss-chart__state-card__description {
+  color: var(--text-color-secondary);
+  text-align: center;
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -11,6 +11,10 @@
   --color-white: white;
   --color-blue: hsl(217 100% 92%);
 
+  --color-info: #0968f8;
+  --color-info-bg: #d6e6ff;
+  --color-info-fg: #0056d7;
+
   --color-info-success: hsl(145, 45%, 42%);
   --color-info-success-bg: hsl(145, 59%, 86%);
   --color-info-success-fg: hsl(145, 63%, 29%);
@@ -185,6 +189,10 @@
   --badge-color: var(--color-base-900);
   --badge-fg-color: var(--color-base-900);
   --badge-bg-color: var(--color-base-400);
+
+  --badge-color-info: var(--color-info);
+  --badge-fg-color-info: var(--color-info-fg);
+  --badge-bg-color-info: var(--color-info-bg);
 
   --badge-color-success: var(--color-info-success);
   --badge-fg-color-success: var(--color-info-success-fg);

--- a/src/views/AccountingOverview/AccountingOverview.tsx
+++ b/src/views/AccountingOverview/AccountingOverview.tsx
@@ -61,11 +61,9 @@ export const AccountingOverview = ({
           asWidget
           elevated={true}
         >
-          <Header>
-            <Heading size={HeadingSize.secondary}>
-              {stringOverrides?.header || 'Profit & Loss'}
-            </Heading>
-          </Header>
+          <ProfitAndLoss.Header
+            text={stringOverrides?.header || 'Profit & Loss'}
+          />
           <ProfitAndLoss.Chart />
         </Container>
         {middleBanner && (

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -54,12 +54,10 @@ export const BookkeepingOverview = ({
             asWidget
             elevated={true}
           >
-            <Header>
-              <Heading size={HeadingSize.secondary}>
-                {stringOverrides?.profitAndLoss?.header || 'Profit & Loss'}
-              </Heading>
-              <ProfitAndLoss.DatePicker />
-            </Header>
+            <ProfitAndLoss.Header
+              text={stringOverrides?.profitAndLoss?.header || 'Profit & Loss'}
+              withDatePicker
+            />
             <div className='Layer__bookkeeping-overview__summaries-row'>
               <ProfitAndLoss.Summaries
                 stringOverrides={stringOverrides?.profitAndLoss?.summaries}


### PR DESCRIPTION
## Description

Support syncing and no-data states on profit and loss chart.

## How this has been tested?

1. NO syncing and NO data

_Bars are just gray placeholders with no action on click_

![image](https://github.com/user-attachments/assets/b8f3837c-2edd-4065-91f3-691f6689e440)


2. NO syncing and data

![image](https://github.com/user-attachments/assets/0c1c255b-5c65-41cb-8bf1-f0e40be1d9c4)


3. Syncing and NO data

_Bars have same animation as in loading state_

![image](https://github.com/user-attachments/assets/90556878-6fd2-4989-b91b-da609e60dfb7)


4. Syncing and data

![image](https://github.com/user-attachments/assets/7bdd7fbd-9b70-4ac0-989c-099870cab2da)

