### PR TITLE
fix: compile warning - flex-end

### DIFF
--- a/src/components/DatePicker/ModeSelector/date-picker-mode-selector.scss
+++ b/src/components/DatePicker/ModeSelector/date-picker-mode-selector.scss
@@ -1,6 +1,6 @@
 .Layer__DatePickerModeSelector__container {
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
   padding-inline: var(--spacing-xs);
   padding-block: var(--spacing-xs);
 }


### PR DESCRIPTION
## Description

Fix warning about using `end` value for `justify-content`.

Before:

```
Compiled with warnings.

Warning
(1016:3) autoprefixer: end value has mixed support, consider using flex-end instead

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

WARNING in ../components/dist/styles/index.css (./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].oneOf[5].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].oneOf[5].use[2]!./node_modules/source-map-loader/dist/cjs.js!../components/dist/styles/index.css)
Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
Warning

(1016:3) autoprefixer: end value has mixed support, consider using flex-end instead

webpack compiled with 1 warning
No issues found.
```

After:

```
Compiled successfully!

You can now view layerfi-demo-finguard in the browser.

  Local:            http://localhost:3001
  On Your Network:  http://192.168.100.2:3001

Note that the development build is not optimized.
To create a production build, use npm run build.

webpack compiled successfully
No issues found.

```