### PR TITLE
fix: rename account to account name in journal

### DIFF
--- a/src/components/JournalTable/JournalTable.tsx
+++ b/src/components/JournalTable/JournalTable.tsx
@@ -184,7 +184,7 @@ const JournalTableContent = ({
             {stringOverrides?.transactionColumnHeader || 'Transaction'}
           </TableCell>
           <TableCell isHeaderCell>
-            {stringOverrides?.accountColumnHeader || 'Account'}
+            {stringOverrides?.accountColumnHeader || 'Account Name'}
           </TableCell>
           <TableCell isHeaderCell align={TableCellAlign.RIGHT}>
             {stringOverrides?.debitColumnHeader || 'Debit'}


### PR DESCRIPTION
## Description

Rename default column name: "Account" to "Account Name" in Journal table.

## Context

[LAY-1029](https://linear.app/layerfi/issue/LAY-1029/journal-entry-creation-rename-date-effective-date)

## How this has been tested?

![image](https://github.com/user-attachments/assets/3aa7935a-1aa3-49fc-aa9b-e6724c69405f)
