### PR TITLE
chore: remove unnecessary imports of `React` global

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -92,6 +92,7 @@ export default tsEslint.config([
           ignoreRestSiblings: true,
         },
       ],
+      'unused-imports/no-unused-imports': 'error',
 
       'react/prop-types': 'off',
     },

--- a/src/components/ActionableList/ActionableList.tsx
+++ b/src/components/ActionableList/ActionableList.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import CheckIcon from '../../icons/Check'
 import ChevronRight from '../../icons/ChevronRight'
 import { Text, TextSize } from '../Typography'
@@ -42,30 +41,34 @@ export const ActionableList = <T,>({
           <div className='Layer__actionable-list__content'>
             <Text size={TextSize.sm}>{x.label}</Text>
             {
-              /*TODO: Replace 'See all categories' with something more generic*/
-              showDescriptions &&
-                x.description &&
-                x.label !== 'See all categories' && (
-                  <Text
-                    className='Layer__actionable-list__content-description'
-                    size={TextSize.sm}
-                  >
-                    {x.description}
-                  </Text>
-                )
+              /* TODO: Replace 'See all categories' with something more generic */
+              showDescriptions
+              && x.description
+              && x.label !== 'See all categories' && (
+                <Text
+                  className='Layer__actionable-list__content-description'
+                  size={TextSize.sm}
+                >
+                  {x.description}
+                </Text>
+              )
             }
           </div>
-          {!x.asLink && selectedId && selectedId === x.id ? (
-            <span className='Layer__actionable-list__select Layer__actionable-list__select--selected'>
-              <CheckIcon
-                size={14}
-                className='Layer__actionable-list__selected-icon'
-              />
-            </span>
-          ) : null}
-          {!x.asLink && (!selectedId || selectedId !== x.id) ? (
-            <span className='Layer__actionable-list__select' />
-          ) : null}
+          {!x.asLink && selectedId && selectedId === x.id
+            ? (
+              <span className='Layer__actionable-list__select Layer__actionable-list__select--selected'>
+                <CheckIcon
+                  size={14}
+                  className='Layer__actionable-list__selected-icon'
+                />
+              </span>
+            )
+            : null}
+          {!x.asLink && (!selectedId || selectedId !== x.id)
+            ? (
+              <span className='Layer__actionable-list__select' />
+            )
+            : null}
           {x.asLink && (
             <ChevronRight
               size={16}

--- a/src/components/ActionableRow/ActionableRow.tsx
+++ b/src/components/ActionableRow/ActionableRow.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import ChevronRightIcon from '../../icons/ChevronRight'
 import { IconButton } from '../Button'
 import { Text } from '../Typography'
@@ -69,13 +69,15 @@ export const ActionableRow = ({
       </div>
       <div className='Layer__actionable_row__action'>
         {button && button}
-        {!button && onClick ? (
-          <IconButton
-            onClick={onClick}
-            icon={<ChevronRightIcon size={11} />}
-            withBorder
-          />
-        ) : null}
+        {!button && onClick
+          ? (
+            <IconButton
+              onClick={onClick}
+              icon={<ChevronRightIcon size={11} />}
+              withBorder
+            />
+          )
+          : null}
       </div>
     </div>
   )

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { ButtonProps } from '../Button/Button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '../Tooltip'
 import classNames from 'classnames'
@@ -54,13 +54,15 @@ export const Badge = ({
     </>
   )
 
-  content = onClick ? (
-    <button role='button' {...baseProps}>
-      {content}
-    </button>
-  ) : (
-    <span {...baseProps}>{content}</span>
-  )
+  content = onClick
+    ? (
+      <button role='button' {...baseProps}>
+        {content}
+      </button>
+    )
+    : (
+      <span {...baseProps}>{content}</span>
+    )
 
   if (tooltip) {
     return (

--- a/src/components/BadgeLoader/BadgeLoader.tsx
+++ b/src/components/BadgeLoader/BadgeLoader.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import LoaderIcon from '../../icons/Loader'
 
 export interface BadgeLoaderProps {

--- a/src/components/BalanceSheet/BalanceSheet.tsx
+++ b/src/components/BalanceSheet/BalanceSheet.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useEffect, useState } from 'react'
+import { PropsWithChildren } from 'react'
 import { BalanceSheetContext } from '../../contexts/BalanceSheetContext'
 import { TableProvider } from '../../contexts/TableContext'
 import { useBalanceSheet } from '../../hooks/useBalanceSheet'

--- a/src/components/BalanceSheet/download/BalanceSheetDownloadButton.tsx
+++ b/src/components/BalanceSheet/download/BalanceSheetDownloadButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { DownloadButton } from '../../Button/DownloadButton'
 import InvisibleDownload, { useInvisibleDownload } from '../../utility/InvisibleDownload'
 import { useBalanceSheetDownload } from './useBalanceSheetDownload'

--- a/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
+++ b/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { DatePicker } from '../DatePicker'
 import { useGlobalDate, useGlobalDateActions } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 

--- a/src/components/BalanceSheetExpandAllButton/BalanceSheetExpandAllButton.tsx
+++ b/src/components/BalanceSheetExpandAllButton/BalanceSheetExpandAllButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useTableExpandRow } from '../../hooks/useTableExpandRow'
 import { View } from '../../types/general'
 import { ExpandCollapseButton } from '../Button'

--- a/src/components/BalanceSheetTable/BalanceSheetTable.tsx
+++ b/src/components/BalanceSheetTable/BalanceSheetTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import { Fragment, ReactNode, useEffect } from 'react'
 import { useTableExpandRow } from '../../hooks/useTableExpandRow'
 import { BalanceSheet, LineItem } from '../../types'
 import { TableCellAlign } from '../../types/table'
@@ -42,7 +42,7 @@ export const BalanceSheetTable = ({
     depth: number = 0,
     rowKey: string,
     rowIndex: number,
-  ): React.ReactNode => {
+  ): ReactNode => {
     const expandable = !!lineItem.line_items && lineItem.line_items.length > 0
 
     const expanded = expandable ? isOpen(rowKey) : true
@@ -54,7 +54,7 @@ export const BalanceSheetTable = ({
     }
 
     return (
-      <React.Fragment key={rowKey + '-' + rowIndex}>
+      <Fragment key={rowKey + '-' + rowIndex}>
         <TableRow
           rowKey={rowKey + '-' + rowIndex}
           expandable={expandable}
@@ -74,16 +74,16 @@ export const BalanceSheetTable = ({
             {(!expandable || (expandable && !expanded)) && lineItem.value}
           </TableCell>
         </TableRow>
-        {showChildren &&
-          lineItem.line_items &&
-          lineItem.line_items.map((subItem, subIdx) =>
-            renderLineItem(
-              subItem,
-              depth + 1,
-              rowKey + ':' + subItem.name,
-              subIdx,
-            ),
-          )}
+        {showChildren
+        && lineItem.line_items
+        && lineItem.line_items.map((subItem, subIdx) =>
+          renderLineItem(
+            subItem,
+            depth + 1,
+            rowKey + ':' + subItem.name,
+            subIdx,
+          ),
+        )}
         {showChildren && expandable && (
           <TableRow
             rowKey={rowKey + '-' + rowIndex + '--summation'}
@@ -96,7 +96,7 @@ export const BalanceSheetTable = ({
             </TableCell>
           </TableRow>
         )}
-      </React.Fragment>
+      </Fragment>
     )
   }
 
@@ -114,15 +114,15 @@ export const BalanceSheetTable = ({
       </TableHead>
       <TableBody>
         {config.map((row, idx) => (
-          <React.Fragment key={row.lineItem}>
-            {data[row.lineItem as keyof BalanceSheet] &&
-              renderLineItem(
-                data[row.lineItem as keyof BalanceSheet] as LineItem,
-                0,
-                row.lineItem,
-                idx,
-              )}
-          </React.Fragment>
+          <Fragment key={row.lineItem}>
+            {data[row.lineItem as keyof BalanceSheet]
+            && renderLineItem(
+              data[row.lineItem as keyof BalanceSheet] as LineItem,
+              0,
+              row.lineItem,
+              idx,
+            )}
+          </Fragment>
         ))}
       </TableBody>
     </Table>

--- a/src/components/BankTransactionList/Assignment.tsx
+++ b/src/components/BankTransactionList/Assignment.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { DATE_FORMAT } from '../../config/general'
 import Scissors from '../../icons/Scissors'
 import { BankTransaction, CategorizationStatus } from '../../types'
@@ -15,8 +14,8 @@ export interface AssignmentProps {
 
 export const Assignment = ({ bankTransaction }: AssignmentProps) => {
   if (
-    bankTransaction.match &&
-    bankTransaction.categorization_status === CategorizationStatus.MATCHED
+    bankTransaction.match
+    && bankTransaction.categorization_status === CategorizationStatus.MATCHED
   ) {
     return (
       <>
@@ -31,8 +30,8 @@ export const Assignment = ({ bankTransaction }: AssignmentProps) => {
             parseISO(bankTransaction.match.bank_transaction.date),
             DATE_FORMAT,
           )}, ${
-            bankTransaction.match.bank_transaction.description ??
-            bankTransaction.match?.details?.description
+            bankTransaction.match.bank_transaction.description
+            ?? bankTransaction.match?.details?.description
           }`}
         </Text>
       </>
@@ -44,12 +43,12 @@ export const Assignment = ({ bankTransaction }: AssignmentProps) => {
       <>
         <Badge
           icon={<Scissors size={11} />}
-          tooltip={
+          tooltip={(
             <SplitTooltipDetails
               classNamePrefix='Layer__bank-transaction-list-item'
               category={bankTransaction.category}
             />
-          }
+          )}
         >
           Split
         </Badge>

--- a/src/components/BankTransactionList/BankTransactionList.tsx
+++ b/src/components/BankTransactionList/BankTransactionList.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { DATE_FORMAT } from '../../config/general'
 import { BankTransaction } from '../../types'
 import {

--- a/src/components/BankTransactionList/BankTransactionListItem.tsx
+++ b/src/components/BankTransactionList/BankTransactionListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useBankTransactionsContext } from '../../contexts/BankTransactionsContext'
 import ChevronDownFill from '../../icons/ChevronDownFill'
 import FileIcon from '../../icons/File'
@@ -88,9 +88,9 @@ export const BankTransactionListItem = ({
 
   useEffect(() => {
     if (
-      editable &&
-      bankTransaction.recently_categorized &&
-      shouldHideAfterCategorize(bankTransaction)
+      editable
+      && bankTransaction.recently_categorized
+      && shouldHideAfterCategorize(bankTransaction)
     ) {
       setTimeout(() => {
         removeTransaction(bankTransaction)
@@ -126,9 +126,9 @@ export const BankTransactionListItem = ({
   const openClassName = open ? `${className}--expanded` : ''
   const rowClassName = classNames(
     className,
-    bankTransaction.recently_categorized &&
-      editable &&
-      shouldHideAfterCategorize(bankTransaction)
+    bankTransaction.recently_categorized
+    && editable
+    && shouldHideAfterCategorize(bankTransaction)
       ? 'Layer__bank-transaction-row--removing'
       : '',
     open ? openClassName : '',
@@ -195,58 +195,64 @@ export const BankTransactionListItem = ({
         />
       </span>
       <span className={`${className}__base-row`}>
-        {!categorized ? (
-          <CategorySelect
-            bankTransaction={bankTransaction}
-            name={`category-${bankTransaction.id}`}
-            value={selectedCategory}
-            onChange={category => {
-              setShowRetry(false)
-              setSelectedCategory(category)
-            }}
-            disabled={bankTransaction.processing}
-            showTooltips={showTooltips}
-          />
-        ) : null}
+        {!categorized
+          ? (
+            <CategorySelect
+              bankTransaction={bankTransaction}
+              name={`category-${bankTransaction.id}`}
+              value={selectedCategory}
+              onChange={(category) => {
+                setShowRetry(false)
+                setSelectedCategory(category)
+              }}
+              disabled={bankTransaction.processing}
+              showTooltips={showTooltips}
+            />
+          )
+          : null}
         {categorized ? <Assignment bankTransaction={bankTransaction} /> : null}
-        {!categorized && !showRetry ? (
-          <SubmitButton
-            onClick={() => {
-              if (!bankTransaction.processing) {
-                save()
-              }
-            }}
-            className='Layer__bank-transaction__submit-btn'
-            processing={bankTransaction.processing}
-            action={!categorized ? SubmitAction.SAVE : SubmitAction.UPDATE}
-          >
-            {!categorized
-              ? stringOverrides?.approveButtonText || 'Approve'
-              : stringOverrides?.updateButtonText || 'Update'}
-          </SubmitButton>
-        ) : null}
-        {!categorized && showRetry ? (
-          <RetryButton
-            onClick={() => {
-              if (!bankTransaction.processing) {
-                save()
-              }
-            }}
-            className='Layer__bank-transaction__retry-btn'
-            processing={bankTransaction.processing}
-            error={
-              'Approval failed. Check connection and retry in few seconds.'
-            }
-          >
-            Retry
-          </RetryButton>
-        ) : null}
+        {!categorized && !showRetry
+          ? (
+            <SubmitButton
+              onClick={() => {
+                if (!bankTransaction.processing) {
+                  save()
+                }
+              }}
+              className='Layer__bank-transaction__submit-btn'
+              processing={bankTransaction.processing}
+              action={!categorized ? SubmitAction.SAVE : SubmitAction.UPDATE}
+            >
+              {!categorized
+                ? stringOverrides?.approveButtonText || 'Approve'
+                : stringOverrides?.updateButtonText || 'Update'}
+            </SubmitButton>
+          )
+          : null}
+        {!categorized && showRetry
+          ? (
+            <RetryButton
+              onClick={() => {
+                if (!bankTransaction.processing) {
+                  save()
+                }
+              }}
+              className='Layer__bank-transaction__retry-btn'
+              processing={bankTransaction.processing}
+              error='Approval failed. Check connection and retry in few seconds.'
+            >
+              Retry
+            </RetryButton>
+          )
+          : null}
       </span>
-      {bankTransaction.error && showRetry ? (
-        <ErrorText>
-          Approval failed. Check connection and retry in few seconds.
-        </ErrorText>
-      ) : null}
+      {bankTransaction.error && showRetry
+        ? (
+          <ErrorText>
+            Approval failed. Check connection and retry in few seconds.
+          </ErrorText>
+        )
+        : null}
     </li>
   )
 }

--- a/src/components/BankTransactionMobileList/BankTransactionMobileForms.tsx
+++ b/src/components/BankTransactionMobileList/BankTransactionMobileForms.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { ReceiptsProvider } from '../../providers/ReceiptsProvider'
 import { BankTransaction } from '../../types'
 import { Purpose } from './BankTransactionMobileListItem'

--- a/src/components/BankTransactionMobileList/BankTransactionMobileList.tsx
+++ b/src/components/BankTransactionMobileList/BankTransactionMobileList.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { BankTransaction } from '../../types'
 import { BankTransactionsMode } from '../BankTransactions/BankTransactions'
 import { BankTransactionMobileListItem } from './BankTransactionMobileListItem'

--- a/src/components/BankTransactionMobileList/BankTransactionMobileListItem.tsx
+++ b/src/components/BankTransactionMobileList/BankTransactionMobileListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useRef, useState, type ChangeEvent } from 'react'
 import { useBankTransactionsContext } from '../../contexts/BankTransactionsContext'
 import { useElementSize } from '../../hooks/useElementSize'
 import FileIcon from '../../icons/File'
@@ -120,7 +120,8 @@ export const BankTransactionMobileListItem = ({
       if (editable && shouldHideAfterCategorize(bankTransaction)) {
         setRemoveAnim(true)
         openNext()
-      } else {
+      }
+      else {
         close()
       }
     }
@@ -149,7 +150,8 @@ export const BankTransactionMobileListItem = ({
       }, index * 20)
 
       return () => clearTimeout(timeoutId)
-    } else {
+    }
+    else {
       setShowComponent(true)
     }
   }, [])
@@ -166,7 +168,7 @@ export const BankTransactionMobileListItem = ({
     }
   }, [bankTransaction.recently_categorized])
 
-  const onChangePurpose = (event: React.ChangeEvent<HTMLInputElement>) =>
+  const onChangePurpose = (event: ChangeEvent<HTMLInputElement>) =>
     setPurpose(event.target.value as Purpose)
 
   const categorized = isCategorized(bankTransaction)
@@ -230,34 +232,36 @@ export const BankTransactionMobileListItem = ({
             className={`${className}__expanded-row__content`}
             ref={formRowRef}
           >
-            {categorizationEnabled(mode) ? (
-              <div className={`${className}__toggle-row`}>
-                <Toggle
-                  name={`purpose-${bankTransaction.id}`}
-                  size={ToggleSize.xsmall}
-                  options={[
-                    {
-                      value: 'business',
-                      label: 'Business',
-                      style: { minWidth: 84 },
-                    },
-                    {
-                      value: 'personal',
-                      label: 'Personal',
-                      style: { minWidth: 84 },
-                    },
-                    {
-                      value: 'more',
-                      label: 'More',
-                      style: { minWidth: 84 },
-                    },
-                  ]}
-                  selected={purpose}
-                  onChange={onChangePurpose}
-                />
-                <CloseButton onClick={() => close()} />
-              </div>
-            ) : null}
+            {categorizationEnabled(mode)
+              ? (
+                <div className={`${className}__toggle-row`}>
+                  <Toggle
+                    name={`purpose-${bankTransaction.id}`}
+                    size={ToggleSize.xsmall}
+                    options={[
+                      {
+                        value: 'business',
+                        label: 'Business',
+                        style: { minWidth: 84 },
+                      },
+                      {
+                        value: 'personal',
+                        label: 'Personal',
+                        style: { minWidth: 84 },
+                      },
+                      {
+                        value: 'more',
+                        label: 'More',
+                        style: { minWidth: 84 },
+                      },
+                    ]}
+                    selected={purpose}
+                    onChange={onChangePurpose}
+                  />
+                  <CloseButton onClick={() => close()} />
+                </div>
+              )
+              : null}
             <BankTransactionMobileForms
               purpose={purpose}
               bankTransaction={bankTransaction}

--- a/src/components/BankTransactionMobileList/BusinessCategories.tsx
+++ b/src/components/BankTransactionMobileList/BusinessCategories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { ActionableList } from '../ActionableList'
 import { Text, TextWeight } from '../Typography'

--- a/src/components/BankTransactionMobileList/BusinessForm.tsx
+++ b/src/components/BankTransactionMobileList/BusinessForm.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { useContext, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
 import { useBankTransactionsContext } from '../../contexts/BankTransactionsContext'
 import { DrawerContext } from '../../contexts/DrawerContext'
 import PaperclipIcon from '../../icons/Paperclip'
@@ -94,13 +94,15 @@ export const BusinessForm = ({
   const onCategorySelect = (category: Option) => {
     if (category.value.type === 'SELECT_CATEGORY') {
       openDrawer()
-    } else {
+    }
+    else {
       if (
         selectedCategory
         && category.value.payload?.id === selectedCategory.value.payload?.id
       ) {
         setSelectedCategory(undefined)
-      } else {
+      }
+      else {
         setSelectedCategory(category)
       }
     }
@@ -137,14 +139,16 @@ export const BusinessForm = ({
 
   return (
     <div className='Layer__bank-transaction-mobile-list-item__business-form'>
-      {showCategorization ? (
-        <ActionableList<Option['value']>
-          options={options}
-          onClick={onCategorySelect}
-          selectedId={selectedCategory?.id}
-          showDescriptions={showTooltips}
-        />
-      ) : null}
+      {showCategorization
+        ? (
+          <ActionableList<Option['value']>
+            options={options}
+            onClick={onCategorySelect}
+            selectedId={selectedCategory?.id}
+            showDescriptions={showTooltips}
+          />
+        )
+        : null}
       {showDescriptions && (
         <InputGroup
           className='Layer__bank-transaction-mobile-list-item__description'
@@ -160,9 +164,8 @@ export const BusinessForm = ({
             name='description'
             placeholder='Add description'
             value={memoText}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-              setMemoText(e.target.value)
-            }
+            onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+              setMemoText(e.target.value)}
           />
         </InputGroup>
       )}
@@ -186,40 +189,46 @@ export const BusinessForm = ({
       <div className='Layer__bank-transaction-mobile-list-item__actions'>
         {showReceiptUploads && (
           <FileInput
-            onUpload={(files) => receiptsRef.current?.uploadReceipt(files[0])}
+            onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
             text='Upload receipt'
             iconOnly={true}
             icon={<PaperclipIcon />}
           />
         )}
-        {options.length === 0 ? (
-          <Button
-            onClick={openDrawer}
-            fullWidth={true}
-            variant={ButtonVariant.secondary}
-          >
-            Select category
-          </Button>
-        ) : null}
-        {options.length > 0 ? (
-          <Button
-            onClick={save}
-            disabled={
-              !selectedCategory || isLoading || bankTransaction.processing
-            }
-            fullWidth={true}
-          >
-            {isLoading || bankTransaction.processing
-              ? 'Confirming...'
-              : 'Confirm'}
-          </Button>
-        ) : null}
+        {options.length === 0
+          ? (
+            <Button
+              onClick={openDrawer}
+              fullWidth={true}
+              variant={ButtonVariant.secondary}
+            >
+              Select category
+            </Button>
+          )
+          : null}
+        {options.length > 0
+          ? (
+            <Button
+              onClick={save}
+              disabled={
+                !selectedCategory || isLoading || bankTransaction.processing
+              }
+              fullWidth={true}
+            >
+              {isLoading || bankTransaction.processing
+                ? 'Confirming...'
+                : 'Confirm'}
+            </Button>
+          )
+          : null}
       </div>
-      {bankTransaction.error && showRetry ? (
-        <ErrorText>
-          Approval failed. Check connection and retry in few seconds.
-        </ErrorText>
-      ) : null}
+      {bankTransaction.error && showRetry
+        ? (
+          <ErrorText>
+            Approval failed. Check connection and retry in few seconds.
+          </ErrorText>
+        )
+        : null}
     </div>
   )
 }

--- a/src/components/BankTransactionMobileList/MatchForm.tsx
+++ b/src/components/BankTransactionMobileList/MatchForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ChangeEvent } from 'react'
 import { useBankTransactionsContext } from '../../contexts/BankTransactionsContext'
 import PaperclipIcon from '../../icons/Paperclip'
 import { BankTransaction } from '../../types'
@@ -29,10 +29,10 @@ export const MatchForm = ({
   const { memoText, setMemoText, saveMemoText } = useMemoTextContext()
   const [selectedMatchId, setSelectedMatchId] = useState<string | undefined>(
     isAlreadyMatched(bankTransaction)
-      ?? (bankTransaction.suggested_matches
+    ?? (bankTransaction.suggested_matches
       && bankTransaction.suggested_matches?.length > 0
-        ? bankTransaction.suggested_matches[0].id
-        : undefined),
+      ? bankTransaction.suggested_matches[0].id
+      : undefined),
   )
   const [formError, setFormError] = useState<string | undefined>()
   const [showRetry, setShowRetry] = useState(false)
@@ -40,7 +40,8 @@ export const MatchForm = ({
   useEffect(() => {
     if (bankTransaction.error) {
       setShowRetry(true)
-    } else if (showRetry) {
+    }
+    else if (showRetry) {
       setShowRetry(false)
     }
   }, [bankTransaction.error])
@@ -63,7 +64,8 @@ export const MatchForm = ({
 
     if (!selectedMatchId) {
       setFormError('Select an option to match the transaction')
-    } else if (
+    }
+    else if (
       selectedMatchId
       && selectedMatchId !== isAlreadyMatched(bankTransaction)
     ) {
@@ -81,7 +83,7 @@ export const MatchForm = ({
         classNamePrefix='Layer__bank-transaction-mobile-list-item'
         bankTransaction={bankTransaction}
         selectedMatchId={selectedMatchId}
-        setSelectedMatchId={id => {
+        setSelectedMatchId={(id) => {
           setFormError(undefined)
           setSelectedMatchId(id)
         }}
@@ -101,9 +103,8 @@ export const MatchForm = ({
             name='description'
             placeholder='Add description'
             value={memoText}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-              setMemoText(e.target.value)
-            }
+            onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+              setMemoText(e.target.value)}
           />
         </InputGroup>
       )}
@@ -127,7 +128,7 @@ export const MatchForm = ({
       <div className='Layer__bank-transaction-mobile-list-item__actions'>
         {showReceiptUploads && (
           <FileInput
-            onUpload={(files) => receiptsRef.current?.uploadReceipt(files[0])}
+            onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
             text='Upload receipt'
             iconOnly={true}
             icon={<PaperclipIcon />}
@@ -149,11 +150,13 @@ export const MatchForm = ({
         </Button>
       </div>
       {formError && <ErrorText>{formError}</ErrorText>}
-      {bankTransaction.error && showRetry ? (
-        <ErrorText>
-          Approval failed. Check connection and retry in few seconds.
-        </ErrorText>
-      ) : null}
+      {bankTransaction.error && showRetry
+        ? (
+          <ErrorText>
+            Approval failed. Check connection and retry in few seconds.
+          </ErrorText>
+        )
+        : null}
     </div>
   )
 }

--- a/src/components/BankTransactionMobileList/PersonalForm.tsx
+++ b/src/components/BankTransactionMobileList/PersonalForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useBankTransactionsContext } from '../../contexts/BankTransactionsContext'
 import PaperclipIcon from '../../icons/Paperclip'
 import { BankTransaction, CategorizationStatus } from '../../types'

--- a/src/components/BankTransactionMobileList/SplitAndMatchForm.tsx
+++ b/src/components/BankTransactionMobileList/SplitAndMatchForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { BankTransaction } from '../../types'
 import { hasMatch } from '../../utils/bankTransactions'
 import { TextButton } from '../Button'

--- a/src/components/BankTransactionMobileList/SplitForm.tsx
+++ b/src/components/BankTransactionMobileList/SplitForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useBankTransactionsContext } from '../../contexts/BankTransactionsContext'
 import PaperclipIcon from '../../icons/Paperclip'
 import Trash from '../../icons/Trash'

--- a/src/components/BankTransactionMobileList/useMemoText.tsx
+++ b/src/components/BankTransactionMobileList/useMemoText.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   createContext,
   ReactNode,
   useContext,

--- a/src/components/BankTransactionReceipts/BankTransactionReceipts.tsx
+++ b/src/components/BankTransactionReceipts/BankTransactionReceipts.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle } from 'react'
+import { forwardRef, useImperativeHandle } from 'react'
 import { useReceiptsContext } from '../../contexts/ReceiptsContext/ReceiptsContext'
 import { ReceiptsProvider } from '../../providers/ReceiptsProvider'
 import { BankTransaction } from '../../types'

--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useBankTransactionsContext } from '../../contexts/BankTransactionsContext'
 import AlertCircle from '../../icons/AlertCircle'
 import ChevronDownFill from '../../icons/ChevronDownFill'

--- a/src/components/BankTransactionRow/MatchBadge.tsx
+++ b/src/components/BankTransactionRow/MatchBadge.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import MinimizeTwo from '../../icons/MinimizeTwo'
 import { centsToDollars as formatMoney } from '../../models/Money'
 import { BankTransaction, CategorizationStatus } from '../../types'
@@ -19,15 +18,15 @@ export const MatchBadge = ({
   text = 'Match',
 }: MatchBadgeProps) => {
   if (
-    bankTransaction.categorization_status === CategorizationStatus.MATCHED &&
-    bankTransaction.match
+    bankTransaction.categorization_status === CategorizationStatus.MATCHED
+    && bankTransaction.match
   ) {
     const { date, amount } = bankTransaction.match.bank_transaction
 
     return (
       <Badge
         icon={<MinimizeTwo size={11} />}
-        tooltip={
+        tooltip={(
           <span className={`${classNamePrefix}__match-tooltip`}>
             <div className={`${classNamePrefix}__match-tooltip__date`}>
               {formatTime(parseISO(date), dateFormat)}
@@ -36,10 +35,11 @@ export const MatchBadge = ({
               {bankTransaction.match?.details?.description ?? ''}
             </div>
             <div className={`${classNamePrefix}__match-tooltip__amount`}>
-              ${formatMoney(amount)}
+              $
+              {formatMoney(amount)}
             </div>
           </span>
-        }
+        )}
       >
         {text}
       </Badge>

--- a/src/components/BankTransactionRow/SplitTooltipDetails.tsx
+++ b/src/components/BankTransactionRow/SplitTooltipDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import { centsToDollars as formatMoney } from '../../models/Money'
 import { Category } from '../../types'
 

--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { BREAKPOINTS } from '../../config/general'
 import {
   BankTransactionsContext,

--- a/src/components/BankTransactions/DataStates.tsx
+++ b/src/components/BankTransactions/DataStates.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import InboxIcon from '../../icons/Inbox'
 import { BankTransaction } from '../../types'
 import { DataState, DataStateStatus } from '../DataState'

--- a/src/components/BankTransactionsLoader/BankTransactionsLoader.tsx
+++ b/src/components/BankTransactionsLoader/BankTransactionsLoader.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import ChevronDownFill from '../../icons/ChevronDownFill'
 import { BankTransaction } from '../../types'
 import { IconButton, SubmitButton } from '../Button'

--- a/src/components/BankTransactionsTable/BankTransactionsTable.tsx
+++ b/src/components/BankTransactionsTable/BankTransactionsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import { DATE_FORMAT } from '../../config/general'
 import { BankTransaction } from '../../types'
 import { toDataProperties } from '../../utils/styleUtils/toDataProperties'

--- a/src/components/Button/BackButton.tsx
+++ b/src/components/Button/BackButton.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes } from 'react'
+import { ButtonHTMLAttributes } from 'react'
 import BackArrow from '../../icons/BackArrow'
 import classNames from 'classnames'
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes, ReactNode, useRef } from 'react'
+import { ButtonHTMLAttributes, ReactNode, useRef } from 'react'
 import LoaderIcon from '../../icons/Loader'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip'
 import classNames from 'classnames'

--- a/src/components/Button/CloseButton.tsx
+++ b/src/components/Button/CloseButton.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes } from 'react'
+import { ButtonHTMLAttributes } from 'react'
 import CloseIcon from '../../icons/CloseIcon'
 import classNames from 'classnames'
 

--- a/src/components/Button/DownloadButton.tsx
+++ b/src/components/Button/DownloadButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import DownloadCloud from '../../icons/DownloadCloud'
 import { Button, ButtonProps, ButtonVariant } from './Button'
 import { RetryButton } from './RetryButton'

--- a/src/components/Button/ExpandButton.tsx
+++ b/src/components/Button/ExpandButton.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes } from 'react'
+import { ButtonHTMLAttributes } from 'react'
 import BackArrow from '../../icons/BackArrow'
 import classNames from 'classnames'
 

--- a/src/components/Button/ExpandCollapseButton.tsx
+++ b/src/components/Button/ExpandCollapseButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import CollapseIcon from '../../icons/Collapse'
 import ExpandIcon from '../../icons/Expand'
 import { Button, ButtonVariant } from './Button'

--- a/src/components/Button/IconButton.tsx
+++ b/src/components/Button/IconButton.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   ButtonHTMLAttributes,
   ReactNode,
 } from 'react'

--- a/src/components/Button/Link.tsx
+++ b/src/components/Button/Link.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   HTMLAttributeAnchorTarget,
   LinkHTMLAttributes,
   ReactNode,

--- a/src/components/Button/RetryButton.tsx
+++ b/src/components/Button/RetryButton.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes } from 'react'
+import { ButtonHTMLAttributes } from 'react'
 import RefreshCcw from '../../icons/RefreshCcw'
 import { Button, ButtonVariant } from './Button'
 import classNames from 'classnames'

--- a/src/components/Button/SubmitButton.tsx
+++ b/src/components/Button/SubmitButton.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes } from 'react'
+import { ButtonHTMLAttributes } from 'react'
 import AlertCircle from '../../icons/AlertCircle'
 import CheckCircle from '../../icons/CheckCircle'
 import Loader from '../../icons/Loader'

--- a/src/components/Button/SwitchButton.tsx
+++ b/src/components/Button/SwitchButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import classNames from 'classnames'
 
 interface SwitchButtonProps {

--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes } from 'react'
+import { ButtonHTMLAttributes } from 'react'
 import classNames from 'classnames'
 
 export type TextButtonProps = ButtonHTMLAttributes<HTMLButtonElement>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import classNames from 'classnames'
 
 export interface CardProps {

--- a/src/components/CategorySelect/CategorySelect.tsx
+++ b/src/components/CategorySelect/CategorySelect.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import Select, {
   DropdownIndicatorProps,
   GroupHeadingProps,

--- a/src/components/CategorySelect/CategorySelectDrawer.tsx
+++ b/src/components/CategorySelect/CategorySelectDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { DrawerContext } from '../../contexts/DrawerContext'
 import ChevronDown from '../../icons/ChevronDown'
 import { BusinessCategories } from '../BankTransactionMobileList/BusinessCategories'

--- a/src/components/ChartOfAccounts/ChartOfAccounts.tsx
+++ b/src/components/ChartOfAccounts/ChartOfAccounts.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { ChartOfAccountsContext } from '../../contexts/ChartOfAccountsContext'
 import { LedgerAccountsContext } from '../../contexts/LedgerAccountsContext'
 import { useChartOfAccounts } from '../../hooks/useChartOfAccounts'

--- a/src/components/ChartOfAccounts/download/AccountBalancesDownloadButton.tsx
+++ b/src/components/ChartOfAccounts/download/AccountBalancesDownloadButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import { DownloadButton } from '../../Button/DownloadButton'
 import InvisibleDownload, { useInvisibleDownload } from '../../utility/InvisibleDownload'
 import { useAccountBalancesDownload } from './useAccountBalancesDownload'

--- a/src/components/ChartOfAccountsDatePicker/ChartOfAccountsDatePicker.tsx
+++ b/src/components/ChartOfAccountsDatePicker/ChartOfAccountsDatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { ChartOfAccountsContext } from '../../contexts/ChartOfAccountsContext'
 import { DatePicker } from '../DatePicker'
 import { endOfMonth, startOfMonth } from 'date-fns'

--- a/src/components/ChartOfAccountsForm/ChartOfAccountsForm.tsx
+++ b/src/components/ChartOfAccountsForm/ChartOfAccountsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react'
+import { useContext, useMemo } from 'react'
 import { ChartOfAccountsContext } from '../../contexts/ChartOfAccountsContext'
 import { flattenAccounts } from '../../hooks/useChartOfAccounts/useChartOfAccounts'
 import { centsToDollars } from '../../models/Money'

--- a/src/components/ChartOfAccountsSidebar/ChartOfAccountsSidebar.tsx
+++ b/src/components/ChartOfAccountsSidebar/ChartOfAccountsSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject } from 'react'
+import { RefObject } from 'react'
 import { ChartOfAccountsForm } from '../ChartOfAccountsForm'
 import { ChartOfAccountsFormStringOverrides } from '../ChartOfAccountsForm/ChartOfAccountsForm'
 

--- a/src/components/ChartOfAccountsTable/ChartOfAccountsTable.tsx
+++ b/src/components/ChartOfAccountsTable/ChartOfAccountsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import { Fragment, useContext, useEffect, useState } from 'react'
 import { ChartOfAccountsContext } from '../../contexts/ChartOfAccountsContext'
 import { LedgerAccountsContext } from '../../contexts/LedgerAccountsContext'
 import { TableProvider } from '../../contexts/TableContext'
@@ -76,7 +76,8 @@ export const ChartOfAccountsTableContent = ({
   useEffect(() => {
     if (expandAll === 'expanded') {
       setIsOpen(accountsRowKeys)
-    } else if (expandAll === 'collapsed') {
+    }
+    else if (expandAll === 'collapsed') {
       setIsOpen([])
     }
   }, [expandAll])
@@ -91,7 +92,7 @@ export const ChartOfAccountsTableContent = ({
       accounts: LedgerAccountBalance[],
       rowKey: string,
     ) => {
-      accounts.map(account => {
+      accounts.map((account) => {
         if (account.sub_accounts.length > 0) {
           setAccountsRowKeys(prev => [...prev, `${rowKey}-${account.id}`])
           searchRowsToExpand(account.sub_accounts, `${rowKey}-${account.id}`)
@@ -112,12 +113,12 @@ export const ChartOfAccountsTableContent = ({
     const expanded = expandable ? isOpen(rowKey) : true
 
     return (
-      <React.Fragment key={rowKey + '-' + index}>
+      <Fragment key={rowKey + '-' + index}>
         <TableRow
           rowKey={rowKey + '-' + index}
           expandable={expandable}
           isExpanded={expanded}
-          onClick={e => {
+          onClick={(e) => {
             e.stopPropagation()
             setAccountId(account.id)
           }}
@@ -125,7 +126,7 @@ export const ChartOfAccountsTableContent = ({
         >
           <TableCell
             withExpandIcon={expandable}
-            onClick={e => {
+            onClick={(e) => {
               e.stopPropagation()
               expandable && setIsOpen(rowKey)
             }}
@@ -142,7 +143,7 @@ export const ChartOfAccountsTableContent = ({
                 rightIcon={<Edit2 size={12} />}
                 iconOnly={true}
                 disabled={!templateAccountsEditable && !!account.stable_name}
-                onClick={e => {
+                onClick={(e) => {
                   e.preventDefault()
                   e.stopPropagation()
                   editAccount(account.id)
@@ -158,18 +159,18 @@ export const ChartOfAccountsTableContent = ({
             </span>
           </TableCell>
         </TableRow>
-        {expandable &&
-          expanded &&
-          account.sub_accounts.map((subItem, subIdx) => {
-            const subRowKey = `${rowKey}-${subItem.id}`
-            return renderChartOfAccountsDesktopRow(
-              subItem,
-              subIdx,
-              subRowKey,
-              depth + 1,
-            )
-          })}
-      </React.Fragment>
+        {expandable
+        && expanded
+        && account.sub_accounts.map((subItem, subIdx) => {
+          const subRowKey = `${rowKey}-${subItem.id}`
+          return renderChartOfAccountsDesktopRow(
+            subItem,
+            subIdx,
+            subRowKey,
+            depth + 1,
+          )
+        })}
+      </Fragment>
     )
   }
 
@@ -193,15 +194,15 @@ export const ChartOfAccountsTableContent = ({
         </TableRow>
       </TableHead>
       <TableBody>
-        {!error &&
-          data.accounts.map((account, idx) =>
-            renderChartOfAccountsDesktopRow(
-              account,
-              idx,
-              `coa-row-${account.id}`,
-              0,
-            ),
-          )}
+        {!error
+        && data.accounts.map((account, idx) =>
+          renderChartOfAccountsDesktopRow(
+            account,
+            idx,
+            `coa-row-${account.id}`,
+            0,
+          ),
+        )}
       </TableBody>
     </Table>
   )

--- a/src/components/ChartOfAccountsTable/ChartOfAccountsTableWithPanel.tsx
+++ b/src/components/ChartOfAccountsTable/ChartOfAccountsTableWithPanel.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useContext, useState } from 'react'
+import { RefObject, useContext, useState } from 'react'
 import { ChartOfAccountsContext } from '../../contexts/ChartOfAccountsContext'
 import PlusIcon from '../../icons/Plus'
 import { View } from '../../types/general'

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode, forwardRef } from 'react'
+import { CSSProperties, ReactNode, forwardRef } from 'react'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { parseStylesFromThemeConfig } from '../../utils/colors'
 import classNames from 'classnames'

--- a/src/components/Container/Header.tsx
+++ b/src/components/Container/Header.tsx
@@ -2,7 +2,7 @@
  * @deprecated- use components/Header instead.
  * This has been kept to not introduce breaking changes.
  */
-import React, { CSSProperties, ReactNode, forwardRef } from 'react'
+import { CSSProperties, ReactNode, forwardRef } from 'react'
 import classNames from 'classnames'
 
 export enum HeaderLayout {

--- a/src/components/DataState/DataState.tsx
+++ b/src/components/DataState/DataState.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import AlertOctagon from '../../icons/AlertOctagon'
 import CheckCircle from '../../icons/CheckCircle'
 import Loader from '../../icons/Loader'

--- a/src/components/DatePicker/DatePickerOptions.tsx
+++ b/src/components/DatePicker/DatePickerOptions.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import { TextButton } from '../Button'
 import {
   endOfMonth,

--- a/src/components/DatePicker/ModeSelector/DatePickerModeSelector.tsx
+++ b/src/components/DatePicker/ModeSelector/DatePickerModeSelector.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import { Toggle } from '../../Toggle'
 import { ToggleSize } from '../../Toggle/Toggle'
 import type { DatePickerMode, DateRangePickerMode } from '../../../providers/GlobalDateStore/GlobalDateStoreProvider'

--- a/src/components/DateTime/DateTime.tsx
+++ b/src/components/DateTime/DateTime.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import { DATE_FORMAT, TIME_FORMAT } from '../../config/general'
 import { Text, TextSize, TextWeight } from '../Typography'
 import { parseISO, format as formatTime } from 'date-fns'

--- a/src/components/DetailsList/DetailsList.tsx
+++ b/src/components/DetailsList/DetailsList.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { Header } from '../Container'
 import { Heading, HeadingSize } from '../Typography'
 import classNames from 'classnames'

--- a/src/components/DetailsList/DetailsListItem.tsx
+++ b/src/components/DetailsList/DetailsListItem.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { SkeletonLoader } from '../SkeletonLoader'
 import { Text, TextSize, TextWeight } from '../Typography'
 

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { DrawerContext } from '../../contexts/DrawerContext'
 
 const DrawerBackground = ({

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { ErrorInfo, Component, type PropsWithChildren } from 'react'
+import { ErrorInfo, Component, type PropsWithChildren } from 'react'
 import { LayerError, reportError } from '../../models/ErrorHandler'
 import { ErrorBoundaryMessage } from './ErrorBoundaryMessage'
 

--- a/src/components/ErrorBoundary/ErrorBoundaryMessage.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundaryMessage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import { DataState, DataStateStatus } from '../DataState'
 
 export const ErrorBoundaryMessage = () => {

--- a/src/components/ExpandedBankTransactionRow/APIErrorNotifications.tsx
+++ b/src/components/ExpandedBankTransactionRow/APIErrorNotifications.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import AlertOctagon from '../../icons/AlertOctagon'
 import { BankTransaction } from '../../types'
 import { Text } from '../Typography'

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   forwardRef,
   useImperativeHandle,
   useState,

--- a/src/components/FileThumb/FileThumb.tsx
+++ b/src/components/FileThumb/FileThumb.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import DownloadCloud from '../../icons/DownloadCloud'
 import EyeIcon from '../../icons/Eye'
 import LoaderIcon from '../../icons/Loader'

--- a/src/components/GlobalWidgets/GlobalWidgets.tsx
+++ b/src/components/GlobalWidgets/GlobalWidgets.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react'
+import { useContext, useEffect } from 'react'
 import { DrawerContext } from '../../contexts/DrawerContext'
 import { useSizeClass } from '../../hooks/useWindowSize'
 import { Drawer } from '../Drawer'

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   CSSProperties,
   MutableRefObject,
   ReactNode,

--- a/src/components/Header/HeaderCol.tsx
+++ b/src/components/Header/HeaderCol.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode } from 'react'
+import { CSSProperties, ReactNode } from 'react'
 import classNames from 'classnames'
 
 interface HeaderColProps {

--- a/src/components/Header/HeaderRow.tsx
+++ b/src/components/Header/HeaderRow.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode } from 'react'
+import { CSSProperties, ReactNode } from 'react'
 import classNames from 'classnames'
 
 interface HeaderRowProps {

--- a/src/components/HoverMenu/HoverMenu.tsx
+++ b/src/components/HoverMenu/HoverMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useRef, useState } from 'react'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
 import type { Awaitable } from '../../types/utility/promises'
 

--- a/src/components/IconBox/IconBox.tsx
+++ b/src/components/IconBox/IconBox.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 interface IconBoxProps {
   children: ReactNode

--- a/src/components/Input/AmountInput.tsx
+++ b/src/components/Input/AmountInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 import classNames from 'classnames'
 import CurrencyInput, { CurrencyInputProps } from 'react-currency-input-field'
 import { Tooltip, TooltipTrigger, TooltipContent } from '../Tooltip'

--- a/src/components/Input/FileInput.tsx
+++ b/src/components/Input/FileInput.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, ChangeEvent } from 'react'
+import { useRef, ChangeEvent } from 'react'
 import UploadCloud from '../../icons/UploadCloud'
 import { Button, TextButton } from '../Button'
 import { ButtonVariant } from '../Button/Button'

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react'
+import { HTMLProps } from 'react'
 import { Tooltip, TooltipTrigger, TooltipContent } from '../Tooltip'
 import classNames from 'classnames'
 

--- a/src/components/Input/InputGroup.tsx
+++ b/src/components/Input/InputGroup.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { Text, TextSize } from '../Typography'
 import classNames from 'classnames'
 

--- a/src/components/Input/InputWithBadge.tsx
+++ b/src/components/Input/InputWithBadge.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react'
+import { HTMLProps } from 'react'
 import { Badge, BadgeVariant } from '../Badge'
 import { Tooltip, TooltipTrigger, TooltipContent } from '../Tooltip'
 import classNames from 'classnames'

--- a/src/components/Input/MultiSelect.tsx
+++ b/src/components/Input/MultiSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import { useCallback } from 'react'
 import ReactSelect, {
   DropdownIndicatorProps,
   GroupBase,

--- a/src/components/Input/Select.tsx
+++ b/src/components/Input/Select.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import { useCallback } from 'react'
 import ReactSelect, {
   DropdownIndicatorProps,
   GroupBase,

--- a/src/components/Journal/Journal.tsx
+++ b/src/components/Journal/Journal.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { ChartOfAccountsContext } from '../../contexts/ChartOfAccountsContext'
 import { JournalContext } from '../../contexts/JournalContext'
 import { useChartOfAccounts } from '../../hooks/useChartOfAccounts'

--- a/src/components/Journal/download/JournalEntriesDownloadButton.tsx
+++ b/src/components/Journal/download/JournalEntriesDownloadButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { DownloadButton } from '../../Button/DownloadButton'
 import InvisibleDownload, { useInvisibleDownload } from '../../utility/InvisibleDownload'
 import { useJournalEntriesDownload } from './useJournalEntriesDownload'

--- a/src/components/JournalEntryDetails/JournalEntryDetails.tsx
+++ b/src/components/JournalEntryDetails/JournalEntryDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { JournalContext } from '../../contexts/JournalContext'
 import AlertCircle from '../../icons/AlertCircle'
 import RefreshCcw from '../../icons/RefreshCcw'

--- a/src/components/JournalForm/JournalFormEntryLines.tsx
+++ b/src/components/JournalForm/JournalFormEntryLines.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { ChartOfAccountsContext } from '../../contexts/ChartOfAccountsContext'
 import { JournalContext } from '../../contexts/JournalContext'
 import Trash from '../../icons/Trash'

--- a/src/components/JournalSidebar/JournalSidebar.tsx
+++ b/src/components/JournalSidebar/JournalSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useContext } from 'react'
+import { RefObject, useContext } from 'react'
 import { JournalContext } from '../../contexts/JournalContext'
 import { JournalConfig } from '../Journal/Journal'
 import { JournalEntryDetails } from '../JournalEntryDetails'

--- a/src/components/JournalTable/JournalTable.tsx
+++ b/src/components/JournalTable/JournalTable.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react'
+import { Fragment, useContext, useEffect } from 'react'
 import { DATE_FORMAT } from '../../config/general'
 import { JournalContext } from '../../contexts/JournalContext'
 import { TableProvider } from '../../contexts/TableContext'
@@ -75,19 +75,20 @@ const JournalTableContent = ({
     const expanded = expandable ? isOpen(rowKey) : true
 
     return (
-      <React.Fragment key={rowKey + '-' + index}>
+      <Fragment key={rowKey + '-' + index}>
         <TableRow
           rowKey={rowKey + '-' + index}
           expandable={expandable}
           isExpanded={expanded}
           handleExpand={() => setIsOpen(rowKey)}
           selected={selectedEntryId === row.id}
-          onClick={e => {
+          onClick={(e) => {
             e.stopPropagation()
 
             if (selectedEntryId === row.id) {
               closeSelectedEntry()
-            } else {
+            }
+            else {
               setSelectedEntryId(row.id)
             }
           }}
@@ -95,7 +96,7 @@ const JournalTableContent = ({
         >
           <TableCell
             withExpandIcon={expandable}
-            onClick={e => {
+            onClick={(e) => {
               e.stopPropagation()
 
               expandable && setIsOpen(rowKey)
@@ -107,56 +108,64 @@ const JournalTableContent = ({
             {row.entry_at && formatTime(parseISO(row.entry_at), DATE_FORMAT)}
           </TableCell>
           <TableCell>{humanizeEnum(row.entry_type)}</TableCell>
-          <TableCell>({row.line_items.length})</TableCell>
-          <TableCell isCurrency primary align={TableCellAlign.RIGHT}>
-            {'line_items' in row &&
-              Math.abs(
-                row.line_items
-                  .filter(item => item.direction === 'DEBIT')
-                  .map(item => item.amount)
-                  .reduce((a, b) => a + b, 0),
-              )}
+          <TableCell>
+            (
+            {row.line_items.length}
+            )
           </TableCell>
           <TableCell isCurrency primary align={TableCellAlign.RIGHT}>
-            {'line_items' in row &&
-              Math.abs(
-                row.line_items
-                  .filter(item => item.direction === 'CREDIT')
-                  .map(item => item.amount)
-                  .reduce((a, b) => a + b, 0),
-              )}
+            {'line_items' in row
+            && Math.abs(
+              row.line_items
+                .filter(item => item.direction === 'DEBIT')
+                .map(item => item.amount)
+                .reduce((a, b) => a + b, 0),
+            )}
+          </TableCell>
+          <TableCell isCurrency primary align={TableCellAlign.RIGHT}>
+            {'line_items' in row
+            && Math.abs(
+              row.line_items
+                .filter(item => item.direction === 'CREDIT')
+                .map(item => item.amount)
+                .reduce((a, b) => a + b, 0),
+            )}
           </TableCell>
         </TableRow>
-        {expandable &&
-          expanded &&
-          row.line_items.map((subItem, subIdx) => (
-            <TableRow
-              key={rowKey + '-' + index + '-' + subIdx}
-              rowKey={rowKey + '-' + index + '-' + subIdx}
-              depth={depth + 1}
-              selected={selectedEntryId === row.id}
-            >
-              <TableCell />
-              <TableCell />
-              <TableCell />
-              <TableCell>{accountName(subItem)}</TableCell>
-              {subItem.direction === 'DEBIT' && subItem.amount >= 0 ? (
+        {expandable
+        && expanded
+        && row.line_items.map((subItem, subIdx) => (
+          <TableRow
+            key={rowKey + '-' + index + '-' + subIdx}
+            rowKey={rowKey + '-' + index + '-' + subIdx}
+            depth={depth + 1}
+            selected={selectedEntryId === row.id}
+          >
+            <TableCell />
+            <TableCell />
+            <TableCell />
+            <TableCell>{accountName(subItem)}</TableCell>
+            {subItem.direction === 'DEBIT' && subItem.amount >= 0
+              ? (
                 <TableCell isCurrency primary align={TableCellAlign.RIGHT}>
                   {subItem.amount}
                 </TableCell>
-              ) : (
+              )
+              : (
                 <TableCell />
               )}
-              {subItem.direction === 'CREDIT' && subItem.amount >= 0 ? (
+            {subItem.direction === 'CREDIT' && subItem.amount >= 0
+              ? (
                 <TableCell isCurrency primary align={TableCellAlign.RIGHT}>
                   {subItem.amount}
                 </TableCell>
-              ) : (
+              )
+              : (
                 <TableCell />
               )}
-            </TableRow>
-          ))}
-      </React.Fragment>
+          </TableRow>
+        ))}
+      </Fragment>
     )
   }
 

--- a/src/components/JournalTable/JournalTableWithPanel.tsx
+++ b/src/components/JournalTable/JournalTableWithPanel.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useContext, useMemo, useState } from 'react'
+import { RefObject, useContext, useMemo, useState } from 'react'
 import { JournalContext } from '../../contexts/JournalContext'
 import PlusIcon from '../../icons/PlusIcon'
 import { View } from '../../types/general'

--- a/src/components/LedgerAccount/LedgerAccountIndex.tsx
+++ b/src/components/LedgerAccount/LedgerAccountIndex.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   RefObject,
   useContext,
   useEffect,

--- a/src/components/LedgerAccount/LedgerAccountRow.tsx
+++ b/src/components/LedgerAccount/LedgerAccountRow.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { DATE_FORMAT } from '../../config/general'
 import { LedgerAccountsContext } from '../../contexts/LedgerAccountsContext'
 import { centsToDollars } from '../../models/Money'

--- a/src/components/LedgerAccountEntryDetails/LedgerAccountEntryDetails.tsx
+++ b/src/components/LedgerAccountEntryDetails/LedgerAccountEntryDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react'
+import { useContext, useMemo } from 'react'
 import { LedgerAccountsContext } from '../../contexts/LedgerAccountsContext'
 import XIcon from '../../icons/X'
 import { centsToDollars } from '../../models/Money'

--- a/src/components/LinkedAccountOptions/LinkedAccountOptions.tsx
+++ b/src/components/LinkedAccountOptions/LinkedAccountOptions.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import MoreVertical from '../../icons/MoreVertical'
 import { HoverMenu, HoverMenuProps } from '../HoverMenu'
 import classNames from 'classnames'

--- a/src/components/LinkedAccountPill/LinkedAccountPill.tsx
+++ b/src/components/LinkedAccountPill/LinkedAccountPill.tsx
@@ -1,21 +1,22 @@
-import React from 'react'
 import AlertCircle from '../../icons/AlertCircle'
 import { HoverMenu } from '../HoverMenu'
 import { Pill } from '../Pill/Pill'
 
 type Props = {
   text: string
-  config: { name: string; action: () => void }[]
+  config: { name: string, action: () => void }[]
 }
 
 export const LinkedAccountPill = ({ text, config }: Props) => {
   return (
     <>
       <Pill kind='error'>
-        <AlertCircle size={14} /> {text}
+        <AlertCircle size={14} />
+        {' '}
+        {text}
         <div className='Layer__linked-accounts-pill__options-overlay'>
           <HoverMenu config={config}>
-            <div className={'Layer__linked-accounts-pill__invisible-spacer'} />
+            <div className='Layer__linked-accounts-pill__invisible-spacer' />
           </HoverMenu>
         </div>
       </Pill>

--- a/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
+++ b/src/components/LinkedAccountThumb/LinkedAccountThumb.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import InstitutionIcon from '../../icons/InstitutionIcon'
 import LoaderIcon from '../../icons/Loader'
 import { centsToDollars as formatMoney } from '../../models/Money'

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountToConfirm.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountToConfirm.tsx
@@ -1,9 +1,8 @@
-import React from 'react'
 import type { LinkedAccount } from '../../../types/linked_accounts'
 import { Heading } from '../../ui/Typography/Heading'
 import { P } from '../../ui/Typography/Text'
 import { VStack } from '../../ui/Stack/Stack'
-import { Checkbox } from  '../../ui/Checkbox/Checkbox'
+import { Checkbox } from '../../ui/Checkbox/Checkbox'
 
 type LinkedAccountConfirmationProps = {
   account: LinkedAccount
@@ -23,7 +22,9 @@ export function LinkedAccountToConfirm({
       <VStack>
         <Heading level={3} size='sm'>{account.external_account_name}</Heading>
         <P slot='mask'>
-          ••• {account.mask}
+          •••
+          {' '}
+          {account.mask}
         </P>
         <P slot='institution'>
           {account.institution.name}

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Modal } from '../../ui/Modal/Modal'
 import { ModalContextBar, ModalHeading, ModalActions, ModalContent, ModalDescription } from '../../ui/Modal/ModalSlots'
 import { Button } from '../../ui/Button/Button'

--- a/src/components/LinkedAccounts/LinkedAccountItemThumb.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountItemThumb.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { LinkedAccountsContext } from '../../contexts/LinkedAccountsContext'
 import { LinkedAccount } from '../../types/linked_accounts'
 import { LinkedAccountOptions } from '../LinkedAccountOptions'

--- a/src/components/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/components/LinkedAccounts/LinkedAccounts.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { LinkedAccountsContext } from '../../contexts/LinkedAccountsContext'
 import { LinkedAccountsProvider } from '../../providers/LinkedAccountsProvider'
 import { Container, Header } from '../Container'

--- a/src/components/LinkedAccounts/LinkedAccountsContent.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountsContent.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { LinkedAccountsContext } from '../../contexts/LinkedAccountsContext'
 import PlusIcon from '../../icons/PlusIcon'
 import { Text, TextSize } from '../Typography'

--- a/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
+++ b/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { Modal } from '../../ui/Modal/Modal'
 import { ModalContextBar, ModalHeading, ModalActions, ModalContent } from '../../ui/Modal/ModalSlots'
 import { Button } from '../../ui/Button/Button'

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import LoaderIcon from '../../icons/Loader'
 
 export interface LoaderProps {

--- a/src/components/Loader/SmallLoader.tsx
+++ b/src/components/Loader/SmallLoader.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import LoaderIcon from '../../icons/Loader'
 
 export interface SmallLoaderProps {

--- a/src/components/MatchForm/MatchForm.tsx
+++ b/src/components/MatchForm/MatchForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { DATE_FORMAT } from '../../config/general'
 import { centsToDollars as formatMoney } from '../../models/Money'
 import { BankTransaction } from '../../types'
@@ -37,7 +36,8 @@ export const MatchForm = ({
           className={`${classNamePrefix}__match-table__status ${
             bankTransaction.match ? '' : 'no-match'
           }`}
-        ></div>
+        >
+        </div>
       </div>
 
       {bankTransaction.suggested_matches?.map((match, idx) => {
@@ -68,7 +68,8 @@ export const MatchForm = ({
                 {formatTime(parseISO(match.details.date), DATE_FORMAT)}
               </span>
               <span className='amount-next-to-date'>
-                ${formatMoney(match.details.amount)}
+                $
+                {formatMoney(match.details.amount)}
               </span>
             </div>
             <div className={`${classNamePrefix}__match-table__desc`}>
@@ -91,7 +92,8 @@ export const MatchForm = ({
               )}
             </div>
             <div className={`${classNamePrefix}__match-table__amount`}>
-              ${formatMoney(match.details.amount)}
+              $
+              {formatMoney(match.details.amount)}
             </div>
 
             <div

--- a/src/components/MatchForm/MatchFormMobile.tsx
+++ b/src/components/MatchForm/MatchFormMobile.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { MONTH_DAY_FORMAT } from '../../config/general'
 import CheckIcon from '../../icons/Check'
 import { centsToDollars as formatMoney } from '../../models/Money'
@@ -46,7 +45,8 @@ export const MatchFormMobile = ({
                   className={`${classNamePrefix}__match-item__amount`}
                   as='span'
                 >
-                  ${formatMoney(match.details.amount)}
+                  $
+                  {formatMoney(match.details.amount)}
                 </Text>
               </div>
               <div className={`${classNamePrefix}__match-item__details`}>
@@ -61,12 +61,14 @@ export const MatchFormMobile = ({
             </div>
 
             <div className={`${classNamePrefix}__match-item__col-status`}>
-              {selectedMatchId && selectedMatchId === match.id ? (
-                <CheckIcon
-                  size={16}
-                  className={`${classNamePrefix}__match-item__selected-icon`}
-                />
-              ) : null}
+              {selectedMatchId && selectedMatchId === match.id
+                ? (
+                  <CheckIcon
+                    size={16}
+                    className={`${classNamePrefix}__match-item__selected-icon`}
+                  />
+                )
+                : null}
             </div>
           </div>
         )

--- a/src/components/Onboarding/ConnectAccount.tsx
+++ b/src/components/Onboarding/ConnectAccount.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react'
+import { useContext, useMemo } from 'react'
 import { LinkedAccountsContext } from '../../contexts/LinkedAccountsContext'
 import { useBankTransactions } from '../../hooks/useBankTransactions'
 import BellIcon from '../../icons/Bell'

--- a/src/components/Onboarding/Onboarding.tsx
+++ b/src/components/Onboarding/Onboarding.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { LinkedAccountsContext } from '../../contexts/LinkedAccountsContext'
 import { LinkedAccountsProvider } from '../../providers/LinkedAccountsProvider'

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { usePagination, DOTS } from '../../hooks/usePagination'
 import ChevronLeft from '../../icons/ChevronLeft'
 import ChevronRight from '../../icons/ChevronRight'
@@ -43,7 +42,7 @@ export const Pagination = ({
   return (
     <ul className='Layer__pagination'>
       <li
-        key={'page-prev'}
+        key='page-prev'
         className={classnames(
           'Layer__pagination-item Layer__pagination-arrow Layer__pagination-arrow--previous',
           {
@@ -85,17 +84,19 @@ export const Pagination = ({
           </li>
         )
       })}
-      {hasMore && fetchMore ? (
-        <li
-          key={'page-has-more'}
-          className='Layer__pagination-item Layer__pagination-arrow Layer__pagination-arrow--next'
-          onClick={fetchMore}
-        >
-          ...
-        </li>
-      ) : null}
+      {hasMore && fetchMore
+        ? (
+          <li
+            key='page-has-more'
+            className='Layer__pagination-item Layer__pagination-arrow Layer__pagination-arrow--next'
+            onClick={fetchMore}
+          >
+            ...
+          </li>
+        )
+        : null}
       <li
-        key={'page-last'}
+        key='page-last'
         className={classnames(
           'Layer__pagination-item Layer__pagination-arrow Layer__pagination-arrow--next',
           {

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, RefObject, useEffect, useState } from 'react'
+import { ReactNode, RefObject, useEffect, useState } from 'react'
 import classNames from 'classnames'
 
 export interface PanelProps {

--- a/src/components/PeriodPicker/PeriodPicker.tsx
+++ b/src/components/PeriodPicker/PeriodPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Check from '../../icons/Check'
 import ChevronDown from '../../icons/ChevronDown'
 

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react'
+import { PropsWithChildren } from 'react'
 import classNames from 'classnames'
 
 type PillKind = 'default' | 'info' | 'success' | 'warning' | 'error'

--- a/src/components/PlatformOnboarding/LinkAccounts.tsx
+++ b/src/components/PlatformOnboarding/LinkAccounts.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react'
+import { useContext, useMemo } from 'react'
 import { LinkedAccountsContext } from '../../contexts/LinkedAccountsContext'
 import LinkIcon from '../../icons/Link'
 import PlaidIcon from '../../icons/PlaidIcon'

--- a/src/components/ProfitAndLossChart/ChartStateCard.tsx
+++ b/src/components/ProfitAndLossChart/ChartStateCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import BarChart2Icon from '../../icons/BarChart2'
 import { IconBox } from '../IconBox'
 import { Text, TextSize, TextWeight } from '../Typography'

--- a/src/components/ProfitAndLossChart/Indicator.tsx
+++ b/src/components/ProfitAndLossChart/Indicator.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Props as BaseProps } from 'recharts/types/component/Label'
 
 /*

--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, type FunctionComponent } from 'react'
+import { useEffect, useMemo, useState, type FunctionComponent } from 'react'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { useLinkedAccounts } from '../../hooks/useLinkedAccounts'
 import {

--- a/src/components/ProfitAndLossCompareOptions/ProfitAndLossCompareOptions.tsx
+++ b/src/components/ProfitAndLossCompareOptions/ProfitAndLossCompareOptions.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { MultiSelect, Select } from '../Input'
 import { ProfitAndLoss } from '../ProfitAndLoss/ProfitAndLoss'
 import type { StylesConfig } from 'react-select'

--- a/src/components/ProfitAndLossDetailedCharts/DetailedChart.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedChart.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import { SidebarScope } from '../../hooks/useProfitAndLoss/useProfitAndLoss'
 import { centsToDollars as formatMoney } from '../../models/Money'
 import { LineBaseItem } from '../../types/line_item'

--- a/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { DEFAULT_CHART_COLOR_TYPE } from '../../config/charts'
 import {
   Scope,
@@ -42,7 +41,7 @@ export const mapTypesToColors = (
   const typeToLastOpacity: Record<string, number> = {}
   let colorIndex = 0
 
-  return data.map(obj => {
+  return data.map((obj) => {
     const type = obj.name ?? obj.type
 
     if (type === 'Uncategorized') {
@@ -56,7 +55,8 @@ export const mapTypesToColors = (
       typeToColor[type] = colorList[colorIndex % colorList.length]
       colorIndex++
       typeToLastOpacity[type] = 1
-    } else {
+    }
+    else {
       typeToLastOpacity[type] -= 0.1
     }
 
@@ -137,8 +137,8 @@ export const DetailedTable = ({
       'Layer__sortable-col',
       sidebarScope && filters[sidebarScope]?.sortBy === column
         ? `sort--${
-            (sidebarScope && filters[sidebarScope]?.sortDirection) ?? 'desc'
-          }`
+          (sidebarScope && filters[sidebarScope]?.sortDirection) ?? 'desc'
+        }`
         : '',
     )
   }
@@ -155,14 +155,16 @@ export const DetailedTable = ({
                 className={buildColClass('category')}
                 onClick={() => sortBy(sidebarScope ?? 'expenses', 'category')}
               >
-                {stringOverrides?.categoryColumnHeader || 'Category'}{' '}
+                {stringOverrides?.categoryColumnHeader || 'Category'}
+                {' '}
                 <SortArrows className='Layer__sort-arrows' />
               </th>
               <th
                 className={buildColClass('type')}
                 onClick={() => sortBy(sidebarScope ?? 'expenses', 'type')}
               >
-                {stringOverrides?.typeColumnHeader || 'Type'}{' '}
+                {stringOverrides?.typeColumnHeader || 'Type'}
+                {' '}
                 <SortArrows className='Layer__sort-arrows' />
               </th>
               <th></th>
@@ -170,7 +172,8 @@ export const DetailedTable = ({
                 className={buildColClass('value')}
                 onClick={() => sortBy(sidebarScope ?? 'expenses', 'value')}
               >
-                {stringOverrides?.valueColumnHeader || 'Value'}{' '}
+                {stringOverrides?.valueColumnHeader || 'Value'}
+                {' '}
                 <SortArrows className='Layer__sort-arrows' />
               </th>
             </tr>
@@ -193,10 +196,14 @@ export const DetailedTable = ({
                   >
                     <td className='category-col'>{item.display_name}</td>
                     <td className='type-col'>{item.type}</td>
-                    <td className='value-col'>${formatMoney(item.value)}</td>
+                    <td className='value-col'>
+                      $
+                      {formatMoney(item.value)}
+                    </td>
                     <td className='share-col'>
                       <span className='share-cell-content'>
-                        {formatPercent(item.share)}%
+                        {formatPercent(item.share)}
+                        %
                         <ValueIcon
                           item={item}
                           typeColorMapping={typeColorMapping}

--- a/src/components/ProfitAndLossDetailedCharts/Filters.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/Filters.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Select, { components } from 'react-select'
 import {
   Scope,
@@ -32,11 +31,11 @@ export const Filters = ({
         classNamePrefix='Layer__select'
         value={
           sidebarScope && filters[sidebarScope]?.types
-            ? sidebarScope &&
-              filters[sidebarScope]?.types?.map(x => ({
-                value: x,
-                label: x,
-              }))
+            ? sidebarScope
+            && filters[sidebarScope]?.types?.map(x => ({
+              value: x,
+              label: x,
+            }))
             : []
         }
         isMulti
@@ -45,9 +44,9 @@ export const Filters = ({
           [...new Set(filteredData?.map(x => x.type))].map(x => ({
             label: x,
             value: x,
-          })) as unknown as readonly { value: string; label: string }[]
+          })) as unknown as readonly { value: string, label: string }[]
         }
-        onChange={selected => {
+        onChange={(selected) => {
           setFilterTypes(
             sidebarScope ?? 'expenses',
             selected.map(x => x.value),

--- a/src/components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+import { useContext, useState } from 'react'
 import { SidebarScope } from '../../hooks/useProfitAndLoss/useProfitAndLoss'
 import XIcon from '../../icons/X'
 import { humanizeTitle } from '../../utils/profitAndLossUtils'

--- a/src/components/ProfitAndLossDownloadButton/ProfitAndLossDownloadButton.tsx
+++ b/src/components/ProfitAndLossDownloadButton/ProfitAndLossDownloadButton.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+import { useContext, useState } from 'react'
 import { Layer } from '../../api/layer'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { MoneyFormat } from '../../types'

--- a/src/components/ProfitAndLossHeader/ProfitAndLossHeader.tsx
+++ b/src/components/ProfitAndLossHeader/ProfitAndLossHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import { Heading, HeadingSize } from '../../components/Typography'
 import { useLinkedAccounts } from '../../hooks/useLinkedAccounts'
 import { Header } from '../Container'

--- a/src/components/ProfitAndLossReport/ProfitAndLossReport.tsx
+++ b/src/components/ProfitAndLossReport/ProfitAndLossReport.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useContext } from 'react'
+import { RefObject, useContext } from 'react'
 import { View as ViewType } from '../../types/general'
 import { ReportsStringOverrides } from '../../views/Reports/Reports'
 import type { TimeRangePickerConfig } from '../../views/Reports/reportTypes'

--- a/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
+++ b/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo, type ReactNode } from 'react'
+import { useContext, useMemo, type ReactNode } from 'react'
 import type { Variants } from '../../utils/styleUtils/sizeVariants'
 import { ProfitAndLoss as PNL } from '../ProfitAndLoss'
 import {

--- a/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesHeading.tsx
+++ b/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesHeading.tsx
@@ -1,5 +1,4 @@
 import { PropsWithChildren, useMemo } from 'react'
-import React from 'react'
 import type { Variants } from '../../../utils/styleUtils/sizeVariants'
 import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'
 

--- a/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesList.tsx
+++ b/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, type PropsWithChildren } from 'react'
+import { useMemo, type PropsWithChildren } from 'react'
 import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'
 
 const LIST_ITEM_CLASS_NAME = 'Layer__ProfitAndLossSummariesListItem'

--- a/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesMiniChart.tsx
+++ b/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesMiniChart.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import type { Scope } from '../../../hooks/useProfitAndLoss/useProfitAndLoss'
 import type { ProfitAndLoss } from '../../../types'
 import type { LineBaseItem } from '../../../types/line_item'
@@ -42,9 +41,9 @@ export function toMiniChartData({
   }
 
   if (
-    !items ||
-    items.length === 0 ||
-    !items.find(x => Math.abs(x.value) !== 0)
+    !items
+    || items.length === 0
+    || !items.find(x => Math.abs(x.value) !== 0)
   ) {
     return CHART_PLACEHOLDER
   }
@@ -104,7 +103,7 @@ export function ProfitAndLossSummariesMiniChart({
           return (
             <Cell
               key={`cell-${index}`}
-              className={'Layer__profit-and-loss-detailed-charts__pie'}
+              className='Layer__profit-and-loss-detailed-charts__pie'
               fill={
                 entry.name === 'placeholder' ? '#e6e6e6' : colorConfig.color
               }

--- a/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesSummary.tsx
+++ b/src/components/ProfitAndLossSummaries/internal/ProfitAndLossSummariesSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, type ReactNode } from 'react'
+import { useMemo, type ReactNode } from 'react'
 import { centsToDollars as formatMoney } from '../../../models/Money'
 import type { Variants } from '../../../utils/styleUtils/sizeVariants'
 import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'

--- a/src/components/ProfitAndLossTable/ProfitAndLossCompareTable.tsx
+++ b/src/components/ProfitAndLossTable/ProfitAndLossCompareTable.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react'
+import { Fragment, useContext, useEffect } from 'react'
 import { useTableExpandRow } from '../../hooks/useTableExpandRow'
 import { LineItem } from '../../types'
 import { ProfitAndLossComparisonPnl } from '../../types/profit_and_loss'
@@ -36,10 +36,10 @@ export const ProfitAndLossCompareTable = ({
 
   useEffect(() => {
     if (
-      dateRange?.startDate &&
-      dateRange?.endDate &&
-      !comparisonData &&
-      !isLoading
+      dateRange?.startDate
+      && dateRange?.endDate
+      && !comparisonData
+      && !isLoading
     ) {
       refetch(
         {
@@ -72,10 +72,10 @@ export const ProfitAndLossCompareTable = ({
       data ? data : []
 
     if (!lineItem) {
-      comparisonData.forEach(item => {
+      comparisonData.forEach((item) => {
         if (
-          rowKey in item.pnl &&
-          item.pnl[rowKey as keyof ProfitAndLossComparisonPnl] !== null
+          rowKey in item.pnl
+          && item.pnl[rowKey as keyof ProfitAndLossComparisonPnl] !== null
         ) {
           rowData.push(item.pnl[rowKey as keyof ProfitAndLossComparisonPnl])
         }
@@ -97,7 +97,7 @@ export const ProfitAndLossCompareTable = ({
     const expanded = expandable ? isOpen(rowKey) : true
 
     return (
-      <React.Fragment key={rowKey}>
+      <Fragment key={rowKey}>
         <TableRow
           rowKey={rowKey}
           expandable={expandable}
@@ -121,16 +121,16 @@ export const ProfitAndLossCompareTable = ({
         </TableRow>
         {expanded && lineItem?.line_items
           ? lineItem.line_items.map(child =>
-              renderRow(
-                child.display_name,
-                depth + 1,
-                child.display_name,
-                child,
-                rowData as (string | number | LineItem)[],
-              ),
-            )
+            renderRow(
+              child.display_name,
+              depth + 1,
+              child.display_name,
+              child,
+              rowData as (string | number | LineItem)[],
+            ),
+          )
           : null}
-      </React.Fragment>
+      </Fragment>
     )
   }
 
@@ -141,15 +141,15 @@ export const ProfitAndLossCompareTable = ({
           <TableRow rowKey=''>
             <TableCell isHeaderCell />
             {compareOptions.map((option, i) => (
-              <React.Fragment key={option + '-' + i}>
+              <Fragment key={option + '-' + i}>
                 <TableCell key={option + '-' + i} primary isHeaderCell>
                   {option.displayName}
                 </TableCell>
-                {compareMonths &&
-                  Array.from({ length: compareMonths - 1 }, (_, index) => (
-                    <TableCell key={option + '-' + index} isHeaderCell />
-                  ))}
-              </React.Fragment>
+                {compareMonths
+                && Array.from({ length: compareMonths - 1 }, (_, index) => (
+                  <TableCell key={option + '-' + index} isHeaderCell />
+                ))}
+              </Fragment>
             ))}
           </TableRow>
         )}
@@ -158,31 +158,33 @@ export const ProfitAndLossCompareTable = ({
         {compareMonths && (
           <TableRow rowKey=''>
             <TableCell isHeaderCell />
-            {compareOptions && compareOptions.length > 0 ? (
-              compareOptions.map((option, i) => (
-                <React.Fragment key={option + '-' + i}>
+            {compareOptions && compareOptions.length > 0
+              ? (
+                compareOptions.map((option, i) => (
+                  <Fragment key={option + '-' + i}>
+                    {generatComparisonMonths(
+                      dateRange.startDate,
+                      compareMonths,
+                    ).map((month: string, index: number) => (
+                      <TableCell key={option + '-' + index} isHeaderCell>
+                        {month}
+                      </TableCell>
+                    ))}
+                  </Fragment>
+                ))
+              )
+              : (
+                <Fragment key='total-1'>
                   {generatComparisonMonths(
                     dateRange.startDate,
                     compareMonths,
                   ).map((month: string, index: number) => (
-                    <TableCell key={option + '-' + index} isHeaderCell>
+                    <TableCell key={'total-' + index + '-cell'} isHeaderCell>
                       {month}
                     </TableCell>
                   ))}
-                </React.Fragment>
-              ))
-            ) : (
-              <React.Fragment key={'total-1'}>
-                {generatComparisonMonths(
-                  dateRange.startDate,
-                  compareMonths,
-                ).map((month: string, index: number) => (
-                  <TableCell key={'total-' + index + '-cell'} isHeaderCell>
-                    {month}
-                  </TableCell>
-                ))}
-              </React.Fragment>
-            )}
+                </Fragment>
+              )}
           </TableRow>
         )}
         {renderRow('income', 0, 'Income')}

--- a/src/components/ProfitAndLossTable/ProfitAndLossTableComponent.tsx
+++ b/src/components/ProfitAndLossTable/ProfitAndLossTableComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react'
+import { Fragment, useContext, useEffect } from 'react'
 import { SidebarScope } from '../../hooks/useProfitAndLoss/useProfitAndLoss'
 import { useTableExpandRow } from '../../hooks/useTableExpandRow'
 import PieChart from '../../icons/PieChart'
@@ -69,7 +69,7 @@ export const ProfitAndLossTableComponent = ({
     const expanded = expandable ? isOpen(rowKey) : true
 
     return (
-      <React.Fragment key={rowKey + '-' + rowIndex}>
+      <Fragment key={rowKey + '-' + rowIndex}>
         <TableRow
           rowKey={rowKey + '-' + rowIndex}
           expandable={expandable}
@@ -83,11 +83,12 @@ export const ProfitAndLossTableComponent = ({
             withExpandIcon={expandable}
             fullWidth={!!setSidebarScope}
           >
-            {lineItem.display_name}{' '}
+            {lineItem.display_name}
+            {' '}
             {setSidebarScope && (
               <span
                 className='Layer__profit-and-loss-row__detailed-chart-btn'
-                onClick={e => {
+                onClick={(e) => {
                   e.stopPropagation()
                   setSidebarScope && setSidebarScope(scope ?? 'expenses')
                 }}
@@ -102,15 +103,15 @@ export const ProfitAndLossTableComponent = ({
         </TableRow>
         {expanded && lineItem.line_items
           ? lineItem.line_items.map((child, i) =>
-              renderLineItem(
-                child,
-                depth + 1,
-                child.display_name + '-' + rowIndex,
-                i,
-              ),
-            )
+            renderLineItem(
+              child,
+              depth + 1,
+              child.display_name + '-' + rowIndex,
+              i,
+            ),
+          )
           : null}
-      </React.Fragment>
+      </Fragment>
     )
   }
 
@@ -179,16 +180,12 @@ export const ProfitAndLossTableComponent = ({
           undefined,
           'summation',
         )}
-        {data.personal_expenses ? (
-          <React.Fragment>
-            {renderLineItem(data.personal_expenses, 0, 'personal_expenses', 7)}
-          </React.Fragment>
-        ) : null}
-        {data.other_outflows ? (
-          <React.Fragment>
-            {renderLineItem(data.other_outflows, 0, 'other_outflows', 6)}
-          </React.Fragment>
-        ) : null}
+        {data.personal_expenses
+          ? renderLineItem(data.personal_expenses, 0, 'personal_expenses', 7)
+          : null}
+        {data.other_outflows
+          ? renderLineItem(data.other_outflows, 0, 'other_outflows', 6)
+          : null}
       </TableBody>
     </Table>
   )

--- a/src/components/ProfitAndLossTable/ProfitAndLossTableWithProvider.tsx
+++ b/src/components/ProfitAndLossTable/ProfitAndLossTableWithProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { TableProvider } from '../../contexts/TableContext'
 import { ProfitAndLoss } from '../ProfitAndLoss'
 import { ProfitAndLossCompareTable } from './ProfitAndLossCompareTable'

--- a/src/components/ProfitAndLossView/ProfitAndLossView.tsx
+++ b/src/components/ProfitAndLossView/ProfitAndLossView.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useContext, useRef } from 'react'
+import { RefObject, useContext, useRef } from 'react'
 import { Container } from '../Container'
 import { DataState, DataStateStatus } from '../DataState'
 import { Panel } from '../Panel'

--- a/src/components/ProjectProfitability/ProjectSelector.tsx
+++ b/src/components/ProjectProfitability/ProjectSelector.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Select from 'react-select'
 import { useTags } from '../../hooks/useProjects'
 
@@ -13,7 +12,7 @@ export function ProjectSelector() {
       placeholder='Select a project...'
       value={activeValue ?? null}
       isClearable
-      onChange={selectedOption => {
+      onChange={(selectedOption) => {
         setActiveValue({ key: 'project', activeValue: selectedOption?.value })
       }}
     />

--- a/src/components/Quickbooks/Quickbooks.tsx
+++ b/src/components/Quickbooks/Quickbooks.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useQuickbooks } from '../../hooks/useQuickbooks'
 
 const Quickbooks = () => {
@@ -13,7 +12,8 @@ const Quickbooks = () => {
   return (
     <div>
       <div>
-        Quickbooks OAuth connection status:{' '}
+        Quickbooks OAuth connection status:
+        {' '}
         {quickbooksIsLinked === undefined
           ? ''
           : quickbooksIsLinked
@@ -32,10 +32,12 @@ const Quickbooks = () => {
           Link Quickbooks
         </button>
       )}
-      {quickbooksIsLinked === true &&
-        (isSyncingFromQuickbooks ? (
+      {quickbooksIsLinked === true
+      && (isSyncingFromQuickbooks
+        ? (
           'Syncing data from Quickbooks...'
-        ) : (
+        )
+        : (
           <div>
             <button onClick={syncFromQuickbooks}>Sync Quickbooks</button>
             <button onClick={unlinkQuickbooks}>Unlink Quickbooks</button>

--- a/src/components/RadioButtonGroup/RadioButton.tsx
+++ b/src/components/RadioButtonGroup/RadioButton.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import type { ChangeEvent } from 'react'
 
 type Props = {
   checked: boolean
   label: string
   name: string
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void
   value: string
   disabled?: boolean
   size: 'small' | 'large'

--- a/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { RadioButton } from './RadioButton'
 
 export type RadioButtonLabel = {

--- a/src/components/SkeletonBalanceSheetRow/SkeletonBalanceSheetRow.tsx
+++ b/src/components/SkeletonBalanceSheetRow/SkeletonBalanceSheetRow.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react'
+import { PropsWithChildren } from 'react'
 import ChevronDown from '../../icons/ChevronDown'
 
 type Props = PropsWithChildren

--- a/src/components/SkeletonLoader/SkeletonLoader.tsx
+++ b/src/components/SkeletonLoader/SkeletonLoader.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import classNames from 'classnames'
 
 export interface SkeletonLoaderProps {

--- a/src/components/SkeletonTableLoader/SkeletonTableLoader.tsx
+++ b/src/components/SkeletonTableLoader/SkeletonTableLoader.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { SkeletonLoader } from '../SkeletonLoader'
 
 interface SkeletonTableLoaderProps {
@@ -20,7 +19,7 @@ export const SkeletonTableLoader = ({
   width = 100,
 }: SkeletonTableLoaderProps) => {
   return (
-    <tbody className={'Layer__skeleton-table-body__loader'}>
+    <tbody className='Layer__skeleton-table-body__loader'>
       {Array.from({ length: rows }).map((_, rowIndex) => (
         <tr key={rowIndex}>
           {cols.map((col, colIndex) => {
@@ -34,24 +33,28 @@ export const SkeletonTableLoader = ({
                 colSpan={col.colSpan}
                 className='Layer__skeleton-loader__row'
               >
-                {col.colComponent ? (
-                  col.colComponent
-                ) : col.parts && col.parts > 1 ? (
-                  <span className='Layer__skeleton-loader__row__group'>
-                    {[...Array(col.parts)].map((_part, partIndex) => (
+                {col.colComponent
+                  ? (
+                    col.colComponent
+                  )
+                  : col.parts && col.parts > 1
+                    ? (
+                      <span className='Layer__skeleton-loader__row__group'>
+                        {Array(col.parts).map((_part, partIndex) => (
+                          <SkeletonLoader
+                            key={`part-${partIndex}`}
+                            width='100%'
+                            height={`${height}px`}
+                          />
+                        ))}
+                      </span>
+                    )
+                    : (
                       <SkeletonLoader
-                        key={`part-${partIndex}`}
-                        width='100%'
+                        width={`${width - trim}%`}
                         height={`${height}px`}
                       />
-                    ))}
-                  </span>
-                ) : (
-                  <SkeletonLoader
-                    width={`${width - trim}%`}
-                    height={`${height}px`}
-                  />
-                )}
+                    )}
               </td>
             )
           })}

--- a/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
+++ b/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { StatementOfCashFlowContext } from '../../contexts/StatementOfCashContext'
 import { TableProvider } from '../../contexts/TableContext'
 import { useStatementOfCashFlow } from '../../hooks/useStatementOfCashFlow'

--- a/src/components/StatementOfCashFlow/download/CashflowStatementDownloadButton.tsx
+++ b/src/components/StatementOfCashFlow/download/CashflowStatementDownloadButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { DownloadButton } from '../../Button/DownloadButton'
 import InvisibleDownload, { useInvisibleDownload } from '../../utility/InvisibleDownload'
 import { useCashflowStatementDownload } from './useCashflowStatementDownload'

--- a/src/components/StatementOfCashFlowTable/StatementOfCashFlowTable.tsx
+++ b/src/components/StatementOfCashFlowTable/StatementOfCashFlowTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { Fragment, ReactNode } from 'react'
 import { useTableExpandRow } from '../../hooks/useTableExpandRow'
 import { StatementOfCashFlow } from '../../types'
 import { LineItem } from '../../types/line_item'
@@ -34,12 +34,12 @@ export const StatementOfCashFlowTable = ({
     depth: number = 0,
     rowKey: string,
     rowIndex: number,
-  ): React.ReactNode => {
+  ): ReactNode => {
     const expandable = !!lineItem.line_items && lineItem.line_items.length > 0
     const expanded = expandable ? isOpen(rowKey) : true
 
     return (
-      <React.Fragment key={rowKey + '-' + rowIndex}>
+      <Fragment key={rowKey + '-' + rowIndex}>
         <TableRow
           rowKey={rowKey + '-' + rowIndex}
           expandable={expandable}
@@ -58,16 +58,16 @@ export const StatementOfCashFlowTable = ({
             {(!expandable || (expandable && !expanded)) && lineItem.value}
           </TableCell>
         </TableRow>
-        {expanded &&
-          lineItem.line_items &&
-          lineItem.line_items.map((subItem, subIdx) =>
-            renderLineItem(
-              subItem,
-              depth + 1,
-              rowKey + ':' + subItem.name,
-              subIdx,
-            ),
-          )}
+        {expanded
+        && lineItem.line_items
+        && lineItem.line_items.map((subItem, subIdx) =>
+          renderLineItem(
+            subItem,
+            depth + 1,
+            rowKey + ':' + subItem.name,
+            subIdx,
+          ),
+        )}
         {expanded && expandable && (
           <TableRow
             rowKey={rowKey + '-' + rowIndex + '--summation'}
@@ -80,7 +80,7 @@ export const StatementOfCashFlowTable = ({
             </TableCell>
           </TableRow>
         )}
-      </React.Fragment>
+      </Fragment>
     )
   }
 
@@ -100,17 +100,18 @@ export const StatementOfCashFlowTable = ({
         {config.map((row, idx) => {
           if (row.type === 'line_item') {
             return (
-              <React.Fragment key={row.lineItem}>
-                {data[row.lineItem as keyof StatementOfCashFlow] &&
-                  renderLineItem(
-                    data[row.lineItem as keyof StatementOfCashFlow] as LineItem,
-                    0,
-                    row.lineItem ? row.lineItem : '',
-                    idx,
-                  )}
-              </React.Fragment>
+              <Fragment key={row.lineItem}>
+                {data[row.lineItem as keyof StatementOfCashFlow]
+                && renderLineItem(
+                  data[row.lineItem as keyof StatementOfCashFlow] as LineItem,
+                  0,
+                  row.lineItem ? row.lineItem : '',
+                  idx,
+                )}
+              </Fragment>
             )
-          } else {
+          }
+          else {
             return (
               <TableRow
                 key={row.name + '-' + idx}

--- a/src/components/SyncingBadge/SyncingBadge.tsx
+++ b/src/components/SyncingBadge/SyncingBadge.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Loader from '../../icons/Loader'
 import { Badge, BadgeVariant } from '../Badge'
 import { BadgeSize } from '../Badge/Badge'

--- a/src/components/SyncingComponent/SyncingComponent.tsx
+++ b/src/components/SyncingComponent/SyncingComponent.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import RefreshCcw from '../../icons/RefreshCcw'
 import { IconButton } from '../Button'
 import { SmallLoader } from '../Loader'
@@ -59,11 +58,13 @@ export const SyncingComponent = ({
       )}
     >
       <div className='Layer__syncing-component__actions'>
-        {inProgress ? (
-          <SmallLoader />
-        ) : (
-          <IconButton icon={<RefreshCcw />} onClick={handleRefresh} />
-        )}
+        {inProgress
+          ? (
+            <SmallLoader />
+          )
+          : (
+            <IconButton icon={<RefreshCcw />} onClick={handleRefresh} />
+          )}
       </div>
       {!hideContent && (
         <div className='Layer__syncing-component__content'>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { TableProps } from '../../types/table'
 import classNames from 'classnames'
 

--- a/src/components/TableBody/TableBody.tsx
+++ b/src/components/TableBody/TableBody.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { TableBodyProps } from '../../types/table'
 
 export const TableBody = ({ children }: TableBodyProps) => {

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import ChevronDownFill from '../../icons/ChevronDownFill'
 import { centsToDollars } from '../../models/Money'
 import { TableCellProps } from '../../types/table'
@@ -57,7 +56,8 @@ export const TableCell = ({
             size={16}
           />
         )}
-        {isCurrency ? amountString : children}{' '}
+        {isCurrency ? amountString : children}
+        {' '}
       </span>
     </td>
   )

--- a/src/components/TableHead/TableHead.tsx
+++ b/src/components/TableHead/TableHead.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { TableHeadProps } from '../../types/table'
 
 export const TableHead = ({ children }: TableHeadProps) => {

--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { TableRowProps } from '../../types/table'
 import classNames from 'classnames'
 
@@ -21,7 +20,8 @@ export const TableRow: React.FC<TableRowProps> = ({
   ) => {
     if (onClick) {
       onClick(e)
-    } else {
+    }
+    else {
       if (variant === 'summation' || !expandable) return
       handleExpand && handleExpand()
     }
@@ -32,11 +32,11 @@ export const TableRow: React.FC<TableRowProps> = ({
     !isHeadRow && `Layer__table-row--depth-${depth}`,
     !isHeadRow && `Layer__table-row--variant-${variant}`,
     selected && 'Layer__table-row--selected',
-    !isHeadRow &&
-      expandable &&
-      (isExpanded
-        ? 'Layer__table-row--expanded'
-        : 'Layer__table-row--collapsed'),
+    !isHeadRow
+    && expandable
+    && (isExpanded
+      ? 'Layer__table-row--expanded'
+      : 'Layer__table-row--collapsed'),
   ])
 
   return (

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, ReactNode } from 'react'
+import { ChangeEvent, ReactNode } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip'
 
 interface TabProps {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, ReactNode, useEffect, useState } from 'react'
+import { ChangeEvent, ReactNode, useEffect, useState } from 'react'
 import { useElementSize } from '../../hooks/useElementSize'
 import { Tab } from './Tab'
 import classNames from 'classnames'

--- a/src/components/Tasks/Tasks.tsx
+++ b/src/components/Tasks/Tasks.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   createContext,
   ReactNode,
   useContext,

--- a/src/components/TasksList/TasksList.tsx
+++ b/src/components/TasksList/TasksList.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { TasksContext } from '../../contexts/TasksContext'
 import SmileIcon from '../../icons/SmileIcon'
 import { isComplete, Task } from '../../types/tasks'

--- a/src/components/TasksListItem/TasksListItem.tsx
+++ b/src/components/TasksListItem/TasksListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import { TasksContext } from '../../contexts/TasksContext'
 import AlertCircle from '../../icons/AlertCircle'
 import Check from '../../icons/Check'

--- a/src/components/TasksMonthSelector/TaskMonthTile.tsx
+++ b/src/components/TasksMonthSelector/TaskMonthTile.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { TaskMonthTileProps } from './types'
 import classNames from 'classnames'
 import { Text, TextSize } from '../Typography'
@@ -19,9 +18,11 @@ const TaskMonthTile = ({ monthData, onClick, active, disabled }: TaskMonthTilePr
         {monthData.monthStr}
       </Text>
       <Text size={TextSize.sm} className='Layer__tasks-month-selector__month__total'>
-        {monthData.total > 0 && isCompleted ? (
-          monthData.total
-        ) : ''}
+        {monthData.total > 0 && isCompleted
+          ? (
+            monthData.total
+          )
+          : ''}
       </Text>
       {isCompleted && monthData.total > 0 && (
         <span className='Layer__tasks-month-selector__month__completed'>

--- a/src/components/TasksMonthSelector/TasksMonthSelector.tsx
+++ b/src/components/TasksMonthSelector/TasksMonthSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import { endOfMonth, format, getMonth, getYear, isAfter, isBefore, set, startOfMonth } from 'date-fns'
 import { MonthData, TasksMonthSelectorProps } from './types'
 import { TaskMonthTile } from './TaskMonthTile'

--- a/src/components/TasksPending/TasksPending.tsx
+++ b/src/components/TasksPending/TasksPending.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react'
+import { useContext, useMemo } from 'react'
 import { TASKS_CHARTS_COLORS } from '../../config/charts'
 import { TasksContext } from '../../contexts/TasksContext'
 import { isComplete } from '../../types/tasks'

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react'
+import { HTMLProps } from 'react'
 import { Tooltip, TooltipTrigger, TooltipContent } from '../Tooltip'
 import classNames from 'classnames'
 

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useLayerContext } from '../../contexts/LayerContext'
 import classNames from 'classnames'
 

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   CSSProperties,
   ChangeEvent,
   ReactNode,

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   ReactNode,
   forwardRef,
   HTMLProps,

--- a/src/components/Tooltip/useTooltip.ts
+++ b/src/components/Tooltip/useTooltip.ts
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useMemo, useState, createContext, useContext } from 'react'
 import { TooltipOptions } from './Tooltip'
 import {
   useFloating,
@@ -16,10 +16,10 @@ import {
 
 export type ContextType = ReturnType<typeof useTooltip> | null
 
-export const TooltipContext = React.createContext<ContextType>(null)
+export const TooltipContext = createContext<ContextType>(null)
 
 export const useTooltipContext = () => {
-  const context = React.useContext(TooltipContext)
+  const context = useContext(TooltipContext)
 
   if (context == null) {
     throw new Error('Tooltip components must be wrapped in <Tooltip />')
@@ -81,7 +81,7 @@ export const useTooltip = ({
     duration: 300,
   })
 
-  return React.useMemo(
+  return useMemo(
     () => ({
       open,
       setOpen,

--- a/src/components/Typography/ErrorText.tsx
+++ b/src/components/Typography/ErrorText.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { TextProps, Text } from './Text'
 import classNames from 'classnames'
 

--- a/src/components/Typography/Heading.tsx
+++ b/src/components/Typography/Heading.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import classNames from 'classnames'
 
 export enum HeadingSize {

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef, useState, useEffect } from 'react'
+import { ReactNode, useRef, useState, useEffect } from 'react'
 import { Tooltip, TooltipTrigger, TooltipContent } from '../Tooltip'
 import classNames from 'classnames'
 

--- a/src/components/UpsellBanner/BookkeepingUpsellBar.tsx
+++ b/src/components/UpsellBanner/BookkeepingUpsellBar.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import CoffeeIcon from '../../icons/Coffee'
 import { Button, ButtonVariant, Link } from '../Button'
 import { IconBox } from '../IconBox'
@@ -31,15 +30,19 @@ export const BookkeepingUpsellBar = ({
           </Text>
         </div>
       </div>
-      {onClick ? (
-        <Button variant={ButtonVariant.secondary} onClick={onClick}>
-          Schedule a demo
-        </Button>
-      ) : href ? (
-        <Link href={href} target='_blank' variant={ButtonVariant.secondary}>
-          Schedule a demo
-        </Link>
-      ) : null}
+      {onClick
+        ? (
+          <Button variant={ButtonVariant.secondary} onClick={onClick}>
+            Schedule a demo
+          </Button>
+        )
+        : href
+          ? (
+            <Link href={href} target='_blank' variant={ButtonVariant.secondary}>
+              Schedule a demo
+            </Link>
+          )
+          : null}
     </div>
   )
 }

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, ReactNode } from 'react'
+import { forwardRef, ReactNode } from 'react'
 import { ViewHeader } from '../../components/ViewHeader'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { parseStylesFromThemeConfig } from '../../utils/colors'

--- a/src/components/ViewHeader/ViewHeader.tsx
+++ b/src/components/ViewHeader/ViewHeader.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { Heading } from '../Typography'
 import classNames from 'classnames'
 

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo } from 'react'
+import { forwardRef, useMemo } from 'react'
 import { Button as ReactAriaButton, type ButtonProps } from 'react-aria-components'
 import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'
 
@@ -21,22 +21,24 @@ const Button = forwardRef<
     children,
     ...restProps
   },
-  ref
+  ref,
 ) => {
   const dataProperties = useMemo(() => toDataProperties({
     icon,
     size,
-    variant
+    variant,
   }), [icon, size, variant])
 
-  return <ReactAriaButton
-    {...restProps}
-    {...dataProperties}
-    className={BUTTON_CLASS_NAME}
-    ref={ref}
-  >
-    {children}
-  </ReactAriaButton>
+  return (
+    <ReactAriaButton
+      {...restProps}
+      {...dataProperties}
+      className={BUTTON_CLASS_NAME}
+      ref={ref}
+    >
+      {children}
+    </ReactAriaButton>
+  )
 })
 Button.displayName = 'IconButton'
 

--- a/src/components/ui/Checkbox/Checkbox.tsx
+++ b/src/components/ui/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import { Check } from 'lucide-react'
-import React, { ReactNode, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Checkbox as ReactAriaCheckbox, type CheckboxProps as AriaCheckboxProps } from 'react-aria-components'
 import { withRenderProp } from '../../utility/withRenderProp'
 import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'

--- a/src/components/ui/Loading/LoadingSpinner.tsx
+++ b/src/components/ui/Loading/LoadingSpinner.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { LoaderCircle, type LucideProps } from 'lucide-react'
 
 const CLASS_NAME = 'Layer__LoadingSpinner'

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo, type ComponentProps, type PropsWithChildren } from 'react'
+import { forwardRef, useMemo, type ComponentProps, type PropsWithChildren } from 'react'
 import {
   Dialog as ReactAriaDialog,
   type DialogProps,

--- a/src/components/ui/Modal/ModalSlots.tsx
+++ b/src/components/ui/Modal/ModalSlots.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type ComponentProps, type PropsWithChildren } from 'react'
+import { forwardRef, type ComponentProps, type PropsWithChildren } from 'react'
 import { X } from 'lucide-react'
 import { Button } from '../Button/Button'
 import { Heading } from '../Typography/Heading'

--- a/src/components/ui/Stack/Stack.tsx
+++ b/src/components/ui/Stack/Stack.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, type PropsWithChildren } from 'react'
+import { useMemo, type PropsWithChildren } from 'react'
 import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'
 
 export type StackProps = PropsWithChildren<{

--- a/src/components/ui/Typography/Heading.tsx
+++ b/src/components/ui/Typography/Heading.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import { forwardRef, type ComponentProps } from 'react'
 import { Heading as ReactAriaHeading } from 'react-aria-components'
 import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'

--- a/src/components/ui/Typography/Text.tsx
+++ b/src/components/ui/Typography/Text.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo } from 'react'
+import { forwardRef, useMemo } from 'react'
 import type { PropsWithChildren } from 'react'
 import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'
 

--- a/src/components/utility/ConditionalList.tsx
+++ b/src/components/utility/ConditionalList.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react'
+import type { PropsWithChildren } from 'react'
 
 type ConditionalListProps<T> = {
   list: ReadonlyArray<T>

--- a/src/components/utility/InvisibleDownload.tsx
+++ b/src/components/utility/InvisibleDownload.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useImperativeHandle, useRef } from 'react'
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react'
 import { runDelayedSync } from '../../utils/delay/runDelayed'
 
 type InvisibleDownloadHandle = {
@@ -9,7 +9,7 @@ export function useInvisibleDownload() {
   const invisibleDownloadRef = useRef<InvisibleDownloadHandle>(null)
 
   const triggerInvisibleDownload = useCallback((options: { url: string }) => {
-    invisibleDownloadRef.current?.trigger(options)
+    void invisibleDownloadRef.current?.trigger(options)
   }, [])
 
   return { invisibleDownloadRef, triggerInvisibleDownload }

--- a/src/contexts/TableContext/TableContext.tsx
+++ b/src/contexts/TableContext/TableContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, ReactNode } from 'react'
+import { createContext, useState, ReactNode } from 'react'
 import { TableContextProps } from '../../types/table'
 
 const defaultValue: TableContextProps = {

--- a/src/icons/MoreVertical.tsx
+++ b/src/icons/MoreVertical.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { IconSvgProps } from './types'
 
 const MoreVertical = ({ size = 18, ...props }: IconSvgProps) => {

--- a/src/icons/Paperclip.tsx
+++ b/src/icons/Paperclip.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { IconSvgProps } from './types'
 
 const Paperclip = ({ size = 20, ...props }: IconSvgProps) => {

--- a/src/icons/PlaidIcon.tsx
+++ b/src/icons/PlaidIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const PlaidIcon = () => {
   return (
     <img

--- a/src/icons/WarningCircle.tsx
+++ b/src/icons/WarningCircle.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { IconSvgProps } from './types'
 
 const WarningCircle = ({ size = 18, ...props }: IconSvgProps) => (

--- a/src/providers/AccountConfirmationStoreProvider.tsx
+++ b/src/providers/AccountConfirmationStoreProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useState, createContext, type PropsWithChildren, useContext } from 'react'
+import { useState, createContext, type PropsWithChildren, useContext } from 'react'
 import { createStore, useStore } from 'zustand'
 
 type AccountConfirmationVisibility = 'PRELOADED' | 'DEFAULT' | 'DISMISSED'

--- a/src/providers/AuthInputProvider.tsx
+++ b/src/providers/AuthInputProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useMemo, type PropsWithChildren } from 'react'
+import { createContext, useContext, useMemo, type PropsWithChildren } from 'react'
 
 type AuthInputShape = {
   appId?: string

--- a/src/providers/BankTransactionsProvider/BankTransactionsProvider.tsx
+++ b/src/providers/BankTransactionsProvider/BankTransactionsProvider.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { BankTransactionsContext } from '../../contexts/BankTransactionsContext'
 import { useBankTransactions } from '../../hooks/useBankTransactions'
 

--- a/src/providers/BusinessProvider/BusinessProvider.tsx
+++ b/src/providers/BusinessProvider/BusinessProvider.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useReducer, useEffect, Reducer } from 'react'
+import { PropsWithChildren, useReducer, useEffect, Reducer } from 'react'
 import { Layer } from '../../api/layer'
 import { GlobalWidgets } from '../../components/GlobalWidgets'
 import { ToastProps } from '../../components/Toast/Toast'

--- a/src/providers/Environment/EnvironmentInputProvider.tsx
+++ b/src/providers/Environment/EnvironmentInputProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useMemo, type PropsWithChildren } from 'react'
+import { createContext, useContext, useMemo, type PropsWithChildren } from 'react'
 import { EnvironmentConfigs, type Environment } from './environmentConfigs'
 
 type EnvironmentInputShape = {

--- a/src/providers/LayerProvider/LayerProvider.tsx
+++ b/src/providers/LayerProvider/LayerProvider.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useState } from 'react'
+import { PropsWithChildren, useState } from 'react'
 import { LayerError } from '../../models/ErrorHandler'
 import { BusinessProvider } from '../../providers/BusinessProvider/BusinessProvider'
 import { LayerThemeConfig } from '../../types/layer_context'

--- a/src/providers/LinkedAccountsProvider/LinkedAccountsProvider.tsx
+++ b/src/providers/LinkedAccountsProvider/LinkedAccountsProvider.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react'
+import { type PropsWithChildren } from 'react'
 import { LinkedAccountsContext } from '../../contexts/LinkedAccountsContext'
 import { useLinkedAccounts } from '../../hooks/useLinkedAccounts'
 import { AccountConfirmationStoreProvider } from '../AccountConfirmationStoreProvider'

--- a/src/providers/ReceiptsProvider/ReceiptsProvider.tsx
+++ b/src/providers/ReceiptsProvider/ReceiptsProvider.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { ReceiptsContext } from '../../contexts/ReceiptsContext'
 import { useReceipts } from '../../hooks/useReceipts'
 import { BankTransaction } from '../../types'

--- a/src/views/AccountingOverview/AccountingOverview.tsx
+++ b/src/views/AccountingOverview/AccountingOverview.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react'
+import { ReactNode, useState } from 'react'
 import { Container } from '../../components/Container'
 import { Header, HeaderCol, HeaderRow } from '../../components/Header'
 import { Onboarding } from '../../components/Onboarding'

--- a/src/views/AccountingOverview/internal/TransactionsToReview.tsx
+++ b/src/views/AccountingOverview/internal/TransactionsToReview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { Badge } from '../../../components/Badge'
 import { BadgeSize, BadgeVariant } from '../../../components/Badge/Badge'
 import { BadgeLoader } from '../../../components/BadgeLoader'

--- a/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
+++ b/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { BankTransactions } from '../../components/BankTransactions'
 import {
   BankTransactionsMode,

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Container } from '../../components/Container'
 import { ProfitAndLoss } from '../../components/ProfitAndLoss'
 import { ProfitAndLossDetailedChartsStringOverrides } from '../../components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts'

--- a/src/views/BookkeepingOverview/internal/BookkeepingProfitAndLossSummariesContainer.tsx
+++ b/src/views/BookkeepingOverview/internal/BookkeepingProfitAndLossSummariesContainer.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react'
+import { PropsWithChildren } from 'react'
 
 const CLASS_NAME = 'Layer__BookkeepingProfitAndLossSummariesContainer'
 

--- a/src/views/GeneralLedger/GeneralLedger.tsx
+++ b/src/views/GeneralLedger/GeneralLedger.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { ChartOfAccounts } from '../../components/ChartOfAccounts'
 import { ChartOfAccountsStringOverrides } from '../../components/ChartOfAccounts/ChartOfAccounts'
 import { Journal } from '../../components/Journal'

--- a/src/views/ProjectProfitability/ProjectProfitability.tsx
+++ b/src/views/ProjectProfitability/ProjectProfitability.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import Select, { Options } from 'react-select'
 import { BankTransactions } from '../../components/BankTransactions'
 import { Container } from '../../components/Container'

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useState } from 'react'
+import { RefObject, useState } from 'react'
 import { BalanceSheet } from '../../components/BalanceSheet'
 import { BalanceSheetStringOverrides } from '../../components/BalanceSheet/BalanceSheet'
 import { Container } from '../../components/Container'


### PR DESCRIPTION
## Description

The `React` global has not been required since React 17. This PR has a ton of file changes, but makes no attempt to change functionality.