### PR TITLE
fix: rename date to effective date in journal form

### DIFF
--- a/src/components/JournalForm/JournalForm.tsx
+++ b/src/components/JournalForm/JournalForm.tsx
@@ -92,7 +92,7 @@ export const JournalForm = ({
       )}
 
       <div className='Layer__journal__form__input-group'>
-        <InputGroup name='date' label='Date' inline={true}>
+        <InputGroup name='date' label='Effective Date' inline={true}>
           <div className='Layer__journal__datepicker__wrapper'>
             <DatePicker
               selected={


### PR DESCRIPTION
## Description

Rename "Date" to "Effective Date" in Journal form.

## Context

[LAY-1029](https://linear.app/layerfi/issue/LAY-1029/journal-entry-creation-rename-date-effective-date)

## How this has been tested?

![image](https://github.com/user-attachments/assets/c856ad52-3314-4e1c-be58-3854bc153970)

