### PR TITLE
fix: disappearing receipts on screen resize

### DIFF
--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -137,6 +137,7 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
     const {
       categorize: categorizeBankTransaction,
       match: matchBankTransaction,
+      updateOneLocal: updateBankTransaction,
     } = useBankTransactionsContext()
     const [purpose, setPurpose] = useState<Purpose>(
       bankTransaction.category
@@ -512,13 +513,24 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
           apiUrl,
           auth.access_token,
         )
-        await uploadDocument({
+        const result = await uploadDocument({
           businessId: businessId,
           bankTransactionId: bankTransaction.id,
           file: file,
           documentType: 'RECEIPT',
         })
         await fetchDocuments()
+        // Update the bank transaction with the new document id
+        if (
+          result?.data?.id &&
+          bankTransaction?.document_ids &&
+          bankTransaction.document_ids.length === 0
+        ) {
+          updateBankTransaction({
+            ...bankTransaction,
+            document_ids: [result.data.id],
+          })
+        }
       } catch (_err) {
         const newReceiptUrls = receipts.map(url => {
           if (url.id === id) {

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -800,9 +800,8 @@ export const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
                       deletePending={url.status === 'deleting'}
                       name={url.name ?? `Receipt ${index + 1}`}
                       date={url.date}
-                      enableOpen={url.type === 'application/pdf'}
                       onOpen={
-                        url.url && url.type !== 'application/pdf'
+                        url.url && url.type && url.type.startsWith('image/')
                           ? openReceiptInNewTab(url.url, index)
                           : undefined
                       }


### PR DESCRIPTION
## Description

1. Fix disappearing receipts on page resize.
2. Allow to delete failed uploads
3. Show "open" button only for images

## Context

[LAY-1039](https://linear.app/layerfi/issue/LAY-1039/errored-uploads-call-all-uploads-to-disappear-when-adjusting-the-grid)
[LAY-1038](https://linear.app/layerfi/issue/LAY-1038/allow-deletion-of-documents-that-failed-to-upload)
[LAY-1037](https://linear.app/layerfi/issue/LAY-1037/hide-view-receipt-button-for-non-images)

## How this has been tested?


https://github.com/user-attachments/assets/358a88be-6287-441b-8b44-b5de9d0462cd


https://github.com/user-attachments/assets/026bf7c5-a5e7-4609-8603-8408faf5213e



