### PR TITLE
fix: formatting reversal value in journal entry details

### DIFF
--- a/src/components/JournalEntryDetails/JournalEntryDetails.tsx
+++ b/src/components/JournalEntryDetails/JournalEntryDetails.tsx
@@ -84,7 +84,7 @@ export const JournalEntryDetails = () => {
         </DetailsListItem>
         {entry?.reversal_id && (
           <DetailsListItem label='Reversal' isLoading={isLoadingEntry}>
-            Journal Entry #{entry?.reversal_id}
+            {`Journal Entry #${entry?.reversal_id.substring(0, 5)}`}
           </DetailsListItem>
         )}
       </DetailsList>

--- a/src/components/LedgerAccountEntryDetails/LedgerAccountEntryDetails.tsx
+++ b/src/components/LedgerAccountEntryDetails/LedgerAccountEntryDetails.tsx
@@ -10,7 +10,8 @@ import {
   ManualLedgerEntrySource,
   OpeningBalanceLedgerEntrySource,
   PayoutLedgerEntrySource,
-  RefundLedgerEntrySource, RefundPaymentLedgerEntrySource,
+  RefundLedgerEntrySource,
+  RefundPaymentLedgerEntrySource,
   TransactionLedgerEntrySource,
 } from '../../types/ledger_accounts'
 import { TableCellAlign } from '../../types/table'


### PR DESCRIPTION
## Description

Fix Reversal value formatting

## Context
[LAY-1021](https://linear.app/layerfi/issue/LAY-1021/reversal-text-sizing-is-unstyled)

## How this has been tested?

![image](https://github.com/user-attachments/assets/692e7e0b-141d-4376-8b28-9c44f1d47fd0)
