### PR TITLE
fix: bank transactions in mobile + bookeeping view consistency

### DIFF
--- a/src/api/layer/bankTransactions.ts
+++ b/src/api/layer/bankTransactions.ts
@@ -120,7 +120,7 @@ export const listBankTransactionDocuments = get<{
   errors: unknown
 }>(
   ({ businessId, bankTransactionId }) =>
-    `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/documents?content_disposition=INLINE`,
+    `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/documents?content_disposition=ATTACHMENT`,
 )
 
 export const getBankTransactionDocument = get<{
@@ -128,7 +128,7 @@ export const getBankTransactionDocument = get<{
   errors: unknown
 }>(
   ({ businessId, bankTransactionId, documentId }) =>
-    `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/documents/${documentId}?content_disposition=INLINE`,
+    `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/documents/${documentId}?content_disposition=ATTACHMENT`,
 )
 
 export const archiveBankTransactionDocument = post<{
@@ -141,26 +141,26 @@ export const archiveBankTransactionDocument = post<{
 
 export const uploadBankTransactionDocument =
   (baseUrl: string, accessToken?: string) =>
-  ({
-    businessId,
-    bankTransactionId,
-    file,
-    documentType,
-  }: {
-    businessId: string
-    bankTransactionId: string
-    file: File
-    documentType: string
-  }) => {
-    const formData = new FormData()
-    formData.append('file', file)
-    formData.append('documentType', documentType)
+    ({
+      businessId,
+      bankTransactionId,
+      file,
+      documentType,
+    }: {
+      businessId: string
+      bankTransactionId: string
+      file: File
+      documentType: string
+    }) => {
+      const formData = new FormData()
+      formData.append('file', file)
+      formData.append('documentType', documentType)
 
-    const endpoint = `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/documents`
-    return postWithFormData<{ data: FileMetadata; errors: unknown }>(
-      endpoint,
-      formData,
-      baseUrl,
-      accessToken,
-    )
-  }
+      const endpoint = `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/documents`
+      return postWithFormData<{ data: FileMetadata; errors: unknown }>(
+        endpoint,
+        formData,
+        baseUrl,
+        accessToken,
+      )
+    }

--- a/src/components/BankTransactionMobileList/BankTransactionMobileForms.tsx
+++ b/src/components/BankTransactionMobileList/BankTransactionMobileForms.tsx
@@ -11,6 +11,7 @@ interface BankTransactionMobileFormsProps {
   purpose: Purpose
   bankTransaction: BankTransaction
   showTooltips: boolean
+  showCategorization?: boolean
   showReceiptUploads?: boolean
   showDescriptions?: boolean
   isOpen?: boolean
@@ -20,6 +21,7 @@ export const BankTransactionMobileForms = ({
   purpose,
   bankTransaction,
   showTooltips,
+  showCategorization,
   showReceiptUploads,
   showDescriptions,
   isOpen,
@@ -30,6 +32,7 @@ export const BankTransactionMobileForms = ({
         return (
           <BusinessForm
             bankTransaction={bankTransaction}
+            showCategorization={showCategorization}
             showTooltips={showTooltips}
             showReceiptUploads={showReceiptUploads}
             showDescriptions={showDescriptions}

--- a/src/components/BankTransactionMobileList/BankTransactionMobileListItem.tsx
+++ b/src/components/BankTransactionMobileList/BankTransactionMobileListItem.tsx
@@ -156,9 +156,9 @@ export const BankTransactionMobileListItem = ({
 
   useEffect(() => {
     if (
-      editable &&
-      bankTransaction.recently_categorized &&
-      shouldHideAfterCategorize(bankTransaction)
+      editable
+      && bankTransaction.recently_categorized
+      && shouldHideAfterCategorize(bankTransaction)
     ) {
       setTimeout(() => {
         removeTransaction(bankTransaction)
@@ -221,16 +221,16 @@ export const BankTransactionMobileListItem = ({
           </div>
         </div>
       </span>
-      {categorizationEnabled(mode) ? (
-        <div
-          className={`${className}__expanded-row`}
-          style={{ height: !open || removeAnim ? 0 : height }}
-        >
-          {open && (
-            <div
-              className={`${className}__expanded-row__content`}
-              ref={formRowRef}
-            >
+      <div
+        className={`${className}__expanded-row`}
+        style={{ height: !open || removeAnim ? 0 : height }}
+      >
+        {open && (
+          <div
+            className={`${className}__expanded-row__content`}
+            ref={formRowRef}
+          >
+            {categorizationEnabled(mode) ? (
               <div className={`${className}__toggle-row`}>
                 <Toggle
                   name={`purpose-${bankTransaction.id}`}
@@ -240,19 +240,16 @@ export const BankTransactionMobileListItem = ({
                       value: 'business',
                       label: 'Business',
                       style: { minWidth: 84 },
-                      disabled: !categorizationEnabled(mode),
                     },
                     {
                       value: 'personal',
                       label: 'Personal',
                       style: { minWidth: 84 },
-                      disabled: !categorizationEnabled(mode),
                     },
                     {
                       value: 'more',
                       label: 'More',
                       style: { minWidth: 84 },
-                      disabled: !categorizationEnabled(mode),
                     },
                   ]}
                   selected={purpose}
@@ -260,20 +257,19 @@ export const BankTransactionMobileListItem = ({
                 />
                 <CloseButton onClick={() => close()} />
               </div>
-              <BankTransactionMobileForms
-                purpose={purpose}
-                bankTransaction={bankTransaction}
-                showTooltips={showTooltips}
-                showReceiptUploads={showReceiptUploads}
-                showDescriptions={showDescriptions}
-                isOpen={open}
-              />
-            </div>
-          )}
-        </div>
-      ) : (
-        <></>
-      )}
+            ) : null}
+            <BankTransactionMobileForms
+              purpose={purpose}
+              bankTransaction={bankTransaction}
+              showCategorization={categorizationEnabled(mode)}
+              showTooltips={showTooltips}
+              showReceiptUploads={showReceiptUploads}
+              showDescriptions={showDescriptions}
+              isOpen={open}
+            />
+          </div>
+        )}
+      </div>
     </li>
   )
 }

--- a/src/components/BankTransactionMobileList/BusinessForm.tsx
+++ b/src/components/BankTransactionMobileList/BusinessForm.tsx
@@ -19,6 +19,7 @@ import classNames from 'classnames'
 interface BusinessFormProps {
   bankTransaction: BankTransaction
   showTooltips: boolean
+  showCategorization?: boolean
   showReceiptUploads?: boolean
   showDescriptions?: boolean
 }
@@ -26,6 +27,7 @@ interface BusinessFormProps {
 export const BusinessForm = ({
   bankTransaction,
   showTooltips,
+  showCategorization,
   showReceiptUploads,
   showDescriptions,
 }: BusinessFormProps) => {
@@ -48,11 +50,11 @@ export const BusinessForm = ({
 
   const options = useMemo(() => {
     const options =
-      bankTransaction?.categorization_flow?.type ===
-      CategorizationType.ASK_FROM_SUGGESTIONS
+      bankTransaction?.categorization_flow?.type
+      === CategorizationType.ASK_FROM_SUGGESTIONS
         ? bankTransaction.categorization_flow.suggestions.map(x =>
-            mapCategoryToOption(x),
-          )
+          mapCategoryToOption(x),
+        )
         : []
 
     if (selectedCategory && !options.find(x => x.id === selectedCategory?.id)) {
@@ -94,8 +96,8 @@ export const BusinessForm = ({
       openDrawer()
     } else {
       if (
-        selectedCategory &&
-        category.value.payload?.id === selectedCategory.value.payload?.id
+        selectedCategory
+        && category.value.payload?.id === selectedCategory.value.payload?.id
       ) {
         setSelectedCategory(undefined)
       } else {
@@ -115,13 +117,13 @@ export const BusinessForm = ({
 
     const payload = selectedCategory?.value?.payload?.id
       ? {
-          type: 'AccountId' as const,
-          id: selectedCategory.value.payload.id,
-        }
+        type: 'AccountId' as const,
+        id: selectedCategory.value.payload.id,
+      }
       : {
-          type: 'StableName' as const,
-          stable_name: selectedCategory.value.payload?.stable_name || '',
-        }
+        type: 'StableName' as const,
+        stable_name: selectedCategory.value.payload?.stable_name || '',
+      }
 
     categorizeBankTransaction(
       bankTransaction.id,
@@ -135,12 +137,14 @@ export const BusinessForm = ({
 
   return (
     <div className='Layer__bank-transaction-mobile-list-item__business-form'>
-      <ActionableList<Option['value']>
-        options={options}
-        onClick={onCategorySelect}
-        selectedId={selectedCategory?.id}
-        showDescriptions={showTooltips}
-      />
+      {showCategorization ? (
+        <ActionableList<Option['value']>
+          options={options}
+          onClick={onCategorySelect}
+          selectedId={selectedCategory?.id}
+          showDescriptions={showTooltips}
+        />
+      ) : null}
       {showDescriptions && (
         <InputGroup
           className='Layer__bank-transaction-mobile-list-item__description'

--- a/src/components/BankTransactionMobileList/SplitAndMatchForm.tsx
+++ b/src/components/BankTransactionMobileList/SplitAndMatchForm.tsx
@@ -8,6 +8,7 @@ import { SplitForm } from './SplitForm'
 interface SplitAndMatchFormProps {
   bankTransaction: BankTransaction
   showTooltips: boolean
+  showCategorization?: boolean
   showReceiptUploads?: boolean
   showDescriptions?: boolean
 }

--- a/src/styles/file_thumb.scss
+++ b/src/styles/file_thumb.scss
@@ -38,10 +38,9 @@
 }
 
 .Layer__file-thumb__main {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
   gap: var(--spacing-2xs);
-  align-items: flex-start;
-  justify-content: flex-start;
 }
 
 .Layer__file-thumb__actions {
@@ -119,4 +118,8 @@
 
 .Layer__file-thumb__details__error {
   color: var(--color-danger);
+}
+
+.Layer__file-thumb__details__name {
+  word-break: break-word;
 }


### PR DESCRIPTION
## Description

- For transactions in mobile view, only show categorization to self-serve clients
- On mobile web, downloading an attachment will not change the browser URL (due to `content-disposition: attachment`)

### Screenshot

<img width="600" alt="Screenshot 2024-11-22 at 5 14 23 PM" src="https://github.com/user-attachments/assets/338a84d0-b079-418e-bed0-9082fb32642f">
