### PR TITLE
fix: journal rows expanded by default

### DIFF
--- a/src/components/JournalTable/JournalTable.tsx
+++ b/src/components/JournalTable/JournalTable.tsx
@@ -16,17 +16,6 @@ import { Table, TableBody, TableCell, TableHead, TableRow } from '../Table'
 import { JournalTableStringOverrides } from './JournalTableWithPanel'
 import { parseISO, format as formatTime } from 'date-fns'
 
-const rowId = (row: JournalEntry | JournalEntryLineItem | JournalEntryLine) => {
-  if ('id' in row) {
-    return row.id
-  }
-  if ('account_identifier' in row) {
-    return `${row.account_identifier.id}-${Math.random()}`
-  }
-
-  return `${Math.random()}`
-}
-
 const accountName = (
   row: JournalEntry | JournalEntryLine | JournalEntryLineItem,
 ) => {
@@ -72,9 +61,9 @@ const JournalTableContent = ({
 
   useEffect(() => {
     if (data.length > 0) {
-      setIsOpen([`journal-row- + ${data[0].id}`])
+      setIsOpen(data.map(x => `journal-row-${x.id}`))
     }
-  }, [])
+  }, [data])
 
   const renderJournalRow = (
     row: JournalEntry,
@@ -84,6 +73,7 @@ const JournalTableContent = ({
   ) => {
     const expandable = !!row.line_items && row.line_items.length > 0
     const expanded = expandable ? isOpen(rowKey) : true
+
     return (
       <React.Fragment key={rowKey + '-' + index}>
         <TableRow


### PR DESCRIPTION
## Description

Journal table rows expanded by default.

## Context

[LAY-1033](https://linear.app/layerfi/issue/LAY-1033/default-expand-journal-list)


## How this has been tested?

![image](https://github.com/user-attachments/assets/f4e34c9c-686f-491d-9706-a9a0e823568f)
