### PR TITLE
Fix QB OAuth bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.26.8",

--- a/src/hooks/useQuickbooks/useQuickbooks.ts
+++ b/src/hooks/useQuickbooks/useQuickbooks.ts
@@ -1,88 +1,90 @@
-import { useEffect, useRef, useState } from 'react'
-import { Layer } from '../../api/layer'
-import { useLayerContext } from '../../contexts/LayerContext'
+import { useEffect, useRef, useState } from "react";
+import { Layer } from "../../api/layer";
+import { useLayerContext } from "../../contexts/LayerContext";
 
 type UseQuickbooks = () => {
-  linkQuickbooks: () => Promise<string>
-  unlinkQuickbooks: () => void
-  syncFromQuickbooks: () => void
-  isSyncingFromQuickbooks: boolean
-  quickbooksIsLinked: boolean | null
-}
+  linkQuickbooks: () => Promise<string>;
+  unlinkQuickbooks: () => void;
+  syncFromQuickbooks: () => void;
+  isSyncingFromQuickbooks: boolean;
+  quickbooksIsLinked: boolean | null;
+};
 
-const DEBUG = true
+const DEBUG = true;
 
 export const useQuickbooks: UseQuickbooks = () => {
-  const { auth, businessId, apiUrl } = useLayerContext()
+  const { auth, businessId, apiUrl } = useLayerContext();
   const [isSyncingFromQuickbooks, setIsSyncingFromQuickbooks] =
-    useState<boolean>(false)
+    useState<boolean>(false);
   const [quickbooksIsLinked, setQuickbooksIsLinked] = useState<boolean | null>(
-    null,
-  )
-  const syncStatusIntervalRef = useRef<NodeJS.Timeout | null>(null)
+    null
+  );
+  const syncStatusIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   // Poll the server to determine when the Quickbooks sync is complete
   useEffect(() => {
     if (isSyncingFromQuickbooks && syncStatusIntervalRef.current === null) {
-      const interval = setInterval(() => fetchIsSyncingFromQuickbooks(), 2000)
-      syncStatusIntervalRef.current = interval
-      return () => clearInterval(interval)
+      const interval = setInterval(() => fetchIsSyncingFromQuickbooks(), 2000);
+      syncStatusIntervalRef.current = interval;
+      return () => clearInterval(interval);
     } else if (!isSyncingFromQuickbooks && syncStatusIntervalRef.current) {
-      clearInterval(syncStatusIntervalRef.current)
-      syncStatusIntervalRef.current = null
+      clearInterval(syncStatusIntervalRef.current);
+      syncStatusIntervalRef.current = null;
     }
-  }, [isSyncingFromQuickbooks])
+  }, [isSyncingFromQuickbooks]);
 
   // Determine whether there exists an active Quickbooks connection or not
   useEffect(() => {
-    fetchQuickbooksConnectionStatus()
-  }, [])
+    if (auth?.access_token) {
+      fetchQuickbooksConnectionStatus();
+    }
+  }, [auth?.access_token]);
 
   const fetchQuickbooksConnectionStatus = async () => {
     const isConnected = (
       await Layer.statusOfQuickbooksConnection(apiUrl, auth.access_token, {
         params: { businessId },
       })()
-    ).data.is_connected
-    setQuickbooksIsLinked(isConnected)
-  }
+    ).data.is_connected;
+    setQuickbooksIsLinked(isConnected);
+  };
 
   const syncFromQuickbooks = () => {
-    DEBUG && console.debug('Triggering sync from Quickbooks...')
-    setIsSyncingFromQuickbooks(true)
+    DEBUG && console.debug("Triggering sync from Quickbooks...");
+    setIsSyncingFromQuickbooks(true);
     try {
       Layer.syncFromQuickbooks(apiUrl, auth.access_token, {
         params: { businessId },
-      })
+      });
     } catch {
-      setIsSyncingFromQuickbooks(false)
+      setIsSyncingFromQuickbooks(false);
     }
-  }
+  };
 
   const fetchIsSyncingFromQuickbooks = async () => {
-    DEBUG && console.debug('Fetching status of sync from Quickbooks...')
+    DEBUG && console.debug("Fetching status of sync from Quickbooks...");
     const isSyncing = (
       await Layer.statusOfSyncFromQuickbooks(apiUrl, auth.access_token, {
         params: { businessId },
       })()
-    ).data.is_syncing
-    setIsSyncingFromQuickbooks(isSyncing)
-  }
+    ).data.is_syncing;
+    setIsSyncingFromQuickbooks(isSyncing);
+  };
 
   const linkQuickbooks = async () => {
     const res = await Layer.initQuickbooksOAuth(apiUrl, auth.access_token, {
       params: { businessId },
-    })
+    });
 
-    return res.data.redirect_url
-  }
+    return res.data.redirect_url;
+  };
 
   const unlinkQuickbooks = async () => {
     await Layer.unlinkQuickbooksConnection(apiUrl, auth.access_token, {
       params: { businessId },
-    })
-    fetchQuickbooksConnectionStatus()
-  }
+    });
+    fetchQuickbooksConnectionStatus();
+  };
 
   return {
     isSyncingFromQuickbooks,
@@ -90,5 +92,5 @@ export const useQuickbooks: UseQuickbooks = () => {
     quickbooksIsLinked,
     linkQuickbooks,
     unlinkQuickbooks,
-  }
-}
+  };
+};


### PR DESCRIPTION
When QB redirects back to the Layer app, there was a race condition between fetching the auth token and fetching some quickbooks data. This ensures we have the auth token before querying the quickbooks data