### PR TITLE
Daniel/lg summary style suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/*
 node_modules
 .vim_backups/
 .idea/
+.vscode/

--- a/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
+++ b/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
@@ -89,6 +89,7 @@ export function Internal_ProfitAndLossSummaries({
                 <ProfitAndLossSummariesMiniChart
                   data={revenueChartData}
                   chartColorsList={chartColorsList}
+                  variants={variants}
                 />
               ),
             }}
@@ -108,6 +109,7 @@ export function Internal_ProfitAndLossSummaries({
                 <ProfitAndLossSummariesMiniChart
                   data={expensesChartData}
                   chartColorsList={chartColorsList}
+                  variants={variants}
                 />
               ),
             }}

--- a/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesHeading.tsx
+++ b/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesHeading.tsx
@@ -1,0 +1,24 @@
+import { PropsWithChildren, useMemo } from 'react'
+import React from 'react'
+import type { Variants } from '../../../utils/styleUtils/sizeVariants'
+import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'
+
+type ProfitAndLossSummariesHeadingProps = {
+  variants?: Variants
+} & PropsWithChildren
+
+const HEADING_CLASS_NAME = 'Layer__ProfitAndLossSummariesSummaryHeading'
+
+export function ProfitAndLossSummariesHeading({
+  variants,
+  children,
+}: ProfitAndLossSummariesHeadingProps) {
+  const { size = 'sm' } = variants ?? {}
+  const labelDataProperties = useMemo(() => toDataProperties({ size }), [size])
+
+  return (
+    <h3 className={HEADING_CLASS_NAME} {...labelDataProperties}>
+      {children}
+    </h3>
+  )
+}

--- a/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesMiniChart.tsx
+++ b/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesMiniChart.tsx
@@ -6,6 +6,7 @@ import {
   collectExpensesItems,
   collectRevenueItems,
 } from '../../../utils/profitAndLossUtils'
+import { Variants } from '../../../utils/styleUtils/sizeVariants'
 import { mapTypesToColors } from '../../ProfitAndLossDetailedCharts/DetailedTable'
 import { PieChart, Pie, Cell } from 'recharts'
 
@@ -54,28 +55,46 @@ export function toMiniChartData({
 type ProfitAndLossMiniChartProps = {
   data: LineBaseItem[]
   chartColorsList?: string[]
+  variants?: Variants
 }
 
 export function ProfitAndLossSummariesMiniChart({
   data,
   chartColorsList,
+  variants,
 }: ProfitAndLossMiniChartProps) {
   const typeColorMapping = mapTypesToColors(data, chartColorsList)
 
+  let chartDimension: number = 52
+  let innerRadius: number = 10
+  let outerRadius: number = 16
+  switch (variants?.size) {
+    case 'sm':
+      chartDimension = 52
+      innerRadius = 10
+      outerRadius = 16
+      break
+    case 'lg':
+      chartDimension = 64
+      innerRadius = 12
+      outerRadius = 20
+      break
+  }
+
   return (
-    <PieChart width={52} height={52}>
+    <PieChart width={chartDimension} height={chartDimension}>
       <Pie
         data={data}
         dataKey='value'
         nameKey='name'
         cx='50%'
         cy='50%'
-        innerRadius={10}
-        outerRadius={16}
+        innerRadius={innerRadius}
+        outerRadius={outerRadius}
         paddingAngle={0.4}
         fill='#8884d8'
-        width={24}
-        height={24}
+        width={36}
+        height={36}
         animationDuration={250}
         animationEasing='ease-in-out'
       >

--- a/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesSummary.tsx
+++ b/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesSummary.tsx
@@ -3,11 +3,11 @@ import { centsToDollars as formatMoney } from '../../../models/Money'
 import type { Variants } from '../../../utils/styleUtils/sizeVariants'
 import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'
 import { SkeletonLoader } from '../../SkeletonLoader'
+import { ProfitAndLossSummariesHeading } from './ProfitAndLossSummariesHeading'
 
 const CLASS_NAME = 'Layer__ProfitAndLossSummariesSummary'
 
 const CHART_AREA_CLASS_NAME = 'Layer__ProfitAndLossSummariesSummaryChartArea'
-const HEADING_CLASS_NAME = 'Layer__ProfitAndLossSummariesSummaryHeading'
 const AMOUNT_CLASS_NAME = 'Layer__ProfitAndLossSummariesSummaryAmount'
 
 type ProfitAndLossSummariesSummaryProps = {
@@ -31,7 +31,6 @@ export function ProfitAndLossSummariesSummary({
   const { size = 'sm' } = variants ?? {}
 
   const dataProperties = useMemo(() => toDataProperties({ size }), [size])
-  const labelDataProperties = useMemo(() => toDataProperties({ size }), [size])
   const amountDataProperties = useMemo(
     () =>
       toDataProperties({
@@ -45,9 +44,9 @@ export function ProfitAndLossSummariesSummary({
   return (
     <div className={CLASS_NAME} {...dataProperties}>
       {Chart && <div className={CHART_AREA_CLASS_NAME}>{Chart}</div>}
-      <h3 className={HEADING_CLASS_NAME} {...labelDataProperties}>
+      <ProfitAndLossSummariesHeading variants={variants}>
         {label}
-      </h3>
+      </ProfitAndLossSummariesHeading>
       {isLoading ? (
         <SkeletonLoader />
       ) : (

--- a/src/components/ProfitAndLossSummaries/internal/profit_and_loss_summaries_heading.scss
+++ b/src/components/ProfitAndLossSummaries/internal/profit_and_loss_summaries_heading.scss
@@ -1,0 +1,12 @@
+.Layer__ProfitAndLossSummariesSummaryHeading {
+  grid-area: heading;
+  align-self: end;
+  margin: unset;
+
+  color: var(--color-base-700);
+  font-size: var(--text-sm);
+
+  &[data-size="lg"] {
+    font-size: var(--text-lg);
+  }
+}

--- a/src/components/ProfitAndLossSummaries/internal/profit_and_loss_summaries_summary.scss
+++ b/src/components/ProfitAndLossSummaries/internal/profit_and_loss_summaries_summary.scss
@@ -23,19 +23,6 @@
   background: var(--color-base-50);
 }
 
-.Layer__ProfitAndLossSummariesSummaryHeading {
-  grid-area: heading;
-  align-self: end;
-  margin: unset;
-
-  color: var(--color-base-700);
-  font-size: var(--text-sm);
-
-  &[data-size="lg"] {
-    font-size: var(--text-lg);
-  }
-}
-
 .Layer__ProfitAndLossSummariesSummaryAmount {
   grid-area: amount;
 

--- a/src/components/ProfitAndLossSummaries/profit_and_loss_summaries.scss
+++ b/src/components/ProfitAndLossSummaries/profit_and_loss_summaries.scss
@@ -1,5 +1,6 @@
 @import "./internal/profit_and_loss_summaries_list.scss";
 @import "./internal/profit_and_loss_summaries_summary.scss";
+@import "./internal/profit_and_loss_summaries_heading.scss";
 
 .Layer__ProfitAndLossSummaries {
   display: grid;

--- a/src/components/ui/Stack.tsx
+++ b/src/components/ui/Stack.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, type PropsWithChildren } from 'react'
 import { toDataProperties } from '../../utils/styleUtils/toDataProperties'
 
-type StackProps = PropsWithChildren<{
-  gap?: '3xs' | '2xs' | 'xs'
+export type StackProps = PropsWithChildren<{
+  gap?: '3xs' | '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '5xl'
   align?: 'start'
 }>
 

--- a/src/components/ui/stack.scss
+++ b/src/components/ui/stack.scss
@@ -15,4 +15,26 @@
   &[data-gap="xs"] {
     gap: var(--spacing-xs);
   }
+  &[data-gap="sm"] {
+    gap: var(--spacing-sm);
+  }
+  &[data-gap="md"] {
+    gap: var(--spacing-md);
+  }
+  &[data-gap="lg"] {
+    gap: var(--spacing-lg);
+  }
+  &[data-gap="xl"] {
+    gap: var(--spacing-xl);
+  }
+  &[data-gap="2xl"] {
+    gap: var(--spacing-2xl);
+  }
+  &[data-gap="3xl"] {
+    gap: var(--spacing-3xl);
+  }
+  &[data-gap="5xl"] {
+    gap: var(--spacing-5xl);
+  }
+
 }

--- a/src/views/AccountingOverview/internal/TransactionsToReview.tsx
+++ b/src/views/AccountingOverview/internal/TransactionsToReview.tsx
@@ -1,20 +1,22 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useMemo, useState } from 'react'
 import { Badge } from '../../../components/Badge'
 import { BadgeSize, BadgeVariant } from '../../../components/Badge/Badge'
 import { BadgeLoader } from '../../../components/BadgeLoader'
 import { IconButton } from '../../../components/Button'
 import { ProfitAndLoss } from '../../../components/ProfitAndLoss'
 import { Text, TextSize } from '../../../components/Typography'
-import { VStack } from '../../../components/ui/Stack'
+import { StackProps, VStack } from '../../../components/ui/Stack'
 import { useProfitAndLossLTM } from '../../../hooks/useProfitAndLoss/useProfitAndLossLTM'
 import BellIcon from '../../../icons/Bell'
 import CheckIcon from '../../../icons/Check'
 import ChevronRight from '../../../icons/ChevronRight'
 import RefreshCcw from '../../../icons/RefreshCcw'
 import type { Variants } from '../../../utils/styleUtils/sizeVariants'
+import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'
 import { getMonth, getYear, startOfMonth } from 'date-fns'
 
 const CLASS_NAME = 'Layer__TransactionsToReview'
+const HEADING_CLASS_NAME = 'Layer__ProfitAndLossSummariesSummaryHeading'
 
 type TransactionsToReviewProps = {
   onClick?: () => void
@@ -65,12 +67,22 @@ export function TransactionsToReview({
     }
   }
 
+  const labelDataProperties = useMemo(() => toDataProperties({ size }), [size])
+  let verticalGap: StackProps['gap'] = '3xs'
+  switch (size) {
+    case 'sm':
+      verticalGap = '3xs'
+      break
+    case 'lg':
+      verticalGap = 'sm'
+      break
+  }
   return (
     <div onClick={onClick} className={CLASS_NAME}>
-      <VStack gap='3xs' align='start'>
-        <Text size={size === 'lg' ? TextSize.lg : TextSize.sm}>
+      <VStack gap={verticalGap} align='start'>
+        <h3 className={HEADING_CLASS_NAME} {...labelDataProperties}>
           Transactions to review
-        </Text>
+        </h3>
         {loaded === 'initial' || loaded === 'loading' ? <BadgeLoader /> : null}
 
         {loaded === 'complete' && error ? (

--- a/src/views/AccountingOverview/internal/TransactionsToReview.tsx
+++ b/src/views/AccountingOverview/internal/TransactionsToReview.tsx
@@ -4,6 +4,7 @@ import { BadgeSize, BadgeVariant } from '../../../components/Badge/Badge'
 import { BadgeLoader } from '../../../components/BadgeLoader'
 import { IconButton } from '../../../components/Button'
 import { ProfitAndLoss } from '../../../components/ProfitAndLoss'
+import { ProfitAndLossSummariesHeading } from '../../../components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesHeading'
 import { Text, TextSize } from '../../../components/Typography'
 import { StackProps, VStack } from '../../../components/ui/Stack'
 import { useProfitAndLossLTM } from '../../../hooks/useProfitAndLoss/useProfitAndLossLTM'
@@ -67,7 +68,6 @@ export function TransactionsToReview({
     }
   }
 
-  const labelDataProperties = useMemo(() => toDataProperties({ size }), [size])
   let verticalGap: StackProps['gap'] = '3xs'
   switch (size) {
     case 'sm':
@@ -80,9 +80,9 @@ export function TransactionsToReview({
   return (
     <div onClick={onClick} className={CLASS_NAME}>
       <VStack gap={verticalGap} align='start'>
-        <h3 className={HEADING_CLASS_NAME} {...labelDataProperties}>
+        <ProfitAndLossSummariesHeading variants={variants}>
           Transactions to review
-        </h3>
+        </ProfitAndLossSummariesHeading>
         {loaded === 'initial' || loaded === 'loading' ? <BadgeLoader /> : null}
 
         {loaded === 'complete' && error ? (

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -8,6 +8,7 @@ import { TasksStringOverrides } from '../../components/Tasks/Tasks'
 import { Toggle } from '../../components/Toggle'
 import { View } from '../../components/View'
 import { useWindowSize } from '../../hooks/useWindowSize'
+import { Variants } from '../../utils/styleUtils/sizeVariants'
 import { BookkeepingProfitAndLossSummariesContainer } from './internal/BookkeepingProfitAndLossSummariesContainer'
 import classNames from 'classnames'
 
@@ -21,6 +22,13 @@ export interface BookkeepingOverviewProps {
       header?: string
       detailedCharts?: ProfitAndLossDetailedChartsStringOverrides
       summaries?: ProfitAndLossSummariesStringOverrides
+    }
+  }
+  slotProps?: {
+    profitAndLoss?: {
+      summaries?: {
+        variants?: Variants
+      }
     }
   }
 }
@@ -64,6 +72,7 @@ export const BookkeepingOverview = ({
             <BookkeepingProfitAndLossSummariesContainer>
               <ProfitAndLoss.Summaries
                 stringOverrides={stringOverrides?.profitAndLoss?.summaries}
+                variants={{ size: 'lg' }}
               />
             </BookkeepingProfitAndLossSummariesContainer>
             <ProfitAndLoss.Chart />

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -13,7 +13,6 @@ import { BookkeepingProfitAndLossSummariesContainer } from './internal/Bookkeepi
 import classNames from 'classnames'
 
 export interface BookkeepingOverviewProps {
-  title?: string // deprecated
   showTitle?: boolean
   stringOverrides?: {
     title?: string
@@ -31,17 +30,24 @@ export interface BookkeepingOverviewProps {
       }
     }
   }
+  /**
+   * @deprecated Use `stringOverrides.title` instead
+   */
+  title?: string
 }
 
 type PnlToggleOption = 'revenue' | 'expenses'
 
 export const BookkeepingOverview = ({
-  title, // deprecated
+  title,
   showTitle = true,
   stringOverrides,
+  slotProps,
 }: BookkeepingOverviewProps) => {
   const [pnlToggle, setPnlToggle] = useState<PnlToggleOption>('expenses')
   const [width] = useWindowSize()
+
+  const profitAndLossSummariesVariants = slotProps?.profitAndLoss?.summaries?.variants
 
   return (
     <ProfitAndLoss asContainer={false}>
@@ -72,7 +78,7 @@ export const BookkeepingOverview = ({
             <BookkeepingProfitAndLossSummariesContainer>
               <ProfitAndLoss.Summaries
                 stringOverrides={stringOverrides?.profitAndLoss?.summaries}
-                variants={{ size: 'lg' }}
+                variants={profitAndLossSummariesVariants}
               />
             </BookkeepingProfitAndLossSummariesContainer>
             <ProfitAndLoss.Chart />


### PR DESCRIPTION
# Transactions to Review Title
1. I've made it share the styling as the headers of the other cards using the same CSS class. 
2. I've made the vertical spacing depend on the `variant.size` so it looks more like the spacing on the other cards.

#### Before
<img width="616" alt="image" src="https://github.com/user-attachments/assets/9f721018-a54d-495e-a8e3-1aac9d6845eb">

#### After
<img width="625" alt="image" src="https://github.com/user-attachments/assets/28136ae3-2a41-46d6-a900-62d4e15885de">


# MiniCharts
I've made the minicharts scale up in size as well. 
#### Side by side comparison
<img width="627" alt="image" src="https://github.com/user-attachments/assets/eb7e6e15-1018-4307-885e-0b3a825cf2fa">
