### PR TITLE
chore: remove many uses of explicit `any`

### DIFF
--- a/src/api/layer/journal.ts
+++ b/src/api/layer/journal.ts
@@ -9,7 +9,7 @@ export const createJournalEntries = post<{ data: JournalEntry[] }>(
   ({ businessId }) => `/v1/businesses/${businessId}/ledger/manual-entries`,
 )
 
-export const reverseJournalEntry = post<{}>(
+export const reverseJournalEntry = post<Record<never, never>>(
   ({ businessId, entryId }) =>
     `/v1/businesses/${businessId}/ledger/entries/${entryId}/reverse`,
 )

--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -26,9 +26,9 @@ import {
 import { DataStates } from './DataStates'
 import { MobileComponentType } from './constants'
 import { endOfMonth, startOfMonth } from 'date-fns'
+import type { LayerError } from '../../models/ErrorHandler'
 
 const COMPONENT_NAME = 'bank-transactions'
-const TEST_EMPTY_STATE = false
 
 export type BankTransactionsMode = 'bookkeeping-client' | 'self-serve'
 
@@ -68,7 +68,7 @@ export interface BankTransactionsProps {
 }
 
 export interface BankTransactionsWithErrorProps extends BankTransactionsProps {
-  onError?: (error: Error) => void
+  onError?: (error: LayerError) => void
 }
 
 export const BankTransactions = ({
@@ -200,17 +200,15 @@ const BankTransactionsContent = ({
     }
   }, [loadingStatus])
 
-  const bankTransactions = TEST_EMPTY_STATE
-    ? []
-    : useMemo(() => {
-        if (monthlyView) {
-          return data
-        }
+  const bankTransactions = useMemo(() => {
+    if (monthlyView) {
+      return data
+    }
 
-        const firstPageIndex = (currentPage - 1) * pageSize
-        const lastPageIndex = firstPageIndex + pageSize
-        return data?.slice(firstPageIndex, lastPageIndex)
-      }, [currentPage, data, monthlyView])
+    const firstPageIndex = (currentPage - 1) * pageSize
+    const lastPageIndex = firstPageIndex + pageSize
+    return data?.slice(firstPageIndex, lastPageIndex)
+  }, [currentPage, data, monthlyView, pageSize])
 
   const onCategorizationDisplayChange = (
     event: React.ChangeEvent<HTMLInputElement>,

--- a/src/components/ChartOfAccountsTable/ChartOfAccountsTable.tsx
+++ b/src/components/ChartOfAccountsTable/ChartOfAccountsTable.tsx
@@ -32,7 +32,7 @@ export const ChartOfAccountsTable = ({
   view: View
   data: ChartWithBalances
   stringOverrides?: ChartOfAccountsTableStringOverrides
-  error?: any
+  error?: unknown
   expandAll?: ExpandActionState
   cumulativeIndex: number
   accountsLength: number
@@ -62,7 +62,7 @@ export const ChartOfAccountsTableContent = ({
   view: View
   data: ChartWithBalances
   stringOverrides?: ChartOfAccountsTableStringOverrides
-  error?: any
+  error?: unknown
   expandAll?: ExpandActionState
   cumulativeIndex: number
   accountsLength: number

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -14,9 +14,11 @@ import classNames from 'classnames'
 /**
  * @see https://github.com/Hacker0x01/react-datepicker/issues/1333#issuecomment-2363284612
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 const ReactDatePicker = (((RDP.default as any).default as any)
   || (RDP.default as any)
   || (RDP as any)) as typeof RDP.default
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 interface DatePickerProps {
   mode: DatePickerMode

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,9 +1,9 @@
-import React, { ErrorInfo, Component } from 'react'
+import React, { ErrorInfo, Component, type PropsWithChildren } from 'react'
 import { LayerError, reportError } from '../../models/ErrorHandler'
 import { ErrorBoundaryMessage } from './ErrorBoundaryMessage'
 
 interface ErrorBoundaryProps {
-  onError?: (error: Error) => void
+  onError?: (error: LayerError) => void
 }
 
 interface ErrorBoundaryState {
@@ -11,12 +11,12 @@ interface ErrorBoundaryState {
 }
 
 export class ErrorBoundary extends Component<
-  React.PropsWithChildren<ErrorBoundaryProps>,
+  PropsWithChildren<ErrorBoundaryProps>,
   ErrorBoundaryState
 > {
-  onError: (err: LayerError) => void
+  onError?: (err: LayerError) => void
 
-  constructor(props: any) {
+  constructor(props: PropsWithChildren<ErrorBoundaryProps>) {
     super(props)
     this.onError = props.onError
     this.state = { hasError: false }
@@ -39,6 +39,7 @@ export class ErrorBoundary extends Component<
     if (this.state.hasError) {
       return <ErrorBoundaryMessage />
     }
-    return (this.props as { children: any }).children
+
+    return this.props.children
   }
 }

--- a/src/components/Input/MultiSelect.tsx
+++ b/src/components/Input/MultiSelect.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import ReactSelect, {
   DropdownIndicatorProps,
   GroupBase,
@@ -26,17 +26,6 @@ export interface SelectProps<T> {
   styles?: StylesConfig<T, true, GroupBase<T>>
 }
 
-const DropdownIndicator:
-  | React.ComponentType<DropdownIndicatorProps<any, true, GroupBase<any>>>
-  | null
-  | undefined = props => {
-  return (
-    <components.DropdownIndicator {...props}>
-      <ChevronDownFill />
-    </components.DropdownIndicator>
-  )
-}
-
 export const MultiSelect = <T,>({
   name,
   options,
@@ -56,6 +45,13 @@ export const MultiSelect = <T,>({
     isInvalid ? 'Layer__select--error' : '',
     className,
   )
+
+  const DropdownIndicator = useCallback((props: DropdownIndicatorProps<T, true>) => (
+    <components.DropdownIndicator {...props}>
+      <ChevronDownFill />
+    </components.DropdownIndicator>
+  ), [])
+
   return (
     <Tooltip disabled={!isInvalid || !errorMessage}>
       <TooltipTrigger className='Layer__input-tooltip'>

--- a/src/components/Input/Select.tsx
+++ b/src/components/Input/Select.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import ReactSelect, {
   DropdownIndicatorProps,
   GroupBase,
@@ -22,17 +22,6 @@ export interface SelectProps<T> {
   errorMessage?: string
 }
 
-const DropdownIndicator:
-  | React.ComponentType<DropdownIndicatorProps<any, false, GroupBase<any>>>
-  | null
-  | undefined = props => {
-  return (
-    <components.DropdownIndicator {...props}>
-      <ChevronDownFill />
-    </components.DropdownIndicator>
-  )
-}
-
 export const Select = <T,>({
   name,
   options,
@@ -50,6 +39,13 @@ export const Select = <T,>({
     isInvalid ? 'Layer__select--error' : '',
     className,
   )
+
+  const DropdownIndicator = useCallback((props: DropdownIndicatorProps<T, false>) => (
+    <components.DropdownIndicator {...props}>
+      <ChevronDownFill />
+    </components.DropdownIndicator>
+  ), [])
+
   return (
     <Tooltip disabled={!isInvalid || !errorMessage}>
       <TooltipTrigger className='Layer__input-tooltip'>

--- a/src/components/ProfitAndLossChart/Indicator.tsx
+++ b/src/components/ProfitAndLossChart/Indicator.tsx
@@ -25,10 +25,6 @@ export const Indicator = ({
   setCustomCursorSize,
   viewBox = {},
 }: Props) => {
-  if (!className?.match(/selected/)) {
-    return null
-  }
-
   const [opacityIndicator, setOpacityIndicator] = useState(0)
 
   const { x: animateTo = 0, width = 0 } =
@@ -51,6 +47,10 @@ export const Indicator = ({
       setOpacityIndicator(1)
     }, 200)
   }, [animateTo])
+
+  if (!className?.match(/selected/)) {
+    return null
+  }
 
   const rectRef = (ref: SVGRectElement | null) => {
     if (ref) {

--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react'
+import React, { useContext, useEffect, useMemo, useState, type FunctionComponent } from 'react'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { useLinkedAccounts } from '../../hooks/useLinkedAccounts'
 import {
@@ -53,8 +53,8 @@ const getChartWindow = ({
   const current = startOfMonth(new Date(currentYear, currentMonth - 1, 1))
 
   if (
-    differenceInMonths(startOfMonth(chartWindow.start), current) < 0 &&
-    differenceInMonths(startOfMonth(chartWindow.end), current) > 1
+    differenceInMonths(startOfMonth(chartWindow.start), current) < 0
+    && differenceInMonths(startOfMonth(chartWindow.end), current) > 1
   ) {
     return chartWindow
   }
@@ -67,9 +67,9 @@ const getChartWindow = ({
   }
 
   if (
-    differenceInMonths(endOfMonth(chartWindow.end), endOfMonth(current)) ===
-      1 &&
-    differenceInMonths(today, current) >= 1
+    differenceInMonths(endOfMonth(chartWindow.end), endOfMonth(current))
+      === 1
+    && differenceInMonths(today, current) >= 1
   ) {
     return {
       start: startOfMonth(sub(current, { months: 10 })),
@@ -78,8 +78,8 @@ const getChartWindow = ({
   }
 
   if (
-    differenceInMonths(current, startOfMonth(chartWindow.end)) === 0 &&
-    differenceInMonths(current, startOfMonth(today)) > 0
+    differenceInMonths(current, startOfMonth(chartWindow.end)) === 0
+    && differenceInMonths(current, startOfMonth(today)) > 0
   ) {
     return {
       start: startOfMonth(sub(current, { months: 11 })),
@@ -170,8 +170,8 @@ export const ProfitAndLossChart = ({
 
   useEffect(() => {
     if (
-      Number(dateRange.startDate) !== Number(localDateRange.startDate) ||
-      Number(dateRange.endDate) !== Number(localDateRange.endDate)
+      Number(dateRange.startDate) !== Number(localDateRange.startDate)
+      || Number(dateRange.endDate) !== Number(localDateRange.endDate)
     ) {
       setLocalDateRange(dateRange)
     }
@@ -186,13 +186,13 @@ export const ProfitAndLossChart = ({
     return Boolean(
       data?.find(
         x =>
-          x.income !== 0 ||
-          x.costOfGoodsSold !== 0 ||
-          x.grossProfit !== 0 ||
-          x.operatingExpenses !== 0 ||
-          x.profitBeforeTaxes !== 0 ||
-          x.taxes !== 0 ||
-          x.totalExpenses !== 0,
+          x.income !== 0
+          || x.costOfGoodsSold !== 0
+          || x.grossProfit !== 0
+          || x.operatingExpenses !== 0
+          || x.profitBeforeTaxes !== 0
+          || x.taxes !== 0
+          || x.totalExpenses !== 0,
       ),
     )
   }, [data])
@@ -210,10 +210,10 @@ export const ProfitAndLossChart = ({
     if (loaded === 'complete' && data) {
       const foundCurrent = data.find(
         x =>
-          Number(startOfMonth(new Date(x.year, x.month - 1, 1))) >=
-            Number(localDateRange.startDate) &&
-          Number(startOfMonth(new Date(x.year, x.month - 1, 1))) <
-            Number(localDateRange.endDate),
+          Number(startOfMonth(new Date(x.year, x.month - 1, 1)))
+            >= Number(localDateRange.startDate)
+          && Number(startOfMonth(new Date(x.year, x.month - 1, 1)))
+            < Number(localDateRange.endDate),
       )
 
       if (!foundCurrent) {
@@ -224,10 +224,10 @@ export const ProfitAndLossChart = ({
 
       const foundBefore = data.find(
         x =>
-          Number(startOfMonth(new Date(x.year, x.month - 1, 1))) >=
-            Number(sub(localDateRange.startDate, { months: 1 })) &&
-          Number(startOfMonth(new Date(x.year, x.month - 1, 1))) <
-            Number(sub(localDateRange.endDate, { months: 1 })),
+          Number(startOfMonth(new Date(x.year, x.month - 1, 1)))
+            >= Number(sub(localDateRange.startDate, { months: 1 }))
+          && Number(startOfMonth(new Date(x.year, x.month - 1, 1)))
+            < Number(sub(localDateRange.endDate, { months: 1 })),
       )
 
       if (!foundBefore) {
@@ -247,8 +247,8 @@ export const ProfitAndLossChart = ({
     })
 
     if (
-      Number(newChartWindow.start) !== Number(chartWindow.start) ||
-      Number(newChartWindow.end) !== Number(chartWindow.end)
+      Number(newChartWindow.start) !== Number(chartWindow.start)
+      || Number(newChartWindow.end) !== Number(chartWindow.end)
     ) {
       setChartWindow(newChartWindow)
     }
@@ -265,9 +265,9 @@ export const ProfitAndLossChart = ({
   const getMonthName = (pnl: ProfitAndLossSummaryData | undefined) =>
     pnl
       ? format(
-          new Date(pnl.year, pnl.month - 1, 1),
-          compactView ? 'LLLLL' : 'LLL',
-        )
+        new Date(pnl.year, pnl.month - 1, 1),
+        compactView ? 'LLLLL' : 'LLL',
+      )
       : ''
 
   const summarizePnL = (pnl: ProfitAndLossSummaryData | undefined) => ({
@@ -280,9 +280,9 @@ export const ProfitAndLossChart = ({
     uncategorizedOutflowsInverse: pnl?.uncategorizedOutflowsInverse || 0,
     netProfit: pnl?.netProfit || 0,
     selected:
-      !!pnl &&
-      pnl.month === selectionMonth.month + 1 &&
-      pnl.year === selectionMonth.year,
+      !!pnl
+      && pnl.month === selectionMonth.month + 1
+      && pnl.year === selectionMonth.year,
     year: pnl?.year,
     month: pnl?.month,
     base: 0,
@@ -339,16 +339,16 @@ export const ProfitAndLossChart = ({
           differenceInMonths(
             startOfMonth(new Date(x.year, x.month - 1, 1)),
             chartWindow.start,
-          ) >= 0 &&
-          differenceInMonths(
+          ) >= 0
+          && differenceInMonths(
             startOfMonth(new Date(x.year, x.month - 1, 1)),
             chartWindow.start,
-          ) < 12 &&
-          differenceInMonths(
+          ) < 12
+          && differenceInMonths(
             chartWindow.end,
             startOfMonth(new Date(x.year, x.month - 1, 1)),
-          ) >= 0 &&
-          differenceInMonths(
+          ) >= 0
+          && differenceInMonths(
             chartWindow.end,
             startOfMonth(new Date(x.year, x.month - 1, 1)),
           ) <= 12,
@@ -528,7 +528,10 @@ export const ProfitAndLossChart = ({
     )
   }
 
-  const CustomizedCursor = ({ points }: { points: [{ x: number, y: number }] }) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const CustomizedCursor: FunctionComponent<any> = (
+    { points }: { points: [{ x: number, y: number }] }
+  ) => {
     const { width, height } = customCursorSize
 
     return (
@@ -643,7 +646,7 @@ export const ProfitAndLossChart = ({
           />
           <XAxis dataKey='name' xAxisId='revenue' tickLine={false} />
           <XAxis dataKey='name' xAxisId='expenses' tickLine={false} hide />
-          <YAxis tick={<CustomizedYTick />} />
+          <YAxis tick={CustomizedYTick} />
           <Bar
             dataKey='loading'
             barSize={barSize}
@@ -652,8 +655,8 @@ export const ProfitAndLossChart = ({
             radius={[2, 2, 0, 0]}
             className={classNames(
               'Layer__profit-and-loss-chart__bar--loading',
-              loaded !== 'complete' &&
-                'Layer__profit-and-loss-chart__bar--loading-anim',
+              loaded !== 'complete'
+                && 'Layer__profit-and-loss-chart__bar--loading-anim',
             )}
             xAxisId='revenue'
             stackId='revenue'
@@ -666,8 +669,8 @@ export const ProfitAndLossChart = ({
             radius={[2, 2, 0, 0]}
             className={classNames(
               'Layer__profit-and-loss-chart__bar--loading',
-              loaded !== 'complete' &&
-                'Layer__profit-and-loss-chart__bar--loading-anim',
+              loaded !== 'complete'
+                && 'Layer__profit-and-loss-chart__bar--loading-anim',
             )}
             xAxisId='expenses'
             stackId='expenses'

--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -508,16 +508,27 @@ export const ProfitAndLossChart = ({
     )
   }
 
-  const CustomizedYTick = (props: any) => {
+  const CustomizedYTick = (
+    {
+      verticalAnchor: _verticalAnchor,
+      visibleTicksCount: _visibleTicksCount,
+      tickFormatter: _tickFormatter,
+      payload,
+      ...restProps
+    }: {
+      verticalAnchor: unknown
+      visibleTicksCount: unknown
+      tickFormatter: unknown
+      payload: { value: string | number }
+    }) => {
     return (
-      <text {...props} className='Layer__chart_y-axis-tick'>
-        <tspan dy='0.355em'>{formatYAxisValue(props.payload.value)}</tspan>
+      <text {...restProps} className='Layer__chart_y-axis-tick'>
+        <tspan dy='0.355em'>{formatYAxisValue(payload.value)}</tspan>
       </text>
     )
   }
 
-  const CustomizedCursor = (props: any) => {
-    const { points } = props
+  const CustomizedCursor = ({ points }: { points: [{ x: number, y: number }] }) => {
     const { width, height } = customCursorSize
 
     return (

--- a/src/components/ProfitAndLossCompareOptions/ProfitAndLossCompareOptions.tsx
+++ b/src/components/ProfitAndLossCompareOptions/ProfitAndLossCompareOptions.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react'
 import { MultiSelect, Select } from '../Input'
 import { ProfitAndLoss } from '../ProfitAndLoss/ProfitAndLoss'
+import type { StylesConfig } from 'react-select'
 
 export interface ProfitAndLossCompareOptionsProps {
   tagComparisonOptions: TagComparisonOption[]
@@ -24,13 +25,13 @@ export type TagFilterInput =
   | 'None'
 
 const selectStyles = {
-  valueContainer: (styles: any) => {
+  valueContainer: (styles) => {
     return {
       ...styles,
       flexWrap: 'nowrap',
     }
   },
-}
+} satisfies StylesConfig<TagComparisonOption, true>
 
 export const ProfitAndLossCompareOptions = ({
   tagComparisonOptions,

--- a/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
@@ -143,7 +143,7 @@ export const DetailedTable = ({
     )
   }
 
-  const typeColorMapping: any = mapTypesToColors(filteredData, chartColorsList)
+  const typeColorMapping = mapTypesToColors(filteredData, chartColorsList)
 
   return (
     <div className='details-container'>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -36,6 +36,8 @@ export const TooltipTrigger = forwardRef<
   HTMLProps<HTMLElement> & { asChild?: boolean }
 >(function TooltipTrigger({ children, asChild = false, ...props }, propRef) {
   const context = useTooltipContext()
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const childrenRef = (children as any).ref
   const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef])
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -4,6 +4,7 @@ import React, {
   HTMLProps,
   isValidElement,
   cloneElement,
+  type Ref,
 } from 'react'
 import { TooltipContext, useTooltip, useTooltipContext } from './useTooltip'
 import { useMergeRefs, FloatingPortal } from '@floating-ui/react'
@@ -36,9 +37,9 @@ export const TooltipTrigger = forwardRef<
   HTMLProps<HTMLElement> & { asChild?: boolean }
 >(function TooltipTrigger({ children, asChild = false, ...props }, propRef) {
   const context = useTooltipContext()
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const childrenRef = (children as any).ref
+  const childrenRef = (isValidElement(children) && 'ref' in children)
+    ? children.ref as Ref<unknown>
+    : null
   const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef])
 
   if (asChild && isValidElement(children)) {

--- a/src/hooks/useProfitAndLoss/useProfitAndLossLTM.tsx
+++ b/src/hooks/useProfitAndLoss/useProfitAndLossLTM.tsx
@@ -26,7 +26,7 @@ type UseProfitAndLossLTMReturn = (props?: UseProfitAndLossLTMProps) => {
   data: ProfitAndLossSummaryData[]
   isLoading?: boolean
   loaded?: LoadedStatus
-  error?: any
+  error?: unknown
   pullData: (date: Date) => void
   refetch: () => void
 }

--- a/src/hooks/useProfitAndLoss/useProfitAndLossQuery.tsx
+++ b/src/hooks/useProfitAndLoss/useProfitAndLossQuery.tsx
@@ -22,7 +22,7 @@ type UseProfitAndLossQueryReturn = (props?: UseProfitAndLossQueryProps) => {
   data?: ProfitAndLoss
   isLoading: boolean
   isValidating: boolean
-  error: any
+  error: unknown
   refetch: () => void
   startDate: Date
   endDate: Date

--- a/src/hooks/useReceipts/useReceipts.ts
+++ b/src/hooks/useReceipts/useReceipts.ts
@@ -56,14 +56,15 @@ export const useReceipts: UseReceipts = ({
       },
     )
     const result = await listBankTransactionDocuments()
-    const retrievedDocs = result.data.documentUrls.map((docUrl: any) => ({
+    const retrievedDocs = result.data.documentUrls.map((docUrl) => ({
       id: docUrl.documentId,
-      url: docUrl.presignedUrl as string,
-      type: docUrl.fileType as string | undefined,
+      url: docUrl.presignedUrl,
+      type: docUrl.fileType,
       status: 'uploaded' as const,
       name: docUrl.fileName,
       date: readDate(docUrl.createdAt),
     }))
+
     setReceiptUrls(retrievedDocs)
   }
 

--- a/src/types/chart_of_accounts.ts
+++ b/src/types/chart_of_accounts.ts
@@ -4,7 +4,7 @@ import { Category } from './categories'
 export interface ChartOfAccounts {
   type: string
   accounts: Account[]
-  entries?: any[]
+  entries?: unknown[]
 }
 
 export interface AccountEntry {

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -13,6 +13,7 @@ export interface S3PresignedUrl {
   fileType: string
   fileName: string
   createdAt: string
+  documentId?: string
 }
 
 export type LoadedStatus = 'initial' | 'loading' | 'complete'


### PR DESCRIPTION
## Description

This is part of an effort to get us down to a few linter errors as possible. Once we can get it to zero, then we can fail the production build 