### PR TITLE
fix: 2 in bank transactions metadata url

### DIFF
--- a/src/api/layer/bankTransactions.ts
+++ b/src/api/layer/bankTransactions.ts
@@ -104,7 +104,7 @@ export const getBankTransactionMetadata = get<{
   errors: unknown
 }>(
   ({ businessId, bankTransactionId }) =>
-    `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}2/metadata`,
+    `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/metadata`,
 )
 
 export const updateBankTransactionMetadata = put<


### PR DESCRIPTION
## Description

`2` was wrongly added into bank transaction's metadata API url

## Changes

- remove wrongly added `2` to the API url

## How this has been tested?

Before, the API call respond with `400`. Now it correctly fetches data:

![image](https://github.com/user-attachments/assets/5a6346c5-8198-497c-9053-39b75846029f)

