### PR TITLE
fix: `BookkeeppingTasks` component should scroll when there are many tasks

### DIFF
--- a/src/styles/tasks.scss
+++ b/src/styles/tasks.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
+  overflow-y: auto;
   border-radius: 8px;
   box-shadow: 0px 0px 0px 1px var(--color-base-300);
   background-color: var(--color-base-0);


### PR DESCRIPTION
## Description

When the overflow is hidden, the element will not get any taller than its sibling (the main content). This is a major issue when there are more than a few tasks.