### PR TITLE
fix: debit before credit in journal

### DIFF
--- a/src/components/JournalEntryDetails/JournalEntryDetails.tsx
+++ b/src/components/JournalEntryDetails/JournalEntryDetails.tsx
@@ -33,6 +33,14 @@ export const JournalEntryDetails = () => {
     return
   }, [data, selectedEntryId])
 
+  const sortedLineItems = useMemo(
+    () =>
+      entry?.line_items?.sort((a, b) =>
+        a.direction > b.direction ? -1 : a.direction < b.direction ? 1 : 0,
+      ),
+    [entry?.line_items],
+  )
+
   return (
     <div className='Layer__journal__entry-details'>
       <Header className='Layer__journal__entry-details__mobile-header'>
@@ -113,7 +121,7 @@ export const JournalEntryDetails = () => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {entry?.line_items?.map((item, index) => (
+                {sortedLineItems?.map((item, index) => (
                   <TableRow
                     key={`ledger-line-item-${index}`}
                     rowKey={`ledger-line-item-${index}`}

--- a/src/components/JournalForm/JournalFormEntryLines.tsx
+++ b/src/components/JournalForm/JournalFormEntryLines.tsx
@@ -44,113 +44,115 @@ export const JournalFormEntryLines = ({
 
   return (
     <>
-      {Object.keys(Direction).map((direction, idx) => {
-        return (
-          <div
-            key={'Layer__journal__form__input-group-' + idx}
-            className='Layer__journal__form__input-group Layer__journal__form__input-group__border'
-          >
-            <Text
-              className='Layer__journal__form__input-group__title'
-              size={TextSize.lg}
+      {Object.keys(Direction)
+        .reverse()
+        .map((direction, idx) => {
+          return (
+            <div
+              key={'Layer__journal__form__input-group-' + idx}
+              className='Layer__journal__form__input-group Layer__journal__form__input-group__border'
             >
-              Add {humanizeEnum(direction)} Account
-            </Text>
-            {entrylineItems?.map((item, idx) => {
-              if (item.direction !== direction) {
-                return null
-              }
-              return (
-                <div
-                  className='Layer__journal__form__input-group__line-item'
-                  key={direction + '-' + idx}
-                >
-                  <InputGroup name={direction} label='Amount' inline={true}>
-                    <InputWithBadge
-                      name={direction}
-                      placeholder='$0.00'
-                      value={convertNumberToCurrency(item.amount)}
-                      disabled={sendingForm}
-                      badge={humanizeEnum(direction)}
-                      variant={
-                        item.direction === 'CREDIT'
-                          ? BadgeVariant.SUCCESS
-                          : BadgeVariant.WARNING
-                      }
-                      onChange={e =>
-                        changeFormData(
-                          'amount',
-                          convertCurrencyToNumber(
-                            (e.target as HTMLInputElement).value,
-                          ),
-                          idx,
-                        )
-                      }
-                      isInvalid={Boolean(
-                        form?.errors?.lineItems.find(
-                          x => x.id === idx && x.field === 'amount',
-                        ),
-                      )}
-                      errorMessage={
-                        form?.errors?.lineItems.find(
-                          x => x.id === idx && x.field === 'amount',
-                        )?.message
-                      }
-                    />
-                  </InputGroup>
-                  <InputGroup
-                    name='account-name'
-                    label='Account name'
-                    inline={true}
-                  >
-                    <Select
-                      options={parentOptions}
-                      value={{
-                        value: item.account_identifier.id,
-                        label: item.account_identifier.name,
-                      }}
-                      onChange={sel =>
-                        changeFormData(
-                          'parent',
-                          sel,
-                          idx,
-                          accountsData?.accounts,
-                        )
-                      }
-                      isInvalid={Boolean(
-                        form?.errors?.lineItems.find(
-                          x => x.id === idx && x.field === 'account',
-                        ),
-                      )}
-                      errorMessage={
-                        form?.errors?.lineItems.find(
-                          x => x.id === idx && x.field === 'account',
-                        )?.message
-                      }
-                    />
-                    {idx >= 2 && (
-                      <IconButton
-                        className='Layer__remove__button'
-                        onClick={() => removeEntryLine(idx)}
-                        icon={<Trash />}
-                      />
-                    )}
-                  </InputGroup>
-                </div>
-              )
-            })}
-            {(config.form.addEntryLinesLimit === undefined ||
-              config.form.addEntryLinesLimit > entrylineItems?.length) && (
-              <TextButton
-                className='Layer__journal__add-entry-line'
-                onClick={() => addEntryLine(direction as Direction)}
+              <Text
+                className='Layer__journal__form__input-group__title'
+                size={TextSize.lg}
               >
-                Add next account
-              </TextButton>
-            )}
-          </div>
-        )
-      })}
+                Add {humanizeEnum(direction)} Account
+              </Text>
+              {entrylineItems?.map((item, idx) => {
+                if (item.direction !== direction) {
+                  return null
+                }
+                return (
+                  <div
+                    className='Layer__journal__form__input-group__line-item'
+                    key={direction + '-' + idx}
+                  >
+                    <InputGroup name={direction} label='Amount' inline={true}>
+                      <InputWithBadge
+                        name={direction}
+                        placeholder='$0.00'
+                        value={convertNumberToCurrency(item.amount)}
+                        disabled={sendingForm}
+                        badge={humanizeEnum(direction)}
+                        variant={
+                          item.direction === 'CREDIT'
+                            ? BadgeVariant.SUCCESS
+                            : BadgeVariant.WARNING
+                        }
+                        onChange={e =>
+                          changeFormData(
+                            'amount',
+                            convertCurrencyToNumber(
+                              (e.target as HTMLInputElement).value,
+                            ),
+                            idx,
+                          )
+                        }
+                        isInvalid={Boolean(
+                          form?.errors?.lineItems.find(
+                            x => x.id === idx && x.field === 'amount',
+                          ),
+                        )}
+                        errorMessage={
+                          form?.errors?.lineItems.find(
+                            x => x.id === idx && x.field === 'amount',
+                          )?.message
+                        }
+                      />
+                    </InputGroup>
+                    <InputGroup
+                      name='account-name'
+                      label='Account name'
+                      inline={true}
+                    >
+                      <Select
+                        options={parentOptions}
+                        value={{
+                          value: item.account_identifier.id,
+                          label: item.account_identifier.name,
+                        }}
+                        onChange={sel =>
+                          changeFormData(
+                            'parent',
+                            sel,
+                            idx,
+                            accountsData?.accounts,
+                          )
+                        }
+                        isInvalid={Boolean(
+                          form?.errors?.lineItems.find(
+                            x => x.id === idx && x.field === 'account',
+                          ),
+                        )}
+                        errorMessage={
+                          form?.errors?.lineItems.find(
+                            x => x.id === idx && x.field === 'account',
+                          )?.message
+                        }
+                      />
+                      {idx >= 2 && (
+                        <IconButton
+                          className='Layer__remove__button'
+                          onClick={() => removeEntryLine(idx)}
+                          icon={<Trash />}
+                        />
+                      )}
+                    </InputGroup>
+                  </div>
+                )
+              })}
+              {(config.form.addEntryLinesLimit === undefined ||
+                config.form.addEntryLinesLimit > entrylineItems?.length) && (
+                <TextButton
+                  className='Layer__journal__add-entry-line'
+                  onClick={() => addEntryLine(direction as Direction)}
+                >
+                  Add next account
+                </TextButton>
+              )}
+            </div>
+          )
+        })}
     </>
   )
 }

--- a/src/components/JournalForm/JournalFormEntryLines.tsx
+++ b/src/components/JournalForm/JournalFormEntryLines.tsx
@@ -44,115 +44,113 @@ export const JournalFormEntryLines = ({
 
   return (
     <>
-      {Object.keys(Direction)
-        .reverse()
-        .map((direction, idx) => {
-          return (
-            <div
-              key={'Layer__journal__form__input-group-' + idx}
-              className='Layer__journal__form__input-group Layer__journal__form__input-group__border'
+      {['DEBIT', 'CREDIT'].map((direction, idx) => {
+        return (
+          <div
+            key={'Layer__journal__form__input-group-' + idx}
+            className='Layer__journal__form__input-group Layer__journal__form__input-group__border'
+          >
+            <Text
+              className='Layer__journal__form__input-group__title'
+              size={TextSize.lg}
             >
-              <Text
-                className='Layer__journal__form__input-group__title'
-                size={TextSize.lg}
-              >
-                Add {humanizeEnum(direction)} Account
-              </Text>
-              {entrylineItems?.map((item, idx) => {
-                if (item.direction !== direction) {
-                  return null
-                }
-                return (
-                  <div
-                    className='Layer__journal__form__input-group__line-item'
-                    key={direction + '-' + idx}
-                  >
-                    <InputGroup name={direction} label='Amount' inline={true}>
-                      <InputWithBadge
-                        name={direction}
-                        placeholder='$0.00'
-                        value={convertNumberToCurrency(item.amount)}
-                        disabled={sendingForm}
-                        badge={humanizeEnum(direction)}
-                        variant={
-                          item.direction === 'CREDIT'
-                            ? BadgeVariant.SUCCESS
-                            : BadgeVariant.WARNING
-                        }
-                        onChange={e =>
-                          changeFormData(
-                            'amount',
-                            convertCurrencyToNumber(
-                              (e.target as HTMLInputElement).value,
-                            ),
-                            idx,
-                          )
-                        }
-                        isInvalid={Boolean(
-                          form?.errors?.lineItems.find(
-                            x => x.id === idx && x.field === 'amount',
-                          ),
-                        )}
-                        errorMessage={
-                          form?.errors?.lineItems.find(
-                            x => x.id === idx && x.field === 'amount',
-                          )?.message
-                        }
-                      />
-                    </InputGroup>
-                    <InputGroup
-                      name='account-name'
-                      label='Account name'
-                      inline={true}
-                    >
-                      <Select
-                        options={parentOptions}
-                        value={{
-                          value: item.account_identifier.id,
-                          label: item.account_identifier.name,
-                        }}
-                        onChange={sel =>
-                          changeFormData(
-                            'parent',
-                            sel,
-                            idx,
-                            accountsData?.accounts,
-                          )
-                        }
-                        isInvalid={Boolean(
-                          form?.errors?.lineItems.find(
-                            x => x.id === idx && x.field === 'account',
-                          ),
-                        )}
-                        errorMessage={
-                          form?.errors?.lineItems.find(
-                            x => x.id === idx && x.field === 'account',
-                          )?.message
-                        }
-                      />
-                      {idx >= 2 && (
-                        <IconButton
-                          className='Layer__remove__button'
-                          onClick={() => removeEntryLine(idx)}
-                          icon={<Trash />}
-                        />
-                      )}
-                    </InputGroup>
-                  </div>
-                )
-              })}
-              {(config.form.addEntryLinesLimit === undefined ||
-                config.form.addEntryLinesLimit > entrylineItems?.length) && (
-                <TextButton
-                  className='Layer__journal__add-entry-line'
-                  onClick={() => addEntryLine(direction as Direction)}
+              Add {humanizeEnum(direction)} Account
+            </Text>
+            {entrylineItems?.map((item, idx) => {
+              if (item.direction !== direction) {
+                return null
+              }
+              return (
+                <div
+                  className='Layer__journal__form__input-group__line-item'
+                  key={direction + '-' + idx}
                 >
-                  Add next account
-                </TextButton>
-              )}
-            </div>
-          )
-        })}
+                  <InputGroup name={direction} label='Amount' inline={true}>
+                    <InputWithBadge
+                      name={direction}
+                      placeholder='$0.00'
+                      value={convertNumberToCurrency(item.amount)}
+                      disabled={sendingForm}
+                      badge={humanizeEnum(direction)}
+                      variant={
+                        item.direction === 'CREDIT'
+                          ? BadgeVariant.SUCCESS
+                          : BadgeVariant.WARNING
+                      }
+                      onChange={e =>
+                        changeFormData(
+                          'amount',
+                          convertCurrencyToNumber(
+                            (e.target as HTMLInputElement).value,
+                          ),
+                          idx,
+                        )
+                      }
+                      isInvalid={Boolean(
+                        form?.errors?.lineItems.find(
+                          x => x.id === idx && x.field === 'amount',
+                        ),
+                      )}
+                      errorMessage={
+                        form?.errors?.lineItems.find(
+                          x => x.id === idx && x.field === 'amount',
+                        )?.message
+                      }
+                    />
+                  </InputGroup>
+                  <InputGroup
+                    name='account-name'
+                    label='Account name'
+                    inline={true}
+                  >
+                    <Select
+                      options={parentOptions}
+                      value={{
+                        value: item.account_identifier.id,
+                        label: item.account_identifier.name,
+                      }}
+                      onChange={sel =>
+                        changeFormData(
+                          'parent',
+                          sel,
+                          idx,
+                          accountsData?.accounts,
+                        )
+                      }
+                      isInvalid={Boolean(
+                        form?.errors?.lineItems.find(
+                          x => x.id === idx && x.field === 'account',
+                        ),
+                      )}
+                      errorMessage={
+                        form?.errors?.lineItems.find(
+                          x => x.id === idx && x.field === 'account',
+                        )?.message
+                      }
+                    />
+                    {idx >= 2 && (
+                      <IconButton
+                        className='Layer__remove__button'
+                        onClick={() => removeEntryLine(idx)}
+                        icon={<Trash />}
+                      />
+                    )}
+                  </InputGroup>
+                </div>
+              )
+            })}
+            {(config.form.addEntryLinesLimit === undefined ||
+              config.form.addEntryLinesLimit > entrylineItems?.length) && (
+              <TextButton
+                className='Layer__journal__add-entry-line'
+                onClick={() => addEntryLine(direction as Direction)}
+              >
+                Add next account
+              </TextButton>
+            )}
+          </div>
+        )
+      })}
     </>
   )
 }


### PR DESCRIPTION
## Description

Move "Debit" before "Credit" in Journal form and details.

## Context

[LAY-1027](https://linear.app/layerfi/issue/LAY-1027/debit-line-items-should-be-shown-above-credit-line-items)
[LAY-1028](https://linear.app/layerfi/issue/LAY-1028/journal-entry-creation-debits-before-credits)

## How this has been tested?

![image](https://github.com/user-attachments/assets/7aaded91-e23d-419e-823f-0fccc5184ba3)

![image](https://github.com/user-attachments/assets/024949e0-b8a7-4b0b-a7f5-2a1db4d30684)
