### PR TITLE
build: expose legacy style import through `exports` field in package.json

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -60,18 +60,6 @@ async function moveStyles(baseDir, { withMap = false } = {}) {
         : null
     ].filter(Boolean)
   );
-
-  // Preserve legacy directory structure for deep imports
-  await mkdir(`${OUT_DIR}/styles`, { recursive: true })
-  await Promise.all(
-    [
-      copyFile(`${OUT_DIR}/index.css`, `${OUT_DIR}/styles/index.css`),
-      withMap
-        ? copyFile(`${OUT_DIR}/index.css.map`, `${OUT_DIR}/styles/index.css.map`)
-        : null
-    ].filter(Boolean)
-  );
-
   await rm(`${baseDir}/styles`, { recursive: true })
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.26.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -12,7 +12,8 @@
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.cjs"
     },
-    "./index.css": "./dist/index.css"
+    "./index.css": "./dist/index.css",
+    "./dist/styles/index.css": "./dist/index.css"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
## Description

Our `exports` field limits the ability of consumers to import from "deep" within our package.