### PR TITLE
feat: account balance inputs

### DIFF
--- a/src/api/layer.ts
+++ b/src/api/layer.ts
@@ -38,6 +38,7 @@ import {
   breakPlaidItemConnection,
   syncConnection,
   updateConnectionStatus,
+  updateOpeningBalance,
 } from './layer/linked_accounts'
 import {
   getProfitAndLoss,
@@ -98,6 +99,7 @@ export const Layer = {
   unlinkPlaidItem,
   confirmAccount,
   excludeAccount,
+  updateOpeningBalance,
   getTasks,
   completeTaskWithUpload,
   submitResponseToTask,

--- a/src/api/layer/linked_accounts.ts
+++ b/src/api/layer/linked_accounts.ts
@@ -83,6 +83,23 @@ export const unlinkConnection = post<
     `/v1/businesses/${businessId}/plaid/external-accounts/connection/${connectionId}/archive`,
 )
 
+type UpdateOpeningBalanceBody = {
+  effective_at?: string
+  balance?: string
+}
+
+export const updateOpeningBalance = post<
+  never,
+  UpdateOpeningBalanceBody,
+  {
+    businessId: string
+    accountId: string
+  }
+>(
+  ({ businessId, accountId }) =>
+    `/v1/businesses/${businessId}/external-accounts/${accountId}/opening-balance`,
+)
+
 export const unlinkAccount = post<
   Record<string, unknown>,
   Record<string, unknown>,

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -331,6 +331,7 @@ export const DatePicker = ({
             : undefined
         }
         onChange={handleDateChange}
+        disabled={disabled}
         calendarClassName={calendarClassNames}
         popperClassName={popperClassNames}
         enableTabLoop={false}
@@ -381,7 +382,6 @@ export const DatePicker = ({
             pickerRef.current.setOpen(!pickerRef.current.isCalendarOpen())
           }
         }}
-        disabled={disabled}
         {...props}
       >
         {ModeSelector && (

--- a/src/components/Input/AmountInput.tsx
+++ b/src/components/Input/AmountInput.tsx
@@ -1,5 +1,6 @@
 import React, { HTMLProps } from 'react'
 import { Input } from './Input'
+import classNames from 'classnames'
 
 export interface AmountInputProps extends Omit<HTMLProps<HTMLInputElement>, 'onChange'> {
   isInvalid?: boolean
@@ -13,8 +14,14 @@ export interface AmountInputProps extends Omit<HTMLProps<HTMLInputElement>, 'onC
  */
 export const AmountInput = ({
   onChange,
+  className,
   ...props
 }: AmountInputProps) => {
+  const baseClassName = classNames(
+    'Layer__amount-input',
+    className,
+  )
+
   const onInputChange = (e: React.FormEvent<HTMLInputElement>) => {
     try {
       onChange && onChange((e.target as HTMLInputElement).value.replace(/[^\d.]/g, ''))
@@ -24,6 +31,6 @@ export const AmountInput = ({
   }
 
   return (
-    <Input onChange={onInputChange} {...props} />
+    <Input type='number' className={baseClassName} onChange={onInputChange} {...props} />
   )
 }

--- a/src/components/Input/AmountInput.tsx
+++ b/src/components/Input/AmountInput.tsx
@@ -5,7 +5,7 @@ export interface AmountInputProps extends Omit<HTMLProps<HTMLInputElement>, 'onC
   isInvalid?: boolean
   errorMessage?: string
   leftText?: string
-  onChange?: (value?: number) => void
+  onChange?: (value?: string) => void
 }
 
 /** @TODO this component is oversimplified.
@@ -17,7 +17,7 @@ export const AmountInput = ({
 }: AmountInputProps) => {
   const onInputChange = (e: React.FormEvent<HTMLInputElement>) => {
     try {
-      onChange && onChange(Number((e.target as HTMLInputElement).value))
+      onChange && onChange((e.target as HTMLInputElement).value.replace(/[^\d.]/g, ''))
     } catch {
       return
     }

--- a/src/components/Input/AmountInput.tsx
+++ b/src/components/Input/AmountInput.tsx
@@ -1,0 +1,29 @@
+import React, { HTMLProps } from 'react'
+import { Input } from './Input'
+
+export interface AmountInputProps extends Omit<HTMLProps<HTMLInputElement>, 'onChange'> {
+  isInvalid?: boolean
+  errorMessage?: string
+  leftText?: string
+  onChange?: (value?: number) => void
+}
+
+/** @TODO this component is oversimplified.
+ * Need to have better number conversion and decorations
+ */
+export const AmountInput = ({
+  onChange,
+  ...props
+}: AmountInputProps) => {
+  const onInputChange = (e: React.FormEvent<HTMLInputElement>) => {
+    try {
+      onChange && onChange(Number((e.target as HTMLInputElement).value))
+    } catch {
+      return
+    }
+  }
+
+  return (
+    <Input onChange={onInputChange} {...props} />
+  )
+}

--- a/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
+++ b/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import InstitutionIcon from '../../icons/InstitutionIcon'
 import LoaderIcon from '../../icons/Loader'
 import { centsToDollars as formatMoney } from '../../models/Money'
@@ -6,6 +6,10 @@ import { LinkedAccount } from '../../types/linked_accounts'
 import { LinkedAccountPill } from '../LinkedAccountPill'
 import { Text, TextSize } from '../Typography'
 import classNames from 'classnames'
+import { Pill } from '../Pill/Pill'
+import AlertCircle from '../../icons/AlertCircle'
+import PlusIcon from '../../icons/PlusIcon'
+import { OpeningBalanceModal } from '../LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal'
 
 export interface LinkedAccountThumbProps {
   account: LinkedAccount
@@ -15,6 +19,7 @@ export interface LinkedAccountThumbProps {
     text: string
     config: { name: string; action: () => void }[]
   }
+  addOpeningBankBalance?: () => void
 }
 
 const AccountNumber = ({ accountNumber }: { accountNumber: string }) => (
@@ -28,7 +33,10 @@ export const LinkedAccountThumb = ({
   asWidget,
   showLedgerBalance,
   pillConfig,
+  addOpeningBankBalance,
 }: LinkedAccountThumbProps) => {
+  const [showOpeningBalanceModal, setShowOpeningBalanceModal] = useState(false)
+
   const linkedAccountThumbClassName = classNames(
     'Layer__linked-account-thumb',
     asWidget && '--as-widget',
@@ -57,91 +65,109 @@ export const LinkedAccountThumb = ({
   }
 
   return (
-    <div className={linkedAccountThumbClassName}>
-      <div className={linkedAccountInfoClassName}>
-        <div className='topbar-details'>
-          <Text as='div' className='account-name'>
-            {account.external_account_name}
-          </Text>
-          {!asWidget && account.mask && (
-            <AccountNumber accountNumber={account.mask} />
-          )}
-          <Text
-            as='span'
-            className='account-institution'
-            size={'sm' as TextSize}
-          >
-            {account.institution?.name
-              ? account.institution?.name
-              : account.external_account_name}
-          </Text>
-        </div>
-        <div className='topbar-logo'>
-          {account.institution?.logo != undefined ? (
-            <img
-              width={28}
-              height={28}
-              src={`data:image/png;base64,${account.institution.logo}`}
-              alt={
-                account.institution?.name
-                  ? account.institution?.name
-                  : account.external_account_name
-              }
-            />
-          ) : (
-            <InstitutionIcon />
-          )}
-        </div>
-      </div>
-      {account.is_syncing ? (
-        <div className='loadingbar'>
-          <div className='loading-text Layer__text--sm'>
-            <div>Syncing account data</div>
-            <div className='syncing-data-description'>
-              This may take up to 5 minutes
+    <>
+      <div className={linkedAccountThumbClassName}>
+        <div className={linkedAccountInfoClassName}>
+          <div className='topbar-details'>
+            <div className='topbar-details-main'>
+              <div className='topbar-details-main__name'>
+                <Text as='div' className='account-name'>
+                  {account.external_account_name}
+                </Text>
+                {!asWidget && account.mask && (
+                  <AccountNumber accountNumber={account.mask} />
+                )}
+              </div>
+              <div className='topbar-logo'>
+                {account.institution?.logo != undefined ? (
+                  <img
+                      width={28}
+                      height={28}
+                      src={`data:image/png;base64,${account.institution.logo}`}
+                      alt={
+                        account.institution?.name
+                          ? account.institution?.name
+                          : account.external_account_name
+                      }
+                    />
+                  ) : (
+                    <InstitutionIcon />
+                  )}
+              </div>
             </div>
-          </div>
-          <div className='loading-wrapper'>
-            <LoaderIcon size={11} className='Layer__anim--rotating' />
-          </div>
-        </div>
-      ) : (
-        <>
-          {!asWidget && (
-            <div className='middlebar'>
+            <div className='topbar-details-secondary'>
               <Text
                 as='span'
-                className={classNames(
-                  'account-balance-text',
-                  !showLedgerBalance && '--hide-ledger-balance',
-                )}
+                className='account-institution'
                 size={'sm' as TextSize}
               >
-                Bank balance
+                {account.institution?.name
+                  ? account.institution?.name
+                  : account.external_account_name}
               </Text>
-              {bankBalance}
+              {/** @TODO remove !addOpeningBankBalance */}
+              {!pillConfig && (addOpeningBankBalance || !addOpeningBankBalance) ? (
+                <Pill kind='info' onClick={() => setShowOpeningBalanceModal(true)}>
+                  <PlusIcon size={14} /> Add opening balance
+                </Pill>
+              ) : null}
             </div>
-          )}
-          {showLedgerBalance && (
-            <div className='bottombar'>
-              {asWidget && account.mask ? (
-                <AccountNumber accountNumber={account.mask} />
-              ) : (
+          </div>
+        </div>
+        {account.is_syncing ? (
+          <div className='loadingbar'>
+            <div className='loading-text Layer__text--sm'>
+              <div>Syncing account data</div>
+              <div className='syncing-data-description'>
+                This may take up to 5 minutes
+              </div>
+            </div>
+            <div className='loading-wrapper'>
+              <LoaderIcon size={11} className='Layer__anim--rotating' />
+            </div>
+          </div>
+        ) : (
+          <>
+            {!asWidget && (
+              <div className='middlebar'>
                 <Text
                   as='span'
-                  className='account-balance-text'
+                  className={classNames(
+                    'account-balance-text',
+                    !showLedgerBalance && '--hide-ledger-balance',
+                  )}
                   size={'sm' as TextSize}
                 >
-                  Ledger balance
+                  Bank balance
                 </Text>
-              )}
-              <Text as='span' className='account-balance'>
-                {`${formatMoney(account.current_ledger_balance)}`}
-              </Text>
-            </div>
-          )}
-        </>
-      )}
-    </div>
+                {bankBalance}
+              </div>
+            )}
+            {showLedgerBalance && (
+              <div className='bottombar'>
+                {asWidget && account.mask ? (
+                  <AccountNumber accountNumber={account.mask} />
+                ) : (
+                  <Text
+                    as='span'
+                    className='account-balance-text'
+                    size={'sm' as TextSize}
+                  >
+                    Ledger balance
+                  </Text>
+                )}
+                <Text as='span' className='account-balance'>
+                  {`${formatMoney(account.current_ledger_balance)}`}
+                </Text>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+      <OpeningBalanceModal
+        account={showOpeningBalanceModal ? account : undefined}
+        onClose={() => setShowOpeningBalanceModal(false)}
+      />
+    </>
   )
 }

--- a/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
+++ b/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
@@ -105,8 +105,7 @@ export const LinkedAccountThumb = ({
                   ? account.institution?.name
                   : account.external_account_name}
               </Text>
-              {/** @TODO remove !addOpeningBankBalance */}
-              {!pillConfig && (addOpeningBankBalance || !addOpeningBankBalance) ? (
+              {!pillConfig && addOpeningBankBalance ? (
                 <Pill kind='info' onClick={() => setShowOpeningBalanceModal(true)}>
                   <PlusIcon size={14} /> Add opening balance
                 </Pill>

--- a/src/components/LinkedAccounts/ConfirmAndOpeningBalanceForm/ConfirmAndOpeningBalanceForm.tsx
+++ b/src/components/LinkedAccounts/ConfirmAndOpeningBalanceForm/ConfirmAndOpeningBalanceForm.tsx
@@ -86,13 +86,18 @@ ref) => {
               }}
               selected={formState.openingDate ?? startOfDay(new Date())}
               currentDateOption={false}
+              disabled={!formState.isConfirmed}
             />
           </InputGroup>
           <InputGroup label='Opening balance'>
             <AmountInput
-              name='openingBalance' defaultValue={formState.openingBalance} onChange={value => 
+              name='openingBalance'
+              defaultValue={formState.openingBalance}
+              onChange={value => 
                 setFormState({ ...formState, openingBalance: value })
-              } />
+              }
+              disabled={!formState.isConfirmed}
+            />
           </InputGroup>
         </Stack>
       </VStack>

--- a/src/components/LinkedAccounts/ConfirmAndOpeningBalanceForm/ConfirmAndOpeningBalanceForm.tsx
+++ b/src/components/LinkedAccounts/ConfirmAndOpeningBalanceForm/ConfirmAndOpeningBalanceForm.tsx
@@ -11,34 +11,34 @@ import { AmountInput } from '../../Input/AmountInput'
 import { DatePicker } from '../../DatePicker'
 import InstitutionIcon from '../../../icons/InstitutionIcon'
 
-export type LinkAccountForm = {
+export type ConfirmAndOpeningBalanceFormData = {
   account: LinkedAccount
   isConfirmed: boolean
   openingDate?: Date
-  openingBalance?: number
+  openingBalance?: string
 }
 
-export type LinkAccountToConfirmRef = {
-  getData: () => LinkAccountForm
+export type ConfirmAndOpeningBalanceFormRef = {
+  getData: () => ConfirmAndOpeningBalanceFormData
 }
 
-type LinkedAccountConfirmationProps = {
+type ConfirmAndOpeningBalanceFormProps = {
   account: LinkedAccount
-  defaultValue: LinkAccountForm
+  defaultValue: ConfirmAndOpeningBalanceFormData
   compact?: boolean
   disableConfirmExclude?: boolean
 }
 
-const CLASS_NAME = 'Layer__LinkedAccountToConfirm'
+const CLASS_NAME = 'Layer__confirm-and-opening-balance-form'
 
-const LinkedAccountToConfirm = forwardRef(({
+const ConfirmAndOpeningBalanceForm = forwardRef(({
   account,
   defaultValue,
   compact,
   disableConfirmExclude = false,
-}: LinkedAccountConfirmationProps,
+}: ConfirmAndOpeningBalanceFormProps,
 ref) => {
-  const [formState, setFormState] = useState<LinkAccountForm>(defaultValue)
+  const [formState, setFormState] = useState<ConfirmAndOpeningBalanceFormData>(defaultValue)
   
   useImperativeHandle(ref, () => ({
     getData: () => formState,
@@ -109,6 +109,6 @@ ref) => {
   )
 })
 
-LinkedAccountToConfirm.displayName = 'LinkedAccountToConfirm'
+ConfirmAndOpeningBalanceForm.displayName = 'ConfirmAndOpeningBalanceForm'
 
-export { LinkedAccountToConfirm }
+export { ConfirmAndOpeningBalanceForm }

--- a/src/components/LinkedAccounts/ConfirmAndOpeningBalanceForm/confirmAndOpeningBalanceForm.scss
+++ b/src/components/LinkedAccounts/ConfirmAndOpeningBalanceForm/confirmAndOpeningBalanceForm.scss
@@ -1,4 +1,4 @@
-.Layer__LinkedAccountToConfirm {
+.Layer__confirm-and-opening-balance-form {
   background-color: var(--bg-subtle);
 
   padding-inline: var(--spacing-md);
@@ -12,7 +12,7 @@
     width: 100%;
   }
 
-  &.Layer__LinkedAccountToConfirm--compact {
+  &.Layer__confirm-and-opening-balance-form--compact {
     .Layer__input-group {
       width: 100%;
       max-width: 180px;
@@ -23,7 +23,7 @@
     }
   }
 
-  &:not(.Layer__LinkedAccountToConfirm--compact) {
+  &:not(.Layer__confirm-and-opening-balance-form--compact) {
     .Layer__input-group {
       width: 50%;
       max-width: 180px;
@@ -35,11 +35,11 @@
   }
 }
 
-.Layer__LinkedAccountToConfirm__main-col {
+.Layer__confirm-and-opening-balance-form__main-col {
   flex: 1;
 }
 
-.Layer__LinkedAccountToConfirm__form {
+.Layer__confirm-and-opening-balance-form__form {
   padding-top: var(--spacing-xs);
   border-top: 1px solid var(--border-color);
 }

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountToConfirm.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountToConfirm.tsx
@@ -6,7 +6,8 @@ import { Heading } from '../../ui/Typography/Heading'
 import { P } from '../../ui/Typography/Text'
 import { VStack, Stack } from '../../ui/Stack/Stack'
 import { Checkbox } from  '../../ui/Checkbox/Checkbox'
-import { Input, InputGroup } from '../../Input'
+import { InputGroup } from '../../Input'
+import { AmountInput } from '../../Input/AmountInput'
 import { DatePicker } from '../../DatePicker'
 import InstitutionIcon from '../../../icons/InstitutionIcon'
 
@@ -25,6 +26,7 @@ type LinkedAccountConfirmationProps = {
   account: LinkedAccount
   defaultValue: LinkAccountForm
   compact?: boolean
+  disableConfirmExclude?: boolean
 }
 
 const CLASS_NAME = 'Layer__LinkedAccountToConfirm'
@@ -33,6 +35,7 @@ const LinkedAccountToConfirm = forwardRef(({
   account,
   defaultValue,
   compact,
+  disableConfirmExclude = false,
 }: LinkedAccountConfirmationProps,
 ref) => {
   const [formState, setFormState] = useState<LinkAccountForm>(defaultValue)
@@ -86,28 +89,22 @@ ref) => {
             />
           </InputGroup>
           <InputGroup label='Opening balance'>
-            <Input
-              name='openingBalance' defaultValue={formState.openingBalance} onChange={e => {
-                try {
-                  /**
-               * @TODO better handling here
-               */
-                  const v = Number((e.target as HTMLInputElement).value)
-                  setFormState({ ...formState, openingBalance: v })
-                } catch(_err) {
-                  console.debug('format issue')
-                }
-              }} />
+            <AmountInput
+              name='openingBalance' defaultValue={formState.openingBalance} onChange={value => 
+                setFormState({ ...formState, openingBalance: value })
+              } />
           </InputGroup>
         </Stack>
       </VStack>
-      <VStack justify='start'>
-        <Checkbox
-          isSelected={formState.isConfirmed}
-          onChange={v => setFormState({ ...formState, isConfirmed: v })}
-          aria-label='Confirm Account Inclusion'
-        />
-      </VStack> 
+      {!disableConfirmExclude && (
+        <VStack justify='start'>
+          <Checkbox
+            isSelected={formState.isConfirmed}
+            onChange={v => setFormState({ ...formState, isConfirmed: v })}
+            aria-label='Confirm Account Inclusion'
+          />
+        </VStack> 
+      )}
     </div>
   )
 })

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
@@ -8,17 +8,17 @@ import { VStack } from '../../ui/Stack/Stack'
 import { useLinkedAccounts } from '../../../hooks/useLinkedAccounts'
 import { useAccountConfirmationStore } from '../../../providers/AccountConfirmationStoreProvider'
 import { ConditionalList } from '../../utility/ConditionalList'
-import { LinkAccountForm, LinkAccountToConfirmRef, LinkedAccountToConfirm } from './LinkedAccountToConfirm'
+import { ConfirmAndOpeningBalanceFormData, ConfirmAndOpeningBalanceFormRef, ConfirmAndOpeningBalanceForm } from '../ConfirmAndOpeningBalanceForm/ConfirmAndOpeningBalanceForm'
 import { Layer } from '../../../api/layer'
 import type { Awaitable } from '../../../types/utility/promises'
 import { P } from '../../ui/Typography/Text'
 import { useAuth } from '../../../hooks/useAuth'
 import { useLayerContext } from '../../../contexts/LayerContext'
 import { LoadingSpinner } from '../../ui/Loading/LoadingSpinner'
-import { getAccountsNeedingConfirmation } from '../../../hooks/useLinkedAccounts/useLinkedAccounts'
 import { useUpdateOpeningBalanceAndDate } from '../OpeningBalanceModal/OpeningBalanceModal'
+import { getAccountsNeedingConfirmation } from '../../../hooks/useLinkedAccounts/useLinkedAccounts'
 
-type AccountConfirmExcludeFormState = LinkAccountForm[]
+type AccountConfirmExcludeFormState = ConfirmAndOpeningBalanceFormData[]
 
 type LinkedAccountsConfirmationModalStringOverrides = {
   title?: string
@@ -202,9 +202,9 @@ function LinkedAccountsConfirmationModalContent({
 }) {
   const { accounts, onDismiss, onFinish, refetchAccounts } = useLinkedAccountsConfirmationModal()
 
-  const childRefs = useRef<LinkAccountToConfirmRef[]>([])
+  const childRefs = useRef<ConfirmAndOpeningBalanceFormRef[]>([])
 
-  const [ formState, setFormState ] = useState<LinkAccountForm[]>([])
+  const [ formState, setFormState ] = useState<ConfirmAndOpeningBalanceFormData[]>([])
 
   const {
     trigger: triggerConfirmAndExclude,
@@ -276,8 +276,8 @@ function LinkedAccountsConfirmationModalContent({
           Container={({ children }) => <VStack gap='md'>{children}</VStack>}
         >
           {({ item }, index) =>
-            <LinkedAccountToConfirm
-              ref={(el: LinkAccountToConfirmRef) => childRefs.current[index] = el}
+            <ConfirmAndOpeningBalanceForm
+              ref={(el: ConfirmAndOpeningBalanceFormRef) => childRefs.current[index] = el}
               key={item.id}
               account={item}
               defaultValue={{ account: item, isConfirmed: true }}

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
@@ -15,6 +15,8 @@ import { P } from '../../ui/Typography/Text'
 import { useAuth } from '../../../hooks/useAuth'
 import { useLayerContext } from '../../../contexts/LayerContext'
 import { LoadingSpinner } from '../../ui/Loading/LoadingSpinner'
+import { getAccountsNeedingConfirmation } from '../../../hooks/useLinkedAccounts/useLinkedAccounts'
+import { useUpdateOpeningBalanceAndDate } from '../OpeningBalanceModal/OpeningBalanceModal'
 
 type AccountConfirmExcludeFormState = LinkAccountForm[]
 
@@ -78,53 +80,6 @@ function useConfirmAndExcludeMultiple(
   )
 }
 
-function useUpdateOpeningBalanceAndDate(
-  formState: AccountConfirmExcludeFormState,
-  { onSuccess }: { onSuccess: () => Awaitable<unknown> }
-) {
-  const { data: _auth } = useAuth()
-  const { businessId } = useLayerContext()
-
-  const updateData = ({
-    account: { id: _accountId },
-    openingBalance: _openingBalance,
-    openingDate: _openingDate,
-  }: LinkAccountForm) => {
-    /**
-     * @TODO - add API call to update opening balances and dates
-    */
-    // return Layer.----(
-    //   auth?.apiUrl ?? '',
-    //   auth?.access_token,
-    //   {
-    //     params: {
-    //       businessId,
-    //       accountId,
-    //     },
-    //     body: {
-    //       is_irrelevant: true,
-    //     }
-    //   }
-    // )
-    return Promise.resolve()
-  }
-
-  return useSWRMutation(
-    `/v1/businesses/${businessId}/external-accounts/balances`,
-    () => Promise.all(
-      formState.map((item) =>
-        updateData(item)
-      )
-    )
-      .then(() => onSuccess())
-      .then(() => true as const),
-    {
-      revalidate: false,
-      throwOnError: false,
-    }
-  )
-}
-
 function getButtonLabel(
   { totalCount, confirmedCount }: { totalCount: number, confirmedCount: number }
 ) {
@@ -165,7 +120,8 @@ function useLinkedAccountsConfirmationModal() {
   /**
    * @TODO revert changes below
    */
-  const accountsNeedingConfirmation = data ?? [] //getAccountsNeedingConfirmation(data ?? [])
+  // const accountsNeedingConfirmation = data ?? [] //getAccountsNeedingConfirmation(data ?? [])
+  const accountsNeedingConfirmation = getAccountsNeedingConfirmation(data ?? [])
 
   const {
     visibility,

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
@@ -17,6 +17,7 @@ import { useLayerContext } from '../../../contexts/LayerContext'
 import { LoadingSpinner } from '../../ui/Loading/LoadingSpinner'
 import { useUpdateOpeningBalanceAndDate } from '../OpeningBalanceModal/OpeningBalanceModal'
 import { getAccountsNeedingConfirmation } from '../../../hooks/useLinkedAccounts/useLinkedAccounts'
+import { getActivationDate } from '../../../utils/business'
 
 type AccountConfirmExcludeFormState = ConfirmAndOpeningBalanceFormData[]
 
@@ -117,10 +118,6 @@ function getFormComponentLabels(formState: AccountConfirmExcludeFormState) {
 
 function useLinkedAccountsConfirmationModal() {
   const { data, refetchAccounts } = useLinkedAccounts()
-  /**
-   * @TODO revert changes below
-   */
-  // const accountsNeedingConfirmation = data ?? [] //getAccountsNeedingConfirmation(data ?? [])
   const accountsNeedingConfirmation = getAccountsNeedingConfirmation(data ?? [])
 
   const {
@@ -200,6 +197,7 @@ function LinkedAccountsConfirmationModalContent({
   compact?: boolean
   stringOverrides?: LinkedAccountsConfirmationModalStringOverrides
 }) {
+  const { business } = useLayerContext()
   const { accounts, onDismiss, onFinish, refetchAccounts } = useLinkedAccountsConfirmationModal()
 
   const childRefs = useRef<ConfirmAndOpeningBalanceFormRef[]>([])
@@ -280,7 +278,7 @@ function LinkedAccountsConfirmationModalContent({
               ref={(el: ConfirmAndOpeningBalanceFormRef) => childRefs.current[index] = el}
               key={item.id}
               account={item}
-              defaultValue={{ account: item, isConfirmed: true }}
+              defaultValue={{ account: item, isConfirmed: true, openingDate: getActivationDate(business) }}
               compact={compact}
             />
           }

--- a/src/components/LinkedAccounts/ConfirmationModal/linkedAccountToConfirm.scss
+++ b/src/components/LinkedAccounts/ConfirmationModal/linkedAccountToConfirm.scss
@@ -4,6 +4,43 @@
   padding-inline: var(--spacing-md);
   padding-block: var(--spacing-sm);
 
-  display: grid;
-  grid-template-columns: 1fr auto;
+  display: flex;
+  gap: var(--spacing-sm);
+
+  .Layer__datepicker__wrapper .react-datepicker__input-container input {
+    max-width: none;
+    width: 100%;
+  }
+
+  &.Layer__LinkedAccountToConfirm--compact {
+    .Layer__input-group {
+      width: 100%;
+      max-width: 180px;
+
+      .Layer__input-tooltip input {
+        width: 100%;
+      }
+    }
+  }
+
+  &:not(.Layer__LinkedAccountToConfirm--compact) {
+    .Layer__input-group {
+      width: 50%;
+      max-width: 180px;
+
+      .Layer__input-label {
+        white-space: nowrap;
+      }
+    }
+  }
 }
+
+.Layer__LinkedAccountToConfirm__main-col {
+  flex: 1;
+}
+
+.Layer__LinkedAccountToConfirm__form {
+  padding-top: var(--spacing-xs);
+  border-top: 1px solid var(--border-color);
+}
+

--- a/src/components/LinkedAccounts/LinkedAccountItemThumb.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountItemThumb.tsx
@@ -59,8 +59,7 @@ export const LinkedAccountItemThumb = ({
         },
       ],
     }
-    /** @TODO temporary - remove */
-  } else if (account.connection_needs_repair_as_of || true) {
+  } else if (account.connection_needs_repair_as_of) {
     pillConfig = {
       text: 'Fix account',
       config: [

--- a/src/components/LinkedAccounts/LinkedAccountItemThumb.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountItemThumb.tsx
@@ -59,7 +59,8 @@ export const LinkedAccountItemThumb = ({
         },
       ],
     }
-  } else if (account.connection_needs_repair_as_of) {
+    /** @TODO temporary - remove */
+  } else if (account.connection_needs_repair_as_of || true) {
     pillConfig = {
       text: 'Fix account',
       config: [

--- a/src/components/LinkedAccounts/LinkedAccountsContent.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountsContent.tsx
@@ -57,7 +57,7 @@ export const LinkedAccountsContent = ({
           </div>
         </div>
       </div>
-      <LinkedAccountsConfirmationModal />
+      <LinkedAccountsConfirmationModal compact={true} />
     </>
   )
 }

--- a/src/components/LinkedAccounts/LinkedAccountsContent.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountsContent.tsx
@@ -5,7 +5,6 @@ import { Text, TextSize } from '../Typography'
 import { LinkedAccountItemThumb } from './LinkedAccountItemThumb'
 import classNames from 'classnames'
 import { LinkedAccountsConfirmationModal } from '../LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal'
-import { LinkedAccount } from '../../types/linked_accounts'
 
 interface LinkedAccountsDataProps {
   asWidget?: boolean

--- a/src/components/LinkedAccounts/LinkedAccountsContent.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountsContent.tsx
@@ -5,6 +5,7 @@ import { Text, TextSize } from '../Typography'
 import { LinkedAccountItemThumb } from './LinkedAccountItemThumb'
 import classNames from 'classnames'
 import { LinkedAccountsConfirmationModal } from '../LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal'
+import { LinkedAccount } from '../../types/linked_accounts'
 
 interface LinkedAccountsDataProps {
   asWidget?: boolean

--- a/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
+++ b/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { Modal } from '../../ui/Modal/Modal'
+import { ModalContextBar, ModalHeading, ModalActions, ModalContent, ModalDescription } from '../../ui/Modal/ModalSlots'
+import useSWRMutation from 'swr/mutation'
+
+import { Button } from '../../ui/Button/Button'
+import { VStack } from '../../ui/Stack/Stack'
+import { useLinkedAccounts } from '../../../hooks/useLinkedAccounts'
+import { ConditionalList } from '../../utility/ConditionalList'
+import { LinkAccountForm, LinkAccountToConfirmRef, LinkedAccountToConfirm } from '../ConfirmationModal/LinkedAccountToConfirm'
+import type { Awaitable } from '../../../types/utility/promises'
+import { P } from '../../ui/Typography/Text'
+import { useAuth } from '../../../hooks/useAuth'
+import { useLayerContext } from '../../../contexts/LayerContext'
+import { LinkedAccount } from '../../../types/linked_accounts'
+import { Layer } from '../../../api/layer'
+
+type OpeningBalanceModalStringOverrides = {
+  title?: string
+  description?: string
+  buttonText?: string
+}
+
+export function useUpdateOpeningBalanceAndDate(
+  formState: LinkAccountForm[],
+  { onSuccess }: { onSuccess: () => Awaitable<unknown> }
+) {
+  const { data: auth } = useAuth()
+  const { businessId } = useLayerContext()
+
+  const updateData = ({
+    account: { id: accountId },
+    openingBalance: openingBalance,
+    openingDate: openingDate,
+  }: LinkAccountForm) => {
+    return Layer.updateOpeningBalance(
+      auth?.apiUrl ?? '',
+      auth?.access_token,
+      {
+        params: {
+          businessId,
+          accountId,
+        },
+        body: {
+          effective_at: openingDate?.toISOString(),
+          balance: openingBalance ? openingBalance.toString() : undefined,
+        }
+      }
+    )
+  }
+
+  return useSWRMutation(
+    `/v1/businesses/${businessId}/external-accounts/opening-balance`,
+    () => Promise.all(
+      formState.map((item) => {
+        if (item.openingBalance && item.openingDate) {
+          updateData(item)
+        }
+      }
+      )
+    )
+      .then(() => onSuccess())
+      .then(() => true as const),
+    {
+      revalidate: false,
+      throwOnError: false,
+    }
+  )
+}
+
+function LinkedAccountsOpeningBalanceModalContent({
+  onClose,
+  account,
+  stringOverrides,
+}: {
+  onClose: () => void
+  account: LinkedAccount
+  stringOverrides?: OpeningBalanceModalStringOverrides
+}) {
+  const { refetchAccounts } = useLinkedAccounts()
+
+  const childRefs = useRef<LinkAccountToConfirmRef[]>([])
+
+  const [ formState, setFormState ] = useState<LinkAccountForm[]>([])
+
+  const {
+    trigger,
+    isMutating,
+    error: hasError
+  } = useUpdateOpeningBalanceAndDate(formState, {
+    onSuccess: refetchAccounts
+  })
+
+  useEffect(() => {
+    if (formState.length > 0) {
+      saveData()
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formState])
+
+  const handleDismiss = () => {
+    onClose()
+  }
+
+  const handleFinish = () => {
+    const data = childRefs.current.map(ref => ref.getData())
+    setFormState(data)
+  }
+
+  const saveData = async () => {
+    const successBalanceUpdate = await trigger()
+
+    if (successBalanceUpdate) {
+      onClose()
+    }
+  }
+
+  return (
+    <>
+      <ModalContextBar onClose={handleDismiss} />
+      <ModalHeading pbe='2xs'>
+        {stringOverrides?.title ?? 'Add opening balance'}
+      </ModalHeading>
+      <ModalDescription pbe='md'>
+        {stringOverrides?.description}
+      </ModalDescription>
+      <ModalContent>
+        <ConditionalList
+          list={[account]}
+          Empty={
+            <VStack slot='center'>
+              <P align='center'>
+                You can close this modal.
+              </P>
+            </VStack>
+          }
+          Container={({ children }) => <VStack gap='md'>{children}</VStack>}
+        >
+          {({ item }, index) =>
+            <LinkedAccountToConfirm
+              ref={(el: LinkAccountToConfirmRef) => childRefs.current[index] = el}
+              key={item.id}
+              account={item}
+              defaultValue={{ account: item, isConfirmed: true }}
+              compact={true}
+              disableConfirmExclude={true}
+            />
+          }
+        </ConditionalList>
+      </ModalContent>
+      <ModalActions>
+        <VStack gap='md'>
+          {hasError
+            ? (
+              <>
+                <P size='sm'>
+                  An error occurred while add opening balance.
+                  You will have an opportunity to try again later.
+                </P>
+                <Button size='lg' onPress={handleDismiss}>
+                  Close
+                </Button>
+              </>
+            )
+            : (
+              <Button size='lg' onPress={handleFinish} isPending={isMutating}>
+                {stringOverrides?.buttonText ?? 'Submit'}
+              </Button>
+            )
+          }
+        </VStack>
+      </ModalActions>
+    </>
+  )
+}
+
+export function OpeningBalanceModal({
+  account,
+  onClose,
+  stringOverrides,
+}: {
+  account?: LinkedAccount
+  onClose: () => void
+  stringOverrides?: OpeningBalanceModalStringOverrides
+}) {
+  if (!account) {
+    return null
+  }
+
+  return (
+    <Modal isOpen={Boolean(account)}>
+      {({ close }) => (
+        <LinkedAccountsOpeningBalanceModalContent
+          account={account}
+          onClose={() => {
+            close()
+            onClose()
+          }}
+          stringOverrides={stringOverrides}
+        />
+      )}
+    </Modal>
+  )
+}

--- a/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
+++ b/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
@@ -14,6 +14,7 @@ import { useAuth } from '../../../hooks/useAuth'
 import { useLayerContext } from '../../../contexts/LayerContext'
 import { LinkedAccount } from '../../../types/linked_accounts'
 import { Layer } from '../../../api/layer'
+import { getActivationDate } from '../../../utils/business'
 
 type OpeningBalanceModalStringOverrides = {
   title?: string
@@ -53,8 +54,8 @@ export function useUpdateOpeningBalanceAndDate(
     `/v1/businesses/${businessId}/external-accounts/opening-balance`,
     () => Promise.all(
       formState.map((item) => {
-        if (item.openingBalance && item.openingDate) {
-          updateData(item)
+        if (item.openingBalance && item.openingDate && item.isConfirmed) {
+          return updateData(item)
         }
       }
       )
@@ -78,6 +79,7 @@ function LinkedAccountsOpeningBalanceModalContent({
   account: LinkedAccount
   stringOverrides?: OpeningBalanceModalStringOverrides
 }) {
+  const { business } = useLayerContext()
   const { refetchAccounts } = useLinkedAccounts()
 
   const childRefs = useRef<ConfirmAndOpeningBalanceFormRef[]>([])
@@ -142,7 +144,7 @@ function LinkedAccountsOpeningBalanceModalContent({
               ref={(el: ConfirmAndOpeningBalanceFormRef) => childRefs.current[index] = el}
               key={item.id}
               account={item}
-              defaultValue={{ account: item, isConfirmed: true }}
+              defaultValue={{ account: item, isConfirmed: true, openingDate: getActivationDate(business) }}
               compact={true}
               disableConfirmExclude={true}
             />

--- a/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
+++ b/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
@@ -7,7 +7,7 @@ import { Button } from '../../ui/Button/Button'
 import { VStack } from '../../ui/Stack/Stack'
 import { useLinkedAccounts } from '../../../hooks/useLinkedAccounts'
 import { ConditionalList } from '../../utility/ConditionalList'
-import { LinkAccountForm, LinkAccountToConfirmRef, LinkedAccountToConfirm } from '../ConfirmationModal/LinkedAccountToConfirm'
+import { ConfirmAndOpeningBalanceFormData, ConfirmAndOpeningBalanceFormRef, ConfirmAndOpeningBalanceForm } from '../ConfirmAndOpeningBalanceForm/ConfirmAndOpeningBalanceForm'
 import type { Awaitable } from '../../../types/utility/promises'
 import { P } from '../../ui/Typography/Text'
 import { useAuth } from '../../../hooks/useAuth'
@@ -22,7 +22,7 @@ type OpeningBalanceModalStringOverrides = {
 }
 
 export function useUpdateOpeningBalanceAndDate(
-  formState: LinkAccountForm[],
+  formState: ConfirmAndOpeningBalanceFormData[],
   { onSuccess }: { onSuccess: () => Awaitable<unknown> }
 ) {
   const { data: auth } = useAuth()
@@ -32,7 +32,7 @@ export function useUpdateOpeningBalanceAndDate(
     account: { id: accountId },
     openingBalance: openingBalance,
     openingDate: openingDate,
-  }: LinkAccountForm) => {
+  }: ConfirmAndOpeningBalanceFormData) => {
     return Layer.updateOpeningBalance(
       auth?.apiUrl ?? '',
       auth?.access_token,
@@ -68,6 +68,7 @@ export function useUpdateOpeningBalanceAndDate(
   )
 }
 
+
 function LinkedAccountsOpeningBalanceModalContent({
   onClose,
   account,
@@ -79,9 +80,9 @@ function LinkedAccountsOpeningBalanceModalContent({
 }) {
   const { refetchAccounts } = useLinkedAccounts()
 
-  const childRefs = useRef<LinkAccountToConfirmRef[]>([])
+  const childRefs = useRef<ConfirmAndOpeningBalanceFormRef[]>([])
 
-  const [ formState, setFormState ] = useState<LinkAccountForm[]>([])
+  const [ formState, setFormState ] = useState<ConfirmAndOpeningBalanceFormData[]>([])
 
   const {
     trigger,
@@ -137,8 +138,8 @@ function LinkedAccountsOpeningBalanceModalContent({
           Container={({ children }) => <VStack gap='md'>{children}</VStack>}
         >
           {({ item }, index) =>
-            <LinkedAccountToConfirm
-              ref={(el: LinkAccountToConfirmRef) => childRefs.current[index] = el}
+            <ConfirmAndOpeningBalanceForm
+              ref={(el: ConfirmAndOpeningBalanceFormRef) => childRefs.current[index] = el}
               key={item.id}
               account={item}
               defaultValue={{ account: item, isConfirmed: true }}

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -1,13 +1,15 @@
+import classNames from 'classnames'
 import React, { PropsWithChildren } from 'react'
 
 type PillKind = 'default' | 'info' | 'success' | 'warning' | 'error'
 
-type Props = PropsWithChildren & { kind?: PillKind; onHover?: () => void }
+type Props = PropsWithChildren & { kind?: PillKind; onHover?: () => void; onClick?: () => void }
 
-export const Pill = ({ children, kind = 'default', onHover }: Props) => (
+export const Pill = ({ children, kind = 'default', onHover, onClick }: Props) => (
   <span
     onMouseOver={onHover}
-    className={`Layer__pill ${kind === 'error' ? 'Layer__pill--error' : ''}`}
+    onClick={onClick}
+    className={classNames(`Layer__pill Layer__pill--${kind}`, onHover || onClick ? 'Layer__pill--actionable' : '')}
   >
     {children}
   </span>

--- a/src/components/ui/Checkbox/Checkbox.tsx
+++ b/src/components/ui/Checkbox/Checkbox.tsx
@@ -10,7 +10,7 @@ export function Checkbox({children, ...props}: Omit<CheckboxProps, 'className'>)
       {() =>
         <>
           <div slot='checkbox'>
-            <Check />
+            <Check size={16} />
           </div>
           {children}
         </>

--- a/src/components/ui/Stack/Stack.tsx
+++ b/src/components/ui/Stack/Stack.tsx
@@ -1,11 +1,14 @@
 import React, { useMemo, type PropsWithChildren } from 'react'
 import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'
+import classNames from 'classnames'
 
 export type StackProps = PropsWithChildren<{
   gap?: '3xs' | '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '5xl'
   align?: 'start' | 'center'
-  justify?: 'center'
+  justify?: 'center' | 'start' | 'end'
+  flex?: string
   slot?: string
+  className?: string
 }>
 
 type InternalStackProps = StackProps & {
@@ -14,14 +17,16 @@ type InternalStackProps = StackProps & {
 
 const CLASS_NAME = 'Layer__Stack'
 
-function Stack({ align, children, direction, gap, justify, ...restProps }: InternalStackProps) {
+export function Stack(
+  { align, children, direction, gap, justify, className, ...restProps }: InternalStackProps
+) {
   const dataProperties = useMemo(
     () => toDataProperties({ align, gap, justify, direction }),
     [align, direction, gap, justify],
   )
 
   return (
-    <div {...restProps} {...dataProperties} className={CLASS_NAME}>
+    <div {...restProps} {...dataProperties} className={classNames(CLASS_NAME, className)}>
       {children}
     </div>
   )

--- a/src/components/utility/ConditionalList.tsx
+++ b/src/components/utility/ConditionalList.tsx
@@ -28,7 +28,7 @@ export function ConditionalList<T>({
     return Empty
   }
 
-  const listItems = list.map((item) => children({ item }))
+  const listItems = list.map((item, index) => children({ item }, index))
 
   return Container ? <Container>{listItems}</Container> : listItems
 }

--- a/src/hooks/useLinkedAccounts/useLinkedAccounts.ts
+++ b/src/hooks/useLinkedAccounts/useLinkedAccounts.ts
@@ -17,10 +17,6 @@ export function getAccountsNeedingConfirmation(linkedAccounts: ReadonlyArray<Lin
   )
 }
 
-function accountNeedsConfirmation(linkedAccounts: ReadonlyArray<LinkedAccount>) {
-  return getAccountsNeedingConfirmation(linkedAccounts).length > 0
-}
-
 type UseLinkedAccounts = () => {
   data?: LinkedAccount[]
   isLoading: boolean
@@ -43,9 +39,6 @@ type UseLinkedAccounts = () => {
 
 const DEBUG = false
 const USE_MOCK_RESPONSE_DATA = false
-
-const MAX_POLLING_ATTEMPTS = 5
-const POLLING_INTERVAL = 1000
 
 type LinkMode = 'update' | 'add'
 

--- a/src/hooks/useLinkedAccounts/useLinkedAccounts.ts
+++ b/src/hooks/useLinkedAccounts/useLinkedAccounts.ts
@@ -98,6 +98,7 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     if (!isLoading && loadingStatus === 'loading') {
       setLoadingStatus('complete')
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading])
 
   /**
@@ -340,12 +341,14 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     if (queryKey && (isLoading || isValidating)) {
       read(DataModel.LINKED_ACCOUNTS, queryKey)
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading, isValidating])
 
   useEffect(() => {
     if (queryKey && hasBeenTouched(queryKey)) {
       refetchAccounts()
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [syncTimestamps])
 
   return {

--- a/src/styles/datepicker.scss
+++ b/src/styles/datepicker.scss
@@ -2,6 +2,8 @@
 
 .Layer__datepicker__wrapper,
 #Layer__datepicker__portal {
+  position: relative;
+  z-index: 101;
   display: inline-flex;
   align-items: center;
   max-height: 36px;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -28,7 +28,7 @@
 
 @import '../components/ui/index.scss';
 @import '../components/utility/index.scss';
-@import '../components/LinkedAccounts/ConfirmationModal/linkedAccountToConfirm.scss';
+@import '../components/LinkedAccounts/ConfirmAndOpeningBalanceForm/confirmAndOpeningBalanceForm.scss';
 
 @import '../components/TasksMonthSelector/tasksMonthSelector.scss';
 

--- a/src/styles/linked_accounts.scss
+++ b/src/styles/linked_accounts.scss
@@ -146,8 +146,8 @@
   background: var(--color-base-0);
   border: 1px solid var(--color-base-100);
   box-sizing: border-box;
-  width: 286px;
-  height: 136px;
+  width: 300px;
+  height: 170px;
   justify-content: space-between;
 
   &.--show-ledger-balance {
@@ -180,25 +180,47 @@
 
     .account-institution {
       color: var(--color-base-500);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .topbar-details {
       display: flex;
       flex-direction: column;
-      gap: var(--spacing-4xs);
+      gap: var(--spacing-2xs);
       justify-content: stretch;
+      width: 100%;
+    }
+
+    .topbar-details-main {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .topbar-details-main__name {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .topbar-details-secondary {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      min-height: 27px;
     }
 
     .topbar-logo {
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 52px;
-      height: 28px;
+      width: 36px;
+      height: 36px;
       padding: var(--spacing-3xs) 0;
       background: var(--color-base-0);
       color: var(--color-base-200);
       border-radius: var(--border-radius-3xs);
+      box-sizing: border-box;
     }
 
     .account-name {

--- a/src/styles/pill.scss
+++ b/src/styles/pill.scss
@@ -20,3 +20,16 @@
   background-color: var(--color-info-error-bg);
   color: var(--color-info-error-fg);
 }
+
+.Layer__pill--info {
+  background-color: var(--color-info-bg);
+  color: var(--color-info-fg);
+}
+
+.Layer__pill--actionable {
+  cursor: pointer;
+}
+
+.Layer__pill--actionable:hover {
+  opacity: 0.7;
+}

--- a/src/types/linked_accounts.ts
+++ b/src/types/linked_accounts.ts
@@ -48,6 +48,7 @@ export type LinkedAccount = {
   connection_external_id?: string
   connection_needs_repair_as_of: string | null
   is_syncing: boolean
+  opening_account_balance_missing?: boolean
 }
 
 export type LinkedAccounts = {


### PR DESCRIPTION
## Description

Add "Account balance" and "Account date" inputs to linking account.

Missing:

`external_accounts` need some field that tells if "Add account balance" should be shown. When API is ready, we can tweak: `LinkedAccountItemThumb.tsx` by adding:

```ts
   <LinkedAccountThumb
        account={account}
        asWidget={asWidget}
        showLedgerBalance={showLedgerBalance}
        pillConfig={pillConfig}
        addOpeningBankBalance={account.<field_name>} // <--- new field
      />
```

## How this has been tested?

Regular:

![Screenshot 2024-12-09 at 07 33 23](https://github.com/user-attachments/assets/375e5dd1-ae94-4a71-977a-6446adbf7d96)

<br/>

Compact:

![Screenshot 2024-12-09 at 07 33 54](https://github.com/user-attachments/assets/314b88f7-4431-4f8f-a24d-2d06d8a36625)


https://github.com/user-attachments/assets/487c84e5-1e0f-4fb2-923e-c175b963e5b6

```
{
    "errors": [
        {
            "type": "LedgerOperationFailed",
            "description": "Cannot archive PLAID transaction 72f4a6ff-acff-474f-8c20-0b2a06479863 since it has ledger entries associated with it: 4165d42e-5e04-4e86-b1e1-98bae77701f0, 69c95eaa-60bc-4820-b8dc-ca8647763b39, 27daf12b-c751-449e-bb46-c23683ce4519, d195aa9f-8887-4d1d-b709-5c11a47aaf17, 4b93cc23-9d2e-47bc-831b-b8bd612f6b61, 3ed02690-85c4-4cd4-ae43-fcb6b9ce34ae, f10bd8fb-c77c-42ac-a140-87a676e7a757, 78e8dfbc-ae21-49ae-9be9-0c8389cc5052, f0c65e66-beb7-4321-acf6-a5c6b5099e8a, b0904de9-6332-47ae-9710-1d206ed520d9, 69a42181-02ca-4c38-8ff8-407ce798a8e3, 4a910c79-ba0d-42f3-8aac-2b5e806ea8e5, ee87af39-415c-4fcd-98a3-0b1380676332, 0cfe5f1e-4bb5-4794-85c3-d4e42cbe21ce, 511ed0ed-85ec-4f16-9d8c-80aa5b30cefe, 24d97852-fd44-436c-8f21-46f6d267ab16, 030260b4-f1b6-462e-ba27-a5611d81bad1, d0477fd0-7181-4e69-9286-806ab40190c9."
        }
    ]
}
```