### PR TITLE
fix(build): force target ES2016

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -10,12 +10,17 @@ new Generator({
 }).generate()
 
 const entryPoints = ['src/index.tsx']
+
+/**
+ * @type {import('esbuild').BuildOptions}
+ */
 const sharedConfig = {
   entryPoints,
   bundle: true,
   minify: false,
   sourcemap: true,
   tsconfig: './tsconfig.json',
+  target: 'es2016',
   external: [
     ...Object.keys(dependencies || {}),
     ...Object.keys(peerDependencies || {}),


### PR DESCRIPTION
## Description

A breaking change was made in [esbuild v0.18.0](https://github.com/evanw/esbuild/blob/main/CHANGELOG-2023.md#0180) that dropped inference of `target` from the supplied tsconfig file.