### PR TITLE
fix: `keepPreviousData` on our useAuth hook

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -102,6 +102,7 @@ export function useAuth() {
         .then(data => ({ apiUrl, ...data }))
     },
     {
+      keepPreviousData: true,
       revalidateOnFocus: true,
       revalidateOnReconnect: true,
       refreshInterval: (latestData) => {


### PR DESCRIPTION
## Description

See [this diagram](https://swr.vercel.app/docs/advanced/understanding#key-change--previous-data) to understand the design of SWR.

This change is defensive and motivated by some issues surfaced by testing document upload with Carry.

If a new business access token is requested by their outer SWR (not controlled by us), then our `useAuth` hook could momentarily return `data === undefined` before it resolves with the new token. Since all other data-loading is derived from `useAuth`, we can potentially avoid flickering of other SWR keys by continuing to pass the stale values.
