### PR TITLE
open receipt in new tab, add new fields + endpoints

### DIFF
--- a/src/api/layer.ts
+++ b/src/api/layer.ts
@@ -9,6 +9,8 @@ import {
   updateBankTransactionMetadata,
   listBankTransactionDocuments,
   uploadBankTransactionDocument,
+  getBankTransactionDocument,
+  archiveBankTransactionDocument,
 } from './layer/bankTransactions'
 import { getBusiness } from './layer/business'
 import { getCategories } from './layer/categories'
@@ -67,6 +69,8 @@ export const Layer = {
   getBankTransactionsCsv,
   getBankTransactionMetadata,
   listBankTransactionDocuments,
+  getBankTransactionDocument,
+  archiveBankTransactionDocument,
   updateBankTransactionMetadata,
   uploadBankTransactionDocument,
   getCategories,

--- a/src/api/layer/bankTransactions.ts
+++ b/src/api/layer/bankTransactions.ts
@@ -7,7 +7,7 @@ import {
 } from '../../types/bank_transactions'
 import { FileMetadata } from '../../types/file_upload'
 import { S3PresignedUrl } from '../../types/general'
-import { get, put, postWithFormData } from './authenticated_http'
+import { get, put, postWithFormData, post } from './authenticated_http'
 
 export type GetBankTransactionsReturn = {
   data?: BankTransaction[]
@@ -118,7 +118,23 @@ export const listBankTransactionDocuments = get<{
   errors: unknown
 }>(
   ({ businessId, bankTransactionId }) =>
-    `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/documents`,
+    `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/documents?content_disposition=INLINE`,
+)
+
+export const getBankTransactionDocument = get<{
+  data: S3PresignedUrl
+  errors: unknown
+}>(
+  ({ businessId, bankTransactionId, documentId }) =>
+    `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/documents/${documentId}?content_disposition=INLINE`,
+)
+
+export const archiveBankTransactionDocument = post<{
+  data: {}
+  errors: unknown
+}>(
+  ({ businessId, bankTransactionId, documentId }) =>
+    `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/documents/${documentId}/archive`,
 )
 
 export const uploadBankTransactionDocument =

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -661,7 +661,9 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
                       <a
                         key={url}
                         href={url}
-                        onClick={openReceiptInNewTab(url, index)}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        // onClick={openReceiptInNewTab(url, index)}
                       >
                         Receipt {index + 1}
                       </a>

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -272,6 +272,25 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
       setSplitFormError(undefined)
     }
 
+    const openReceiptInNewTab =
+      (url: string, index: number) =>
+      (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+        e.preventDefault()
+        const newWindow = window.open('', '_blank')
+        if (newWindow) {
+          newWindow.document.write(`
+        <html>
+          <head>
+            <title>Receipt ${index + 1}</title>
+          </head>
+          <body style="margin: 0; display: flex; justify-content: center; align-items: center; height: 100vh;">
+            <img src="${url}" style="max-width: 100%; max-height: 100%; object-fit: contain;" />
+          </body>
+        </html>
+      `)
+        }
+      }
+
     const save = async () => {
       if (showDescriptions && memoText != undefined) {
         const result = await Layer.updateBankTransactionMetadata(
@@ -642,8 +661,7 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
                       <a
                         key={url}
                         href={url}
-                        target='_blank'
-                        rel='noopener noreferrer'
+                        onClick={openReceiptInNewTab(url, index)}
                       >
                         Receipt {index + 1}
                       </a>

--- a/src/components/Tasks/Tasks.tsx
+++ b/src/components/Tasks/Tasks.tsx
@@ -24,6 +24,7 @@ export const UseTasksContext = createContext<UseTasksContextType>({
   error: undefined,
   refetch: () => {},
   submitResponseToTask: () => {},
+  uploadDocumentForTask: () => {},
 })
 
 export const useTasksContext = () => useContext(UseTasksContext)

--- a/src/types/bank_transactions.ts
+++ b/src/types/bank_transactions.ts
@@ -41,6 +41,8 @@ export interface BankTransaction extends Record<string, unknown> {
   processing?: boolean
   suggested_matches?: SuggestedMatch[]
   match?: BankTransactionMatch
+  document_ids: String[]
+  metadata: BankTransactionMetadata
 }
 
 export interface SuggestedMatch {

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -11,6 +11,8 @@ export interface S3PresignedUrl {
   type: 'S3_Presigned_Url'
   presignedUrl: string
   fileType: string
+  fileName: string
+  createdAt: string
 }
 
 export type LoadedStatus = 'initial' | 'loading' | 'complete'


### PR DESCRIPTION
- Add endpoints for get document and archive document
- Add query param for content-disposition for documents (not actually needed but is an option now)
- Add transaction metadata and list of document IDs to transaction object
- Add function for opening document image in new tab (need to decide how to handle PDFs)
