### PR TITLE
fix npm run build

### DIFF
--- a/src/components/ProfitAndLossDownloadButton/ProfitAndLossDownloadButton.tsx
+++ b/src/components/ProfitAndLossDownloadButton/ProfitAndLossDownloadButton.tsx
@@ -13,7 +13,7 @@ export interface PnLDownloadButtonStringOverrides {
   retryButtonText?: string
 }
 
-interface ProfitAndLossDownloadButtonProps {
+export interface ProfitAndLossDownloadButtonProps {
   stringOverrides?: PnLDownloadButtonStringOverrides
   moneyFormat?: MoneyFormat
   view: ViewBreakpoint

--- a/src/components/ProfitAndLossReport/ProfitAndLossReport.tsx
+++ b/src/components/ProfitAndLossReport/ProfitAndLossReport.tsx
@@ -11,7 +11,7 @@ import { View } from '../View'
 
 type ViewBreakpoint = ViewType | undefined
 
-interface ProfitAndLossReportProps {
+export interface ProfitAndLossReportProps {
   stringOverrides?: ReportsStringOverrides
   comparisonConfig?: ProfitAndLossCompareOptionsProps
   datePickerMode?: DateRangeDatePickerModes


### PR DESCRIPTION
`npm run build` was not generating `index.d.ts` because some interfaces weren't being exported properly.