### PR TITLE
Bryce/fix task component styling

### DIFF
--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -5,6 +5,7 @@
 .Layer__toasts-container,
 .Layer__drawer,
 .Layer__variables,
+.Layer__tasks-component,
 #Layer__datepicker__portal {
   // 1. BASE VARIABLES:
   --color-black: #1a1a1a;


### PR DESCRIPTION
I noticed that the task component styling appears broken

Before:
<img width="915" alt="Screenshot 2024-09-12 at 9 16 32 PM" src="https://github.com/user-attachments/assets/181bfdff-bf06-4eb3-a499-3977212082a7">

After:
<img width="912" alt="Screenshot 2024-09-12 at 9 17 04 PM" src="https://github.com/user-attachments/assets/5311d99b-3d15-45e4-8c60-0d3bf012d616">
