### PR TITLE
fix: improve types for `compareProfitAndLoss`

### DIFF
--- a/src/api/layer/profit_and_loss.ts
+++ b/src/api/layer/profit_and_loss.ts
@@ -1,7 +1,8 @@
 import { ProfitAndLoss } from '../../types'
 import { S3PresignedUrl } from '../../types/general'
-import {
+import type {
   ProfitAndLossComparison,
+  ProfitAndLossComparisonRequestBody,
   ProfitAndLossSummaries,
 } from '../../types/profit_and_loss'
 import { get, post } from './authenticated_http'
@@ -20,10 +21,13 @@ export const getProfitAndLoss = get<{
     }`,
 )
 
-export const compareProfitAndLoss = post<{
-  data?: ProfitAndLossComparison
-  error?: unknown
-}>(
+export const compareProfitAndLoss = post<
+  {
+    data?: ProfitAndLossComparison
+    error?: unknown
+  },
+  ProfitAndLossComparisonRequestBody
+>(
   ({ businessId }) =>
     `/v1/businesses/${businessId}/reports/profit-and-loss-comparison`,
 )

--- a/src/components/ProfitAndLossCompareOptions/ProfitAndLossCompareOptions.tsx
+++ b/src/components/ProfitAndLossCompareOptions/ProfitAndLossCompareOptions.tsx
@@ -19,9 +19,9 @@ export type TagViewConfig = {
 }
 export type TagFilterInput =
   | {
-      tagKey: string
-      tagValues: string[]
-    }
+    tagKey: string
+    tagValues: string[]
+  }
   | 'None'
 
 const selectStyles = {
@@ -53,7 +53,8 @@ export const ProfitAndLossCompareOptions = ({
   useEffect(() => {
     if (initialDone) {
       fetchData()
-    } else {
+    }
+    else {
       setInitialDone(true)
     }
   }, [compareMode, compareOptions, compareMonths])
@@ -77,7 +78,8 @@ export const ProfitAndLossCompareOptions = ({
   useEffect(() => {
     if (months === 0 && toggle.length > 1) {
       setMonths(1)
-    } else if (months !== compareMonths) {
+    }
+    else if (months !== compareMonths) {
       setCompareMonths && setCompareMonths(months)
     }
   }, [months])
@@ -85,7 +87,8 @@ export const ProfitAndLossCompareOptions = ({
   useEffect(() => {
     if (toggle.length === 0) {
       setToggle(compareOptions?.length > 0 ? compareOptions : [defaultOption])
-    } else if (JSON.stringify(toggle) !== JSON.stringify(compareOptions)) {
+    }
+    else if (JSON.stringify(toggle) !== JSON.stringify(compareOptions)) {
       setCompareOptions && setCompareOptions(toggle)
     }
   }, [toggle])
@@ -97,7 +100,7 @@ export const ProfitAndLossCompareOptions = ({
   ]
 
   const tagComparisonSelectOptions = tagComparisonOptions.map(
-    tagComparisonOption => {
+    (tagComparisonOption) => {
       return {
         value: JSON.stringify(tagComparisonOption.tagFilterConfig),
         label: tagComparisonOption.displayName,
@@ -114,14 +117,14 @@ export const ProfitAndLossCompareOptions = ({
           compareMonths === 0
             ? null
             : timeComparisonOptions.find(
-                option => option.value === compareMonths,
-              )
+              option => option.value === compareMonths,
+            )
         }
         placeholder='Compare months'
       />
       <MultiSelect
         options={tagComparisonSelectOptions}
-        onChange={e => {
+        onChange={(e) => {
           setToggle(
             e
               .map(option =>
@@ -136,7 +139,7 @@ export const ProfitAndLossCompareOptions = ({
           value: JSON.stringify(option.tagFilterConfig),
           label: option.displayName,
         }))}
-        value={compareOptions.map(tagComparisonOption => {
+        value={compareOptions.map((tagComparisonOption) => {
           return {
             value: JSON.stringify(tagComparisonOption.tagFilterConfig),
             label: tagComparisonOption.displayName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { EnumWithUnknownValues } from './types/utility/enumWithUnknownValues'
+
 export { OAuthResponse } from './types/authentication'
 export {
   LayerContextValues,
@@ -61,6 +63,7 @@ export type DateRange<T = Date> = {
   endDate: T
 }
 
-export type ReportingBasis = 'CASH' | 'ACCRUAL'
+type StrictReportingBasis = 'CASH' | 'CASH_COLLECTED' | 'ACCRUAL'
+export type ReportingBasis = EnumWithUnknownValues<StrictReportingBasis>
 
 export type MoneyFormat = 'CENTS' | 'DOLLAR_STRING'

--- a/src/types/profit_and_loss.ts
+++ b/src/types/profit_and_loss.ts
@@ -1,3 +1,5 @@
+import type { ReportingBasis } from '../types'
+import { ReadonlyArrayWithAtLeastOne } from '../utils/array/getArrayWithAtLeastOneOrFallback'
 import { LineItem } from './line_item'
 
 export interface ProfitAndLoss {
@@ -36,6 +38,27 @@ export interface ProfitAndLossComparisonPnl {
   other_outflows?: LineItem | null
   personal_expenses?: LineItem | null
   fully_categorized: boolean
+}
+
+type ProfitAndLossComparisonPeriods = {
+  type: 'Comparison_Months'
+  months: ReadonlyArrayWithAtLeastOne<{ year: number, month: number }>
+} | {
+  type: 'Comparison_Years'
+  years: ReadonlyArrayWithAtLeastOne<{ year: number }>
+} | {
+  type: 'Comparison_Date_Ranges'
+  date_ranges: ReadonlyArrayWithAtLeastOne<{ start_date: string, end_date: string }>
+}
+
+type ProfitAndLossComparisonTags = {
+  required_tags?: ReadonlyArray<{ key: string, value: string }>
+}
+
+export type ProfitAndLossComparisonRequestBody = {
+  periods: ProfitAndLossComparisonPeriods
+  tag_filters?: ReadonlyArrayWithAtLeastOne<ProfitAndLossComparisonTags>
+  reporting_basis?: ReportingBasis
 }
 
 export interface ProfitAndLossComparisonItem {

--- a/src/utils/array/getArrayWithAtLeastOneOrFallback.ts
+++ b/src/utils/array/getArrayWithAtLeastOneOrFallback.ts
@@ -1,12 +1,18 @@
-type ArrayWithAtLeastOne<T> = readonly [T, ...T[]]
+export type ReadonlyArrayWithAtLeastOne<T> = readonly [T, ...T[]]
+
+export function isArrayWithAtLeastOne<T>(
+  list: ReadonlyArray<T>,
+): list is ReadonlyArrayWithAtLeastOne<T> {
+  return list.length > 0
+}
 
 export function getArrayWithAtLeastOneOrFallback<T>(
   list: ReadonlyArray<T>,
-  fallback: ArrayWithAtLeastOne<T>,
-): ArrayWithAtLeastOne<T> {
+  fallback: ReadonlyArrayWithAtLeastOne<T>,
+): ReadonlyArrayWithAtLeastOne<T> {
   if (list.length === 0) {
     return fallback
   }
 
-  return list as ArrayWithAtLeastOne<T>
+  return list as ReadonlyArrayWithAtLeastOne<T>
 }

--- a/src/utils/array/range.ts
+++ b/src/utils/array/range.ts
@@ -1,0 +1,3 @@
+export function range(start: number, end: number): ReadonlyArray<number> {
+  return Array.from({ length: end - start }, (_, index) => start + index)
+}


### PR DESCRIPTION
## Description

This change is intended to help @tomaszantas build-out year picking abilities.

## Testing

I have run various configurations of PNL comparison filtering locally to verify that I have not introduced a regression.