### PR TITLE
[LAY-1128] feat: unify all major date pickers through global state

### DIFF
--- a/src/components/BalanceSheet/BalanceSheet.tsx
+++ b/src/components/BalanceSheet/BalanceSheet.tsx
@@ -3,7 +3,7 @@ import { BalanceSheetContext } from '../../contexts/BalanceSheetContext'
 import { TableProvider } from '../../contexts/TableContext'
 import { useBalanceSheet } from '../../hooks/useBalanceSheet'
 import { useElementViewSize } from '../../hooks/useElementViewSize/useElementViewSize'
-import { BalanceSheetDatePicker } from '../BalanceSheetDatePicker'
+import { BalanceSheetDatePicker } from '../BalanceSheetDatePicker/BalanceSheetDatePicker'
 import { BalanceSheetExpandAllButton } from '../BalanceSheetExpandAllButton'
 import { BalanceSheetTable } from '../BalanceSheetTable'
 import { BalanceSheetTableStringOverrides } from '../BalanceSheetTable/BalanceSheetTable'
@@ -12,8 +12,8 @@ import { Header, HeaderCol, HeaderRow } from '../Header'
 import { Loader } from '../Loader'
 import { View } from '../View'
 import { BALANCE_SHEET_ROWS } from './constants'
-import { format, parse, startOfDay } from 'date-fns'
 import { BalanceSheetDownloadButton } from './download/BalanceSheetDownloadButton'
+import { useGlobalDate } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 
 export interface BalanceSheetStringOverrides {
   balanceSheetTable?: BalanceSheetTableStringOverrides
@@ -51,27 +51,9 @@ const BalanceSheetView = ({
   asWidget = false,
   stringOverrides,
 }: BalanceSheetViewProps) => {
-  const [effectiveDate, setEffectiveDate] = useState(startOfDay(new Date()))
-  const { data, isLoading, refetch } = useBalanceSheet(effectiveDate)
+  const { date: effectiveDate } = useGlobalDate()
+  const { data, isLoading } = useBalanceSheet(effectiveDate)
   const { view, containerRef } = useElementViewSize<HTMLDivElement>()
-
-  useEffect(() => {
-    // Refetch only if selected effectiveDate and data's effectiveDate are different
-    const d1 =
-      effectiveDate
-      && format(startOfDay(effectiveDate), 'yyyy-MM-dd\'T\'HH:mm:ssXXX')
-    const d2 =
-      data?.effective_date
-      && format(
-        startOfDay(
-          parse(data.effective_date, 'yyyy-MM-dd\'T\'HH:mm:ssXXX', new Date()),
-        ),
-        'yyyy-MM-dd\'T\'HH:mm:ssXXX',
-      )
-    if (d1 && (!d2 || (d2 && d2 !== d1))) {
-      refetch()
-    }
-  }, [effectiveDate])
 
   if (asWidget) {
     return (
@@ -80,14 +62,11 @@ const BalanceSheetView = ({
           <View
             type='panel'
             ref={containerRef}
-            header={
+            header={(
               <Header>
                 <HeaderRow>
                   <HeaderCol>
-                    <BalanceSheetDatePicker
-                      effectiveDate={effectiveDate}
-                      setEffectiveDate={setEffectiveDate}
-                    />
+                    <BalanceSheetDatePicker />
                   </HeaderCol>
                   {withExpandAllButton && (
                     <HeaderCol>
@@ -96,19 +75,21 @@ const BalanceSheetView = ({
                   )}
                 </HeaderRow>
               </Header>
-            }
-          >
-            {!data || isLoading ? (
-              <div className={`Layer__${COMPONENT_NAME}__loader-container`}>
-                <Loader />
-              </div>
-            ) : (
-              <BalanceSheetTable
-                data={data}
-                config={BALANCE_SHEET_ROWS}
-                stringOverrides={stringOverrides?.balanceSheetTable}
-              />
             )}
+          >
+            {!data || isLoading
+              ? (
+                <div className={`Layer__${COMPONENT_NAME}__loader-container`}>
+                  <Loader />
+                </div>
+              )
+              : (
+                <BalanceSheetTable
+                  data={data}
+                  config={BALANCE_SHEET_ROWS}
+                  stringOverrides={stringOverrides?.balanceSheetTable}
+                />
+              )}
           </View>
         </Container>
       </TableProvider>
@@ -120,14 +101,11 @@ const BalanceSheetView = ({
       <View
         type='panel'
         ref={containerRef}
-        header={
+        header={(
           <Header>
             <HeaderRow>
               <HeaderCol>
-                <BalanceSheetDatePicker
-                  effectiveDate={effectiveDate}
-                  setEffectiveDate={setEffectiveDate}
-                />
+                <BalanceSheetDatePicker />
               </HeaderCol>
               <HeaderCol>
                 {withExpandAllButton && (
@@ -140,19 +118,21 @@ const BalanceSheetView = ({
               </HeaderCol>
             </HeaderRow>
           </Header>
-        }
-      >
-        {!data || isLoading ? (
-          <div className={`Layer__${COMPONENT_NAME}__loader-container`}>
-            <Loader />
-          </div>
-        ) : (
-          <BalanceSheetTable
-            data={data}
-            config={BALANCE_SHEET_ROWS}
-            stringOverrides={stringOverrides?.balanceSheetTable}
-          />
         )}
+      >
+        {!data || isLoading
+          ? (
+            <div className={`Layer__${COMPONENT_NAME}__loader-container`}>
+              <Loader />
+            </div>
+          )
+          : (
+            <BalanceSheetTable
+              data={data}
+              config={BALANCE_SHEET_ROWS}
+              stringOverrides={stringOverrides?.balanceSheetTable}
+            />
+          )}
       </View>
     </TableProvider>
   )

--- a/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
+++ b/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
@@ -3,7 +3,7 @@ import { DatePicker } from '../DatePicker'
 import { useGlobalDate, useGlobalDateActions } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 
 export function BalanceSheetDatePicker() {
-  const { date, mode } = useGlobalDate()
+  const { date, displayMode } = useGlobalDate()
   const { set } = useGlobalDateActions()
 
   return (
@@ -14,7 +14,7 @@ export function BalanceSheetDatePicker() {
           set({ date })
         }
       }}
-      mode={mode}
+      displayMode={displayMode}
     />
   )
 }

--- a/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
+++ b/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
@@ -1,22 +1,20 @@
 import React from 'react'
 import { DatePicker } from '../DatePicker'
+import { useGlobalDate, useGlobalDateActions } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 
-export type BalanceSheetDatePickerProps = {
-  effectiveDate: Date
-  setEffectiveDate: (date: Date) => void
-}
+export function BalanceSheetDatePicker() {
+  const { date, mode } = useGlobalDate()
+  const { set } = useGlobalDateActions()
 
-export const BalanceSheetDatePicker = ({
-  effectiveDate,
-  setEffectiveDate,
-}: BalanceSheetDatePickerProps) => {
   return (
-    <>
-      <DatePicker
-        selected={effectiveDate}
-        onChange={date => date && setEffectiveDate(date as Date)}
-        mode='dayPicker'
-      />
-    </>
+    <DatePicker
+      selected={date}
+      onChange={(date) => {
+        if (date instanceof Date) {
+          set({ date })
+        }
+      }}
+      mode={mode}
+    />
   )
 }

--- a/src/components/BalanceSheetDatePicker/index.tsx
+++ b/src/components/BalanceSheetDatePicker/index.tsx
@@ -1,1 +1,0 @@
-export { BalanceSheetDatePicker } from './BalanceSheetDatePicker'

--- a/src/components/BankTransactions/BankTransactionsHeader.tsx
+++ b/src/components/BankTransactions/BankTransactionsHeader.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from 'react'
+import { ChangeEvent, useState } from 'react'
 import { Layer } from '../../api/layer'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { DateRange, DisplayState } from '../../types'
@@ -69,12 +69,15 @@ const DownloadButton = ({
       if (result?.data?.presignedUrl) {
         window.location.href = result.data.presignedUrl
         setRequestFailed(false)
-      } else {
+      }
+      else {
         setRequestFailed(true)
       }
-    } catch (e) {
+    }
+    catch (e) {
       setRequestFailed(true)
-    } finally {
+    }
+    finally {
       setIsDownloading(false)
     }
   }
@@ -134,21 +137,23 @@ export const BankTransactionsHeader = ({
             />
           )}
         </div>
-        {withDatePicker && dateRange && setDateRange ? (
-          <DatePicker
-            mode='monthPicker'
-            selected={dateRange.startDate}
-            onChange={date => {
-              if (!Array.isArray(date)) {
-                setDateRange({
-                  startDate: startOfMonth(date),
-                  endDate: endOfMonth(date),
-                })
-              }
-            }}
-            minDate={getEarliestDateToBrowse(business)}
-          />
-        ) : null}
+        {withDatePicker && dateRange && setDateRange
+          ? (
+            <DatePicker
+              displayMode='monthPicker'
+              selected={dateRange.startDate}
+              onChange={(date) => {
+                if (!Array.isArray(date)) {
+                  setDateRange({
+                    startDate: startOfMonth(date),
+                    endDate: endOfMonth(date),
+                  })
+                }
+              }}
+              minDate={getEarliestDateToBrowse(business)}
+            />
+          )
+          : null}
       </div>
       <div className='Layer__header__actions-wrapper'>
         <div className='Layer__header__actions Layer__justify--space-between'>

--- a/src/components/ChartOfAccountsDatePicker/ChartOfAccountsDatePicker.tsx
+++ b/src/components/ChartOfAccountsDatePicker/ChartOfAccountsDatePicker.tsx
@@ -8,9 +8,9 @@ export const ChartOfAccountsDatePicker = () => {
 
   return (
     <DatePicker
-      mode='monthPicker'
+      displayMode='monthPicker'
       selected={dateRange.startDate}
-      onChange={date => {
+      onChange={(date) => {
         if (!Array.isArray(date)) {
           changeDateRange({
             startDate: startOfMonth(date),

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -30,7 +30,7 @@ const ReactDatePicker = (((RDP.default as any).default as any)
 type NavigationArrows = 'desktop' | 'mobile'
 
 interface DatePickerProps {
-  mode: UnifiedPickerMode | 'timePicker'
+  displayMode: UnifiedPickerMode | 'timePicker'
   selected: Date | [Date, Date | null]
   onChange: (date: Date | [Date, Date | null]) => void
   disabled?: boolean
@@ -53,8 +53,8 @@ interface DatePickerProps {
   }
 }
 
-const isRangeMode = (mode: DatePickerProps['mode']) =>
-  mode === 'dayRangePicker' || mode === 'monthRangePicker'
+const isRangeMode = (displayMode: DatePickerProps['displayMode']) =>
+  displayMode === 'dayRangePicker' || displayMode === 'monthRangePicker'
 
 const showNavigationArrows = (navigateArrows?: NavigationArrows[], isDesktop?: boolean) => {
   return (navigateArrows && ((isDesktop && navigateArrows.includes('desktop')) || (!isDesktop && navigateArrows.includes('mobile'))))
@@ -64,11 +64,11 @@ export const DatePicker = ({
   selected,
   onChange,
   disabled,
-  mode = 'dayPicker',
+  displayMode = 'dayPicker',
   allowedModes,
-  dateFormat = mode === 'monthPicker' || mode === 'monthRangePicker'
+  dateFormat = displayMode === 'monthPicker' || displayMode === 'monthRangePicker'
     ? 'MMM, yyyy'
-    : mode === 'timePicker'
+    : displayMode === 'timePicker'
       ? 'h:mm aa'
       : 'MMM d, yyyy',
   timeIntervals = 15,
@@ -81,7 +81,7 @@ export const DatePicker = ({
   minDate,
   maxDate = new Date(),
   currentDateOption = true,
-  navigateArrows = mode === 'monthPicker' ? ['mobile'] : undefined,
+  navigateArrows = displayMode === 'monthPicker' ? ['mobile'] : undefined,
   onChangeMode,
   slots,
   ...props
@@ -95,43 +95,43 @@ export const DatePicker = ({
 
   const pickerMode = useMemo(() => {
     if (!allowedModes) {
-      return mode
+      return displayMode
     }
 
-    if (mode === 'timePicker') {
-      return mode
+    if (displayMode === 'timePicker') {
+      return displayMode
     }
 
-    if (allowedModes.includes(mode)) {
-      return mode
+    if (allowedModes.includes(displayMode)) {
+      return displayMode
     }
 
-    return allowedModes[0] ?? mode
-  }, [mode, allowedModes])
+    return allowedModes[0] ?? displayMode
+  }, [displayMode, allowedModes])
 
   const [firstDate, secondDate] = useMemo(() => {
     if (selected instanceof Date) {
       return [selected, null] as const
     }
 
-    if (isRangeMode(mode)) {
+    if (isRangeMode(displayMode)) {
       return selected
     }
 
     return [selected[0], null] as const
-  }, [selected, mode])
+  }, [selected, displayMode])
 
   const { isDesktop } = useSizeClass()
 
   const wrapperClassNames = classNames(
     'Layer__datepicker__wrapper',
-    mode === 'timePicker' && 'Layer__datepicker__time__wrapper',
+    displayMode === 'timePicker' && 'Layer__datepicker__time__wrapper',
     showNavigationArrows(navigateArrows, isDesktop) && 'Layer__datepicker__wrapper--arrows',
   )
 
   const datePickerWrapperClassNames = classNames(
     'Layer__datepicker',
-    mode === 'timePicker' && 'Layer__datepicker__time',
+    displayMode === 'timePicker' && 'Layer__datepicker__time',
     wrapperClassName,
   )
   const calendarClassNames = classNames(
@@ -140,7 +140,7 @@ export const DatePicker = ({
   )
   const popperClassNames = classNames(
     'Layer__datepicker__popper',
-    mode === 'timePicker' && 'Layer__datepicker__time__popper',
+    displayMode === 'timePicker' && 'Layer__datepicker__time__popper',
     popperClassName,
   )
 
@@ -215,7 +215,7 @@ export const DatePicker = ({
   }
 
   const isTodayOrAfter = useMemo(() => {
-    switch (mode) {
+    switch (displayMode) {
       case 'dayPicker':
         return firstDate >= endOfDay(new Date()) || firstDate >= maxDate
       case 'monthPicker':
@@ -231,7 +231,7 @@ export const DatePicker = ({
       default:
         return false
     }
-  }, [firstDate, maxDate, mode])
+  }, [firstDate, maxDate, displayMode])
 
   const isBeforeMinDate = Boolean(minDate && firstDate <= minDate)
 
@@ -266,18 +266,18 @@ export const DatePicker = ({
         // @ts-expect-error = There is no good way to define the type of the ref
         ref={pickerRef}
         wrapperClassName={datePickerWrapperClassNames}
-        startDate={isRangeMode(mode)
+        startDate={isRangeMode(displayMode)
           ? (isMidSelection
             ? internalStart
             : firstDate)
           : undefined}
-        endDate={isRangeMode(mode)
+        endDate={isRangeMode(displayMode)
           ? (isMidSelection
             ? internalEnd
             : secondDate)
           : undefined}
         selected={
-          mode !== 'dayRangePicker' && mode !== 'monthRangePicker'
+          displayMode !== 'dayRangePicker' && displayMode !== 'monthRangePicker'
             ? firstDate
             : undefined
         }
@@ -286,7 +286,7 @@ export const DatePicker = ({
         popperClassName={popperClassNames}
         enableTabLoop={false}
         popperPlacement='bottom-start'
-        selectsRange={isRangeMode(mode)}
+        selectsRange={isRangeMode(displayMode)}
         showMonthYearPicker={
           pickerMode === 'monthPicker' || pickerMode === 'monthRangePicker'
         }

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState, type FC } from 'react'
+import { useMemo, useRef, useState, type FC } from 'react'
 import * as RDP from 'react-datepicker'
 import { useSizeClass } from '../../hooks/useWindowSize'
 import ChevronLeft from '../../icons/ChevronLeft'
@@ -6,7 +6,7 @@ import ChevronRight from '../../icons/ChevronRight'
 import { Button, ButtonVariant } from '../Button'
 import { CustomDateRange, DatePickerOptions } from './DatePickerOptions'
 import type {
-  DatePickerMode,
+  UnifiedPickerMode,
   DatePickerModeSelectorProps,
 } from './ModeSelector/DatePickerModeSelector'
 import classNames from 'classnames'
@@ -30,11 +30,11 @@ const ReactDatePicker = (((RDP.default as any).default as any)
 type NavigationArrows = 'desktop' | 'mobile'
 
 interface DatePickerProps {
-  mode: DatePickerMode
-  selected: Date | [Date | null, Date | null]
+  mode: UnifiedPickerMode | 'timePicker'
+  selected: Date | [Date, Date | null]
   onChange: (date: Date | [Date, Date | null]) => void
   disabled?: boolean
-  allowedModes?: ReadonlyArray<DatePickerMode>
+  allowedModes?: ReadonlyArray<UnifiedPickerMode>
   dateFormat?: string
   timeIntervals?: number
   timeCaption?: string
@@ -47,29 +47,9 @@ interface DatePickerProps {
   minDate?: Date
   maxDate?: Date
   navigateArrows?: NavigationArrows[]
-  onChangeMode?: (mode: DatePickerMode) => void
+  onChangeMode?: (mode: UnifiedPickerMode) => void
   slots?: {
     ModeSelector: FC<DatePickerModeSelectorProps>
-  }
-}
-
-const getDefaultRangeDate = (
-  date: 'start' | 'end',
-  mode: DatePickerProps['mode'],
-  selected: Date | [Date | null, Date | null],
-) => {
-  try {
-    if (isRangeMode(mode) && selected) {
-      if (date === 'end') {
-        return (selected as [Date | null, Date | null])[1]
-      }
-      return (selected as [Date | null, Date | null])[0]
-    }
-
-    return null
-  }
-  catch (_err) {
-    return null
   }
 }
 
@@ -113,63 +93,35 @@ export const DatePicker = ({
     isCalendarOpen: () => boolean
   }>(null)
 
-  const [updatePickerDate, setPickerDate] = useState<boolean>(false)
-  const [selectedDates, setSelectedDates] = useState<
-    Date | [Date | null, Date | null] | null
-  >(selected)
+  const pickerMode = useMemo(() => {
+    if (!allowedModes) {
+      return mode
+    }
+
+    if (mode === 'timePicker') {
+      return mode
+    }
+
+    if (allowedModes.includes(mode)) {
+      return mode
+    }
+
+    return allowedModes[0] ?? mode
+  }, [mode, allowedModes])
+
+  const [firstDate, secondDate] = useMemo(() => {
+    if (selected instanceof Date) {
+      return [selected, null] as const
+    }
+
+    if (isRangeMode(mode)) {
+      return selected
+    }
+
+    return [selected[0], null] as const
+  }, [selected, mode])
 
   const { isDesktop } = useSizeClass()
-
-  const [startDate, setStartDate] = useState<Date | null>(
-    getDefaultRangeDate('start', mode, selected) ?? new Date(),
-  )
-  const [endDate, setEndDate] = useState<Date | null>(
-    getDefaultRangeDate('end', mode, selected),
-  )
-
-  useEffect(() => {
-    try {
-      setPickerDate(true)
-      if (
-        !isRangeMode(mode)
-        && (selected as Date | null)?.getTime()
-        !== (selectedDates as Date | null)?.getTime()
-      ) {
-        setSelectedDates(selected)
-        return
-      }
-
-      if (isRangeMode(mode) && Array.isArray(selected)) {
-        if ((startDate)?.getTime() !== selected[0]?.getTime()) {
-          setStartDate(selected[0])
-        }
-        if ((endDate)?.getTime() !== selected[1]?.getTime()) {
-          setEndDate(selected[1])
-        }
-      }
-    }
-    catch (_err) {
-      return
-    }
-  }, [selected])
-
-  useEffect(() => {
-    if (
-      onChange
-      && (!isRangeMode(mode) || (isRangeMode(mode) && !updatePickerDate))
-    ) {
-      onChange(selectedDates as Date | [Date, Date])
-    }
-    else {
-      setPickerDate(false)
-    }
-  }, [selectedDates])
-
-  useEffect(() => {
-    if (isRangeMode(mode)) {
-      setSelectedDates([startDate, endDate])
-    }
-  }, [startDate, endDate])
 
   const wrapperClassNames = classNames(
     'Layer__datepicker__wrapper',
@@ -192,157 +144,141 @@ export const DatePicker = ({
     popperClassName,
   )
 
-  const handleDateChange = (date: Date | [Date | null, Date | null]) => {
-    if (isRangeMode(mode)) {
-      const [start, end] = date as [Date | null, Date | null]
-      setStartDate(start)
-      setEndDate(end)
+  const [internalStart, setInternalStart] = useState<Date | null>(null)
+  const [internalEnd, setInternalEnd] = useState<Date | null>(null)
+
+  const isMidSelection = internalStart !== null && internalEnd === null
+
+  const handleDateChange = (selectedDate: Date | [Date, Date | null]) => {
+    if (selectedDate instanceof Date) {
+      onChange(selectedDate)
       return
     }
 
-    setSelectedDates(date)
+    const [start, end] = selectedDate
+
+    if (!end) {
+      if (isRangeMode(pickerMode)) {
+        setInternalStart(start)
+        setInternalEnd(null)
+      }
+      else {
+        onChange(start)
+      }
+      return
+    }
+
+    onChange([start, end])
+    setInternalStart(null)
+    setInternalEnd(null)
+  }
+
+  const handleSetCustomDate = (selectedCustomDate: Date | [Date, Date | null]) => {
+    handleDateChange(selectedCustomDate)
+    pickerRef.current?.setOpen(false)
   }
 
   const isCurrentDate = () => {
     const currentDate = new Date()
-    if (mode === 'dayPicker') {
-      return (
-        selectedDates instanceof Date
-        && selectedDates.toDateString() === currentDate.toDateString()
-      )
+
+    switch (pickerMode) {
+      case 'dayPicker':
+        return firstDate.toDateString() === currentDate.toDateString()
+      case 'monthPicker':
+        return (
+          firstDate.getMonth() === currentDate.getMonth()
+          && firstDate.getFullYear() === currentDate.getFullYear()
+        )
+      case 'yearPicker':
+        return firstDate.getFullYear() === currentDate.getFullYear()
+      default:
+        return false
     }
-    else if (mode === 'monthPicker') {
-      return (
-        selectedDates instanceof Date
-        && selectedDates.getMonth() === currentDate.getMonth()
-        && selectedDates.getFullYear() === currentDate.getFullYear()
-      )
-    }
-    else if (mode === 'yearPicker') {
-      return (
-        selectedDates instanceof Date
-        && selectedDates.getFullYear() === currentDate.getFullYear()
-      )
-    }
-    return false
   }
 
   const setCurrentDate = () => {
     const currentDate = new Date()
-    if (mode === 'dayPicker') {
-      setSelectedDates(currentDate)
-    }
-    else if (mode === 'monthPicker') {
-      setSelectedDates(
-        new Date(currentDate.getFullYear(), currentDate.getMonth(), 1),
-      )
-    }
-    else if (mode === 'yearPicker') {
-      setSelectedDates(
-        new Date(currentDate.getFullYear(), 0, 1),
-      )
+
+    switch (pickerMode) {
+      case 'dayPicker':
+        onChange(currentDate)
+        break
+      case 'monthPicker':
+        onChange(currentDate)
+        break
+      case 'yearPicker':
+        onChange(currentDate)
+        break
+      default:
+        break
     }
   }
 
   const isTodayOrAfter = useMemo(() => {
     switch (mode) {
       case 'dayPicker':
-        return Boolean(
-          selectedDates instanceof Date && (
-            endOfDay(selectedDates) >= endOfDay(new Date()) || endOfDay(selectedDates) >= maxDate
-          ),
-        )
+        return firstDate >= endOfDay(new Date()) || firstDate >= maxDate
       case 'monthPicker':
-        return Boolean(
-          selectedDates instanceof Date && (
-            endOfMonth(selectedDates) >= endOfMonth(new Date())
-            || endOfMonth(selectedDates) >= maxDate
-          ),
+        return (
+          endOfMonth(firstDate) >= endOfMonth(new Date())
+          || endOfMonth(firstDate) >= maxDate
         )
       case 'yearPicker':
-        return Boolean(
-          selectedDates instanceof Date && (
-            endOfYear(selectedDates) >= endOfYear(new Date()) || endOfYear(selectedDates) >= maxDate
-          ),
+        return (
+          endOfYear(firstDate) >= endOfYear(new Date())
+          || endOfYear(firstDate) >= maxDate
         )
       default:
-        return Boolean(
-          selectedDates instanceof Date && (
-            selectedDates >= new Date() || selectedDates >= maxDate
-          ),
-        )
+        return false
     }
-  }, [selectedDates, maxDate, mode])
+  }, [firstDate, maxDate, mode])
 
-  const isBeforeMinDate = Boolean(
-    minDate && selectedDates instanceof Date && selectedDates <= minDate,
-  )
+  const isBeforeMinDate = Boolean(minDate && firstDate <= minDate)
 
-  const changeDate = (value: number) => {
-    if (mode === 'dayPicker') {
-      setSelectedDates(
-        new Date(
-          (selectedDates as Date).setDate(
-            (selectedDates as Date).getDate() + value,
-          ),
-        ),
-      )
-    }
-    else if (mode === 'monthPicker') {
-      setSelectedDates(
-        new Date(
-          (selectedDates as Date).setMonth(
-            (selectedDates as Date).getMonth() + value,
-          ),
-        ),
-      )
-    }
-    else if (mode === 'yearPicker') {
-      setSelectedDates(
-        new Date(
-          (selectedDates as Date).setFullYear(
-            (selectedDates as Date).getFullYear() + value,
-          ),
-        ),
-      )
+  const handleNavigateDate = (value: number) => {
+    switch (pickerMode) {
+      case 'dayPicker':
+        onChange(new Date(firstDate.setDate(firstDate.getDate() + value)))
+        break
+      case 'monthPicker':
+        onChange(new Date(firstDate.setMonth(firstDate.getMonth() + value)))
+        break
+      case 'yearPicker':
+        onChange(new Date(firstDate.setFullYear(firstDate.getFullYear() + value)))
+        break
+      default:
+        break
     }
   }
 
-  const onChangeModeInternal = (mode: DatePickerMode) => {
+  const handleChangeMode = (selectedMode: UnifiedPickerMode) => {
     if (!onChangeMode) {
       console.warn('`onChangeMode` expected when using `ModeSelector`')
       return
     }
 
-    const firstSelectedDate = Array.isArray(selectedDates)
-      ? selectedDates[0]
-      : (selectedDates ?? new Date())
-
-    if (isRangeMode(mode)) {
-      setStartDate(firstSelectedDate)
-      setEndDate(firstSelectedDate)
-      setSelectedDates([firstSelectedDate, firstSelectedDate])
-    }
-    else {
-      setStartDate(null)
-      setEndDate(null)
-      setSelectedDates(firstSelectedDate)
-    }
-
-    onChangeMode(mode)
+    onChangeMode(selectedMode)
   }
 
   return (
     <div className={wrapperClassNames}>
       <ReactDatePicker
-      // @ts-expect-error = There is no good way to define the type of the ref
+        // @ts-expect-error = There is no good way to define the type of the ref
         ref={pickerRef}
         wrapperClassName={datePickerWrapperClassNames}
-        startDate={isRangeMode(mode) ? startDate : undefined}
-        endDate={isRangeMode(mode) ? endDate : undefined}
+        startDate={isRangeMode(mode)
+          ? (isMidSelection
+            ? internalStart
+            : firstDate)
+          : undefined}
+        endDate={isRangeMode(mode)
+          ? (isMidSelection
+            ? internalEnd
+            : secondDate)
+          : undefined}
         selected={
           mode !== 'dayRangePicker' && mode !== 'monthRangePicker'
-            ? (selectedDates as Date)
+            ? firstDate
             : undefined
         }
         onChange={handleDateChange}
@@ -352,9 +288,9 @@ export const DatePicker = ({
         popperPlacement='bottom-start'
         selectsRange={isRangeMode(mode)}
         showMonthYearPicker={
-          mode === 'monthPicker' || mode === 'monthRangePicker'
+          pickerMode === 'monthPicker' || pickerMode === 'monthRangePicker'
         }
-        showYearPicker={mode === 'yearPicker'}
+        showYearPicker={pickerMode === 'yearPicker'}
         dateFormat={dateFormat}
         renderDayContents={day => (
           <span className='Layer__datepicker__day-contents'>{day}</span>
@@ -362,8 +298,8 @@ export const DatePicker = ({
         timeIntervals={timeIntervals}
         timeCaption={timeCaption}
         timeFormat='h mm aa'
-        showTimeSelect={mode === 'timePicker'}
-        showTimeSelectOnly={mode === 'timePicker'}
+        showTimeSelect={pickerMode === 'timePicker'}
+        showTimeSelectOnly={pickerMode === 'timePicker'}
         minDate={minDate}
         maxDate={maxDate}
         withPortal={!isDesktop}
@@ -399,17 +335,19 @@ export const DatePicker = ({
         disabled={disabled}
         {...props}
       >
-        {ModeSelector && (
-          <ModeSelector
-            mode={mode}
-            allowedModes={allowedModes ?? [mode]}
-            onChangeMode={onChangeModeInternal}
-          />
-        )}
-        {mode === 'dayRangePicker' && (
+        {(ModeSelector && pickerMode !== 'timePicker')
+          ? (
+            <ModeSelector
+              mode={pickerMode}
+              allowedModes={allowedModes ?? [pickerMode]}
+              onChangeMode={handleChangeMode}
+            />
+          )
+          : null}
+        {pickerMode === 'dayRangePicker' && (
           <DatePickerOptions
             customDateRanges={customDateRanges}
-            setSelectedDate={setSelectedDates}
+            setSelectedDate={handleSetCustomDate}
           />
         )}
       </ReactDatePicker>
@@ -421,7 +359,7 @@ export const DatePicker = ({
               'Layer__datepicker__prev-button',
               isBeforeMinDate && 'Layer__datepicker__button--disabled',
             )}
-            onClick={() => changeDate(-1)}
+            onClick={() => handleNavigateDate(-1)}
             variant={ButtonVariant.secondary}
             disabled={isBeforeMinDate || disabled}
           >
@@ -436,7 +374,7 @@ export const DatePicker = ({
                 ? 'Layer__datepicker__button--disabled'
                 : undefined,
             )}
-            onClick={() => changeDate(1)}
+            onClick={() => handleNavigateDate(1)}
             disabled={isTodayOrAfter || disabled}
           >
             <ChevronRight
@@ -447,14 +385,19 @@ export const DatePicker = ({
         </>
       )}
       {currentDateOption
-      && (mode === 'dayPicker' || mode === 'monthPicker' || mode === 'yearPicker') && (
+      && (
+        pickerMode === 'dayPicker'
+        || pickerMode === 'monthPicker'
+        || pickerMode === 'yearPicker'
+      )
+      && (
         <Button
           className='Layer__datepicker__current-button'
           onClick={setCurrentDate}
           variant={ButtonVariant.secondary}
           disabled={isCurrentDate() || disabled}
         >
-          {mode === 'dayPicker' ? 'Today' : 'Current'}
+          {pickerMode === 'dayPicker' ? 'Today' : 'Current'}
         </Button>
       )}
     </div>

--- a/src/components/DatePicker/DatePickerOptions.tsx
+++ b/src/components/DatePicker/DatePickerOptions.tsx
@@ -54,7 +54,7 @@ export const DatePickerOptions = ({
   setSelectedDate,
 }: {
   customDateRanges?: CustomDateRange[]
-  setSelectedDate: (dates: [Date | null, Date | null]) => void
+  setSelectedDate: (dates: [Date, Date | null]) => void
 }) => {
   const optionsComponents: React.ReactNode[] = []
 

--- a/src/components/DatePicker/ModeSelector/DatePickerModeSelector.tsx
+++ b/src/components/DatePicker/ModeSelector/DatePickerModeSelector.tsx
@@ -1,20 +1,13 @@
 import React from 'react'
 import { Toggle } from '../../Toggle'
 import { ToggleSize } from '../../Toggle/Toggle'
+import type { DatePickerMode, DateRangePickerMode } from '../../../providers/GlobalDateStore/GlobalDateStoreProvider'
 
-export type SingularPickerMode = 'dayPicker' | 'timePicker'
-export type RangePickerMode =
-  | 'dayRangePicker'
-  | 'monthRangePicker'
-  | 'monthPicker'
-  | 'yearPicker'
-
-export type DatePickerMode = SingularPickerMode | RangePickerMode
+export type UnifiedPickerMode = DatePickerMode | DateRangePickerMode
 
 export const DEFAULT_ALLOWED_PICKER_MODES = ['monthPicker'] as const
 
-const DATE_RANGE_MODE_CONFIG: Record<DatePickerMode, { label: string }> = {
-  timePicker: { label: 'Time' },
+const UNIFIED_PICKER_MODE_CONFIG: Record<UnifiedPickerMode, { label: string }> = {
   dayPicker: { label: 'Day' },
   dayRangePicker: { label: 'Select dates' },
   monthPicker: { label: 'Month' },
@@ -22,17 +15,17 @@ const DATE_RANGE_MODE_CONFIG: Record<DatePickerMode, { label: string }> = {
   yearPicker: { label: 'Year' },
 }
 
-function toToggleOptions(allowedModes: ReadonlyArray<DatePickerMode>) {
+function toToggleOptions(allowedModes: ReadonlyArray<UnifiedPickerMode>) {
   return allowedModes.map(mode => ({
-    label: DATE_RANGE_MODE_CONFIG[mode].label,
+    label: UNIFIED_PICKER_MODE_CONFIG[mode].label,
     value: mode,
   }))
 }
 
 export type DatePickerModeSelectorProps = {
-  mode: DatePickerMode
-  allowedModes: ReadonlyArray<DatePickerMode>
-  onChangeMode: (mode: DatePickerMode) => void
+  mode: UnifiedPickerMode
+  allowedModes: ReadonlyArray<UnifiedPickerMode>
+  onChangeMode: (mode: UnifiedPickerMode) => void
 }
 
 export function DatePickerModeSelector({
@@ -52,7 +45,7 @@ export function DatePickerModeSelector({
         selected={mode}
         options={toToggleOptions(allowedModes)}
         onChange={({ target: { value } }) => {
-          const mode = value as DatePickerMode
+          const mode = value as UnifiedPickerMode
           if (allowedModes.includes(mode)) {
             onChangeMode?.(mode)
           }

--- a/src/components/JournalForm/JournalForm.tsx
+++ b/src/components/JournalForm/JournalForm.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { JournalContext } from '../../contexts/JournalContext'
 import { Button, ButtonVariant, RetryButton, SubmitButton } from '../Button'
 import { DatePicker } from '../DatePicker'
@@ -37,7 +37,7 @@ export const JournalForm = ({
   return (
     <form
       className='Layer__form'
-      onSubmit={e => {
+      onSubmit={(e) => {
         e.preventDefault()
         submitForm()
       }}
@@ -62,7 +62,7 @@ export const JournalForm = ({
               <RetryButton
                 type='submit'
                 processing={sendingForm}
-                error={'Check connection and retry in few seconds.'}
+                error='Check connection and retry in few seconds.'
                 disabled={sendingForm}
               >
                 {stringOverrides?.retryButton || 'Retry'}
@@ -98,12 +98,12 @@ export const JournalForm = ({
               selected={
                 form?.data.entry_at ? new Date(form?.data.entry_at) : new Date()
               }
-              onChange={date => {
+              onChange={(date) => {
                 if (!Array.isArray(date)) {
                   changeFormData('entry_at', date.toISOString())
                 }
               }}
-              mode='dayPicker'
+              displayMode='dayPicker'
               placeholderText='Select date'
               currentDateOption={false}
             />
@@ -111,12 +111,12 @@ export const JournalForm = ({
               selected={
                 form?.data.entry_at ? new Date(form?.data.entry_at) : new Date()
               }
-              onChange={date => {
+              onChange={(date) => {
                 if (!Array.isArray(date)) {
                   changeFormData('entry_at', date.toISOString())
                 }
               }}
-              mode='timePicker'
+              displayMode='timePicker'
               placeholderText='Select time'
               currentDateOption={false}
             />
@@ -138,8 +138,7 @@ export const JournalForm = ({
             placeholder='Add description'
             value={form?.data.memo}
             onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-              changeFormData('memo', e.target.value)
-            }
+              changeFormData('memo', e.target.value)}
             disabled={sendingForm}
           />
         </InputGroup>
@@ -157,7 +156,7 @@ export const JournalForm = ({
           <RetryButton
             type='submit'
             processing={sendingForm}
-            error={'Check connection and retry in few seconds.'}
+            error='Check connection and retry in few seconds.'
             disabled={sendingForm}
           >
             {stringOverrides?.retryButton || 'Retry'}

--- a/src/components/LinkedAccounts/AccountFormBox/AccountFormBox.tsx
+++ b/src/components/LinkedAccounts/AccountFormBox/AccountFormBox.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import { LinkedAccount } from '../../../types/linked_accounts'
 import InstitutionIcon from '../../../icons/InstitutionIcon'
 import { Checkbox } from '../../ui/Checkbox/Checkbox'
@@ -88,7 +88,7 @@ export const AccountFormBox = ({
         <div className={`${CLASS_NAME}__details-col__inputs`}>
           <InputGroup label='Opening date'>
             <DatePicker
-              mode='dayPicker'
+              displayMode='dayPicker'
               onChange={(v) => {
                 if (!value.openingDate || !isEqual(value.openingDate, v as Date)) {
                   onChange({ ...value, openingDate: (v as Date) })

--- a/src/components/ProfitAndLoss/ProfitAndLoss.tsx
+++ b/src/components/ProfitAndLoss/ProfitAndLoss.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, createContext } from 'react'
+import { PropsWithChildren, createContext } from 'react'
 import { PNLComparisonContext } from '../../contexts/ProfitAndLossComparisonContext'
 import { useProfitAndLoss } from '../../hooks/useProfitAndLoss'
 import { useProfitAndLossComparison } from '../../hooks/useProfitAndLossComparison'
@@ -29,6 +29,7 @@ const PNLContext = createContext<PNLContextType>({
     startDate: startOfMonth(new Date()),
     endDate: endOfMonth(new Date()),
   },
+  changeDateRange: () => {},
   refetch: () => {},
   sidebarScope: undefined,
   setSidebarScope: () => {},

--- a/src/components/ProfitAndLoss/ProfitAndLoss.tsx
+++ b/src/components/ProfitAndLoss/ProfitAndLoss.tsx
@@ -29,7 +29,6 @@ const PNLContext = createContext<PNLContextType>({
     startDate: startOfMonth(new Date()),
     endDate: endOfMonth(new Date()),
   },
-  changeDateRange: () => {},
   refetch: () => {},
   sidebarScope: undefined,
   setSidebarScope: () => {},
@@ -63,11 +62,13 @@ const ProfitAndLoss = ({
   return (
     <PNLContext.Provider value={contextData}>
       <PNLComparisonContext.Provider value={comparisonContextData}>
-        {asContainer ? (
-          <Container name='profit-and-loss'>{children}</Container>
-        ) : (
-          children
-        )}
+        {asContainer
+          ? (
+            <Container name='profit-and-loss'>{children}</Container>
+          )
+          : (
+            children
+          )}
       </PNLComparisonContext.Provider>
     </PNLContext.Provider>
   )

--- a/src/components/ProfitAndLossDatePicker/ProfitAndLossDatePicker.tsx
+++ b/src/components/ProfitAndLossDatePicker/ProfitAndLossDatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react'
+import { useCallback, useContext } from 'react'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { getEarliestDateToBrowse } from '../../utils/business'
 import type { TimeRangePickerConfig } from '../../views/Reports/reportTypes'
@@ -30,10 +30,10 @@ export const ProfitAndLossDatePicker = ({
   const {
     allowedDateRangePickerModes,
     dateFormat,
-    rangeMode,
+    rangeDisplayMode,
     selected,
     setSelected,
-    setRangeMode,
+    setRangeDisplayMode,
   } = useGlobalDateRangePicker({
     allowedDatePickerModes,
     defaultDatePickerMode,
@@ -60,11 +60,11 @@ export const ProfitAndLossDatePicker = ({
 
         setSelected({ start, end: end ?? start })
       }}
-      mode={rangeMode}
+      displayMode={rangeDisplayMode}
       allowedModes={allowedDateRangePickerModes}
-      onChangeMode={(rangeMode) => {
-        if (rangeMode !== 'dayPicker') {
-          setRangeMode({ rangeMode })
+      onChangeMode={(rangeDisplayMode) => {
+        if (rangeDisplayMode !== 'dayPicker') {
+          setRangeDisplayMode({ rangeDisplayMode })
         }
       }}
       slots={{

--- a/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
+++ b/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
@@ -1,23 +1,18 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { StatementOfCashFlowContext } from '../../contexts/StatementOfCashContext'
 import { TableProvider } from '../../contexts/TableContext'
 import { useStatementOfCashFlow } from '../../hooks/useStatementOfCashFlow'
 import type { TimeRangePickerConfig } from '../../views/Reports/reportTypes'
-import { DatePicker } from '../DatePicker'
-import type { DatePickerMode } from '../DatePicker/ModeSelector/DatePickerModeSelector'
-import {
-  DatePickerModeSelector,
-  DEFAULT_ALLOWED_PICKER_MODES,
-} from '../DatePicker/ModeSelector/DatePickerModeSelector'
 import { Header, HeaderCol, HeaderRow } from '../Header'
 import { Loader } from '../Loader'
 import { StatementOfCashFlowTable } from '../StatementOfCashFlowTable'
 import { StatementOfCashFlowTableStringOverrides } from '../StatementOfCashFlowTable/StatementOfCashFlowTable'
 import { View } from '../View'
 import { STATEMENT_OF_CASH_FLOW_ROWS } from './constants'
-import { endOfMonth, startOfDay, startOfMonth, subWeeks } from 'date-fns'
 import { CashflowStatementDownloadButton } from './download/CashflowStatementDownloadButton'
 import { useElementViewSize } from '../../hooks/useElementViewSize/useElementViewSize'
+import { useGlobalDateRange } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
+import { StatementOfCashFlowDatePicker } from './datePicker/StatementOfCashFlowDatePicker'
 
 const COMPONENT_NAME = 'statement-of-cash-flow'
 
@@ -44,104 +39,51 @@ type StatementOfCashFlowViewProps = {
 
 const StatementOfCashFlowView = ({
   stringOverrides,
-  datePickerMode: deprecated_datePickerMode,
-  defaultDatePickerMode = 'monthPicker',
   allowedDatePickerModes,
   customDateRanges,
 }: StatementOfCashFlowViewProps) => {
-  const [startDate, setStartDate] = useState(
-    startOfDay(subWeeks(new Date(), 4)),
-  )
-  const [endDate, setEndDate] = useState(startOfDay(new Date()))
-  const { data, isLoading, refetch } = useStatementOfCashFlow(
-    startDate,
-    endDate,
-  )
+  const { start, end } = useGlobalDateRange()
+  const { data, isLoading } = useStatementOfCashFlow(start, end)
   const { view, containerRef } = useElementViewSize<HTMLDivElement>()
-
-  const [datePickerMode, setDatePickerMode] = useState<DatePickerMode>(
-    deprecated_datePickerMode ?? defaultDatePickerMode,
-  )
-
-  const handleDateChange = (dates: [Date | null, Date | null]) => {
-    if (dates[0]) {
-      setStartDate(startOfDay(dates[0]))
-    }
-    if (dates[1]) {
-      setEndDate(startOfDay(dates[1]))
-    }
-
-    if (dates[0] && dates[1]) {
-      refetch()
-    }
-  }
-
-  const datePicker =
-    datePickerMode === 'monthPicker' ? (
-      <DatePicker
-        selected={startDate}
-        onChange={dates => {
-          if (!Array.isArray(dates)) {
-            const date = dates as Date
-            handleDateChange([startOfMonth(date), endOfMonth(date)])
-          }
-        }}
-        dateFormat='MMM'
-        mode={datePickerMode}
-        allowedModes={allowedDatePickerModes ?? DEFAULT_ALLOWED_PICKER_MODES}
-        onChangeMode={setDatePickerMode}
-        slots={{
-          ModeSelector: DatePickerModeSelector,
-        }}
-      />
-    ) : (
-      <DatePicker
-        selected={[startDate, endDate]}
-        customDateRanges={customDateRanges}
-        onChange={dates =>
-          handleDateChange(dates as [Date | null, Date | null])
-        }
-        dateFormat='MMM d'
-        mode={datePickerMode}
-        allowedModes={allowedDatePickerModes ?? DEFAULT_ALLOWED_PICKER_MODES}
-        onChangeMode={setDatePickerMode}
-        slots={{
-          ModeSelector: DatePickerModeSelector,
-        }}
-      />
-    )
 
   return (
     <TableProvider>
       <View
         type='panel'
         ref={containerRef}
-        header={
+        header={(
           <Header>
             <HeaderRow>
-              <HeaderCol>{datePicker}</HeaderCol>
+              <HeaderCol>
+                <StatementOfCashFlowDatePicker
+                  allowedDatePickerModes={allowedDatePickerModes}
+                  customDateRanges={customDateRanges}
+                />
+              </HeaderCol>
               <HeaderCol>
                 <CashflowStatementDownloadButton
-                  startDate={startDate}
-                  endDate={endDate}
+                  startDate={start}
+                  endDate={end}
                   iconOnly={view === 'mobile'}
                 />
               </HeaderCol>
             </HeaderRow>
           </Header>
-        }
-      >
-        {!data || isLoading ? (
-          <div className={`Layer__${COMPONENT_NAME}__loader-container`}>
-            <Loader />
-          </div>
-        ) : (
-          <StatementOfCashFlowTable
-            data={data}
-            config={STATEMENT_OF_CASH_FLOW_ROWS}
-            stringOverrides={stringOverrides?.statementOfCashFlowTable}
-          />
         )}
+      >
+        {!data || isLoading
+          ? (
+            <div className={`Layer__${COMPONENT_NAME}__loader-container`}>
+              <Loader />
+            </div>
+          )
+          : (
+            <StatementOfCashFlowTable
+              data={data}
+              config={STATEMENT_OF_CASH_FLOW_ROWS}
+              stringOverrides={stringOverrides?.statementOfCashFlowTable}
+            />
+          )}
       </View>
     </TableProvider>
   )

--- a/src/components/StatementOfCashFlow/datePicker/StatementOfCashFlowDatePicker.tsx
+++ b/src/components/StatementOfCashFlow/datePicker/StatementOfCashFlowDatePicker.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { DatePickerModeSelector } from '../../DatePicker/ModeSelector/DatePickerModeSelector'
+import type { TimeRangePickerConfig } from '../../../views/Reports/reportTypes'
+import { DatePicker } from '../../DatePicker'
+import { useLayerContext } from '../../../contexts/LayerContext'
+import { getEarliestDateToBrowse } from '../../../utils/business'
+import { useGlobalDateRangePicker } from '../../../providers/GlobalDateStore/useGlobalDateRangePicker'
+
+type StatementOfCashFlowDatePickerProps = Pick<
+  TimeRangePickerConfig,
+  'allowedDatePickerModes' | 'customDateRanges' | 'defaultDatePickerMode'
+>
+
+export function StatementOfCashFlowDatePicker({
+  allowedDatePickerModes,
+  customDateRanges,
+  defaultDatePickerMode,
+}: StatementOfCashFlowDatePickerProps) {
+  const { business } = useLayerContext()
+
+  const {
+    allowedDateRangePickerModes,
+    dateFormat,
+    rangeMode,
+    selected,
+    setRangeMode,
+    setSelected,
+  } = useGlobalDateRangePicker({ allowedDatePickerModes, defaultDatePickerMode })
+
+  const minDate = getEarliestDateToBrowse(business)
+
+  return (
+    <DatePicker
+      selected={selected}
+      onChange={(dates) => {
+        if (dates instanceof Date) {
+          if (rangeMode === 'monthPicker') {
+            setSelected({ start: dates, end: dates })
+          }
+
+          return
+        }
+
+        const [start, end] = dates
+
+        setSelected({ start, end: end ?? start })
+      }}
+      mode={rangeMode}
+      allowedModes={allowedDateRangePickerModes}
+      onChangeMode={(rangeMode) => {
+        if (rangeMode !== 'dayPicker') {
+          setRangeMode({ rangeMode })
+        }
+      }}
+      slots={{
+        ModeSelector: DatePickerModeSelector,
+      }}
+      dateFormat={dateFormat}
+      customDateRanges={customDateRanges}
+      minDate={minDate}
+    />
+  )
+}

--- a/src/components/StatementOfCashFlow/datePicker/StatementOfCashFlowDatePicker.tsx
+++ b/src/components/StatementOfCashFlow/datePicker/StatementOfCashFlowDatePicker.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { DatePickerModeSelector } from '../../DatePicker/ModeSelector/DatePickerModeSelector'
 import type { TimeRangePickerConfig } from '../../../views/Reports/reportTypes'
 import { DatePicker } from '../../DatePicker'
@@ -21,9 +20,9 @@ export function StatementOfCashFlowDatePicker({
   const {
     allowedDateRangePickerModes,
     dateFormat,
-    rangeMode,
+    rangeDisplayMode,
     selected,
-    setRangeMode,
+    setRangeDisplayMode,
     setSelected,
   } = useGlobalDateRangePicker({ allowedDatePickerModes, defaultDatePickerMode })
 
@@ -34,7 +33,7 @@ export function StatementOfCashFlowDatePicker({
       selected={selected}
       onChange={(dates) => {
         if (dates instanceof Date) {
-          if (rangeMode === 'monthPicker') {
+          if (rangeDisplayMode === 'monthPicker') {
             setSelected({ start: dates, end: dates })
           }
 
@@ -45,11 +44,11 @@ export function StatementOfCashFlowDatePicker({
 
         setSelected({ start, end: end ?? start })
       }}
-      mode={rangeMode}
+      displayMode={rangeDisplayMode}
       allowedModes={allowedDateRangePickerModes}
-      onChangeMode={(rangeMode) => {
-        if (rangeMode !== 'dayPicker') {
-          setRangeMode({ rangeMode })
+      onChangeMode={(rangeDisplayMode) => {
+        if (rangeDisplayMode !== 'dayPicker') {
+          setRangeDisplayMode({ rangeDisplayMode })
         }
       }}
       slots={{

--- a/src/components/TasksHeader/TasksHeader.tsx
+++ b/src/components/TasksHeader/TasksHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { TasksContext } from '../../contexts/TasksContext'
 import AlertCircle from '../../icons/AlertCircle'
 import Check from '../../icons/Check'
@@ -54,7 +54,7 @@ export const TasksHeader = ({
     refetch,
     error,
     dateRange,
-    setDateRange
+    setDateRange,
   } = useContext(TasksContext)
   const { business } = useLayerContext()
 
@@ -70,41 +70,49 @@ export const TasksHeader = ({
       <div className='Layer__tasks-header__left-col'>
         <div className='Layer__tasks-header__left-col__title'>
           <Text size={TextSize.lg}>{tasksHeader}</Text>
-          {loadedStatus !== 'complete' && !open ? (
-            <Badge variant={ICONS.loading.badge} icon={ICONS.loading.icon}>
-              {ICONS.loading.text}
-            </Badge>
-          ) : loadedStatus === 'complete' && !open && (!tasks || error) ? (
-            <Badge
-              onClick={() => refetch()}
-              variant={ICONS.refresh.badge}
-              icon={ICONS.refresh.icon}
-            >
-              {ICONS.refresh.text}
-            </Badge>
-          ) : loadedStatus === 'complete' && !open ? (
-            <Badge variant={badgeVariant.badge} icon={badgeVariant.icon}>
-              {badgeVariant.text}
-            </Badge>
-          ) : open ? null : (
-            <Badge variant={badgeVariant.badge} icon={badgeVariant.icon}>
-              {badgeVariant.text}
-            </Badge>
-          )}
+          {loadedStatus !== 'complete' && !open
+            ? (
+              <Badge variant={ICONS.loading.badge} icon={ICONS.loading.icon}>
+                {ICONS.loading.text}
+              </Badge>
+            )
+            : loadedStatus === 'complete' && !open && (!tasks || error)
+              ? (
+                <Badge
+                  onClick={() => refetch()}
+                  variant={ICONS.refresh.badge}
+                  icon={ICONS.refresh.icon}
+                >
+                  {ICONS.refresh.text}
+                </Badge>
+              )
+              : loadedStatus === 'complete' && !open
+                ? (
+                  <Badge variant={badgeVariant.badge} icon={badgeVariant.icon}>
+                    {badgeVariant.text}
+                  </Badge>
+                )
+                : open
+                  ? null
+                  : (
+                    <Badge variant={badgeVariant.badge} icon={badgeVariant.icon}>
+                      {badgeVariant.text}
+                    </Badge>
+                  )}
         </div>
         <div className='Layer__tasks-header__left-col__controls'>
           <DatePicker
             selected={dateRange.startDate}
-            onChange={dates => {
+            onChange={(dates) => {
               if (!Array.isArray(dates)) {
                 setDateRange({
-                  startDate: startOfYear(dates as Date),
-                  endDate: endOfYear(dates as Date)
+                  startDate: startOfYear(dates),
+                  endDate: endOfYear(dates),
                 })
               }
             }}
             dateFormat='YYYY'
-            mode='yearPicker'
+            displayMode='yearPicker'
             minDate={minDate}
             maxDate={endOfYear(new Date())}
             currentDateOption={false}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -21,7 +21,7 @@ async function requestOAuthToken({
   return fetch(authUrl, {
     method: 'POST',
     headers: {
-      Authorization: 'Basic ' + globalThis.btoa(appId + ':' + appSecret),
+      'Authorization': 'Basic ' + globalThis.btoa(appId + ':' + appSecret),
       'Content-Type': 'application/x-www-form-urlencoded',
     },
     body: new URLSearchParams({
@@ -50,7 +50,7 @@ function buildKey({
       apiUrl,
       businessAccessToken,
       mode: 'explicit' as const,
-      tags: [ '#auth' ],
+      tags: ['#auth'],
     }
   }
 
@@ -62,7 +62,7 @@ function buildKey({
       authUrl,
       scope,
       mode: 'client' as const,
-      tags: [ '#auth' ],
+      tags: ['#auth'],
     }
   }
 
@@ -99,16 +99,18 @@ export function useAuth() {
 
       const { apiUrl, appId, appSecret, authUrl, scope } = key
       return requestOAuthToken({ appId, appSecret, authUrl, scope })
-        .then((data) => ({ apiUrl, ...data }))
+        .then(data => ({ apiUrl, ...data }))
     },
     {
+      revalidateOnFocus: true,
+      revalidateOnReconnect: true,
       refreshInterval: (latestData) => {
         if (!latestData) {
           return FALLBACK_REFRESH_MS
         }
 
         return (latestData.expires_in / 2) * 1000
-      }
-    }
+      },
+    },
   )
 }

--- a/src/hooks/useProfitAndLoss/useProfitAndLoss.tsx
+++ b/src/hooks/useProfitAndLoss/useProfitAndLoss.tsx
@@ -1,8 +1,8 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
-  DateRange,
   ReportingBasis,
   SortDirection,
+  type DateRange,
 } from '../../types'
 import {
   collectExpensesItems,
@@ -11,7 +11,10 @@ import {
 } from '../../utils/profitAndLossUtils'
 import { useProfitAndLossLTM } from './useProfitAndLossLTM'
 import { useProfitAndLossQuery } from './useProfitAndLossQuery'
-import { useGlobalDateRange } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
+import {
+  useGlobalDateRange,
+  useGlobalDateRangeActions,
+} from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 
 export type Scope = 'expenses' | 'revenue'
 
@@ -43,6 +46,13 @@ export const useProfitAndLoss = ({
   reportingBasis,
 }: UseProfitAndLossOptions) => {
   const { start, end } = useGlobalDateRange()
+  const { setRange } = useGlobalDateRangeActions()
+
+  const dateRange = useMemo(() => ({ startDate: start, endDate: end }), [start, end])
+  const changeDateRange = useCallback(
+    ({ startDate: start, endDate: end }: DateRange) => setRange({ start, end }),
+    [setRange],
+  )
 
   const [filters, setFilters] = useState<ProfitAndLossFilters>({
     expenses: undefined,
@@ -96,7 +106,7 @@ export const useProfitAndLoss = ({
     const filtered = items.map((x) => {
       if (
         filters['revenue']?.types
-        && filters['revenue']!.types!.length > 0
+        && filters['revenue'].types.length > 0
         && !filters['revenue']?.types?.includes(x.type)
       ) {
         return {
@@ -159,7 +169,7 @@ export const useProfitAndLoss = ({
     const filtered = items.map((x) => {
       if (
         filters['expenses']?.types
-        && filters['expenses']!.types!.length > 0
+        && filters['expenses'].types.length > 0
         && !filters['expenses']?.types?.includes(x.type)
       ) {
         return {
@@ -223,7 +233,8 @@ export const useProfitAndLoss = ({
     isLoading,
     isValidating,
     error: error,
-    dateRange: { startDate: start, endDate: end },
+    dateRange,
+    changeDateRange,
     refetch,
     sidebarScope,
     setSidebarScope,

--- a/src/hooks/useProfitAndLossComparison/useProfitAndLossComparison.tsx
+++ b/src/hooks/useProfitAndLossComparison/useProfitAndLossComparison.tsx
@@ -3,10 +3,8 @@ import { Layer } from '../../api/layer'
 import { TagComparisonOption } from '../../components/ProfitAndLossCompareOptions/ProfitAndLossCompareOptions'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { DateRange, MoneyFormat, ReportingBasis } from '../../types'
-import { S3PresignedUrl } from '../../types/general'
 import {
   ProfitAndLossComparison,
-  ProfitAndLossComparisonItem,
 } from '../../types/profit_and_loss'
 import { startOfMonth, subMonths, getYear, getMonth } from 'date-fns'
 import { useAuth } from '../useAuth'
@@ -18,7 +16,7 @@ export type SidebarScope = Scope | undefined
 
 type Periods = {
   type: 'Comparison_Months'
-  months: Array<{ year: number; month: number }>
+  months: Array<{ year: number, month: number }>
 }
 
 type TagFilter = Array<{
@@ -33,32 +31,14 @@ type Props = {
   reportingBasis?: ReportingBasis
 }
 
-type UseProfitAndLossComparison = (props: Props) => {
-  data: ProfitAndLossComparisonItem[] | undefined
-  isLoading: boolean
-  isValidating: boolean
-  error: unknown
-  compareMode: boolean
-  setCompareMode: (mode: boolean) => void
-  compareMonths: number
-  setCompareMonths: (months: number) => void
-  compareOptions: TagComparisonOption[]
-  setCompareOptions: (options: TagComparisonOption[]) => void
-  refetch: (dateRange: DateRange, actAsInitial?: boolean) => void
-  getProfitAndLossComparisonCsv: (
-    dateRange: DateRange,
-    moneyFormat?: MoneyFormat,
-  ) => Promise<{ data?: S3PresignedUrl; error?: unknown }>
-}
-
 let initialFetchDone = false
 
-export const useProfitAndLossComparison: UseProfitAndLossComparison = ({
+export function useProfitAndLossComparison({
   reportingBasis,
-}: Props) => {
+}: Props) {
   const lastQuery =
     useRef<
-      Promise<{ data?: ProfitAndLossComparison | undefined; error?: unknown }>
+      Promise<{ data?: ProfitAndLossComparison | undefined, error?: unknown }>
     >()
 
   const [compareMode, setCompareMode] = useState(false)
@@ -79,29 +59,31 @@ export const useProfitAndLossComparison: UseProfitAndLossComparison = ({
 
   useEffect(() => {
     if (
-      compareMonths > 1 ||
-      compareOptions.filter(x => x.displayName).length > 0
+      compareMonths > 1
+      || compareOptions.filter(x => x.displayName).length > 0
     ) {
       if (compareMode === false) {
         setCompareMode(true)
       }
-    } else {
+    }
+    else {
       setCompareMode(false)
     }
   }, [compareMonths, compareOptions])
 
   const prepareFiltersBody = (compareOptions: TagComparisonOption[]) => {
     const tagFilters: TagFilter = []
-    compareOptions.map(option => {
+    compareOptions.map((option) => {
       if (option.tagFilterConfig.tagFilters === 'None') {
         tagFilters.push({
           required_tags: [],
           structure: option.tagFilterConfig.structure,
         })
-      } else {
+      }
+      else {
         const tagFilter = option.tagFilterConfig.tagFilters
         tagFilters.push({
-          required_tags: tagFilter.tagValues.map(tagValue => {
+          required_tags: tagFilter.tagValues.map((tagValue) => {
             return {
               key: tagFilter.tagKey,
               value: tagValue,
@@ -142,7 +124,8 @@ export const useProfitAndLossComparison: UseProfitAndLossComparison = ({
   const refetch = (dateRange: DateRange, actAsInitial?: boolean) => {
     if (actAsInitial && !initialFetchDone) {
       fetchPnLComparisonData(dateRange, compareMonths, compareOptions)
-    } else if (!actAsInitial) {
+    }
+    else if (!actAsInitial) {
       fetchPnLComparisonData(dateRange, compareMonths, compareOptions)
     }
   }
@@ -180,7 +163,8 @@ export const useProfitAndLossComparison: UseProfitAndLossComparison = ({
           setIsLoading(false)
           setIsValidating(false)
         }
-      } catch (err) {
+      }
+      catch (err) {
         setError(err)
         setData(undefined)
         setIsLoading(false)

--- a/src/hooks/useQuickbooks/useQuickbooks.ts
+++ b/src/hooks/useQuickbooks/useQuickbooks.ts
@@ -12,8 +12,6 @@ type UseQuickbooks = () => {
   quickbooksIsLinked: boolean | null
 }
 
-const DEBUG = true
-
 export const useQuickbooks: UseQuickbooks = () => {
   const { businessId } = useLayerContext()
   const { apiUrl } = useEnvironment()
@@ -42,7 +40,7 @@ export const useQuickbooks: UseQuickbooks = () => {
   // Determine whether there exists an active Quickbooks connection or not
   useEffect(() => {
     if (auth?.access_token) {
-      fetchQuickbooksConnectionStatus()
+      void fetchQuickbooksConnectionStatus()
     }
   }, [auth?.access_token])
 
@@ -56,20 +54,15 @@ export const useQuickbooks: UseQuickbooks = () => {
   }
 
   const syncFromQuickbooks = () => {
-    DEBUG && console.debug('Triggering sync from Quickbooks...')
     setIsSyncingFromQuickbooks(true)
-    try {
-      Layer.syncFromQuickbooks(apiUrl, auth?.access_token, {
-        params: { businessId },
-      })
-    }
-    catch {
-      setIsSyncingFromQuickbooks(false)
-    }
+
+    void Layer.syncFromQuickbooks(apiUrl, auth?.access_token, {
+      params: { businessId },
+    })
+      .finally(() => setIsSyncingFromQuickbooks(false))
   }
 
   const fetchIsSyncingFromQuickbooks = async () => {
-    DEBUG && console.debug('Fetching status of sync from Quickbooks...')
     const isSyncing = (
       await Layer.statusOfSyncFromQuickbooks(apiUrl, auth?.access_token, {
         params: { businessId },
@@ -86,11 +79,11 @@ export const useQuickbooks: UseQuickbooks = () => {
     return res.data.redirect_url
   }
 
-  const unlinkQuickbooks = async () => {
-    await Layer.unlinkQuickbooksConnection(apiUrl, auth?.access_token, {
+  const unlinkQuickbooks = () => {
+    void Layer.unlinkQuickbooksConnection(apiUrl, auth?.access_token, {
       params: { businessId },
     })
-    fetchQuickbooksConnectionStatus()
+      .then(() => fetchQuickbooksConnectionStatus())
   }
 
   return {

--- a/src/providers/GlobalDateStore/GlobalDateStoreProvider.tsx
+++ b/src/providers/GlobalDateStore/GlobalDateStoreProvider.tsx
@@ -1,0 +1,287 @@
+import {
+  addDays,
+  differenceInDays,
+  differenceInMonths,
+  endOfDay,
+  endOfMonth,
+  endOfYear,
+  startOfDay,
+  startOfMonth,
+  startOfYear,
+  subDays,
+  subMonths,
+  subYears,
+} from 'date-fns'
+import React, { useState, createContext, type PropsWithChildren, useContext } from 'react'
+import { createStore, useStore } from 'zustand'
+import { safeAssertUnreachable } from '../../utils/switch/safeAssertUnreachable'
+import { useStoreWithDateSelected } from '../../utils/zustand/useStoreWithDateSelected'
+
+const _DATE_PICKER_MODES = [
+  'dayPicker',
+] as const
+export type DatePickerMode = typeof _DATE_PICKER_MODES[number]
+
+const _RANGE_PICKER_MODES = [
+  'dayRangePicker',
+  'monthPicker',
+  'monthRangePicker',
+  'yearPicker',
+] as const
+export type DateRangePickerMode = typeof _RANGE_PICKER_MODES[number]
+
+function startOfNextDay(date: Date | number) {
+  return startOfDay(addDays(date, 1))
+}
+
+type CommonShiftOptions = { currentStart: Date }
+type PreShiftOptions = CommonShiftOptions & { currentEnd: Date, newEnd: Date }
+type PostShiftOptions = CommonShiftOptions & { shiftedCurrentEnd: Date, shiftedNewEnd: Date }
+
+function withShiftedEnd<T>(fn: (options: PostShiftOptions) => T) {
+  return ({ currentStart, currentEnd, newEnd }: PreShiftOptions) => {
+    const shiftedCurrentEnd = startOfNextDay(currentEnd)
+    const shiftedNewEnd = startOfNextDay(newEnd)
+
+    return fn({ currentStart, shiftedCurrentEnd, shiftedNewEnd })
+  }
+}
+
+const RANGE_MODE_LOOKUP = {
+  dayRangePicker: {
+    getStart: ({ start }: { start: Date }) => start,
+    getShiftedStart: withShiftedEnd(({ currentStart, shiftedCurrentEnd, shiftedNewEnd }) => {
+      const fullDayCount = differenceInDays(shiftedCurrentEnd, currentStart)
+      return subDays(shiftedNewEnd, fullDayCount)
+    }),
+    getEnd: ({ end }: { end: Date }) => end,
+  },
+  monthPicker: {
+    getStart: ({ start }: { start: Date }) => startOfMonth(start),
+    getShiftedStart: withShiftedEnd(({ shiftedNewEnd }) => {
+      return subMonths(shiftedNewEnd, 1)
+    }),
+    getEnd: ({ end }: { end: Date }) => endOfMonth(end),
+  },
+  monthRangePicker: {
+    getStart: ({ start }: { start: Date }) => startOfMonth(start),
+    getShiftedStart: withShiftedEnd(({ currentStart, shiftedCurrentEnd, shiftedNewEnd }) => {
+      const fullMonthCount = differenceInMonths(shiftedCurrentEnd, currentStart)
+      return subMonths(shiftedNewEnd, fullMonthCount)
+    }),
+    getEnd: ({ end }: { end: Date }) => endOfMonth(end),
+  },
+  yearPicker: {
+    getStart: ({ start }: { start: Date }) => startOfYear(start),
+    getShiftedStart: withShiftedEnd(({ shiftedNewEnd }) => {
+      return subYears(shiftedNewEnd, 1)
+    }),
+    getEnd: ({ end }: { end: Date }) => endOfYear(end),
+  },
+} satisfies Record<
+  DateRangePickerMode,
+  {
+    getStart: ({ start }: { start: Date }) => Date
+    getShiftedStart: (options: { currentStart: Date, currentEnd: Date, newEnd: Date }) => Date
+    getEnd: ({ end }: { end: Date }) => Date
+  }
+>
+
+type DateRange = { start: Date, end: Date }
+
+function withCorrectedRange<TDateRange extends DateRange, TOut>(fn: (options: TDateRange) => TOut) {
+  return (options: TDateRange) => {
+    const { start, end } = options
+
+    if (start > end) {
+      return fn({ ...options, start: end, end: start })
+    }
+
+    return fn({ ...options, start, end })
+  }
+}
+
+type GlobalDateStoreShape = {
+  start: Date
+  end: Date
+
+  mode: DatePickerMode
+  rangeMode: DateRangePickerMode
+
+  actions: {
+    set(options: { date: Date }): void
+
+    setRange: (options: { start: Date, end: Date }) => void
+    setRangeMode(options: { rangeMode: DateRangePickerMode }): void
+    setRangeWithExplicitMode: (
+      options: {
+        start: Date
+        end: Date
+        rangeMode: DateRangePickerMode
+      }
+    ) => void
+    setMonth: (options: { start: Date }) => void
+    setMonthRange: (options: { start: Date, end: Date }) => void
+    setYear: (options: { start: Date }) => void
+  }
+}
+
+function buildStore() {
+  const now = new Date()
+
+  return createStore<GlobalDateStoreShape>((set, get) => {
+    const setRange = withCorrectedRange(({ start, end }) => {
+      set({
+        start: startOfDay(start),
+        end: endOfDay(end),
+        rangeMode: 'dayRangePicker',
+      })
+    })
+    const setMonth = ({ start }: { start: Date }) => {
+      set({
+        start: startOfMonth(start),
+        end: endOfMonth(start),
+        rangeMode: 'monthPicker',
+      })
+    }
+    const setMonthRange = withCorrectedRange(({ start, end }) => {
+      set({
+        start: startOfMonth(start),
+        end: endOfMonth(end),
+        rangeMode: 'monthRangePicker',
+      })
+    })
+    const setYear = ({ start }: { start: Date }) => {
+      set({
+        start: startOfMonth(start),
+        end: endOfMonth(start),
+        rangeMode: 'yearPicker',
+      })
+    }
+
+    const setRangeWithExplicitMode = ({
+      start,
+      end,
+      rangeMode,
+    }: { start: Date, end: Date, rangeMode: DateRangePickerMode }) => {
+      switch (rangeMode) {
+        case 'dayRangePicker':
+          setRange({ start, end })
+          break
+        case 'monthPicker':
+          setMonth({ start })
+          break
+        case 'monthRangePicker':
+          setMonthRange({ start, end })
+          break
+        case 'yearPicker':
+          setYear({ start })
+          break
+        default:
+          safeAssertUnreachable(rangeMode, 'Invalid range mode')
+      }
+    }
+
+    return {
+      start: startOfMonth(now),
+      end: endOfMonth(now),
+
+      mode: 'dayPicker',
+      rangeMode: 'monthPicker',
+
+      actions: {
+        set: ({ date }) => {
+          set(({ start: currentStart, end: currentEnd, rangeMode: currentRangeMode }) => {
+            const newEnd = endOfDay(date)
+
+            return {
+              start: RANGE_MODE_LOOKUP[currentRangeMode].getShiftedStart({
+                currentStart,
+                currentEnd,
+                newEnd,
+              }),
+              end: newEnd,
+              rangeMode: 'dayRangePicker',
+            }
+          })
+        },
+
+        setRange,
+        setRangeMode: ({ rangeMode }) => {
+          const { start, end } = get()
+
+          setRangeWithExplicitMode({ rangeMode, start, end })
+        },
+        setRangeWithExplicitMode,
+        setMonth,
+        setMonthRange,
+        setYear,
+      },
+    }
+  })
+}
+
+const GlobalDateStoreContext = createContext(buildStore())
+
+export function useGlobalDate() {
+  const store = useContext(GlobalDateStoreContext)
+
+  const date = useStoreWithDateSelected(store, ({ end }) => end)
+
+  const mode = useStore(store, ({ mode }) => mode)
+
+  return { date, mode }
+}
+
+export function useGlobalDateActions() {
+  const store = useContext(GlobalDateStoreContext)
+
+  const set = useStore(store, ({ actions: { set } }) => set)
+
+  return { set }
+}
+
+export function useGlobalDateRange() {
+  const store = useContext(GlobalDateStoreContext)
+
+  const start = useStoreWithDateSelected(store, ({ start }) => start)
+  const end = useStoreWithDateSelected(store, ({ end }) => end)
+
+  const rangeMode = useStore(store, ({ rangeMode }) => rangeMode)
+
+  return {
+    start,
+    end,
+    rangeMode,
+  }
+}
+
+export function useGlobalDateRangeActions() {
+  const store = useContext(GlobalDateStoreContext)
+
+  const setRange = useStore(store, ({ actions: { setRange } }) => setRange)
+  const setRangeMode = useStore(store, ({ actions: { setRangeMode } }) => setRangeMode)
+  const setRangeWithExplicitMode = useStore(
+    store,
+    ({ actions: { setRangeWithExplicitMode } }) => setRangeWithExplicitMode,
+  )
+  const setMonth = useStore(store, ({ actions: { setMonth } }) => setMonth)
+  const setMonthRange = useStore(store, ({ actions: { setMonthRange } }) => setMonthRange)
+  const setYear = useStore(store, ({ actions: { setYear } }) => setYear)
+
+  return { setRange, setRangeMode, setRangeWithExplicitMode, setMonth, setMonthRange, setYear }
+}
+
+type GlobalDateStoreProviderProps = PropsWithChildren
+
+export function GlobalDateStoreProvider({
+  children,
+}: GlobalDateStoreProviderProps) {
+  const [store] = useState(() => buildStore())
+
+  return (
+    <GlobalDateStoreContext.Provider value={store}>
+      {children}
+    </GlobalDateStoreContext.Provider>
+  )
+}

--- a/src/providers/GlobalDateStore/useGlobalDateRangePicker.ts
+++ b/src/providers/GlobalDateStore/useGlobalDateRangePicker.ts
@@ -18,20 +18,24 @@ export function useGlobalDateRangePicker({
   defaultDatePickerMode?: DateRangePickerMode
   onSetMonth?: (startOfMonth: Date) => void
 }) {
-  const { start, end, rangeMode } = useGlobalDateRange()
-  const { setMonth, setRangeWithExplicitMode, setRangeMode } = useGlobalDateRangeActions()
+  const { start, end, rangeDisplayMode } = useGlobalDateRange()
+  const {
+    setMonth,
+    setRangeWithExplicitDisplayMode,
+    setRangeDisplayMode,
+  } = useGlobalDateRangeActions()
 
   const allowedDateRangePickerModes = getArrayWithAtLeastOneOrFallback(
     allowedDatePickerModes ?? (defaultDatePickerMode ? [defaultDatePickerMode] : []),
     DEFAULT_ALLOWED_PICKER_MODES,
   )
 
-  const desiredRangeMode = allowedDateRangePickerModes.includes(rangeMode)
-    ? rangeMode
+  const desiredRangeMode = allowedDateRangePickerModes.includes(rangeDisplayMode)
+    ? rangeDisplayMode
     : allowedDateRangePickerModes[0]
 
   const { dateFormat, selected } = useMemo(() => {
-    if (rangeMode === 'monthPicker') {
+    if (rangeDisplayMode === 'monthPicker') {
       return {
         selected: start,
         dateFormat: undefined,
@@ -49,7 +53,7 @@ export function useGlobalDateRangePicker({
   }, [
     start,
     end,
-    rangeMode,
+    rangeDisplayMode,
   ])
 
   const { setSelected } = useMemo(() => {
@@ -65,22 +69,22 @@ export function useGlobalDateRangePicker({
 
     return {
       setSelected: ({ start, end }: { start: Date, end: Date }) => {
-        setRangeWithExplicitMode({ start, end, rangeMode: desiredRangeMode })
+        setRangeWithExplicitDisplayMode({ start, end, rangeDisplayMode: desiredRangeMode })
       },
     } as const
   }, [
     desiredRangeMode,
     onSetMonth,
     setMonth,
-    setRangeWithExplicitMode,
+    setRangeWithExplicitDisplayMode,
   ])
 
   return {
     allowedDateRangePickerModes,
     dateFormat,
-    rangeMode,
+    rangeDisplayMode,
     selected,
     setSelected,
-    setRangeMode,
+    setRangeDisplayMode,
   }
 }

--- a/src/providers/GlobalDateStore/useGlobalDateRangePicker.ts
+++ b/src/providers/GlobalDateStore/useGlobalDateRangePicker.ts
@@ -1,0 +1,86 @@
+import { useMemo } from 'react'
+import {
+  type DateRangePickerMode,
+  useGlobalDateRange,
+  useGlobalDateRangeActions,
+} from './GlobalDateStoreProvider'
+import {
+  DEFAULT_ALLOWED_PICKER_MODES,
+} from '../../components/DatePicker/ModeSelector/DatePickerModeSelector'
+import { getArrayWithAtLeastOneOrFallback } from '../../utils/array/getArrayWithAtLeastOneOrFallback'
+
+export function useGlobalDateRangePicker({
+  allowedDatePickerModes,
+  defaultDatePickerMode,
+  onSetMonth,
+}: {
+  allowedDatePickerModes?: ReadonlyArray<DateRangePickerMode>
+  defaultDatePickerMode?: DateRangePickerMode
+  onSetMonth?: (startOfMonth: Date) => void
+}) {
+  const { start, end, rangeMode } = useGlobalDateRange()
+  const { setMonth, setRangeWithExplicitMode, setRangeMode } = useGlobalDateRangeActions()
+
+  const allowedDateRangePickerModes = getArrayWithAtLeastOneOrFallback(
+    allowedDatePickerModes ?? (defaultDatePickerMode ? [defaultDatePickerMode] : []),
+    DEFAULT_ALLOWED_PICKER_MODES,
+  )
+
+  const desiredRangeMode = allowedDateRangePickerModes.includes(rangeMode)
+    ? rangeMode
+    : allowedDateRangePickerModes[0]
+
+  const { dateFormat, selected } = useMemo(() => {
+    if (rangeMode === 'monthPicker') {
+      return {
+        selected: start,
+        dateFormat: undefined,
+      } as const
+    }
+
+    return {
+      /*
+       * This intentionally needs to be cast to a mutable array. The `DatePicker`
+       * component should accept a readonly array, but that refactor is out of scope.
+       */
+      selected: [start, end] as [Date, Date],
+      dateFormat: 'MMM d',
+    } as const
+  }, [
+    start,
+    end,
+    rangeMode,
+  ])
+
+  const { setSelected } = useMemo(() => {
+    if (desiredRangeMode === 'monthPicker') {
+      return {
+        setSelected: ({ start }: { start: Date }) => {
+          setMonth({ start })
+
+          onSetMonth?.(start)
+        },
+      } as const
+    }
+
+    return {
+      setSelected: ({ start, end }: { start: Date, end: Date }) => {
+        setRangeWithExplicitMode({ start, end, rangeMode: desiredRangeMode })
+      },
+    } as const
+  }, [
+    desiredRangeMode,
+    onSetMonth,
+    setMonth,
+    setRangeWithExplicitMode,
+  ])
+
+  return {
+    allowedDateRangePickerModes,
+    dateFormat,
+    rangeMode,
+    selected,
+    setSelected,
+    setRangeMode,
+  }
+}

--- a/src/providers/LayerProvider/LayerProvider.tsx
+++ b/src/providers/LayerProvider/LayerProvider.tsx
@@ -7,6 +7,7 @@ import type { Environment } from '../Environment/environmentConfigs'
 import { AuthInputProvider } from '../AuthInputProvider'
 import { EnvironmentInputProvider } from '../Environment/EnvironmentInputProvider'
 import { DEFAULT_SWR_CONFIG } from '../../utils/swr/defaultSWRConfig'
+import { GlobalDateStoreProvider } from '../GlobalDateStore/GlobalDateStoreProvider'
 
 export type EventCallbacks = {
   onTransactionCategorized?: (bankTransactionId: string) => void
@@ -33,7 +34,7 @@ export const LayerProvider = ({
   usePlaidSandbox,
   ...restProps
 }: PropsWithChildren<LayerProviderProps>) => {
-  const [ cache ] = useState(() => new Map())
+  const [cache] = useState(() => new Map())
 
   return (
     <SWRConfig value={{ ...DEFAULT_SWR_CONFIG, provider: () => cache }}>
@@ -43,7 +44,9 @@ export const LayerProvider = ({
           appSecret={appSecret}
           businessAccessToken={businessAccessToken}
         >
-          <BusinessProvider {...restProps} />
+          <GlobalDateStoreProvider>
+            <BusinessProvider {...restProps} />
+          </GlobalDateStoreProvider>
         </AuthInputProvider>
       </EnvironmentInputProvider>
     </SWRConfig>

--- a/src/utils/array/getArrayWithAtLeastOneOrFallback.ts
+++ b/src/utils/array/getArrayWithAtLeastOneOrFallback.ts
@@ -1,0 +1,12 @@
+type ArrayWithAtLeastOne<T> = readonly [T, ...T[]]
+
+export function getArrayWithAtLeastOneOrFallback<T>(
+  list: ReadonlyArray<T>,
+  fallback: ArrayWithAtLeastOne<T>,
+): ArrayWithAtLeastOne<T> {
+  if (list.length === 0) {
+    return fallback
+  }
+
+  return list as ArrayWithAtLeastOne<T>
+}

--- a/src/utils/switch/safeAssertUnreachable.ts
+++ b/src/utils/switch/safeAssertUnreachable.ts
@@ -1,0 +1,8 @@
+export function safeAssertUnreachable(value: never, message?: string): never {
+  console.error(
+    message ?? 'Unexpected value encountered in exhaustive check:',
+    value,
+  )
+
+  return undefined as never
+}

--- a/src/utils/zustand/useStoreWithDateSelected.ts
+++ b/src/utils/zustand/useStoreWithDateSelected.ts
@@ -1,0 +1,12 @@
+import type { StoreApi } from 'zustand'
+import { useStoreWithEqualityFn } from 'zustand/traditional'
+
+type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'getInitialState' | 'subscribe'>
+type ExtractState<S> = S extends { getState: () => infer T } ? T : never
+
+export function useStoreWithDateSelected<S extends ReadonlyStoreApi<unknown>>(
+  api: S,
+  selector: (state: ExtractState<S>) => Date,
+) {
+  return useStoreWithEqualityFn(api, selector, (a, b) => a.getTime() === b.getTime())
+}

--- a/src/views/AccountingOverview/AccountingOverview.tsx
+++ b/src/views/AccountingOverview/AccountingOverview.tsx
@@ -76,7 +76,7 @@ export const AccountingOverview = ({
       <View
         title={title}
         showHeader={showTitle}
-        header={
+        header={(
           <Header>
             <HeaderRow>
               <HeaderCol>
@@ -84,7 +84,7 @@ export const AccountingOverview = ({
               </HeaderCol>
             </HeaderRow>
           </Header>
-        }
+        )}
       >
         {enableOnboarding && (
           <Onboarding
@@ -150,7 +150,7 @@ export const AccountingOverview = ({
             name={classNames(
               'accounting-overview-profit-and-loss-chart',
               pnlToggle !== 'revenue'
-                && 'accounting-overview-profit-and-loss-chart--hidden',
+              && 'accounting-overview-profit-and-loss-chart--hidden',
             )}
           >
             <ProfitAndLoss.DetailedCharts
@@ -164,7 +164,7 @@ export const AccountingOverview = ({
             name={classNames(
               'accounting-overview-profit-and-loss-chart',
               pnlToggle !== 'expenses'
-                && 'accounting-overview-profit-and-loss-chart--hidden',
+              && 'accounting-overview-profit-and-loss-chart--hidden',
             )}
           >
             <ProfitAndLoss.DetailedCharts

--- a/src/views/ProjectProfitability/ProjectProfitability.tsx
+++ b/src/views/ProjectProfitability/ProjectProfitability.tsx
@@ -2,15 +2,13 @@ import React, { useState } from 'react'
 import Select, { Options } from 'react-select'
 import { BankTransactions } from '../../components/BankTransactions'
 import { Container } from '../../components/Container'
-import {
-  RangePickerMode,
-} from '../../components/DatePicker/ModeSelector/DatePickerModeSelector'
 import { ProfitAndLoss } from '../../components/ProfitAndLoss'
 import { Toggle } from '../../components/Toggle'
 import { View } from '../../components/View'
 import { PnlTagFilter } from '../../hooks/useProfitAndLoss/useProfitAndLoss'
 import { DisplayState, MoneyFormat } from '../../types'
 import { AccountingOverview } from '../AccountingOverview'
+import type { DateRangePickerMode } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 
 export type TagOption = {
   label: string
@@ -26,7 +24,7 @@ export interface ProjectProfitabilityProps {
   valueOptions: TagOption[]
   showTitle?: boolean
   stringOverrides?: ProjectsStringOverrides
-  datePickerMode?: RangePickerMode
+  datePickerMode?: DateRangePickerMode
   csvMoneyFormat?: MoneyFormat
 }
 
@@ -51,22 +49,22 @@ export const ProjectProfitabilityView = ({
   ) => {
     return selectValue.some(
       value =>
-        value.tagKey === option.tagKey &&
-        JSON.stringify(value.tagValues) === JSON.stringify(option.tagValues),
+        value.tagKey === option.tagKey
+        && JSON.stringify(value.tagValues) === JSON.stringify(option.tagValues),
     )
   }
 
   const getTagFilter = (
     tagFilter: TagOption | null,
-  ): { key: string; values: string[] } | undefined => {
-    return tagFilter &&
-      tagFilter.tagKey &&
-      tagFilter.tagValues &&
-      tagFilter.tagValues.length > 0
+  ): { key: string, values: string[] } | undefined => {
+    return tagFilter
+      && tagFilter.tagKey
+      && tagFilter.tagValues
+      && tagFilter.tagValues.length > 0
       ? {
-          key: tagFilter.tagKey,
-          values: tagFilter.tagValues,
-        }
+        key: tagFilter.tagKey,
+        values: tagFilter.tagValues,
+      }
       : undefined
   }
 
@@ -107,12 +105,12 @@ export const ProjectProfitabilityView = ({
           defaultValue={valueOptions.length > 0 ? valueOptions[0] : undefined}
           value={valueOptions.find(
             option =>
-              tagFilter &&
-              option.tagKey === tagFilter.tagKey &&
-              JSON.stringify(option.tagValues) ===
-                JSON.stringify(tagFilter.tagValues),
+              tagFilter
+              && option.tagKey === tagFilter.tagKey
+              && JSON.stringify(option.tagValues)
+              === JSON.stringify(tagFilter.tagValues),
           )}
-          onChange={selectedOption => {
+          onChange={(selectedOption) => {
             setTagFilter(selectedOption)
             setPnlTagFilter(getTagFilter(selectedOption))
           }}

--- a/src/views/Reports/reportTypes.ts
+++ b/src/views/Reports/reportTypes.ts
@@ -1,15 +1,15 @@
 import type { CustomDateRange } from '../../components/DatePicker/DatePickerOptions'
-import type { RangePickerMode } from '../../components/DatePicker/ModeSelector/DatePickerModeSelector'
+import type { DateRangePickerMode } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 import type { MoneyFormat } from '../../types'
 
 export type TimeRangePickerConfig = {
   /**
    * @deprecated Use `defaultDatePickerMode` instead
    */
-  datePickerMode?: RangePickerMode
-  defaultDatePickerMode?: RangePickerMode
+  datePickerMode?: DateRangePickerMode
+  defaultDatePickerMode?: DateRangePickerMode
 
-  allowedDatePickerModes?: ReadonlyArray<RangePickerMode>
+  allowedDatePickerModes?: ReadonlyArray<DateRangePickerMode>
   csvMoneyFormat?: MoneyFormat
   customDateRanges?: CustomDateRange[]
 }


### PR DESCRIPTION
## Description

**Linear**: LAY-1128

The three major reports - P&L, Balance Sheet, and Cash Flow - now share common date state.

After a user adjusts the date range for viewing one report, they will preserve this same date range for another report. Since the balance sheet is a point in time, it is simply the end of the defined range.

## Limitations + Known Issues

- The Profit and Loss Comparison does not correctly handle non-month time periods. This is already an issue and will be attacked in follow-on work.

- The Profit and Loss Chart still displays reasonably, but the selected range outline _only_ highlights the first month in the range. I don't think it's reasonable to fold-in even more changes to manage that chart in special situations. 