### PR TITLE
feat: download button for casflow statement and balance sheet

### DIFF
--- a/src/api/layer/balance_sheet.ts
+++ b/src/api/layer/balance_sheet.ts
@@ -1,5 +1,17 @@
 import { BalanceSheet } from '../../types'
+import type { S3PresignedUrl } from '../../types/general'
 import { get } from './authenticated_http'
+import { toDefinedSearchParameters } from '../../utils/request/toDefinedSearchParameters'
+
+type GetBalanceSheetParams = {
+  businessId: string
+  effectiveDate: string
+}
+
+type GetBalanceSheetReturn = {
+  data?: BalanceSheet
+  error?: unknown
+}
 
 export const getBalanceSheet = get<
   GetBalanceSheetReturn,
@@ -11,13 +23,15 @@ export const getBalanceSheet = get<
     )}`,
 )
 
-export type GetBalanceSheetReturn = {
-  data?: BalanceSheet
-  error?: unknown
-}
+export const getBalanceSheetCSV = get<
+  { data: S3PresignedUrl },
+  GetBalanceSheetParams
+>(
+  ({ businessId, effectiveDate }) => {
+    const parameters = toDefinedSearchParameters({ effectiveDate })
 
-export interface GetBalanceSheetParams
-  extends Record<string, string | undefined> {
-  businessId: string
-  effectiveDate: string
-}
+    return `/v1/businesses/${businessId}/reports/balance-sheet/exports/csv?${parameters}`
+  }
+)
+
+

--- a/src/api/layer/statement-of-cash-flow.ts
+++ b/src/api/layer/statement-of-cash-flow.ts
@@ -1,5 +1,18 @@
 import { StatementOfCashFlow } from '../../types'
+import type { S3PresignedUrl } from '../../types/general'
+import { toDefinedSearchParameters } from '../../utils/request/toDefinedSearchParameters'
 import { get } from './authenticated_http'
+
+type GetStatementOfCashFlowParams ={
+  businessId: string
+  startDate: string
+  endDate: string
+}
+
+type GetStatementOfCashFlowReturn = {
+  data?: StatementOfCashFlow
+  error?: unknown
+}
 
 export const getStatementOfCashFlow = get<
   GetStatementOfCashFlowReturn,
@@ -11,14 +24,13 @@ export const getStatementOfCashFlow = get<
     )}&end_date=${encodeURIComponent(endDate)}`,
 )
 
-export type GetStatementOfCashFlowReturn = {
-  data?: StatementOfCashFlow
-  error?: unknown
-}
+export const getCashflowStatementCSV = get<
+  { data: S3PresignedUrl },
+  GetStatementOfCashFlowParams
+>(
+  ({ businessId, startDate, endDate }) => {
+    const parameters = toDefinedSearchParameters({ startDate, endDate })
 
-export interface GetStatementOfCashFlowParams
-  extends Record<string, string | undefined> {
-  businessId: string
-  startDate: string
-  endDate: string
-}
+    return `/v1/businesses/${businessId}/reports/cashflow-statement/exports/csv?${parameters}`
+  }
+)

--- a/src/components/BalanceSheet/BalanceSheet.tsx
+++ b/src/components/BalanceSheet/BalanceSheet.tsx
@@ -2,8 +2,7 @@ import React, { PropsWithChildren, useEffect, useState } from 'react'
 import { BalanceSheetContext } from '../../contexts/BalanceSheetContext'
 import { TableProvider } from '../../contexts/TableContext'
 import { useBalanceSheet } from '../../hooks/useBalanceSheet'
-import { useElementViewSize } from '../../hooks/useElementViewSize'
-import { View as ViewType } from '../../types/general'
+import { useElementViewSize } from '../../hooks/useElementViewSize/useElementViewSize'
 import { BalanceSheetDatePicker } from '../BalanceSheetDatePicker'
 import { BalanceSheetExpandAllButton } from '../BalanceSheetExpandAllButton'
 import { BalanceSheetTable } from '../BalanceSheetTable'
@@ -54,11 +53,7 @@ const BalanceSheetView = ({
 }: BalanceSheetViewProps) => {
   const [effectiveDate, setEffectiveDate] = useState(startOfDay(new Date()))
   const { data, isLoading, refetch } = useBalanceSheet(effectiveDate)
-
-  const [view, setView] = useState<ViewType>('desktop')
-  const containerRef = useElementViewSize<HTMLDivElement>(newView =>
-    setView(newView),
-  )
+  const { view, containerRef } = useElementViewSize<HTMLDivElement>()
 
   useEffect(() => {
     // Refetch only if selected effectiveDate and data's effectiveDate are different

--- a/src/components/BalanceSheet/BalanceSheet.tsx
+++ b/src/components/BalanceSheet/BalanceSheet.tsx
@@ -14,6 +14,7 @@ import { Loader } from '../Loader'
 import { View } from '../View'
 import { BALANCE_SHEET_ROWS } from './constants'
 import { format, parse, startOfDay } from 'date-fns'
+import { BalanceSheetDownloadButton } from './download/BalanceSheetDownloadButton'
 
 export interface BalanceSheetStringOverrides {
   balanceSheetTable?: BalanceSheetTableStringOverrides
@@ -62,11 +63,11 @@ const BalanceSheetView = ({
   useEffect(() => {
     // Refetch only if selected effectiveDate and data's effectiveDate are different
     const d1 =
-      effectiveDate &&
-      format(startOfDay(effectiveDate), 'yyyy-MM-dd\'T\'HH:mm:ssXXX')
+      effectiveDate
+      && format(startOfDay(effectiveDate), 'yyyy-MM-dd\'T\'HH:mm:ssXXX')
     const d2 =
-      data?.effective_date &&
-      format(
+      data?.effective_date
+      && format(
         startOfDay(
           parse(data.effective_date, 'yyyy-MM-dd\'T\'HH:mm:ssXXX', new Date()),
         ),
@@ -133,11 +134,15 @@ const BalanceSheetView = ({
                   setEffectiveDate={setEffectiveDate}
                 />
               </HeaderCol>
-              {withExpandAllButton && (
-                <HeaderCol>
+              <HeaderCol>
+                {withExpandAllButton && (
                   <BalanceSheetExpandAllButton view={view} />
-                </HeaderCol>
-              )}
+                )}
+                <BalanceSheetDownloadButton
+                  effectiveDate={effectiveDate}
+                  iconOnly={view === 'mobile'}
+                />
+              </HeaderCol>
             </HeaderRow>
           </Header>
         }

--- a/src/components/BalanceSheet/download/BalanceSheetDownloadButton.tsx
+++ b/src/components/BalanceSheet/download/BalanceSheetDownloadButton.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { DownloadButton } from '../../Button/DownloadButton'
+import InvisibleDownload, { useInvisibleDownload } from '../../utility/InvisibleDownload'
+import { useBalanceSheetDownload } from './useBalanceSheetDownload'
+
+type BalanceSheetDownloadButtonProps = {
+  effectiveDate: Date
+  iconOnly?: boolean
+}
+
+export function BalanceSheetDownloadButton({
+  effectiveDate,
+  iconOnly,
+}: BalanceSheetDownloadButtonProps) {
+  const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
+  const { trigger, isMutating, error } = useBalanceSheetDownload({
+    effectiveDate,
+    onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
+  })
+
+  return (
+    <>
+      <DownloadButton
+        iconOnly={iconOnly}
+        onClick={() => { trigger() }}
+        isDownloading={isMutating}
+        requestFailed={Boolean(error)}
+        text='Download'
+        retryText='Retry'
+      />
+      <InvisibleDownload ref={invisibleDownloadRef} />
+    </>
+  )
+}

--- a/src/components/BalanceSheet/download/useBalanceSheetDownload.ts
+++ b/src/components/BalanceSheet/download/useBalanceSheetDownload.ts
@@ -1,0 +1,66 @@
+import useSWRMutation from 'swr/mutation'
+import { useLayerContext } from '../../../contexts/LayerContext'
+import { useAuth } from '../../../hooks/useAuth'
+import { getBalanceSheetCSV } from '../../../api/layer/balance_sheet'
+import type { S3PresignedUrl } from '../../../types/general'
+import type { Awaitable } from '../../../types/utility/promises'
+
+function buildKey({
+  access_token: accessToken,
+  apiUrl,
+  businessId,
+  effectiveDate,
+}: {
+  access_token?: string
+  apiUrl?: string
+  businessId: string
+  effectiveDate: Date
+}) {
+  if (accessToken && apiUrl) {
+    return {
+      accessToken,
+      apiUrl,
+      businessId,
+      effectiveDate,
+      tags: [ '#balance-sheet', '#exports', '#csv' ],
+    }
+  }
+}
+
+type UseBalanceSheetOptions = {
+  effectiveDate: Date
+  onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>
+}
+
+export function useBalanceSheetDownload({
+  effectiveDate,
+  onSuccess,
+}: UseBalanceSheetOptions) {
+  const { data: auth } = useAuth()
+  const { businessId } = useLayerContext()
+
+  return useSWRMutation(
+    () => buildKey({
+      ...auth,
+      businessId,
+      effectiveDate,
+    }),
+    ({ accessToken, apiUrl, businessId, effectiveDate, }) => getBalanceSheetCSV(
+      apiUrl,
+      accessToken,
+      {
+        params: {
+          businessId,
+          effectiveDate: effectiveDate.toISOString(),
+        }
+      })().then(({ data }) => {
+      if (onSuccess) {
+        return onSuccess(data)
+      }
+    }),
+    {
+      revalidate: false,
+      throwOnError: false,
+    },
+  )
+}

--- a/src/components/ChartOfAccounts/ChartOfAccounts.tsx
+++ b/src/components/ChartOfAccounts/ChartOfAccounts.tsx
@@ -1,10 +1,9 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext } from 'react'
 import { ChartOfAccountsContext } from '../../contexts/ChartOfAccountsContext'
 import { LedgerAccountsContext } from '../../contexts/LedgerAccountsContext'
 import { useChartOfAccounts } from '../../hooks/useChartOfAccounts'
-import { useElementViewSize } from '../../hooks/useElementViewSize'
+import { useElementViewSize } from '../../hooks/useElementViewSize/useElementViewSize'
 import { useLedgerAccounts } from '../../hooks/useLedgerAccounts'
-import { View } from '../../types/general'
 import { ChartOfAccountsTable } from '../ChartOfAccountsTable'
 import { ChartOfAccountsTableStringOverrides } from '../ChartOfAccountsTable/ChartOfAccountsTableWithPanel'
 import { Container } from '../Container'
@@ -49,12 +48,7 @@ const ChartOfAccountsContent = ({
   templateAccountsEditable,
 }: ChartOfAccountsProps) => {
   const { accountId } = useContext(LedgerAccountsContext)
-
-  const [view, setView] = useState<View>('desktop')
-
-  const containerRef = useElementViewSize<HTMLDivElement>(newView =>
-    setView(newView),
-  )
+  const { view, containerRef } = useElementViewSize<HTMLDivElement>()
 
   return (
     <Container name='chart-of-accounts' ref={containerRef} asWidget={asWidget}>

--- a/src/components/Journal/Journal.tsx
+++ b/src/components/Journal/Journal.tsx
@@ -1,10 +1,9 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { ChartOfAccountsContext } from '../../contexts/ChartOfAccountsContext'
 import { JournalContext } from '../../contexts/JournalContext'
 import { useChartOfAccounts } from '../../hooks/useChartOfAccounts'
-import { useElementViewSize } from '../../hooks/useElementViewSize'
+import { useElementViewSize } from '../../hooks/useElementViewSize/useElementViewSize'
 import { useJournal } from '../../hooks/useJournal'
-import { View } from '../../types/general'
 import { Container } from '../Container'
 import { JournalTable } from '../JournalTable'
 import { JournalTableStringOverrides } from '../JournalTable/JournalTableWithPanel'
@@ -48,11 +47,7 @@ const JournalContent = ({
   config = JOURNAL_CONFIG,
   stringOverrides,
 }: JournalProps) => {
-  const [view, setView] = useState<View>('desktop')
-
-  const containerRef = useElementViewSize<HTMLDivElement>(newView =>
-    setView(newView),
-  )
+  const { view, containerRef } = useElementViewSize<HTMLDivElement>()
 
   return (
     <Container name='journal' ref={containerRef} asWidget={asWidget}>

--- a/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
+++ b/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
@@ -16,6 +16,7 @@ import { StatementOfCashFlowTableStringOverrides } from '../StatementOfCashFlowT
 import { View } from '../View'
 import { STATEMENT_OF_CASH_FLOW_ROWS } from './constants'
 import { endOfMonth, startOfDay, startOfMonth, subWeeks } from 'date-fns'
+import { CashflowStatementDownloadButton } from './download/CashflowStatementDownloadButton'
 
 const COMPONENT_NAME = 'statement-of-cash-flow'
 
@@ -116,6 +117,12 @@ const StatementOfCashFlowView = ({
           <Header>
             <HeaderRow>
               <HeaderCol>{datePicker}</HeaderCol>
+              <HeaderCol>
+                <CashflowStatementDownloadButton
+                  startDate={startDate}
+                  endDate={endDate}
+                />
+              </HeaderCol>
             </HeaderRow>
           </Header>
         }

--- a/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
+++ b/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
@@ -17,6 +17,7 @@ import { View } from '../View'
 import { STATEMENT_OF_CASH_FLOW_ROWS } from './constants'
 import { endOfMonth, startOfDay, startOfMonth, subWeeks } from 'date-fns'
 import { CashflowStatementDownloadButton } from './download/CashflowStatementDownloadButton'
+import { useElementViewSize } from '../../hooks/useElementViewSize/useElementViewSize'
 
 const COMPONENT_NAME = 'statement-of-cash-flow'
 
@@ -56,6 +57,7 @@ const StatementOfCashFlowView = ({
     startDate,
     endDate,
   )
+  const { view, containerRef } = useElementViewSize<HTMLDivElement>()
 
   const [datePickerMode, setDatePickerMode] = useState<DatePickerMode>(
     deprecated_datePickerMode ?? defaultDatePickerMode,
@@ -113,6 +115,7 @@ const StatementOfCashFlowView = ({
     <TableProvider>
       <View
         type='panel'
+        ref={containerRef}
         header={
           <Header>
             <HeaderRow>
@@ -121,6 +124,7 @@ const StatementOfCashFlowView = ({
                 <CashflowStatementDownloadButton
                   startDate={startDate}
                   endDate={endDate}
+                  iconOnly={view === 'mobile'}
                 />
               </HeaderCol>
             </HeaderRow>

--- a/src/components/StatementOfCashFlow/download/CashflowStatementDownloadButton.tsx
+++ b/src/components/StatementOfCashFlow/download/CashflowStatementDownloadButton.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { DownloadButton } from '../../Button/DownloadButton'
+import InvisibleDownload, { useInvisibleDownload } from '../../utility/InvisibleDownload'
+import { useCashflowStatementDownload } from './useCashflowStatementDownload'
+
+type CashflowStatementDownloadButtonProps = {
+  startDate: Date
+  endDate: Date
+  iconOnly?: boolean
+}
+
+export function CashflowStatementDownloadButton({
+  startDate,
+  endDate,
+  iconOnly,
+}: CashflowStatementDownloadButtonProps) {
+  const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
+  const { trigger, isMutating, error } = useCashflowStatementDownload({
+    startDate,
+    endDate,
+    onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
+  })
+
+  return (
+    <>
+      <DownloadButton
+        iconOnly={iconOnly}
+        onClick={() => { trigger() }}
+        isDownloading={isMutating}
+        requestFailed={Boolean(error)}
+        text='Download'
+        retryText='Retry'
+      />
+      <InvisibleDownload ref={invisibleDownloadRef} />
+    </>
+  )
+}

--- a/src/components/StatementOfCashFlow/download/useCashflowStatementDownload.ts
+++ b/src/components/StatementOfCashFlow/download/useCashflowStatementDownload.ts
@@ -1,0 +1,73 @@
+import useSWRMutation from 'swr/mutation'
+import { useLayerContext } from '../../../contexts/LayerContext'
+import { useAuth } from '../../../hooks/useAuth'
+import type { S3PresignedUrl } from '../../../types/general'
+import type { Awaitable } from '../../../types/utility/promises'
+import { getCashflowStatementCSV } from '../../../api/layer/statement-of-cash-flow'
+
+function buildKey({
+  access_token: accessToken,
+  apiUrl,
+  businessId,
+  startDate,
+  endDate,
+}: {
+  access_token?: string
+  apiUrl?: string
+  businessId: string
+  startDate: Date
+  endDate: Date
+}) {
+  if (accessToken && apiUrl) {
+    return {
+      accessToken,
+      apiUrl,
+      businessId,
+      startDate,
+      endDate,
+      tags: [ '#cashflow-statement', '#exports', '#csv' ]
+    }
+  }
+}
+
+type UseCashflowStatementDownloadOptions = {
+  startDate: Date
+  endDate: Date
+  onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>
+}
+
+export function useCashflowStatementDownload({
+  startDate,
+  endDate,
+  onSuccess,
+}: UseCashflowStatementDownloadOptions) {
+  const { data: auth } = useAuth()
+  const { businessId } = useLayerContext()
+
+  return useSWRMutation(
+    () => buildKey({
+      ...auth,
+      businessId,
+      startDate,
+      endDate,
+    }),
+    ({ accessToken, apiUrl, businessId, startDate, endDate }) => getCashflowStatementCSV(
+      apiUrl,
+      accessToken,
+      {
+        params: {
+          businessId,
+          startDate: startDate.toISOString(),
+          endDate: endDate.toISOString(),
+        }
+      })().then(({ data }) => {
+      if (onSuccess) {
+        return onSuccess(data)
+      }
+    }),
+    {
+      revalidate: false,
+      throwOnError: false,
+    },
+  )
+}

--- a/src/components/ui/Stack/Stack.tsx
+++ b/src/components/ui/Stack/Stack.tsx
@@ -8,12 +8,16 @@ export type StackProps = PropsWithChildren<{
   slot?: string
 }>
 
-const CLASS_NAME = 'Layer__VStack'
+type InternalStackProps = StackProps & {
+  direction: 'row' | 'column'
+}
 
-export function VStack({ align, children, gap, justify, ...restProps }: StackProps) {
+const CLASS_NAME = 'Layer__Stack'
+
+function Stack({ align, children, direction, gap, justify, ...restProps }: InternalStackProps) {
   const dataProperties = useMemo(
-    () => toDataProperties({ align, gap, justify }),
-    [align, gap, justify],
+    () => toDataProperties({ align, gap, justify, direction }),
+    [align, direction, gap, justify],
   )
 
   return (
@@ -21,4 +25,12 @@ export function VStack({ align, children, gap, justify, ...restProps }: StackPro
       {children}
     </div>
   )
+}
+
+export function VStack(props: StackProps) {
+  return <Stack {...props} direction='column' />
+}
+
+export function HStack(props: StackProps) {
+  return <Stack {...props} direction='row' />
 }

--- a/src/components/ui/Stack/stack.scss
+++ b/src/components/ui/Stack/stack.scss
@@ -1,6 +1,12 @@
-.Layer__VStack {
+.Layer__Stack {
   display: flex;
-  flex-direction: column;
+
+  $directions: row, column;
+  @each $direction in $directions {
+    &[data-direction="#{$direction}"] {
+      flex-direction: $direction;
+    }
+  }
 
   $alignments: start, center, end;
   @each $alignment in $alignments {

--- a/src/components/utility/InvisibleDownload.tsx
+++ b/src/components/utility/InvisibleDownload.tsx
@@ -1,0 +1,39 @@
+import React, { forwardRef, useCallback, useImperativeHandle, useRef } from 'react'
+import { runDelayedSync } from '../../utils/delay/runDelayed'
+
+type InvisibleDownloadHandle = {
+  trigger: (options: { url: string }) => Promise<void>
+}
+
+export function useInvisibleDownload() {
+  const invisibleDownloadRef = useRef<InvisibleDownloadHandle>(null)
+
+  const triggerInvisibleDownload = useCallback((options: { url: string }) => {
+    invisibleDownloadRef.current?.trigger(options)
+  }, [])
+
+  return { invisibleDownloadRef, triggerInvisibleDownload }
+}
+
+const CLASS_NAME = 'Layer__InvisibleDownload'
+
+const InvisibleDownload = forwardRef<InvisibleDownloadHandle>((_props, ref) => {
+  const internalRef = useRef<HTMLAnchorElement>(null)
+
+  useImperativeHandle(ref, () => ({
+    trigger: async ({ url }) => {
+      internalRef.current?.setAttribute('href', url)
+
+      return runDelayedSync(() => internalRef.current?.click())
+    },
+  }))
+
+  const handleContainClick = useCallback((event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.stopPropagation()
+  }, [])
+
+  return <a download className={CLASS_NAME} ref={internalRef} onClick={handleContainClick} />
+})
+InvisibleDownload.displayName = 'InvisibleDownload'
+
+export default InvisibleDownload

--- a/src/components/utility/index.scss
+++ b/src/components/utility/index.scss
@@ -1,0 +1,3 @@
+.Layer__InvisibleDownload {
+  display: none;
+}

--- a/src/hooks/useElementViewSize/index.ts
+++ b/src/hooks/useElementViewSize/index.ts
@@ -1,1 +1,0 @@
-export { useElementViewSize } from './useElementViewSize'

--- a/src/hooks/useElementViewSize/useElementViewSize.tsx
+++ b/src/hooks/useElementViewSize/useElementViewSize.tsx
@@ -1,16 +1,14 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 import { BREAKPOINTS } from '../../config/general'
 import { View } from '../../types/general'
 
-export const useElementViewSize = <T extends HTMLElement>(
-  callback: (view: View) => void,
-) => {
-  const ref = useRef<T>(null)
+export const useElementViewSize = <T extends HTMLElement>() => {
+  const containerRef = useRef<T>(null)
   const [view, setView] = useState<View>('desktop')
   const resizeTimeout = useRef<number | null>(null)
 
   useLayoutEffect(() => {
-    const element = ref?.current
+    const element = containerRef?.current
 
     if (!element) {
       return
@@ -27,9 +25,9 @@ export const useElementViewSize = <T extends HTMLElement>(
           if (width >= BREAKPOINTS.TABLET && view !== 'desktop') {
             setView('desktop')
           } else if (
-            width <= BREAKPOINTS.TABLET &&
-            width > BREAKPOINTS.MOBILE &&
-            view !== 'tablet'
+            width <= BREAKPOINTS.TABLET
+            && width > BREAKPOINTS.MOBILE
+            && view !== 'tablet'
           ) {
             setView('tablet')
           } else if (width < BREAKPOINTS.MOBILE && view !== 'mobile') {
@@ -46,11 +44,7 @@ export const useElementViewSize = <T extends HTMLElement>(
         clearTimeout(resizeTimeout.current)
       }
     }
-  }, [callback, ref, view])
+  }, [containerRef, view])
 
-  useEffect(() => {
-    callback(view)
-  }, [view, callback])
-
-  return ref
+  return { view, containerRef }
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -27,6 +27,7 @@
 @import './view.scss';
 
 @import '../components/ui/index.scss';
+@import '../components/utility/index.scss';
 @import '../components/LinkedAccounts/ConfirmationModal/linkedAccountToConfirm.scss';
 
 @import './ledger_account.scss';

--- a/src/utils/delay/runDelayed.ts
+++ b/src/utils/delay/runDelayed.ts
@@ -1,0 +1,10 @@
+const DEFAULT_DELAY_MS = 50
+
+export function runDelayedSync<T>(
+  block: () => T,
+  delayMs = DEFAULT_DELAY_MS
+): Promise<T> {
+  return new Promise((resolve) =>
+    setTimeout(() => resolve(block()), delayMs)
+  )
+}

--- a/src/utils/request/toDefinedSearchParameters.ts
+++ b/src/utils/request/toDefinedSearchParameters.ts
@@ -1,0 +1,37 @@
+function toSnakeCase(input: string) {
+  const segments = input
+    .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g) ?? []
+
+  return segments
+    .map(segment => segment.toLowerCase())
+    .join('_')
+}
+
+type ParameterValues = Date | string | number | boolean
+
+export function toDefinedSearchParameters(
+  input: Record<string, ParameterValues | null | undefined>
+) {
+  const definedParameters = Object.fromEntries(
+    Object.entries(input)
+      .map(([key, value]) => {
+        if (value === null || value === undefined) {
+          return null
+        }
+
+        if (value instanceof Date) {
+          return [key, value.toISOString()] as const
+        }
+
+        if (typeof value !== 'string') {
+          return [key, String(value)] as const
+        }
+
+        return [key, value] as const
+      })
+      .filter((entry): entry is Exclude<typeof entry, null> => entry !== null)
+      .map(([key, value]) => [toSnakeCase(key), value])
+  )
+
+  return new URLSearchParams(definedParameters)
+}

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -11,7 +11,7 @@ import { StatementOfCashFlow } from '../../components/StatementOfCashFlow'
 import { StatementOfCashFlowStringOverrides } from '../../components/StatementOfCashFlow/StatementOfCashFlow'
 import { Toggle } from '../../components/Toggle'
 import { View } from '../../components/View'
-import { useElementViewSize } from '../../hooks/useElementViewSize'
+import { useElementViewSize } from '../../hooks/useElementViewSize/useElementViewSize'
 import { View as ViewType } from '../../types/general'
 import type { TimeRangePickerConfig } from './reportTypes'
 
@@ -54,21 +54,21 @@ const getOptions = (enabledReports: ReportType[]) => {
   return [
     enabledReports.includes('profitAndLoss')
       ? {
-          value: 'profitAndLoss',
-          label: 'Profit & Loss',
-        }
+        value: 'profitAndLoss',
+        label: 'Profit & Loss',
+      }
       : null,
     enabledReports.includes('balanceSheet')
       ? {
-          value: 'balanceSheet',
-          label: 'Balance Sheet',
-        }
+        value: 'balanceSheet',
+        label: 'Balance Sheet',
+      }
       : null,
     enabledReports.includes('statementOfCashFlow')
       ? {
-          value: 'statementOfCashFlow',
-          label: 'Statement of Cash Flow',
-        }
+        value: 'statementOfCashFlow',
+        label: 'Statement of Cash Flow',
+      }
       : null,
   ].filter(o => !!o) as ReportOption[]
 }
@@ -83,11 +83,7 @@ export const Reports = ({
   statementOfCashFlowConfig,
 }: ReportsProps) => {
   const [activeTab, setActiveTab] = useState<ReportType>(enabledReports[0])
-  const [view, setView] = useState<ViewBreakpoint>('desktop')
-
-  const containerRef = useElementViewSize<HTMLDivElement>(newView =>
-    setView(newView),
-  )
+  const { view, containerRef } = useElementViewSize<HTMLDivElement>()
 
   const options = getOptions(enabledReports)
   const defaultTitle =


### PR DESCRIPTION
## Description

This change adds a button at the top of the balance sheet and cashflow reports to download them in CSV form. The goal is to reach parity with the Income Statement.

### Screenshots

<img width="1400" alt="Balance Sheet w/ Download Button" src="https://github.com/user-attachments/assets/c6556b92-4555-434e-b549-00e1c6ba609f">
<img width="1400" alt="Cashflow Statement w/ Download Button" src="https://github.com/user-attachments/assets/59e604f3-627b-49f8-a1c4-ac3e03388bf2">
