### PR TITLE
default the plaid sandbox env to be based on the env

### DIFF
--- a/src/hooks/useLinkedAccounts/useLinkedAccounts.ts
+++ b/src/hooks/useLinkedAccounts/useLinkedAccounts.ts
@@ -45,7 +45,6 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   } = useLayerContext()
   const [linkToken, setLinkToken] = useState<string | null>(null)
   const [loadingStatus, setLoadingStatus] = useState<LoadedStatus>('initial')
-  const USE_PLAID_SANDBOX = usePlaidSandbox ?? true
   const [linkMode, setLinkMode] = useState<LinkMode>('add')
 
   const queryKey =
@@ -149,7 +148,7 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
       }
     },
     onExit: () => setLinkMode('add'),
-    env: USE_PLAID_SANDBOX ? 'sandbox' : undefined,
+    env: usePlaidSandbox ? 'sandbox' : undefined,
   })
 
   useEffect(() => {

--- a/src/providers/BusinessProvider/BusinessProvider.tsx
+++ b/src/providers/BusinessProvider/BusinessProvider.tsx
@@ -86,7 +86,12 @@ export const BusinessProvider = ({
 
   const colors = buildColorsPalette(theme)
 
-  const { url, scope, apiUrl } = LayerEnvironment[environment]
+  const {
+    url,
+    scope,
+    apiUrl,
+    usePlaidSandbox: defaultUsePlaidSandbox,
+  } = LayerEnvironment[environment]
   const [state, dispatch] = useReducer(reducer, {
     auth: {
       access_token: '',
@@ -100,7 +105,7 @@ export const BusinessProvider = ({
     apiUrl,
     theme,
     colors,
-    usePlaidSandbox,
+    usePlaidSandbox: usePlaidSandbox ?? defaultUsePlaidSandbox,
     onboardingStep: undefined,
     environment,
     toasts: [],

--- a/src/providers/LayerProvider/LayerProvider.tsx
+++ b/src/providers/LayerProvider/LayerProvider.tsx
@@ -8,6 +8,7 @@ type LayerEnvironmentConfig = {
   url: string
   scope: string
   apiUrl: string
+  usePlaidSandbox: boolean
 }
 
 export const LayerEnvironment: Record<string, LayerEnvironmentConfig> = {
@@ -15,21 +16,25 @@ export const LayerEnvironment: Record<string, LayerEnvironmentConfig> = {
     url: 'https://auth.layerfi.com/oauth2/token',
     scope: 'https://api.layerfi.com/production',
     apiUrl: 'https://api.layerfi.com',
+    usePlaidSandbox: false,
   },
   sandbox: {
     url: 'https://auth.layerfi.com/oauth2/token',
     scope: 'https://sandbox.layerfi.com/sandbox',
     apiUrl: 'https://sandbox.layerfi.com',
+    usePlaidSandbox: true,
   },
   staging: {
     url: 'https://auth.layerfi.com/oauth2/token',
     scope: 'https://sandbox.layerfi.com/sandbox',
     apiUrl: 'https://staging.layerfi.com',
+    usePlaidSandbox: true,
   },
   internalStaging: {
     url: 'https://auth.layerfi.com/oauth2/token',
     scope: 'https://sandbox.layerfi.com/sandbox',
     apiUrl: 'https://staging.layerfi.com',
+    usePlaidSandbox: true,
   },
 }
 

--- a/src/types/layer_context.ts
+++ b/src/types/layer_context.ts
@@ -13,7 +13,7 @@ export type LayerContextValues = {
   apiUrl: string
   theme?: LayerThemeConfig
   colors: ColorsPalette
-  usePlaidSandbox?: boolean
+  usePlaidSandbox: boolean
   onboardingStep?: OnboardingStep
   environment: string
   toasts: (ToastProps & { isExiting: boolean })[]


### PR DESCRIPTION
Currently we _default_ to using the plaid sandbox unless the override is set. Which is not intuitive and some clients have been confused. 

This PR continues to allow you to specify the `usePlaidSandbox` override, but otherwise defaults to setting it based on the environment. If you're using Layer production, we'll default to plaid production, otherwise default to plaid sandbox.