### PR TITLE
Proper error handling for invalid doctype

### DIFF
--- a/src/components/Input/FileInput.tsx
+++ b/src/components/Input/FileInput.tsx
@@ -1,39 +1,40 @@
-import React, { useRef, ChangeEvent } from 'react'
-import UploadCloud from '../../icons/UploadCloud'
-import { Button, TextButton } from '../Button'
-import { ButtonVariant } from '../Button/Button'
+import React, { useRef, ChangeEvent } from "react";
+import UploadCloud from "../../icons/UploadCloud";
+import { Button, TextButton } from "../Button";
+import { ButtonVariant } from "../Button/Button";
 
 export interface FileInputProps {
-  text?: string
-  onUpload?: (file: File) => void
-  disabled?: boolean
-  secondary?: boolean
-  iconOnly?: boolean
-  icon?: React.ReactNode
+  text?: string;
+  onUpload?: (file: File) => void;
+  disabled?: boolean;
+  secondary?: boolean;
+  iconOnly?: boolean;
+  icon?: React.ReactNode;
 }
 
 export const FileInput = ({
-  text = 'Upload',
+  text = "Upload",
   onUpload,
   disabled = false,
   secondary,
   iconOnly = false,
   icon,
 }: FileInputProps) => {
-  const hiddenFileInput = useRef<HTMLInputElement>(null)
+  const hiddenFileInput = useRef<HTMLInputElement>(null);
 
   const onClick = () => {
     if (hiddenFileInput.current) {
-      hiddenFileInput.current.click()
+      hiddenFileInput.current.value = ""; // reset in case user is trying reupload
+      hiddenFileInput.current.click();
     }
-  }
+  };
 
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files.length > 0 && onUpload) {
-      const fileUploaded = event.target.files[0]
-      onUpload(fileUploaded)
+      const fileUploaded = event.target.files[0];
+      onUpload(fileUploaded);
     }
-  }
+  };
 
   if (secondary) {
     return (
@@ -42,13 +43,13 @@ export const FileInput = ({
           {text}
         </TextButton>
         <input
-          type='file'
+          type="file"
           onChange={onChange}
           ref={hiddenFileInput}
-          style={{ display: 'none' }}
+          style={{ display: "none" }}
         />
       </>
-    )
+    );
   }
 
   return (
@@ -63,11 +64,11 @@ export const FileInput = ({
         {!iconOnly && text}
       </Button>
       <input
-        type='file'
+        type="file"
         onChange={onChange}
         ref={hiddenFileInput}
-        style={{ display: 'none' }}
+        style={{ display: "none" }}
       />
     </>
-  )
-}
+  );
+};

--- a/src/components/TasksListItem/TasksListItem.tsx
+++ b/src/components/TasksListItem/TasksListItem.tsx
@@ -1,61 +1,61 @@
-import React, { useContext, useEffect, useState } from 'react'
-import { TasksContext } from '../../contexts/TasksContext'
-import AlertCircle from '../../icons/AlertCircle'
-import Check from '../../icons/Check'
-import ChevronDownFill from '../../icons/ChevronDownFill'
-import { isComplete, TaskTypes } from '../../types/tasks'
-import { Button, ButtonVariant } from '../Button'
-import { FileInput } from '../Input'
-import { Textarea } from '../Textarea'
-import { Text, TextSize } from '../Typography'
-import classNames from 'classnames'
+import React, { useContext, useEffect, useState } from "react";
+import { TasksContext } from "../../contexts/TasksContext";
+import AlertCircle from "../../icons/AlertCircle";
+import Check from "../../icons/Check";
+import ChevronDownFill from "../../icons/ChevronDownFill";
+import { isComplete, TaskTypes } from "../../types/tasks";
+import { Button, ButtonVariant } from "../Button";
+import { FileInput } from "../Input";
+import { Textarea } from "../Textarea";
+import { Text, TextSize } from "../Typography";
+import classNames from "classnames";
 
 export const TasksListItem = ({
   task,
   goToNextPageIfAllComplete,
   defaultOpen,
 }: {
-  task: TaskTypes
-  goToNextPageIfAllComplete: (task: TaskTypes) => void
-  defaultOpen: boolean
+  task: TaskTypes;
+  goToNextPageIfAllComplete: (task: TaskTypes) => void;
+  defaultOpen: boolean;
 }) => {
-  const [isOpen, setIsOpen] = useState(defaultOpen)
-  const [userResponse, setUserResponse] = useState(task.user_response || '')
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const [userResponse, setUserResponse] = useState(task.user_response || "");
 
   const { submitResponseToTask, uploadDocumentForTask } =
-    useContext(TasksContext)
+    useContext(TasksContext);
 
   const taskBodyClassName = classNames(
-    'Layer__tasks-list-item__body',
-    isOpen && 'Layer__tasks-list-item__body--expanded',
-    isComplete(task.status) && 'Layer__tasks-list-item--completed',
-  )
+    "Layer__tasks-list-item__body",
+    isOpen && "Layer__tasks-list-item__body--expanded",
+    isComplete(task.status) && "Layer__tasks-list-item--completed"
+  );
 
   const taskHeadClassName = classNames(
-    'Layer__tasks-list-item__head-info',
+    "Layer__tasks-list-item__head-info",
     isComplete(task.status)
-      ? 'Layer__tasks-list-item--completed'
-      : 'Layer__tasks-list-item--pending',
-  )
+      ? "Layer__tasks-list-item--completed"
+      : "Layer__tasks-list-item--pending"
+  );
 
   const taskItemClassName = classNames(
-    'Layer__tasks-list-item',
-    isOpen && 'Layer__tasks-list-item__expanded',
-  )
+    "Layer__tasks-list-item",
+    isOpen && "Layer__tasks-list-item__expanded"
+  );
 
   useEffect(() => {
-    setIsOpen(defaultOpen)
-  }, [defaultOpen])
+    setIsOpen(defaultOpen);
+  }, [defaultOpen]);
 
   return (
-    <div className='Layer__tasks-list-item-wrapper'>
+    <div className="Layer__tasks-list-item-wrapper">
       <div className={taskItemClassName}>
         <div
-          className='Layer__tasks-list-item__head'
+          className="Layer__tasks-list-item__head"
           onClick={() => setIsOpen(!isOpen)}
         >
           <div className={taskHeadClassName}>
-            <div className='Layer__tasks-list-item__head-info__status'>
+            <div className="Layer__tasks-list-item__head-info__status">
               {isComplete(task.status) ? (
                 <Check size={12} />
               ) : (
@@ -66,16 +66,16 @@ export const TasksListItem = ({
           </div>
           <ChevronDownFill
             size={16}
-            className='Layer__tasks__expand-icon'
+            className="Layer__tasks__expand-icon"
             style={{
-              transform: isOpen ? 'rotate(0deg)' : 'rotate(-180deg)',
+              transform: isOpen ? "rotate(0deg)" : "rotate(-180deg)",
             }}
           />
         </div>
         <div className={taskBodyClassName}>
-          <div className='Layer__tasks-list-item__body-info'>
+          <div className="Layer__tasks-list-item__body-info">
             <Text size={TextSize.sm}>{task.question}</Text>
-            {task.user_response_type === 'FREE_RESPONSE' ? (
+            {task.user_response_type === "FREE_RESPONSE" ? (
               <Textarea
                 value={userResponse}
                 onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
@@ -83,15 +83,19 @@ export const TasksListItem = ({
                 }
               />
             ) : null}
-            <div className='Layer__tasks-list-item__actions'>
-              {task.user_response_type === 'UPLOAD_DOCUMENT' ? (
+            <div className="Layer__tasks-list-item__actions">
+              {task.user_response_type === "UPLOAD_DOCUMENT" ? (
                 <FileInput
-                  onUpload={(file: File) => {
-                    uploadDocumentForTask(task.id, file)
-                    setIsOpen(false)
-                    goToNextPageIfAllComplete(task)
+                  onUpload={async (file: File) => {
+                    try {
+                      await uploadDocumentForTask(task.id, file);
+                      setIsOpen(false);
+                      goToNextPageIfAllComplete(task);
+                    } catch (e) {
+                      // If upload fails... no-op
+                    }
                   }}
-                  text='Upload file'
+                  text="Upload file"
                   disabled={
                     task.completed_at != null ||
                     task.user_marked_completed_at != null ||
@@ -106,14 +110,14 @@ export const TasksListItem = ({
                   }
                   variant={ButtonVariant.secondary}
                   onClick={() => {
-                    submitResponseToTask(task.id, userResponse)
-                    setIsOpen(false)
-                    goToNextPageIfAllComplete(task)
+                    submitResponseToTask(task.id, userResponse);
+                    setIsOpen(false);
+                    goToNextPageIfAllComplete(task);
                   }}
                 >
                   {userResponse && userResponse.length === 0
-                    ? 'Update'
-                    : 'Save'}
+                    ? "Update"
+                    : "Save"}
                 </Button>
               )}
             </div>
@@ -121,5 +125,5 @@ export const TasksListItem = ({
         </div>
       </div>
     </div>
-  )
-}
+  );
+};

--- a/src/hooks/useTasks/useTasks.tsx
+++ b/src/hooks/useTasks/useTasks.tsx
@@ -1,87 +1,112 @@
-import { useEffect, useState } from 'react'
-import { Layer } from '../../api/layer'
-import { useLayerContext } from '../../contexts/LayerContext'
-import { LoadedStatus } from '../../types/general'
-import { DataModel } from '../../types/general'
-import { TaskTypes } from '../../types/tasks'
-import { mockData } from './mockData'
-import useSWR from 'swr'
+import { useEffect, useState } from "react";
+import { Layer } from "../../api/layer";
+import { useLayerContext } from "../../contexts/LayerContext";
+import { LoadedStatus } from "../../types/general";
+import { DataModel } from "../../types/general";
+import { TaskTypes } from "../../types/tasks";
+import { mockData } from "./mockData";
+import useSWR from "swr";
+import { APIError } from "../../models/APIError";
 
 type UseTasks = () => {
-  data?: TaskTypes[]
-  isLoading?: boolean
-  loadedStatus?: LoadedStatus
-  isValidating?: boolean
-  error?: unknown
-  refetch: () => void
-  submitResponseToTask: (taskId: string, userResponse: string) => void
-  uploadDocumentForTask: (taskId: string, file: File) => void
-}
+  data?: TaskTypes[];
+  isLoading?: boolean;
+  loadedStatus?: LoadedStatus;
+  isValidating?: boolean;
+  error?: unknown;
+  refetch: () => void;
+  submitResponseToTask: (taskId: string, userResponse: string) => void;
+  uploadDocumentForTask: (taskId: string, file: File) => void;
+};
 
-const DEBUG_MODE = false
+const DEBUG_MODE = false;
 
 export const useTasks: UseTasks = () => {
-  const [loadedStatus, setLoadedStatus] = useState<LoadedStatus>('initial')
-  const { auth, businessId, apiUrl, read, syncTimestamps, hasBeenTouched } =
-    useLayerContext()
+  const [loadedStatus, setLoadedStatus] = useState<LoadedStatus>("initial");
+  const {
+    auth,
+    businessId,
+    apiUrl,
+    read,
+    syncTimestamps,
+    hasBeenTouched,
+    addToast,
+  } = useLayerContext();
 
-  const queryKey = businessId && auth?.access_token && `tasks-${businessId}`
+  const queryKey = businessId && auth?.access_token && `tasks-${businessId}`;
 
   const { data, isLoading, isValidating, error, mutate } = useSWR(
     queryKey,
     Layer.getTasks(apiUrl, auth?.access_token, {
       params: { businessId },
-    }),
-  )
+    })
+  );
 
   useEffect(() => {
-    if (isLoading && loadedStatus === 'initial') {
-      setLoadedStatus('loading')
-    } else if (!isLoading && loadedStatus === 'loading') {
-      setLoadedStatus('complete')
+    if (isLoading && loadedStatus === "initial") {
+      setLoadedStatus("loading");
+    } else if (!isLoading && loadedStatus === "loading") {
+      setLoadedStatus("complete");
     }
-  }, [isLoading])
+  }, [isLoading]);
 
-  const refetch = () => mutate()
+  const refetch = () => mutate();
 
-  const uploadDocumentForTask = (taskId: string, file: File) => {
+  const uploadDocumentForTask = async (taskId: string, file: File) => {
     const uploadDocument = Layer.completeTaskWithUpload(
       apiUrl,
-      auth.access_token,
-    )
-    uploadDocument({
-      businessId,
-      taskId,
-      file,
-    }).then(refetch)
-  }
+      auth.access_token
+    );
+    try {
+      await uploadDocument({
+        businessId,
+        taskId,
+        file,
+      });
+      refetch();
+    } catch (e) {
+      const apiError = e as APIError;
+      addToast({
+        content:
+          apiError.messages?.length &&
+          apiError.messages[0].description &&
+          apiError.messages[0].description.includes(
+            "not valid for document type"
+          )
+            ? "Invalid document type "
+            : "Unknown error occurred",
+        duration: 3000,
+      });
+      throw e;
+    }
+  };
 
   const submitResponseToTask = (taskId: string, userResponse: string) => {
-    if (!taskId || !userResponse || userResponse.length === 0) return
+    if (!taskId || !userResponse || userResponse.length === 0) return;
 
     const data = {
-      type: 'FreeResponse',
+      type: "FreeResponse",
       user_response: userResponse,
-    }
+    };
 
     Layer.submitResponseToTask(apiUrl, auth?.access_token, {
       params: { businessId, taskId },
       body: data,
-    }).then(() => refetch())
-  }
+    }).then(() => refetch());
+  };
 
   // Refetch data if related models has been changed since last fetch
   useEffect(() => {
     if (queryKey && (isLoading || isValidating)) {
-      read(DataModel.TASKS, queryKey)
+      read(DataModel.TASKS, queryKey);
     }
-  }, [isLoading, isValidating])
+  }, [isLoading, isValidating]);
 
   useEffect(() => {
     if (queryKey && hasBeenTouched(queryKey)) {
-      refetch()
+      refetch();
     }
-  }, [syncTimestamps])
+  }, [syncTimestamps]);
 
   return {
     data: DEBUG_MODE ? mockData : data?.data,
@@ -92,5 +117,5 @@ export const useTasks: UseTasks = () => {
     refetch,
     submitResponseToTask,
     uploadDocumentForTask,
-  }
-}
+  };
+};


### PR DESCRIPTION
Formerly, when uploading an invalid filetype, the UI would erroneously show that the file uploaded successfully. Now a warning toast appears (bottom right corner in screenshot) and the UI does not transition to the success state.

<img width="813" alt="Screenshot 2024-11-07 at 9 30 02 AM" src="https://github.com/user-attachments/assets/845bce8d-72eb-4835-91ac-2760d3f7b112">
