### PR TITLE
feat: extending components - for bills

### DIFF
--- a/src/components/Button/SubmitButton.tsx
+++ b/src/components/Button/SubmitButton.tsx
@@ -14,6 +14,7 @@ export interface SubmitButtonProps
   error?: boolean | string
   active?: boolean
   iconOnly?: boolean
+  variant?: ButtonProps['variant']
   action?: SubmitAction
   noIcon?: boolean
   tooltip?: ButtonProps['tooltip']
@@ -78,6 +79,7 @@ export const SubmitButton = ({
   children,
   action = SubmitAction.SAVE,
   noIcon,
+  variant = ButtonVariant.primary,
   ...props
 }: SubmitButtonProps) => {
   const baseClassName = classNames(
@@ -89,7 +91,7 @@ export const SubmitButton = ({
     <Button
       {...props}
       className={baseClassName}
-      variant={ButtonVariant.primary}
+      variant={variant}
       disabled={processing || disabled}
       rightIcon={buildRightIcon({ processing, error, action, noIcon })}
       iconAsPrimary={true}

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -45,7 +45,7 @@ interface DatePickerProps {
   popperClassName?: string
   currentDateOption?: boolean
   minDate?: Date
-  maxDate?: Date
+  maxDate?: Date | null
   navigateArrows?: NavigationArrows[]
   onChangeMode?: (mode: UnifiedPickerMode) => void
   slots?: {
@@ -217,16 +217,16 @@ export const DatePicker = ({
   const isTodayOrAfter = useMemo(() => {
     switch (displayMode) {
       case 'dayPicker':
-        return firstDate >= endOfDay(new Date()) || firstDate >= maxDate
+        return firstDate >= endOfDay(new Date()) || (maxDate && firstDate >= maxDate)
       case 'monthPicker':
         return (
           endOfMonth(firstDate) >= endOfMonth(new Date())
-          || endOfMonth(firstDate) >= maxDate
+          || (maxDate && endOfMonth(firstDate) >= maxDate)
         )
       case 'yearPicker':
         return (
           endOfYear(firstDate) >= endOfYear(new Date())
-          || endOfYear(firstDate) >= maxDate
+          || (maxDate && endOfYear(firstDate) >= maxDate)
         )
       default:
         return false

--- a/src/components/Header/HeaderCol.tsx
+++ b/src/components/Header/HeaderCol.tsx
@@ -1,14 +1,23 @@
-import { CSSProperties, ReactNode } from 'react'
+import { CSSProperties, ReactNode, useMemo } from 'react'
 import classNames from 'classnames'
+import { toDataProperties } from '../../utils/styleUtils/toDataProperties'
 
 interface HeaderColProps {
   className?: string
   style?: CSSProperties
+  noPadding?: boolean
   children: ReactNode
 }
 
-export const HeaderCol = ({ className, children, style }: HeaderColProps) => (
-  <div className={classNames('Layer__header__col', className)} style={style}>
-    {children}
-  </div>
-)
+export const HeaderCol = ({ className, children, style, noPadding = false }: HeaderColProps) => {
+  const dataProperties = useMemo(
+    () => toDataProperties({ 'no-padding': noPadding }),
+    [noPadding],
+  )
+
+  return (
+    <div {...dataProperties} className={classNames('Layer__header__col', className)} style={style}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/Header/HeaderCol.tsx
+++ b/src/components/Header/HeaderCol.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode, useMemo } from 'react'
+import { CSSProperties, ReactNode } from 'react'
 import classNames from 'classnames'
 import { toDataProperties } from '../../utils/styleUtils/toDataProperties'
 
@@ -10,10 +10,7 @@ interface HeaderColProps {
 }
 
 export const HeaderCol = ({ className, children, style, noPadding = false }: HeaderColProps) => {
-  const dataProperties = useMemo(
-    () => toDataProperties({ 'no-padding': noPadding }),
-    [noPadding],
-  )
+  const dataProperties = toDataProperties({ 'no-padding': noPadding })
 
   return (
     <div {...dataProperties} className={classNames('Layer__header__col', className)} style={style}>

--- a/src/components/Input/StaticValue.tsx
+++ b/src/components/Input/StaticValue.tsx
@@ -1,0 +1,22 @@
+import { Text } from '../Typography'
+import { TextProps } from '../Typography/Text'
+import classNames from 'classnames'
+
+export type StaticValueProps = TextProps
+
+/**
+ * Use in places where you want to show a static value instead of (disabled) input.
+ * Usually it can be used on a summary view after submitting the form,
+ * where showing disable input doesn't look right.
+ */
+export const StaticValue = (props: StaticValueProps) => {
+  return (
+    <Text
+      className={classNames(
+        'Layer__input--static-value',
+        props.className ?? '',
+      )}
+      {...props}
+    />
+  )
+}

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -16,6 +16,7 @@ export const TableCell = ({
   onClick,
   style,
   width,
+  nowrap,
 }: TableCellProps) => {
   const amount = typeof children === 'number' ? children : 0
   const isPositive = amount >= 0
@@ -24,10 +25,12 @@ export const TableCell = ({
   const cellClassNames = classNames(
     'Layer__table-cell',
     (primary || isHeaderCell) && 'Layer__table-cell--primary',
+    isHeaderCell && 'Layer__table-header',
     isCurrency && 'Layer__table-cell-amount',
     isCurrency && isPositive && 'Layer__table-cell-amount--positive',
     isCurrency && !isPositive && 'Layer__table-cell-amount--negative',
     align && `Layer__table-cell--${align}`,
+    nowrap && 'Layer__table-cell--nowrap',
     className,
   )
 

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -55,14 +55,14 @@ export const Toggle = ({
   const [currentWidth, setCurrentWidth] = useState(0)
   const [thumbPos, setThumbPos] = useState({ left: 0, width: 0 })
   const [initialized, setInitialized] = useState(false)
+  const [activeOption, setActiveOption] = useState(selected || options[0].value)
 
-  const toggleRef = useElementSize<HTMLDivElement>((a, b, c) => {
+  const toggleRef = useElementSize<HTMLDivElement>((_a, _b, c) => {
     if (c.width && c?.width !== currentWidth) {
       setCurrentWidth(c.width)
     }
   })
 
-  const selectedValue = selected || options[0].value
   const baseClassName = classNames(
     'Layer__toggle',
     `Layer__toggle--${size}`,
@@ -70,6 +70,8 @@ export const Toggle = ({
   )
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value
+    setActiveOption(newValue)
     updateThumbPosition(Number(e.target.getAttribute('data-idx') ?? 0))
     onChange(e)
   }
@@ -80,11 +82,11 @@ export const Toggle = ({
     }
 
     const optionsNodes = [...toggleRef.current.children]
-      .map(x => {
+      .map((x) => {
         if (
-          x.className.includes('Layer__tooltip-trigger') &&
-          x.children &&
-          x.children.length > 0
+          x.className.includes('Layer__tooltip-trigger')
+          && x.children
+          && x.children.length > 0
         ) {
           return x.children[0]
         }
@@ -99,7 +101,8 @@ export const Toggle = ({
     optionsNodes.forEach((c, i) => {
       if (i < active) {
         shift = shift + (c as HTMLElement).offsetWidth
-      } else if (i === active) {
+      }
+      else if (i === active) {
         width = (c as HTMLElement).offsetWidth
       }
     })
@@ -116,16 +119,18 @@ export const Toggle = ({
     setTimeout(() => {
       setInitialized(true)
     }, 400)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {
     const selectedIndex = getSelectedIndex()
     updateThumbPosition(selectedIndex)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentWidth])
 
   const getSelectedIndex = () => {
     const selectedIndex = options.findIndex(
-      option => option.value === selectedValue,
+      option => option.value === activeOption,
     )
     if (selectedIndex === -1) {
       return 0
@@ -142,7 +147,7 @@ export const Toggle = ({
           size={size}
           key={option.value}
           name={name}
-          checked={selectedValue === option.value}
+          checked={activeOption === option.value}
           onChange={handleChange}
           disabled={option.disabled ?? false}
           disabledMessage={option.disabledMessage}
@@ -167,12 +172,16 @@ const ToggleOption = ({
   style,
   index,
 }: ToggleOptionProps) => {
+  const optionClassName = classNames('Layer__toggle-option', {
+    'Layer__toggle-option--active': checked,
+  })
+
   if (disabled) {
     return (
       <Tooltip>
         <TooltipTrigger>
           <label
-            className={'Layer__toggle-option'}
+            className={optionClassName}
             data-checked={checked}
             style={style}
           >
@@ -182,7 +191,7 @@ const ToggleOption = ({
               name={name}
               onChange={onChange}
               value={value}
-              disabled={disabled ?? false}
+              disabled={disabled}
               data-idx={index}
             />
             <span className='Layer__toggle-option-content'>
@@ -201,18 +210,14 @@ const ToggleOption = ({
   }
 
   return (
-    <label
-      className={'Layer__toggle-option'}
-      data-checked={checked}
-      style={style}
-    >
+    <label className={optionClassName} data-checked={checked} style={style}>
       <input
         type='radio'
         checked={checked}
         name={name}
         onChange={onChange}
         value={value}
-        disabled={disabled ?? false}
+        disabled={disabled}
         data-idx={index}
       />
       <span className='Layer__toggle-option-content'>

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -55,7 +55,13 @@ export const Toggle = ({
   const [currentWidth, setCurrentWidth] = useState(0)
   const [thumbPos, setThumbPos] = useState({ left: 0, width: 0 })
   const [initialized, setInitialized] = useState(false)
-  const [activeOption, setActiveOption] = useState(selected || options[0].value)
+  const [activeOption, setActiveOption] = useState(
+    selected
+      ? selected
+      : options.length > 0
+        ? options[0].value
+        : undefined,
+  )
 
   const toggleRef = useElementSize<HTMLDivElement>((_a, _b, c) => {
     if (c.width && c?.width !== currentWidth) {

--- a/src/components/Typography/ErrorText.tsx
+++ b/src/components/Typography/ErrorText.tsx
@@ -1,9 +1,7 @@
 import { TextProps, Text } from './Text'
-import classNames from 'classnames'
 
 export type ErrorTextProps = TextProps
 
-export const ErrorText = ({ className, ...props }: ErrorTextProps) => {
-  const baseClassName = classNames('Layer__text--error', className)
-  return <Text {...props} className={baseClassName} />
-}
+export const ErrorText = ({ className, ...props }: ErrorTextProps) => (
+  <Text {...props} status='error' className={className} />
+)

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useRef, useState, useEffect } from 'react'
 import { Tooltip, TooltipTrigger, TooltipContent } from '../Tooltip'
 import classNames from 'classnames'
+import { toDataProperties } from '../../utils/styleUtils/toDataProperties'
 
 export enum TextSize {
   lg = 'lg',
@@ -18,6 +19,8 @@ export enum TextUseTooltip {
   always = 'always',
 }
 
+export type TextStatus = 'success' | 'error' | 'warning'
+
 export interface TextTooltipOptions {
   contentClassName?: string
   offset?: number
@@ -30,9 +33,11 @@ export interface TextProps {
   children: ReactNode
   size?: TextSize
   weight?: TextWeight
+  status?: TextStatus
   htmlFor?: string
   withTooltip?: TextUseTooltip
   tooltipOptions?: TextTooltipOptions
+  ellipsis?: boolean
 }
 
 export const Text = ({
@@ -42,8 +47,12 @@ export const Text = ({
   size = TextSize.md,
   weight = TextWeight.normal,
   withTooltip,
+  ellipsis,
+  status,
   ...props
 }: TextProps) => {
+  const dataProperties = toDataProperties({ status, ellipsis })
+
   const baseClassName = classNames(
     `Layer__text Layer__text--${size} Layer__text--${weight}`,
     className,
@@ -57,6 +66,7 @@ export const Text = ({
         size={size}
         weight={weight}
         withTooltip={withTooltip}
+        {...dataProperties}
         {...props}
       >
         {children}
@@ -65,7 +75,7 @@ export const Text = ({
   }
 
   return (
-    <Component {...props} className={baseClassName}>
+    <Component {...props} {...dataProperties} className={baseClassName}>
       {children}
     </Component>
   )
@@ -85,8 +95,8 @@ export const TextWithTooltip = ({
   const compareSize = () => {
     if (textElementRef.current) {
       const compare =
-        textElementRef.current.children[0].scrollWidth >
-        textElementRef.current.children[0].clientWidth
+        textElementRef.current.children[0].scrollWidth
+        > textElementRef.current.children[0].clientWidth
       setHover(compare)
     }
   }

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -7,7 +7,7 @@
 .Layer__header--sticky {
   position: sticky;
   top: 0;
-  background: rgba(255, 255, 255, 0.5);
+  background: rgb(255 255 255 / 50%);
   backdrop-filter: blur(6px);
   z-index: 10;
 }
@@ -33,10 +33,15 @@
   padding: var(--spacing-md);
   min-height: 68px;
   box-sizing: border-box;
+
+  &[data-no-padding='true'] {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 @container (min-width: 1400px) {
   .Layer__header__col {
-    padding: var(--spacing-md) var(--spacing-xl);
+    padding: var(--spacing-sm) var(--spacing-xl);
   }
 }

--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -11,6 +11,7 @@
     align-items: center;
     width: 100%;
     flex: 1;
+    gap: var(--spacing-sm);
 
     & label {
       width: 33%;
@@ -45,22 +46,22 @@
 .Layer__textarea {
   width: 100%;
   resize: none;
-  box-shadow:
-    0px 0px 0px 1px var(--input-border-color),
-    0px 0px 0px 2px rgba(0, 0, 0, 0);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 1px var(--input-border-color),
+    0 0 0 2px rgb(0 0 0 / 0%);
   border: 1px solid var(--border-color);
   border-radius: var(--input-border-radius);
-  border-width: 0px;
+  border-width: 0;
   min-height: 100px;
+  margin: 1px;
   padding: var(--spacing-xs);
   font-family: var(--font-family);
   font-size: var(--input-font-size);
   line-height: 140%;
 
   &.Layer__textarea--error {
-    box-shadow:
-      0px 0px 0px 1px var(--color-base-300),
-      0px 0px 0px 2px var(--color-danger);
+    box-shadow: 0 0 0 1px var(--color-base-300),
+      0 0 0 2px var(--color-danger);
   }
 
   &:disabled {
@@ -71,9 +72,8 @@
   &:focus,
   &:active,
   &:focus-visible {
-    box-shadow:
-      0px 0px 0px 3px rgba(26, 26, 26, 0.08),
-      0px 0px 0px 1px var(--color-base-700);
+    box-shadow: 0 0 0 3px rgb(26 26 26 / 8%),
+      0 0 0 1px var(--color-base-700);
     outline: none;
   }
 }
@@ -84,19 +84,17 @@
   position: relative;
   border: 1px solid var(--border-color);
   border-radius: var(--input-border-radius);
-  border-width: 0px;
-  box-shadow:
-    0px 0px 0px 1px var(--input-border-color),
-    0px 0px 0px 2px rgba(0, 0, 0, 0);
+  border-width: 0;
+  box-shadow: 0 0 0 1px var(--input-border-color),
+    0 0 0 2px rgb(0 0 0 / 0%);
   margin: 1px;
   font-family: var(--font-family);
   font-size: var(--input-font-size);
   line-height: 140%;
 
   &.Layer__input--error {
-    box-shadow:
-      0px 0px 0px 1px var(--color-base-300),
-      0px 0px 0px 2px var(--color-danger);
+    box-shadow: 0 0 0 1px var(--color-base-300),
+      0 0 0 2px var(--color-danger);
   }
 
   &:disabled {
@@ -107,9 +105,8 @@
   &:focus,
   &:active,
   &:focus-visible {
-    box-shadow:
-      0px 0px 0px 3px rgba(26, 26, 26, 0.08),
-      0px 0px 0px 1px var(--color-base-700);
+    box-shadow: 0 0 0 3px rgb(26 26 26 / 8%),
+      0 0 0 1px var(--color-base-700);
     outline: none;
   }
 }
@@ -138,26 +135,6 @@
   position: relative;
 }
 
-.Layer__textarea {
-  padding: 10px 14px;
-  border-radius: var(--input-border-radius);
-  border-width: 0px;
-  box-sizing: border-box;
-  box-shadow: 0px 0px 0px 1px var(--input-border-color);
-  margin: 1px;
-  font-family: var(--font-family);
-  font-size: var(--input-font-size);
-
-  &:focus,
-  &:active,
-  &:focus-visible {
-    box-shadow:
-      0px 0px 0px 3px rgba(26, 26, 26, 0.08),
-      0px 0px 0px 1px var(--color-base-700);
-    outline: none;
-  }
-}
-
 .Layer__toggle {
   display: flex;
   width: max-content;
@@ -167,17 +144,13 @@
   padding: 2px;
   height: 38px;
   background: var(--color-base-100);
-  box-shadow: 0px 0px 0px 1px var(--color-base-300);
+  box-shadow: 0 0 0 1px var(--color-base-300);
   margin: 1px;
   cursor: pointer;
   position: relative;
   isolation: isolate;
   -webkit-tap-highlight-color: transparent;
   -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 
   .Layer__toggle-option-content {
@@ -237,8 +210,7 @@
     font-family: var(--font-family);
     font-size: var(--btn-font-size);
     cursor: pointer;
-    transition:
-      color var(--transition-speed) ease-in-out,
+    transition: color var(--transition-speed) ease-in-out,
       background-color 150ms ease-in-out;
     justify-content: center;
 
@@ -279,19 +251,16 @@
   left: 0;
   top: 1px;
   z-index: 1;
-
   box-sizing: border-box;
   padding: 8px 16px;
   height: 36px;
   border-radius: 52px;
-
   background: var(--color-white);
-  box-shadow:
-    0px 0px 0px 1px var(--color-base-300),
-    0px 1px 1px 0px rgba(0, 0, 0, 0.04),
-    0px 2px 3px 0px rgba(0, 0, 0, 0.04),
-    0px 3px 4px 0px rgba(0, 0, 0, 0.02),
-    0px 4px 5px 0px rgba(0, 0, 0, 0.01);
+  box-shadow: 0 0 0 1px var(--color-base-300),
+    0 1px 1px 0 rgb(0 0 0 / 4%),
+    0 2px 3px 0 rgb(0 0 0 / 4%),
+    0 3px 4px 0 rgb(0 0 0 / 2%),
+    0 4px 5px 0 rgb(0 0 0 / 1%);
 }
 
 .Layer__toggle.Layer__toggle--small .Layer__toggle__thumb {
@@ -301,20 +270,18 @@
 
 .Layer__toggle--initialized {
   .Layer__toggle__thumb {
-    transition:
-      left 150ms ease,
+    transition: left 150ms ease,
       width 150ms ease;
   }
 }
 
 .Layer__select {
-  border-width: 0px;
+  border-width: 0;
   font-family: var(--font-family);
   font-size: var(--input-font-size);
   font-weight: var(--font-weight-normal);
   font-variant-numeric: lining-nums proportional-nums;
-  font-feature-settings:
-    'cv10' on,
+  font-feature-settings: 'cv10' on,
     'cv05' on,
     'cv08' on,
     'ss03' on;
@@ -322,23 +289,21 @@
   width: 100%;
 
   & .Layer__select__control {
-    border-width: 0px;
+    border-width: 0;
     border-radius: var(--input-border-radius);
-    box-shadow: 0px 0px 0px 1px var(--color-base-300);
+    box-shadow: 0 0 0 1px var(--color-base-300);
     margin: 1px;
     min-height: 36px;
   }
 
   & .Layer__select__control--is-focused {
-    box-shadow:
-      0px 0px 0px 3px rgba(26, 26, 26, 0.08),
-      0px 0px 0px 1px var(--color-base-700);
+    box-shadow: 0 0 0 3px rgb(26 26 26 / 8%),
+      0 0 0 1px var(--color-base-700);
   }
 
   &.Layer__select--error .Layer__select__control {
-    box-shadow:
-      0px 0px 0px 1px var(--color-base-300),
-      0px 0px 0px 2px var(--color-danger);
+    box-shadow: 0 0 0 1px var(--color-base-300),
+      0 0 0 2px var(--color-danger);
   }
 
   .Layer__select__multi-value {
@@ -381,8 +346,7 @@
     font-family: var(--font-family);
     font-weight: var(--font-weight-normal);
     font-variant-numeric: lining-nums proportional-nums;
-    font-feature-settings:
-      'cv10' on,
+    font-feature-settings: 'cv10' on,
       'cv05' on,
       'cv08' on,
       'ss03' on;
@@ -438,13 +402,14 @@
   .Layer__select__menu-notice {
     font-family: var(--font-family);
     font-size: 12px;
-    color: #999999;
+    color: #999;
   }
 
   .Layer__select__option-menu-content {
     display: flex;
     justify-content: space-between;
     align-items: center;
+
     .Layer__select__option-menu--name {
       display: flex;
       align-items: center;
@@ -529,10 +494,9 @@
   position: relative;
   border: 1px solid var(--border-color);
   border-radius: var(--input-border-radius);
-  border-width: 0px;
-  box-shadow:
-    0px 0px 0px 1px var(--input-border-color),
-    0px 0px 0px 2px rgba(0, 0, 0, 0);
+  border-width: 0;
+  box-shadow: 0 0 0 1px var(--input-border-color),
+    0 0 0 2px rgb(0 0 0 / 0%);
   margin: 1px;
   font-family: var(--font-family);
   font-size: var(--input-font-size);
@@ -558,7 +522,7 @@
   }
 }
 
-@media screen and (max-width: 400px) {
+@media screen and (width <= 400px) {
   .Layer__select__menu-portal .Layer__select__option {
     font-size: var(--text-sm) !important;
   }
@@ -607,8 +571,7 @@
   align-items: center;
   text-align: center;
   padding: 0 var(--spacing-xs);
-  transition:
-    opacity 0.7s ease-in-out,
+  transition: opacity 0.7s ease-in-out,
     transform 0.4s ease-in-out;
   width: 33%;
   position: relative;
@@ -627,7 +590,7 @@
   position: absolute;
   right: -10px;
   bottom: 1px;
-  background: linear-gradient(-90deg, #fff 50%, rgba(255, 255, 255, 0) 100%);
+  background: linear-gradient(-90deg, #fff 50%, rgb(255 255 255 / 0%) 100%);
   z-index: 2;
 }
 
@@ -649,7 +612,7 @@
   }
 }
 
-@media screen and (-webkit-min-device-pixel-ratio: 2) {
+@media screen and (resolution >= 2dppx) {
   .Layer__component {
     .Layer__textarea,
     .Layer__select__control,
@@ -659,9 +622,13 @@
     }
 
     .Layer__bank-transaction-list-item__expanded-row
-      .Layer__select
-      .Layer__select__control {
+    .Layer__select
+    .Layer__select__control {
       min-height: 36px;
     }
   }
+}
+
+.Layer__input--static-value {
+  padding: 0 calc(var(--spacing-xs) + 1px);
 }

--- a/src/styles/table.scss
+++ b/src/styles/table.scss
@@ -1,5 +1,6 @@
 .Layer__table {
   width: 100%;
+  border-collapse: separate;
   border-spacing: 0;
 
   &.Layer__table__seperate-rows {
@@ -34,8 +35,7 @@
     font-size: var(--text-sm);
     font-weight: var(--font-weight-normal);
     font-variant-numeric: lining-nums proportional-nums;
-    font-feature-settings:
-      'cv10' on,
+    font-feature-settings: 'cv10' on,
       'cv05' on,
       'cv08' on,
       'ss03' on;
@@ -48,6 +48,11 @@
 
     .Layer__table-cell {
       border-top: none;
+    }
+
+    .Layer__table-cell-content {
+      color: var(--text-color-secondary);
+      font-size: var(--text-sm);
     }
 
     &.Layer__table-header--primary {
@@ -76,6 +81,7 @@
   .Layer__table-row--selected {
     .Layer__table-cell:first-child {
       position: relative;
+
       &::after {
         content: '';
         display: block;
@@ -138,10 +144,15 @@
     text-align: left;
     color: var(--text-color-secondary);
     border-top: 1px solid var(--border-color);
+    height: var(--spacing-5xl);
     padding: 0;
 
+    &.Layer__table-cell--nowrap {
+      white-space: nowrap;
+    }
+
     &.Layer__table-cell--primary {
-      color: var(--color-base-800);
+      color: var(--color-base-900);
       font-weight: var(--font-weight-bold);
     }
 
@@ -168,11 +179,12 @@
       display: flex;
       align-items: center;
       height: 100%;
-      top: 0px;
+      top: 0;
       padding: var(--spacing-sm) var(--spacing-md);
       box-sizing: border-box;
       transition: all var(--transition-speed) ease-out;
       position: relative;
+
       .Layer__table-row--expand-icon {
         transition: transform 0.1s ease-in-out;
         width: 16px;
@@ -191,8 +203,8 @@
 }
 
 .Layer__table-row--active
-  .Layer__table-cell:first-child
-  .Layer__table-cell-content:before {
+.Layer__table-cell:first-child
+.Layer__table-cell-content::before {
   content: '';
   background-color: var(--color-base-400);
   height: 100%;
@@ -222,8 +234,7 @@
   &.Layer__table-row--collapsed {
     .Layer__table-cell {
       & > .Layer__table-cell-content {
-        transition:
-          height 60ms ease-out,
+        transition: height 60ms ease-out,
           opacity 50ms ease-in-out,
           padding 50ms ease-in-out;
       }
@@ -241,23 +252,23 @@
 }
 
 .Layer__table.with-cell-separators
-  > tbody
-  > tr
-  > td:first-child
-  .Layer__table-cell-content::after,
+> tbody
+> tr
+> td:first-child
+.Layer__table-cell-content::after,
 .Layer__table.with-cell-separators
-  > tbody
-  > tr
-  > td:last-child
-  .Layer__table-cell-content::after,
+> tbody
+> tr
+> td:last-child
+.Layer__table-cell-content::after,
 .Layer__table.with-cell-separators
-  > thead
-  > tr
-  > th:first-child.Layer__table-header::after,
+> thead
+> tr
+> th:first-child.Layer__table-header::after,
 .Layer__table.with-cell-separators
-  > thead
-  > tr
-  > th:last-child.Layer__table-header::after {
+> thead
+> tr
+> th:last-child.Layer__table-header::after {
   display: none;
 }
 
@@ -276,56 +287,12 @@
   height: calc(100% - 160px);
 }
 
-.Layer__table-row--active
-  .Layer__table-cell:first-child
-  .Layer__table-cell-content:before {
-  content: '';
-  background-color: var(--color-base-400);
-  height: 100%;
-  width: 4px;
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-}
-
-.Layer__table--hover-effect .Layer__table-row:hover {
-  background-color: var(--color-base-50);
-  cursor: pointer;
-}
-
-.Layer__table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-
-  &::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: #f1f1f1;
-    border-radius: 4px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: #e2e2e2;
-    border-radius: 4px;
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background: #999;
-  }
-}
-
 .Layer__table-header {
   color: var(--text-color-secondary);
   font-size: var(--text-sm);
   font-weight: var(--font-weight-normal);
   font-variant-numeric: lining-nums proportional-nums;
-  font-feature-settings:
-    'cv10' on,
+  font-feature-settings: 'cv10' on,
     'cv05' on,
     'cv08' on,
     'ss03' on;
@@ -344,48 +311,19 @@
 
 .Layer__table-cell--primary,
 .Layer__table-cell--primary .Layer__table-cell-content {
-  color: var(--color-base-800);
+  color: var(--color-base-900);
   font-weight: var(--font-weight-bold);
-}
-
-.Layer__table-cell {
-  font-size: var(--text-md);
-  text-align: left;
-  color: var(--text-color-secondary);
-  border-top: 1px solid var(--border-color);
-  height: var(--spacing-5xl);
-  padding: 0;
 }
 
 .Layer__table-cell-content {
   display: flex;
   align-items: center;
   height: 100%;
-  top: 0px;
+  top: 0;
   padding: var(--spacing-sm) var(--spacing-md);
   box-sizing: border-box;
   transition: all var(--transition-speed) ease-out;
   position: relative;
-}
-
-.Layer__table-cell-content-indentation {
-  height: 100%;
-  display: flex;
-  align-items: center;
-  box-sizing: border-box;
-}
-
-.Layer__table-row--active
-  .Layer__table-cell:first-child
-  .Layer__table-cell-content:before {
-  content: '';
-  background-color: var(--color-base-400);
-  height: 100%;
-  width: 4px;
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
 }
 
 .Layer__table--hover-effect .Layer__table-row:hover {
@@ -399,45 +337,9 @@
   text-align: right;
 }
 
-.Layer__table.with-cell-separators
-  > tbody
-  > tr
-  > td:first-child
-  .Layer__table-cell-content::after,
-.Layer__table.with-cell-separators
-  > tbody
-  > tr
-  > td:last-child
-  .Layer__table-cell-content::after,
-.Layer__table.with-cell-separators
-  > thead
-  > tr
-  > th:first-child.Layer__table-header::after,
-.Layer__table.with-cell-separators
-  > thead
-  > tr
-  > th:last-child.Layer__table-header::after {
-  display: none;
-}
-
-.Layer__table-state-container {
-  padding: var(--spacing-2xl) var(--spacing-sm);
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: calc(100vh - 200px);
-}
-
-.Layer__component--as-widget .Layer__table-state-container {
-  height: calc(100% - 160px);
-}
-
 .Layer__bank-transaction-row--removing {
   .Layer__table-cell-content {
-    max-height: 0px;
+    max-height: 0;
     top: 1px;
     padding-top: 0;
     padding-bottom: 0;
@@ -457,46 +359,10 @@
   }
 }
 
-.Layer__table-row--hidden .Layer__table-cell {
-  border-top-width: 0;
-}
-
-.Layer__table-cell {
-  height: auto;
-
-  & > .Layer__table-cell-content {
-    overflow: hidden;
-    transition: all 50ms ease-out;
-  }
-}
-
-.Layer__table-row {
-  transition: all 100ms ease-in-out;
-
-  &.Layer__table-row--collapsed {
-    .Layer__table-cell {
-      & > .Layer__table-cell-content {
-        transition:
-          height 60ms ease-out,
-          opacity 50ms ease-in-out,
-          padding 50ms ease-in-out;
-      }
-    }
-  }
-}
-
-.Layer__table-row.Layer__table-row--with-show:not(.initial-load) {
-  opacity: 0.5;
-
-  &.show {
-    transition: opacity 50ms ease-out;
-    opacity: 1;
-  }
-}
-
 .Layer__table-row.Layer__table-row--anim-starting-state {
   opacity: 0;
-  height: 0px;
+  height: 0;
+
   td {
     .Layer__table-cell-content {
       opacity: 0;
@@ -522,6 +388,7 @@ tbody {
 
 .Layer__table-row.Layer__table-row--anim-complete-state {
   height: var(--spacing-5xl);
+
   td {
     .Layer__table-cell-content {
       opacity: 1;
@@ -538,6 +405,7 @@ tbody {
 
 .Layer__table-wrapper--bottom-spacing {
   padding-bottom: var(--spacing-lg);
+
   .Layer__table {
     border-bottom: 1px solid var(--border-color);
   }

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -33,8 +33,7 @@
   font-family: var(--font-family);
   font-weight: var(--font-weight-normal);
   font-variant-numeric: lining-nums proportional-nums;
-  font-feature-settings:
-    'cv10' on,
+  font-feature-settings: 'cv10' on,
     'cv05' on,
     'cv08' on,
     'ss03' on;
@@ -57,10 +56,29 @@
 .Layer__text--bold,
 .Layer__text.Layer__text--bold {
   font-weight: var(--font-weight-bold);
+  font-variation-settings: 'wght' 540;
 }
 
 .Layer__text--error {
   color: var(--color-danger);
+}
+
+.Layer__text[data-status='error'] {
+  color: var(--color-danger);
+}
+
+.Layer__text[data-status='warning'] {
+  color: var(--color-info-warning);
+}
+
+.Layer__text[data-status='success'] {
+  color: var(--color-success);
+}
+
+.Layer__text[data-ellipsis] {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .Layer__label {

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -2,6 +2,7 @@
   color: var(--text-color-primary);
   font-size: var(--text-heading);
   font-weight: var(--font-weight-bold);
+  font-variation-settings: 'wght' var(--font-weight-bold);
   line-height: 140%;
   letter-spacing: -0.12px;
   margin: 0;
@@ -13,6 +14,7 @@
   color: var(--text-color-primary);
   font-size: var(--text-heading-sm);
   font-weight: var(--font-weight-bold);
+  font-variation-settings: 'wght' var(--font-weight-bold);
 }
 
 .Layer__heading--view,
@@ -20,6 +22,7 @@
   color: var(--text-color-primary);
   font-size: var(--text-heading-view);
   font-weight: var(--font-weight-bold);
+  font-variation-settings: 'wght' var(--font-weight-bold);
 }
 
 .Layer__heading--page,
@@ -27,6 +30,7 @@
   color: var(--text-color-primary);
   font-size: var(--text-heading-page);
   font-weight: var(--font-weight-bold);
+  font-variation-settings: 'wght' var(--font-weight-bold);
 }
 
 .Layer__text {
@@ -56,7 +60,7 @@
 .Layer__text--bold,
 .Layer__text.Layer__text--bold {
   font-weight: var(--font-weight-bold);
-  font-variation-settings: 'wght' 540;
+  font-variation-settings: 'wght' var(--font-weight-bold);
 }
 
 .Layer__text--error {

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -50,6 +50,7 @@ export interface TableCellProps {
   isHeaderCell?: boolean
   align?: TableCellAlign
   primary?: boolean
+  nowrap?: boolean
   withExpandIcon?: boolean
   fullWidth?: boolean
   width?: string


### PR DESCRIPTION
## Description

This PR brings a chunk of smaller changes to existing components that will be then used with the Bills.
This is a part of efforts aiming to minify large Bills PR.

## Changes

- allow to control button variant in `SubmitButton`
- make DatePicker's `maxDate` optional
- allow to use `HeaderCol` without paddings
- add `StaticValue` - it can be use as a replacement to the (disabled) inputs, ie. on summary view after submitting the form when we want to keep similar layout, but showing disabled input doesn't look right. `StaticValue` has similar sizings as `Input`
- add `nowrap` prop to `TableCell` so the cell content is not wrapped
- fix `Toggle` state management
- add `ellipsis` prop to `Text` so it sets `text-overflow: ellipsis`
- add `status` prop to `Text` so we can easily set basic colors like error, success, warning
- clean up `inputs.scss` and `tables.scss` files

NOTE: [Low-Priority] Some components touched in this PR, like `Text`, requires further refactors in new PRs, ie. switching from css classes to data-attributes.
