### PR TITLE
feat: small changes from bills pr

### DIFF
--- a/src/api/layer/authenticated_http.ts
+++ b/src/api/layer/authenticated_http.ts
@@ -103,7 +103,7 @@ export const postWithFormData = <
 
 const handleResponse = async <Return>(res: Response) => {
   if (!res.ok) {
-    const errors = await tryToReadErrorsFromResponse()
+    const errors = await tryToReadErrorsFromResponse(res)
     const apiError = new APIError(
       'An error occurred while fetching the data from API.',
       res.status,

--- a/src/components/Button/RetryButton.tsx
+++ b/src/components/Button/RetryButton.tsx
@@ -16,7 +16,7 @@ export const RetryButton = ({
   className,
   processing,
   disabled,
-  error: _error,
+  error,
   children,
   ...props
 }: RetryButtonProps) => {
@@ -34,6 +34,7 @@ export const RetryButton = ({
       disabled={processing || disabled}
       rightIcon={<RefreshCcw size={12} />}
       justify='center'
+      tooltip={error}
     >
       {children}
     </Button>

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -6,10 +6,11 @@ export interface ToastProps {
   content: string
   duration?: number
   isExiting?: boolean
+  type?: 'success' | 'default'
 }
 
 const Toast = (props: ToastProps & { isExiting: boolean }) => {
-  const { id, content, isExiting } = props
+  const { id, content, isExiting, type = 'default' } = props
   const { removeToast } = useLayerContext()
 
   return (
@@ -18,7 +19,7 @@ const Toast = (props: ToastProps & { isExiting: boolean }) => {
       className={classNames('Layer__toast', {
         enter: !isExiting,
         exit: isExiting,
-      })}
+      }, `Layer__toast--${type}`)}
       onClick={() => removeToast(props)}
     >
       <p>{content}</p>

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -19,7 +19,7 @@ export enum TextUseTooltip {
   always = 'always',
 }
 
-export type TextStatus = 'success' | 'error' | 'warning'
+export type TextStatus = 'success' | 'error' | 'warning' | 'disabled'
 
 export interface TextTooltipOptions {
   contentClassName?: string

--- a/src/config/general.ts
+++ b/src/config/general.ts
@@ -1,4 +1,5 @@
 export const DATE_FORMAT = 'LLL d, yyyy'
+export const DATE_FORMAT_SHORT = 'M/d/yyyy'
 export const MONTH_DAY_FORMAT = 'LLL d'
 export const TIME_FORMAT = 'p'
 

--- a/src/styles/toast.scss
+++ b/src/styles/toast.scss
@@ -15,15 +15,24 @@
     opacity: 0;
     transform: translateY(20px);
     transition: opacity 0.6s linear, transform 0.6s linear;
-    box-shadow: 0px 4px 4px 0px var(--base-transparent-5, rgba(16, 24, 40, 0.05)),
-      0px 3px 3px 0px var(--base-transparent-6, rgba(16, 24, 40, 0.06)),
-      0px 2px 2px 0px var(--base-transparent-8, rgba(16, 24, 40, 0.08)),
-      0px 1px 0px 0px var(--base-transparent-12, rgba(16, 24, 40, 0.12)), 0px 0px 0px 1px var(--base-900, #05132f);
+    box-shadow: 0 4px 4px 0 var(--base-transparent-5, rgb(16 24 40 / 5%)),
+      0 3px 3px 0 var(--base-transparent-6, rgb(16 24 40 / 6%)),
+      0 2px 2px 0 var(--base-transparent-8, rgb(16 24 40 / 8%)),
+      0 1px 0 0 var(--base-transparent-12, rgb(16 24 40 / 12%)), 0 0 0 1px var(--base-900, #05132f);
 
     p {
       margin: 0;
       font-size: 14px;
       color: var(--color-base-0);
+    }
+
+    &.Layer__toast--success {
+      background: var(--color-info-success-bg);
+      box-shadow: 0 0 0 1px var(--color-info-success);
+
+      p {
+        color: var(--color-info-success-fg);
+      }
     }
   }
 }
@@ -39,7 +48,7 @@
   transition: opacity 0.5s linear, transform 0.5s linear;
 }
 
-@media screen and (max-width: 400px) {
+@media screen and (width <= 400px) {
   .Layer__toasts-container {
     right: 50%;
     transform: translateX(50%);

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -79,6 +79,10 @@
   color: var(--color-success);
 }
 
+.Layer__text[data-status='disabled'] {
+  color: var(--color-base-500);
+}
+
 .Layer__text[data-ellipsis] {
   white-space: nowrap;
   overflow: hidden;

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -33,7 +33,7 @@ export interface TableRowProps {
   children: ReactNode
   depth?: number
   expandable?: boolean
-  variant?: 'expandable' | 'default' | 'summation'
+  variant?: 'expandable' | 'main' | 'default' | 'summation'
   withDivider?: boolean
   withDividerPosition?: 'top' | 'bottom'
   isExpanded?: boolean

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -89,9 +89,9 @@ export const convertCurrencyToNumber = (amount: string): string =>
  * 100.01 -> 10001
  * 100.001 -> 10000
  */
-export const convertToCents = (amount?: number | string): number | undefined => {
+export const convertToCents = (amount?: number | string | null): number | undefined => {
   try {
-    if (amount === undefined) {
+    if (amount === undefined || amount === null) {
       return undefined
     }
 
@@ -108,9 +108,11 @@ export const convertToCents = (amount?: number | string): number | undefined => 
  * 10000 -> 100
  * 10001 -> 100.01
  */
-export const convertFromCents = (amount?: number | string): number | undefined => {
+export const convertFromCents = (
+  amount?: number | string | readonly string[] | null,
+): number | undefined => {
   try {
-    if (amount === undefined) {
+    if (amount === undefined || amount === null) {
       return undefined
     }
 

--- a/src/utils/vendors.ts
+++ b/src/utils/vendors.ts
@@ -1,5 +1,5 @@
 import { Vendor } from '../types/vendors'
 
 export const getVendorName = (vendor?: Vendor): string => (
-  vendor?.individual_name ?? vendor?.company_name ?? ''
+  vendor?.individual_name ?? vendor?.company_name ?? vendor?.external_id ?? ''
 )


### PR DESCRIPTION
## Description

Selected changes from the Bills PR #357 are moved here to make the original PR easier to review.

## Changes

- fix: pass the API error message down to the JS API Error object
- show tooltip on `RetryButton` if `error` message prop provided
- add `success` styling to Toast
- add `disabled` (muted) styling to the Text
- add `DATE_FORMAT_SHORT` to config
- add `main` variant for the Table Row - such rows use lighter background by default
- allow to `vendor?.external_id` if `individual_name` and `company_name` are not provided when we want to show vendor's name in UI


## How this has been tested?


Success Toast:

![image](https://github.com/user-attachments/assets/a3f15fc3-204d-4f31-82a4-41816e21748f)

Retry Button with the error message in the tooltip:

![image](https://github.com/user-attachments/assets/91033061-1195-418c-9866-f684f699a81a)


