### PR TITLE
fix: missing split form on bank transactions mobile list

### DIFF
--- a/src/components/BankTransactionMobileList/BankTransactionMobileForms.tsx
+++ b/src/components/BankTransactionMobileList/BankTransactionMobileForms.tsx
@@ -27,7 +27,7 @@ export const BankTransactionMobileForms = ({
 }: BankTransactionMobileFormsProps) => {
   const getContent = () => {
     switch (purpose) {
-      case 'business':
+      case Purpose.business:
         return (
           <BusinessForm
             bankTransaction={bankTransaction}
@@ -37,7 +37,7 @@ export const BankTransactionMobileForms = ({
             showDescriptions={showDescriptions}
           />
         )
-      case 'personal':
+      case Purpose.personal:
         return (
           <PersonalForm
             bankTransaction={bankTransaction}
@@ -45,10 +45,11 @@ export const BankTransactionMobileForms = ({
             showDescriptions={showDescriptions}
           />
         )
-      case 'more':
+      case Purpose.more:
         return (
           <SplitAndMatchForm
             bankTransaction={bankTransaction}
+            showCategorization={showCategorization}
             showTooltips={showTooltips}
             showReceiptUploads={showReceiptUploads}
             showDescriptions={showDescriptions}

--- a/src/components/BankTransactionMobileList/SplitAndMatchForm.tsx
+++ b/src/components/BankTransactionMobileList/SplitAndMatchForm.tsx
@@ -23,6 +23,7 @@ export const SplitAndMatchForm = ({
   showTooltips,
   showReceiptUploads,
   showDescriptions,
+  showCategorization,
 }: SplitAndMatchFormProps) => {
   const anyMatch = hasMatch(bankTransaction)
   const [formType, setFormType] = useState(
@@ -41,6 +42,7 @@ export const SplitAndMatchForm = ({
           showTooltips={showTooltips}
           showReceiptUploads={showReceiptUploads}
           showDescriptions={showDescriptions}
+          showCategorization={showCategorization}
         />
       )}
       {formType === Purpose.match && (
@@ -50,20 +52,24 @@ export const SplitAndMatchForm = ({
           showDescriptions={showDescriptions}
         />
       )}
-      {anyMatch && formType === Purpose.match ? (
-        <div className='Layer__bank-transaction-mobile-list-item__switch-form-btns'>
-          <TextButton onClick={() => setFormType(Purpose.categorize)}>
-            or split transaction
-          </TextButton>
-        </div>
-      ) : null}
-      {anyMatch && formType === Purpose.categorize ? (
-        <div className='Layer__bank-transaction-mobile-list-item__switch-form-btns'>
-          <TextButton onClick={() => setFormType(Purpose.match)}>
-            or find match
-          </TextButton>
-        </div>
-      ) : null}
+      {anyMatch && formType === Purpose.match
+        ? (
+          <div className='Layer__bank-transaction-mobile-list-item__switch-form-btns'>
+            <TextButton onClick={() => setFormType(Purpose.categorize)}>
+              or split transaction
+            </TextButton>
+          </div>
+        )
+        : null}
+      {anyMatch && formType === Purpose.categorize
+        ? (
+          <div className='Layer__bank-transaction-mobile-list-item__switch-form-btns'>
+            <TextButton onClick={() => setFormType(Purpose.match)}>
+              or find match
+            </TextButton>
+          </div>
+        )
+        : null}
     </div>
   )
 }


### PR DESCRIPTION
## Description

The `showCategorization` prop wasn't passed down to the Split form in Bank Transactions mobile list.

## Changes

- pass the `showCategorization` prop down to the Split form
- minor lint fixes in touched files


## How this has been tested?


**Before**

https://github.com/user-attachments/assets/680892fd-521d-4355-ab34-7601399468bf



**After**


https://github.com/user-attachments/assets/21834f4d-b6f2-4371-b0fb-0c0e053996ef


