### PR TITLE
feat: journal - use entry_at as date

### DIFF
--- a/src/components/Journal/Journal.tsx
+++ b/src/components/Journal/Journal.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import { BREAKPOINTS } from '../../config/general'
 import { ChartOfAccountsContext } from '../../contexts/ChartOfAccountsContext'
 import { JournalContext } from '../../contexts/JournalContext'
 import { useChartOfAccounts } from '../../hooks/useChartOfAccounts'

--- a/src/components/JournalTable/JournalTable.tsx
+++ b/src/components/JournalTable/JournalTable.tsx
@@ -104,7 +104,7 @@ const JournalTableContent = ({
             {entryNumber(row)}
           </TableCell>
           <TableCell>
-            {row.date && formatTime(parseISO(row.date), DATE_FORMAT)}
+            {row.entry_at && formatTime(parseISO(row.entry_at), DATE_FORMAT)}
           </TableCell>
           <TableCell>{humanizeEnum(row.entry_type)}</TableCell>
           <TableCell>({row.line_items.length})</TableCell>

--- a/src/components/JournalTable/JournalTableWithPanel.tsx
+++ b/src/components/JournalTable/JournalTableWithPanel.tsx
@@ -1,10 +1,10 @@
 import React, { RefObject, useContext, useMemo, useState } from 'react'
 import { JournalContext } from '../../contexts/JournalContext'
 import PlusIcon from '../../icons/PlusIcon'
+import { View } from '../../types/general'
 import { Button } from '../Button'
 import { DataState, DataStateStatus } from '../DataState'
 import { Header, HeaderCol, HeaderRow } from '../Header'
-import { View } from '../../types/general'
 import { JournalConfig } from '../Journal/Journal'
 import { JournalFormStringOverrides } from '../JournalForm/JournalForm'
 import { JournalSidebar } from '../JournalSidebar'
@@ -57,7 +57,7 @@ export const JournalTableWithPanel = ({
     const firstPageIndex = (currentPage - 1) * pageSize
     const lastPageIndex = firstPageIndex + pageSize
     return rawData
-      ?.sort((a, b) => Date.parse(b.date) - Date.parse(a.date))
+      ?.sort((a, b) => Date.parse(b.entry_at) - Date.parse(a.entry_at))
       ?.slice(firstPageIndex, lastPageIndex)
   }, [rawData, currentPage])
 


### PR DESCRIPTION
## Description

Sort Journal by `entry_at` and display `entry_at` in the Date column.

## How this has been tested?

![image](https://github.com/user-attachments/assets/3632856d-e1e1-4e0f-a72e-16d366bc7554)
