### PR TITLE
[LAY-1153] fix: load all categories for manual journal entries

### DIFF
--- a/src/api/layer/categories.ts
+++ b/src/api/layer/categories.ts
@@ -1,9 +1,20 @@
+import { toDefinedSearchParameters } from '../../utils/request/toDefinedSearchParameters'
 import { Category } from '../../types'
 import { get } from './authenticated_http'
 
-export const getCategories = get<{
-  data: {
-    type: 'Category_List'
-    categories: Category[]
+export const getCategories = get<
+  {
+    data: {
+      type: 'Category_List'
+      categories: Category[]
+    }
+  },
+  {
+    businessId: string
+    mode?: 'ALL'
   }
-}>(({ businessId }) => `/v1/businesses/${businessId}/categories`)
+>(({ businessId, mode }) => {
+  const parameters = toDefinedSearchParameters({ mode })
+
+  return `/v1/businesses/${businessId}/categories?${parameters}`
+})

--- a/src/hooks/categories/useAllCategories.ts
+++ b/src/hooks/categories/useAllCategories.ts
@@ -1,0 +1,44 @@
+import useSWR from 'swr'
+import { useLayerContext } from '../../contexts/LayerContext'
+import { useAuth } from '../useAuth'
+import { getCategories } from '../../api/layer/categories'
+
+function buildKey({
+  access_token: accessToken,
+  apiUrl,
+  businessId,
+}: {
+  access_token?: string
+  apiUrl?: string
+  businessId: string
+}) {
+  if (accessToken && apiUrl) {
+    return {
+      accessToken,
+      apiUrl,
+      businessId,
+      tags: ['#categories'],
+    }
+  }
+}
+
+export function useAllCategories() {
+  const { data: auth } = useAuth()
+  const { businessId } = useLayerContext()
+
+  return useSWR(
+    () => buildKey({
+      ...auth,
+      businessId,
+    }),
+    ({ accessToken, apiUrl, businessId }) => getCategories(
+      apiUrl,
+      accessToken,
+      {
+        params: {
+          businessId,
+          mode: 'ALL',
+        },
+      })().then(({ data }) => data.categories),
+  )
+}

--- a/src/hooks/categories/useAllCategories.ts
+++ b/src/hooks/categories/useAllCategories.ts
@@ -17,8 +17,9 @@ function buildKey({
       accessToken,
       apiUrl,
       businessId,
+      mode: 'ALL',
       tags: ['#categories'],
-    }
+    } as const
   }
 }
 
@@ -31,13 +32,13 @@ export function useAllCategories() {
       ...auth,
       businessId,
     }),
-    ({ accessToken, apiUrl, businessId }) => getCategories(
+    ({ accessToken, apiUrl, businessId, mode }) => getCategories(
       apiUrl,
       accessToken,
       {
         params: {
           businessId,
-          mode: 'ALL',
+          mode,
         },
       })().then(({ data }) => data.categories),
   )


### PR DESCRIPTION
## Description

**Linear**: LAY-1153

We are now loading journal entries from the categories endpoint.

### (Unrelated) Known Issues

If a user doesn't touch the date selector at all, no date has been set. 