### PR TITLE
Fix category select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "Layer React Components",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/CategorySelect/CategorySelect.tsx
+++ b/src/components/CategorySelect/CategorySelect.tsx
@@ -173,8 +173,15 @@ const Option = (
       className={`Layer__select__option-menu-content ${props.className}`}
     >
       <div className='Layer__select__option-menu--name'>
+        {props.isSelected ? (
+          <span className='Layer__select__option-menu-content-check'>
+          <Check size={16} />
+        </span>
+        ) : null}
         <div>{props.data.payload.display_name}</div>
-        {props.data.payload.description && (
+      </div>
+      {props.data.payload.description && (
+        <div className='Layer__select__option-menu--tooltip'>
           <Tooltip>
             <TooltipTrigger>
               <InfoIcon />
@@ -188,13 +195,8 @@ const Option = (
               </Text>
             </TooltipContent>
           </Tooltip>
-        )}
-      </div>
-      {props.isSelected ? (
-        <span className='Layer__select__option-menu-content-check'>
-          <Check size={16} />
-        </span>
-      ) : null}
+        </div>
+      )}
     </components.Option>
   )
 }

--- a/src/components/CategorySelect/CategorySelect.tsx
+++ b/src/components/CategorySelect/CategorySelect.tsx
@@ -343,6 +343,7 @@ export const CategorySelect = ({
       components={{ DropdownIndicator, GroupHeading, Option }}
       isDisabled={disabled}
       isOptionDisabled={option => option.disabled ?? false}
+      isOptionSelected={option => selected?.payload.display_name == option.payload.display_name}
     />
   )
 }

--- a/src/components/CategorySelect/CategorySelect.tsx
+++ b/src/components/CategorySelect/CategorySelect.tsx
@@ -177,7 +177,11 @@ const Option = (
           <span className='Layer__select__option-menu-content-check'>
           <Check size={16} />
         </span>
-        ) : null}
+        ) : (
+          <span className="Layer__select__option-menu-content-check">
+          <div style={{ width: 16, height: 16 }} />
+        </span>
+        )}
         <div>{props.data.payload.display_name}</div>
       </div>
       {props.data.payload.description && (


### PR DESCRIPTION
Prevent multiple options being shown as selected, move check box for selected to the left of the category name, move the tooltip to the right side of the option.

<img width="331" alt="Screenshot 2024-09-19 at 1 12 06 PM" src="https://github.com/user-attachments/assets/58b64dfe-27bd-4db9-9971-25736ca77f85">
