### PR TITLE
feat: modal default size, checkbox variants

### DIFF
--- a/src/components/LinkedAccounts/AccountFormBox/AccountFormBox.tsx
+++ b/src/components/LinkedAccounts/AccountFormBox/AccountFormBox.tsx
@@ -121,6 +121,7 @@ export const AccountFormBox = ({
       {!disableConfirmExclude && (
         <div className={`${CLASS_NAME}__confirm-col`}>
           <Checkbox
+            size='lg'
             isSelected={value.isConfirmed}
             onChange={v => onChange({ ...value, isConfirmed: v })}
             aria-label='Confirm Account Inclusion'

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountToConfirm.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountToConfirm.tsx
@@ -27,11 +27,13 @@ export function LinkedAccountToConfirm({
           {account.mask}
         </P>
         <P slot='institution'>
-          {account.institution.name}
+          {account.institution?.name}
         </P>
       </VStack>
       <VStack justify='center'>
         <Checkbox
+          size='lg'
+          variant='dark'
           isSelected={isConfirmed}
           onChange={onChangeConfirmed}
           aria-label='Confirm Account Inclusion'

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountToConfirm.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountToConfirm.tsx
@@ -33,7 +33,6 @@ export function LinkedAccountToConfirm({
       <VStack justify='center'>
         <Checkbox
           size='lg'
-          variant='dark'
           isSelected={isConfirmed}
           onChange={onChangeConfirmed}
           aria-label='Confirm Account Inclusion'

--- a/src/components/ui/Checkbox/Checkbox.tsx
+++ b/src/components/ui/Checkbox/Checkbox.tsx
@@ -8,17 +8,20 @@ import classNames from 'classnames'
 
 const CLASS_NAME = 'Layer__Checkbox'
 
-type CheckboxVariant = 'default' | 'dark'
+type CheckboxVariant = 'default' | 'success'
 type CheckboxSize = 'md' | 'lg'
 
 type CheckboxProps = Omit<AriaCheckboxProps, 'className'> & {
   className?: string
   variant?: CheckboxVariant
   size?: CheckboxSize
+}
+
+type CheckboxWithTooltipProps = CheckboxProps & {
   tooltip?: string
 }
 
-export function Checkbox({ children, className, variant = 'default', size = 'md', tooltip, ...props }: CheckboxProps) {
+export function Checkbox({ children, className, variant = 'default', size = 'md', ...props }: CheckboxProps) {
   const dataProperties = useMemo(() => toDataProperties({
     size,
     variant,
@@ -26,23 +29,29 @@ export function Checkbox({ children, className, variant = 'default', size = 'md'
   }), [children, size, variant])
 
   return (
+    <ReactAriaCheckbox
+      {...dataProperties}
+      {...props}
+      className={classNames(CLASS_NAME, className)}
+    >
+      {withRenderProp(children, node => (
+        <>
+          <div slot='checkbox'>
+            <Check size={size === 'lg' ? 16 : 12} />
+          </div>
+          {node}
+        </>
+      ))}
+    </ReactAriaCheckbox>
+  )
+}
+
+export function CheckboxWithTooltip({ tooltip, ...props }: CheckboxWithTooltipProps) {
+  return (
     <div className='Layer__checkbox-wrapper'>
       <Tooltip disabled={!tooltip}>
         <TooltipTrigger className='Layer__input-tooltip'>
-          <ReactAriaCheckbox
-            {...dataProperties}
-            {...props}
-            className={classNames(CLASS_NAME, className)}
-          >
-            {withRenderProp(children, node => (
-              <>
-                <div slot='checkbox'>
-                  <Check size={size === 'lg' ? 16 : 12} />
-                </div>
-                {node}
-              </>
-            ))}
-          </ReactAriaCheckbox>
+          <Checkbox {...props} />
         </TooltipTrigger>
         <TooltipContent className='Layer__tooltip'>{tooltip}</TooltipContent>
       </Tooltip>

--- a/src/components/ui/Checkbox/Checkbox.tsx
+++ b/src/components/ui/Checkbox/Checkbox.tsx
@@ -3,30 +3,49 @@ import { useMemo } from 'react'
 import { Checkbox as ReactAriaCheckbox, type CheckboxProps as AriaCheckboxProps } from 'react-aria-components'
 import { withRenderProp } from '../../utility/withRenderProp'
 import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'
+import { Tooltip, TooltipTrigger, TooltipContent } from '../../Tooltip'
+import classNames from 'classnames'
 
 const CLASS_NAME = 'Layer__Checkbox'
 
-type CheckboxProps = Omit<AriaCheckboxProps, 'className'>
+type CheckboxVariant = 'default' | 'dark'
+type CheckboxSize = 'md' | 'lg'
 
-export function Checkbox({ children, ...props }: CheckboxProps) {
+type CheckboxProps = Omit<AriaCheckboxProps, 'className'> & {
+  className?: string
+  variant?: CheckboxVariant
+  size?: CheckboxSize
+  tooltip?: string
+}
+
+export function Checkbox({ children, className, variant = 'default', size = 'md', tooltip, ...props }: CheckboxProps) {
   const dataProperties = useMemo(() => toDataProperties({
+    size,
+    variant,
     labeled: typeof children === 'string' && children.length > 0,
-  }), [children])
+  }), [children, size, variant])
 
   return (
-    <ReactAriaCheckbox
-      {...dataProperties}
-      {...props}
-      className={CLASS_NAME}
-    >
-      {withRenderProp(children, node => (
-        <>
-          <div slot='checkbox'>
-            <Check size={16} />
-          </div>
-          {node}
-        </>
-      ))}
-    </ReactAriaCheckbox>
+    <div className='Layer__checkbox-wrapper'>
+      <Tooltip disabled={!tooltip}>
+        <TooltipTrigger className='Layer__input-tooltip'>
+          <ReactAriaCheckbox
+            {...dataProperties}
+            {...props}
+            className={classNames(CLASS_NAME, className)}
+          >
+            {withRenderProp(children, node => (
+              <>
+                <div slot='checkbox'>
+                  <Check size={size === 'lg' ? 16 : 12} />
+                </div>
+                {node}
+              </>
+            ))}
+          </ReactAriaCheckbox>
+        </TooltipTrigger>
+        <TooltipContent className='Layer__tooltip'>{tooltip}</TooltipContent>
+      </Tooltip>
+    </div>
   )
 }

--- a/src/components/ui/Checkbox/checkbox.scss
+++ b/src/components/ui/Checkbox/checkbox.scss
@@ -5,28 +5,33 @@
   position: relative;
 
   [slot="checkbox"] {
-    background-color: var(--color-base-50);
+    background-color: var(--checkbox-bg);
     color: transparent;
-    border: 2px solid var(--color-base-300);
-    border-radius: var(--border-radius-3xs);
+    border: 2px solid var(--checkbox-border-color);
+    border-radius: var(--checkbox-radius);
     display: grid;
     place-items: center;
-    width: 16px;
-    height: 16px;
+    width: var(--checkbox-size);
+    height: var(--checkbox-size);
+    transition: all 100ms ease-out;
+
+    &[data-hovered] {
+      box-shadow: 0 0 0 1px rgb(0 0 0 / 5%);
+    }
   }
 
   &[data-size="lg"] [slot="checkbox"] {
-    width: 24px;
-    height: 24px;
-    border-radius: var(--border-radius-2xs);
+    width: var(--checkbox-size-lg);
+    height: var(--checkbox-size-lg);
+    border-radius: var(--checkbox-radius-lg);
 
-    &:hover {
+    &[data-hovered] {
       box-shadow: 0 0 0 2px rgb(0 0 0 / 5%);
     }
   }
 
   svg {
-    transition: all 120ms;
+    transition: all 100ms ease-out;
   }
 
   &[data-pressed] [slot="checkbox"] {
@@ -38,36 +43,32 @@
     outline-offset: 2px;
   }
 
-  &[data-selected] {
+  &[data-selected] [slot="checkbox"] {
+    color: var(--checkbox-color-selected);
+    background-color: var(--checkbox-bg-selected);
+    border-color: var(--checkbox-border-color-selected);
+  }
+
+  &[data-selected][data-variant="success"] {
     [slot="checkbox"] {
-      color: var(--bg-default);
-      background-color: var(--color-info-success);
-      border-color: var(--color-info-success);
+      background-color: var(--checkbox-bg-success-selected);
+      border-color: var(--checkbox-border-color-success-selected);
     }
   }
 
-  &[data-selected][data-variant="dark"] {
+  &[data-disabled] {
+    cursor: not-allowed;
+
     [slot="checkbox"] {
-      color: var(--bg-default);
-      background-color: var(--fg-default);
-      border-color: var(--fg-default);
+      background-color: var(--checkbox-bg-disabled);
+
+      &[data-hovered] {
+        box-shadow: 0 0 0 1px rgb(0 0 0 / 2%);
+      }
     }
   }
 
   &[data-labeled] {
     gap: var(--spacing-xs);
-  }
-
-  &:focus {
-    outline: none;
-    box-shadow: 0 0 0 1px var(--color-info-success-bg);
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-
-    &:hover {
-      border-color: var(--color-base-300);
-    }
   }
 }

--- a/src/components/ui/Checkbox/checkbox.scss
+++ b/src/components/ui/Checkbox/checkbox.scss
@@ -2,19 +2,31 @@
   display: inline-flex;
   align-items: center;
   cursor: pointer;
+  position: relative;
 
   [slot="checkbox"] {
-    background-color: var(--bg-default);
+    background-color: var(--color-base-50);
     color: transparent;
-    padding: var(--spacing-3xs);
-    border: 2px solid var(--outline-default);
-    border-radius: var(--border-radius-xs);
+    border: 2px solid var(--color-base-300);
+    border-radius: var(--border-radius-3xs);
     display: grid;
     place-items: center;
+    width: 16px;
+    height: 16px;
+  }
+
+  &[data-size="lg"] [slot="checkbox"] {
+    width: 24px;
+    height: 24px;
+    border-radius: var(--border-radius-2xs);
+
+    &:hover {
+      box-shadow: 0 0 0 2px rgb(0 0 0 / 5%);
+    }
   }
 
   svg {
-    transition: all 200ms;
+    transition: all 120ms;
   }
 
   &[data-pressed] [slot="checkbox"] {
@@ -22,18 +34,40 @@
   }
 
   &[data-focus-visible] [slot="checkbox"] {
-    outline: 2px solid var(--outline-active);
+    outline: 1px solid var(--outline-active);
     outline-offset: 2px;
   }
 
   &[data-selected] {
     [slot="checkbox"] {
       color: var(--bg-default);
+      background-color: var(--color-info-success);
+      border-color: var(--color-info-success);
+    }
+  }
+
+  &[data-selected][data-variant="dark"] {
+    [slot="checkbox"] {
+      color: var(--bg-default);
       background-color: var(--fg-default);
+      border-color: var(--fg-default);
     }
   }
 
   &[data-labeled] {
     gap: var(--spacing-xs);
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 1px var(--color-info-success-bg);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+
+    &:hover {
+      border-color: var(--color-base-300);
+    }
   }
 }

--- a/src/components/ui/Modal/modal.scss
+++ b/src/components/ui/Modal/modal.scss
@@ -18,8 +18,8 @@
 }
 
 .Layer__Modal {
-  inline-size: min(24rem, 90dvi);
-  block-size: min(24rem, 90dvb);
+  inline-size: min(32rem, 90dvi);
+  block-size: min(32rem, 90dvb);
 
   &[data-entering] {
     animation-duration: 300ms;

--- a/src/styles/internal_variables.scss
+++ b/src/styles/internal_variables.scss
@@ -6,9 +6,7 @@
    */
   --bg-default: var(--color-base-0);
   --bg-subtle: var(--color-base-50);
-
   --fg-default: var(--color-base-900);
-
   --outline-subtle: var(--color-base-100);
   --outline-default: var(--color-base-200);
   --outline-active: var(--color-base-400);
@@ -19,13 +17,27 @@
   --button-bg-default: var(--color-base-900);
   --button-bg-active: var(--color-base-1000);
   --button-bg-disabled: var(--color-base-700);
-
   --button-fg-default: var(--color-base-0);
   --button-fg-disabled: var(--color-base-200);
-
   --button-bg-ghost-active: var(--color-base-50);
   --button-outline-ghost-active: var(--color-base-100);
-
   --button-fg-ghost: var(--color-base-900);
   --button-fg-ghost-active: var(--color-base-1000);
+
+  /*
+   * Checkbox
+   */
+  --checkbox-bg: var(--bg-subtle);
+  --checkbox-size: 16px;
+  --checkbox-radius: var(--border-radius-3xs);
+  --checkbox-border-color: var(--color-base-300);
+  --checkbox-color-selected: var(--bg-default);
+  --checkbox-bg-selected: var(--fg-default);
+  --checkbox-border-color-selected: var(--fg-default);
+  --checkbox-bg-disabled: var(--color-base-200);
+  --checkbox-size-lg: 24px;
+  --checkbox-radius-lg: var(--border-radius-2xs);
+  --checkbox-bg-success-selected: var(--color-info-success);
+  --checkbox-border-color-success-selected: var(--color-info-success);
+
 }

--- a/src/types/linked_accounts.ts
+++ b/src/types/linked_accounts.ts
@@ -39,7 +39,7 @@ export type LinkedAccount = {
     created_at: string
   }
   current_ledger_balance: number
-  institution: {
+  institution?: {
     name: string
     logo: string | null
   }

--- a/src/types/linked_accounts.ts
+++ b/src/types/linked_accounts.ts
@@ -39,10 +39,10 @@ export type LinkedAccount = {
     created_at: string
   }
   current_ledger_balance: number
-  institution?: {
+  institution: {
     name: string
     logo: string | null
-  }
+  } | null
   notifications?: ReadonlyArray<AccountNotification>
   mask?: string
   connection_id?: string


### PR DESCRIPTION
## Description

- change the default modal size 
- add success and dark variations to the checkbox
- add large and small variations to the checkbox
- add optional tooltip to the checkbox (ie. can be used to explain why checkbox is disabled)

## How this has been tested?

Modal default size before:

![Screenshot 2025-02-25 at 18 37 17](https://github.com/user-attachments/assets/e83ac9a0-e76f-4a02-9ba9-eb2e9e498440)


Modal default size after:

![Screenshot 2025-02-25 at 18 44 20](https://github.com/user-attachments/assets/028b86df-44af-42b6-af03-1b44622dcdb0)


Checkboxes:

![image](https://github.com/user-attachments/assets/dd54726c-1200-49a0-8384-9d0dee154192)

![Screenshot 2025-02-25 at 18 52 18](https://github.com/user-attachments/assets/41b6aa8d-1d43-4f8d-bdbf-23c90b9676b8)

![Screenshot 2025-02-25 at 18 55 58](https://github.com/user-attachments/assets/12cc717a-8dcb-431e-a8d1-be5be63165e0)


