### PR TITLE
fix: allow for cents in journal

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -69,10 +69,12 @@ export const convertNumberToCurrency = (amount: number | undefined): string => {
   return formattedValue.length > 0 ? `$${formattedValue}` : ''
 }
 
-export const convertCurrencyToNumber = (amount: string): number => {
-  const inputValue = amount.replace(/[^0-9.]/g, '')
-
-  return parseFloat(inputValue)
-}
-
-export const CURRENCY_INPUT_PATTERN = '[0-9]+(.[0-9]+)?'
+export const convertCurrencyToNumber = (amount: string): string =>
+  amount
+    .replace('$', '')
+    .replace(',', '')
+    .replace(/[^\d.]/g, '')
+    .replace(/(?!^)-/g, '')
+    .replace(/(\..*)\./g, '$1')
+    .replace(/(\.\d{2})\d+/, '$1')
+    .replace(/^0(?!\.)/, '')


### PR DESCRIPTION
## Description

Allow for cents in Journal form. It doesn't allow for negative values and use only 2 decimal places.

## How this has been tested?


https://github.com/user-attachments/assets/a7f43e3b-f64d-4556-aa8e-78878e387e43

