### PR TITLE
flag for making template accounts uneditable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "description": "Layer React Components",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/ChartOfAccounts/ChartOfAccounts.tsx
+++ b/src/components/ChartOfAccounts/ChartOfAccounts.tsx
@@ -22,6 +22,7 @@ export interface ChartOfAccountsProps {
   withDateControl?: boolean
   withExpandAllButton?: boolean
   stringOverrides?: ChartOfAccountsStringOverrides
+  templateAccountsEditable?: boolean
 }
 
 export const ChartOfAccounts = (props: ChartOfAccountsProps) => {
@@ -43,6 +44,7 @@ const ChartOfAccountsContent = ({
   withDateControl,
   withExpandAllButton,
   stringOverrides,
+  templateAccountsEditable,
 }: ChartOfAccountsProps) => {
   const { accountId } = useContext(LedgerAccountsContext)
 
@@ -68,6 +70,7 @@ const ChartOfAccountsContent = ({
           view={view}
           containerRef={containerRef}
           stringOverrides={stringOverrides?.chartOfAccountsTable}
+          templateAccountsEditable={templateAccountsEditable}
         />
       )}
     </Container>

--- a/src/components/ChartOfAccountsTable/ChartOfAccountsTable.tsx
+++ b/src/components/ChartOfAccountsTable/ChartOfAccountsTable.tsx
@@ -8,12 +8,13 @@ import {
   ChartWithBalances,
   LedgerAccountBalance,
 } from '../../types/chart_of_accounts'
-import { Button, ButtonVariant } from '../Button'
 import { View } from '../../types/general'
+import { Button, ButtonVariant } from '../Button'
 import { Table, TableBody } from '../Table'
 import { TableCell } from '../TableCell'
 import { TableHead } from '../TableHead'
 import { TableRow } from '../TableRow'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip'
 import {
   ChartOfAccountsTableStringOverrides,
   ExpandActionState,
@@ -27,6 +28,7 @@ export const ChartOfAccountsTable = ({
   expandAll,
   cumulativeIndex,
   accountsLength,
+  templateAccountsEditable = true,
 }: {
   view: View
   data: ChartWithBalances
@@ -35,6 +37,7 @@ export const ChartOfAccountsTable = ({
   expandAll?: ExpandActionState
   cumulativeIndex: number
   accountsLength: number
+  templateAccountsEditable?: boolean
 }) => (
   <TableProvider>
     <ChartOfAccountsTableContent
@@ -45,6 +48,7 @@ export const ChartOfAccountsTable = ({
       expandAll={expandAll}
       cumulativeIndex={cumulativeIndex}
       accountsLength={accountsLength}
+      templateAccountsEditable={templateAccountsEditable}
     />
   </TableProvider>
 )
@@ -54,6 +58,7 @@ export const ChartOfAccountsTableContent = ({
   data,
   error,
   expandAll,
+  templateAccountsEditable,
 }: {
   view: View
   data: ChartWithBalances
@@ -62,6 +67,7 @@ export const ChartOfAccountsTableContent = ({
   expandAll?: ExpandActionState
   cumulativeIndex: number
   accountsLength: number
+  templateAccountsEditable: boolean
 }) => {
   const { setAccountId } = useContext(LedgerAccountsContext)
   const { editAccount } = useContext(ChartOfAccountsContext)
@@ -106,6 +112,18 @@ export const ChartOfAccountsTableContent = ({
     const expandable = !!account.sub_accounts && account.sub_accounts.length > 0
     const expanded = expandable ? isOpen(rowKey) : true
 
+    const editButton = <Edit2 size={12} />
+    const disabledEditButtonWithTooltip = (
+      <Tooltip offset={12}>
+        <TooltipTrigger>
+          <Edit2 size={12} />
+        </TooltipTrigger>
+        <TooltipContent className='Layer__tooltip'>
+          {'System accounts cannot be modified'}
+        </TooltipContent>
+      </Tooltip>
+    )
+
     return (
       <React.Fragment key={rowKey + '-' + index}>
         <TableRow
@@ -134,8 +152,13 @@ export const ChartOfAccountsTableContent = ({
             <span className='Layer__coa__actions'>
               <Button
                 variant={ButtonVariant.secondary}
-                rightIcon={<Edit2 size={12} />}
+                rightIcon={
+                  !templateAccountsEditable && account.stable_name
+                    ? disabledEditButtonWithTooltip
+                    : editButton
+                }
                 iconOnly={true}
+                disabled={!templateAccountsEditable && !!account.stable_name}
                 onClick={e => {
                   e.preventDefault()
                   e.stopPropagation()

--- a/src/components/ChartOfAccountsTable/ChartOfAccountsTableWithPanel.tsx
+++ b/src/components/ChartOfAccountsTable/ChartOfAccountsTableWithPanel.tsx
@@ -33,6 +33,7 @@ export const ChartOfAccountsTableWithPanel = ({
   withDateControl = false,
   withExpandAllButton = false,
   stringOverrides,
+  templateAccountsEditable,
 }: {
   view: View
   containerRef: RefObject<HTMLDivElement>
@@ -40,6 +41,7 @@ export const ChartOfAccountsTableWithPanel = ({
   withDateControl?: boolean
   withExpandAllButton?: boolean
   stringOverrides?: ChartOfAccountsTableStringOverrides
+  templateAccountsEditable?: boolean
 }) => {
   const { data, isLoading, addAccount, error, isValidating, refetch, form } =
     useContext(ChartOfAccountsContext)
@@ -92,9 +94,7 @@ export const ChartOfAccountsTableWithPanel = ({
                             : 'collapsed',
                         )
                       }
-                      expanded={
-                        !Boolean(!expandAll || expandAll === 'collapsed')
-                      }
+                      expanded={!(!expandAll || expandAll === 'collapsed')}
                       variant={ButtonVariant.secondary}
                     />
                   )}
@@ -126,6 +126,7 @@ export const ChartOfAccountsTableWithPanel = ({
           expandAll={expandAll}
           accountsLength={accountsLength}
           cumulativeIndex={cumulativeIndex}
+          templateAccountsEditable={templateAccountsEditable}
         />
       )}
 

--- a/src/components/ProfitAndLossDownloadButton/ProfitAndLossDownloadButton.tsx
+++ b/src/components/ProfitAndLossDownloadButton/ProfitAndLossDownloadButton.tsx
@@ -13,7 +13,7 @@ export interface PnLDownloadButtonStringOverrides {
   retryButtonText?: string
 }
 
-interface ProfitAndLossDownloadButtonProps {
+export interface ProfitAndLossDownloadButtonProps {
   stringOverrides?: PnLDownloadButtonStringOverrides
   moneyFormat?: MoneyFormat
   view: ViewBreakpoint

--- a/src/components/ProfitAndLossReport/ProfitAndLossReport.tsx
+++ b/src/components/ProfitAndLossReport/ProfitAndLossReport.tsx
@@ -11,7 +11,7 @@ import { View } from '../View'
 
 type ViewBreakpoint = ViewType | undefined
 
-interface ProfitAndLossReportProps {
+export interface ProfitAndLossReportProps {
   stringOverrides?: ReportsStringOverrides
   comparisonConfig?: ProfitAndLossCompareOptionsProps
   datePickerMode?: DateRangeDatePickerModes

--- a/src/views/GeneralLedger/GeneralLedger.tsx
+++ b/src/views/GeneralLedger/GeneralLedger.tsx
@@ -16,16 +16,21 @@ export interface GeneralLedgerStringOverrides {
   journal: JournalStringOverrides
 }
 
+export interface ChartOfAccountsOptions {
+  templateAccountsEditable?: boolean
+}
 export interface GeneralLedgerProps {
   title?: string // deprecated
   showTitle?: boolean
   stringOverrides?: GeneralLedgerStringOverrides
+  chartOfAccountsOptions?: ChartOfAccountsOptions
 }
 
 export const GeneralLedgerView = ({
   title, // deprecated
   showTitle = true,
   stringOverrides,
+  chartOfAccountsOptions,
 }: GeneralLedgerProps) => {
   const [activeTab, setActiveTab] = useState('chartOfAccounts')
 
@@ -58,6 +63,9 @@ export const GeneralLedgerView = ({
             asWidget
             withExpandAllButton
             stringOverrides={stringOverrides?.chartOfAccounts}
+            templateAccountsEditable={
+              chartOfAccountsOptions?.templateAccountsEditable
+            }
           />
         ) : (
           <Journal stringOverrides={stringOverrides?.journal} />


### PR DESCRIPTION
When setting is enabled, it adds an uneditable state (with a tooltip) for accounts with a stable name, i.e. accounts created by  the system.
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/83336711-14c5-4e49-bd73-f45c0b46fba6">
