### PR TITLE
feat: due status

### DIFF
--- a/src/components/DueStatus/DueStatus.tsx
+++ b/src/components/DueStatus/DueStatus.tsx
@@ -6,7 +6,6 @@ import { toDataProperties } from '../../utils/styleUtils/toDataProperties'
 export interface DueStatusProps {
   dueDate: Date | string
   paidAt?: Date | string
-  paid?: boolean
 }
 
 const dueStatusTitle = (daysDiff: number, paid?: boolean) => {
@@ -81,21 +80,21 @@ const getDiff = (refDate: Date | string) => {
   return differenceInDays(today, d)
 }
 
-export const DueStatus = ({ dueDate, paidAt, paid }: DueStatusProps) => {
+export const DueStatus = ({ dueDate, paidAt }: DueStatusProps) => {
   const date = useMemo(() => {
     try {
-      const diff = getDiff(paid && paidAt ? paidAt : dueDate)
+      const diff = getDiff(paidAt ? paidAt : dueDate)
 
       if (diff === null) {
         return null
       }
 
-      return dueStatusTitle(diff, paid)
+      return dueStatusTitle(diff, Boolean(paidAt))
     }
     catch (_err) {
       return null
     }
-  }, [dueDate, paid, paidAt])
+  }, [dueDate, paidAt])
 
   if (!date) {
     return null

--- a/src/components/DueStatus/DueStatus.tsx
+++ b/src/components/DueStatus/DueStatus.tsx
@@ -1,0 +1,120 @@
+import { useMemo } from 'react'
+import { Text, TextSize, TextWeight } from '../Typography'
+import { parseISO, differenceInDays } from 'date-fns'
+import { toDataProperties } from '../../utils/styleUtils/toDataProperties'
+
+export interface DueStatusProps {
+  dueDate: Date | string
+  paidAt?: Date | string
+  paid?: boolean
+}
+
+const dueStatusTitle = (daysDiff: number, paid?: boolean) => {
+  if (paid && daysDiff > 0) {
+    return {
+      type: 'paid',
+      diff: daysDiff,
+      title: 'Paid',
+      diffText: `${daysDiff} ${daysDiff === 1 ? 'day' : 'days'} ago`,
+    }
+  }
+
+  if (paid && daysDiff === 0) {
+    return {
+      type: 'paid',
+      diff: daysDiff,
+      title: 'Paid',
+      diffText: 'Today',
+    }
+  }
+
+  if (paid && daysDiff < 0) {
+    return {
+      type: 'paid',
+      diff: daysDiff,
+      title: 'Paid',
+    }
+  }
+
+  if (daysDiff === 0) {
+    return {
+      type: 'today',
+      diff: daysDiff,
+      title: 'Due today',
+    }
+  }
+
+  if (daysDiff > 0) {
+    return {
+      type: 'overdue',
+      diff: daysDiff,
+      title: 'Overdue',
+      diffText: `${daysDiff} ${daysDiff === 1 ? 'day' : 'days'} ago`,
+    }
+  }
+
+  if (daysDiff < 0 && daysDiff > -4) {
+    return {
+      type: 'soon',
+      diff: daysDiff,
+      title: 'Due soon',
+      diffText: `Due in ${Math.abs(daysDiff)} ${
+        daysDiff === -1 ? 'day' : 'days'
+      }`,
+    }
+  }
+
+  return {
+    type: 'before',
+    diff: daysDiff,
+    diffText: `Due in ${Math.abs(daysDiff)} days`,
+  }
+}
+
+const getDiff = (refDate: Date | string) => {
+  const d = (refDate instanceof Date ? refDate : parseISO(refDate)).setHours(0, 0, 0, 0)
+  if (isNaN(d)) {
+    return null
+  }
+
+  const today = new Date().setHours(0, 0, 0, 0)
+  return differenceInDays(today, d)
+}
+
+export const DueStatus = ({ dueDate, paidAt, paid }: DueStatusProps) => {
+  const date = useMemo(() => {
+    try {
+      const diff = getDiff(paid && paidAt ? paidAt : dueDate)
+
+      if (diff === null) {
+        return null
+      }
+
+      return dueStatusTitle(diff, paid)
+    }
+    catch (_err) {
+      return null
+    }
+  }, [dueDate, paid, paidAt])
+
+  if (!date) {
+    return null
+  }
+
+  const dataProps = toDataProperties({ status: date.type })
+
+  return (
+    <div {...dataProps} className='Layer__due-status'>
+      {date.title && (
+        <Text className='Layer__due-status__title' weight={TextWeight.bold}>
+          {date.title}
+        </Text>
+      )}
+      {date.diffText && (
+        <Text className='Layer__due-status__subtitle' size={TextSize.sm}>
+          {date.diffText}
+        </Text>
+      )}
+    </div>
+  )
+}

--- a/src/components/DueStatus/due_status.scss
+++ b/src/components/DueStatus/due_status.scss
@@ -1,0 +1,35 @@
+.Layer__due-status {
+  display: flex;
+  flex-direction: column;
+  white-space: nowrap;
+}
+
+.Layer__due-status[data-status='overdue'] {
+  .Layer__due-status__title {
+    color: var(--color-info-error);
+  }
+}
+
+.Layer__due-status[data-status='today'] {
+  .Layer__due-status__title {
+    color: var(--color-info-warning);
+  }
+}
+
+.Layer__due-status[data-status='paid'] {
+  .Layer__due-status__title {
+    color: var(--color-info-success);
+  }
+}
+
+.Layer__due-status[data-status='soon'] {
+  .Layer__due-status__title {
+    color: var(--color-base-800);
+  }
+}
+
+.Layer__due-status[data-status='before'] {
+  .Layer__due-status__title {
+    color: var(--color-base-800);
+  }
+}

--- a/src/components/DueStatus/due_status.scss
+++ b/src/components/DueStatus/due_status.scss
@@ -2,34 +2,34 @@
   display: flex;
   flex-direction: column;
   white-space: nowrap;
-}
 
-.Layer__due-status[data-status='overdue'] {
-  .Layer__due-status__title {
-    color: var(--color-info-error);
+  &[data-status='overdue'] {
+    .Layer__due-status__title {
+      color: var(--color-info-error);
+    }
   }
-}
 
-.Layer__due-status[data-status='today'] {
-  .Layer__due-status__title {
-    color: var(--color-info-warning);
+  &[data-status='today'] {
+    .Layer__due-status__title {
+      color: var(--color-info-warning);
+    }
   }
-}
 
-.Layer__due-status[data-status='paid'] {
-  .Layer__due-status__title {
-    color: var(--color-info-success);
+  &[data-status='paid'] {
+    .Layer__due-status__title {
+      color: var(--color-info-success);
+    }
   }
-}
 
-.Layer__due-status[data-status='soon'] {
-  .Layer__due-status__title {
-    color: var(--color-base-800);
+  &[data-status='soon'] {
+    .Layer__due-status__title {
+      color: var(--color-base-800);
+    }
   }
-}
 
-.Layer__due-status[data-status='before'] {
-  .Layer__due-status__title {
-    color: var(--color-base-800);
+  &[data-status='before'] {
+    .Layer__due-status__title {
+      color: var(--color-base-800);
+    }
   }
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -25,6 +25,7 @@
 @forward './view';
 @forward '../components/ui/index';
 @forward '../components/utility/index';
+@forward '../components/DueStatus/due_status';
 @forward '../components/LinkedAccounts/ConfirmationModal/linkedAccountToConfirm';
 @forward '../components/LinkedAccounts/AccountFormBox/AccountFormBox';
 @forward '../components/TasksMonthSelector/tasksMonthSelector';


### PR DESCRIPTION
## Description

To make large Bills PR easier to review, this PR adds `<DueStatus />` component used on Bills pages.

## Changes
- `<DueStatus />` component

## Context

![image](https://github.com/user-attachments/assets/5526af3b-e9fa-48d9-b0ea-b2785bca1927)


## How this has been tested?


```
        <div style={{ padding: 12 }}>
          <DueStatus dueDate={new Date()} paidAt={new Date()} paid={true} />
        </div>
        <div style={{ padding: 12 }}>
          <DueStatus dueDate={sub(new Date(), { days: 3 })} />
        </div>
        <div style={{ padding: 12 }}>
          <DueStatus dueDate={sub(new Date(), { days: 13 })} />
        </div>
        <div style={{ padding: 12 }}>
          <DueStatus dueDate={sub(new Date(), { days: -1 })} />
        </div>
        <div style={{ padding: 12 }}>
          <DueStatus dueDate={sub(new Date(), { days: -4 })} />
        </div>
```

![image](https://github.com/user-attachments/assets/555163b7-305e-47f3-b1a2-290010252631)

