### PR TITLE
refactor: remove reference to `requires_user_confirmation_as_of`

### DIFF
--- a/src/components/LinkedAccounts/LinkedAccountItemThumb.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountItemThumb.tsx
@@ -5,6 +5,12 @@ import { LinkedAccount } from '../../types/linked_accounts'
 import { LinkedAccountOptions } from '../LinkedAccountOptions'
 import { LinkedAccountThumb } from '../LinkedAccountThumb'
 
+function accountNeedsUniquenessConfirmation({
+  notifications
+}: Pick<LinkedAccount, 'notifications'>) {
+  return notifications?.some(({ type }) => type === 'CONFIRM_UNIQUE')
+}
+
 export interface LinkedAccountItemThumbProps {
   account: LinkedAccount
   asWidget?: boolean
@@ -31,7 +37,7 @@ export const LinkedAccountItemThumb = ({
   const { environment } = useLayerContext()
 
   let pillConfig
-  if (account.requires_user_confirmation_as_of) {
+  if (accountNeedsUniquenessConfirmation(account)) {
     pillConfig = {
       text: 'Confirm account',
       config: [

--- a/src/hooks/useLinkedAccounts/mockData.ts
+++ b/src/hooks/useLinkedAccounts/mockData.ts
@@ -23,7 +23,6 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
     connection_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
     connection_external_id: '11111',
     connection_needs_repair_as_of: null,
-    requires_user_confirmation_as_of: null,
     is_syncing: true,
   },
   {
@@ -48,7 +47,6 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
     connection_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
     connection_external_id: '11111',
     connection_needs_repair_as_of: null,
-    requires_user_confirmation_as_of: null,
     is_syncing: false,
   },
   {
@@ -73,7 +71,6 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
     connection_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
     connection_external_id: '11111',
     connection_needs_repair_as_of: '2024-03-06T16:44:35.715458Z',
-    requires_user_confirmation_as_of: null,
     is_syncing: false,
   },
   {
@@ -98,7 +95,6 @@ export const LINKED_ACCOUNTS_MOCK_DATA: LinkedAccount[] = [
     connection_id: '0Br385JmgbTryJn8nEBnUb4A5ydv06U9Vbqqq',
     connection_external_id: '11111',
     connection_needs_repair_as_of: null,
-    requires_user_confirmation_as_of: '2024-03-06T16:44:35.715458Z',
     is_syncing: false,
   },
 ]

--- a/src/hooks/useLinkedAccounts/useLinkedAccounts.ts
+++ b/src/hooks/useLinkedAccounts/useLinkedAccounts.ts
@@ -39,7 +39,7 @@ type UseLinkedAccounts = () => {
   breakConnection: (source: AccountSource, connectionExternalId: string) => void
 }
 
-const DEBUG = true
+const DEBUG = false
 const USE_MOCK_RESPONSE_DATA = false
 
 const MAX_POLLING_ATTEMPTS = 5

--- a/src/types/linked_accounts.ts
+++ b/src/types/linked_accounts.ts
@@ -47,7 +47,6 @@ export type LinkedAccount = {
   connection_id?: string
   connection_external_id?: string
   connection_needs_repair_as_of: string | null
-  requires_user_confirmation_as_of: string | null
   is_syncing: boolean
 }
 


### PR DESCRIPTION
## Description

This change to the components will allow us to safely deprecate the value in the API.