### PR TITLE
dedicated lineEntryNumber method

### DIFF
--- a/src/components/LedgerAccount/LedgerAccountRow.tsx
+++ b/src/components/LedgerAccount/LedgerAccountRow.tsx
@@ -4,7 +4,7 @@ import { LedgerAccountsContext } from '../../contexts/LedgerAccountsContext'
 import { centsToDollars } from '../../models/Money'
 import { Direction, LedgerAccountLineItem } from '../../types'
 import { View } from '../../types/general'
-import { entryNumber } from '../../utils/journal'
+import { lineEntryNumber } from '../../utils/journal'
 import { Text, TextWeight } from '../Typography'
 import classNames from 'classnames'
 import { parseISO, format as formatTime } from 'date-fns'
@@ -34,7 +34,8 @@ export const LedgerAccountRow = ({
       }, index * 10)
 
       return () => clearTimeout(timeoutId)
-    } else {
+    }
+    else {
       setShowComponent(true)
     }
   }, [])
@@ -53,7 +54,8 @@ export const LedgerAccountRow = ({
         onClick={() => {
           if (selectedEntryId === row.entry_id) {
             closeSelectedEntry()
-          } else {
+          }
+          else {
             setSelectedEntryId(row.entry_id)
           }
         }}
@@ -68,7 +70,7 @@ export const LedgerAccountRow = ({
                 weight={TextWeight.normal}
                 className='Layer__ledger_account-table__journal-id'
               >
-                {entryNumber(row)}
+                {lineEntryNumber(row)}
               </Text>
             </div>
             <Text>{row.source?.display_description ?? ''}</Text>
@@ -76,14 +78,14 @@ export const LedgerAccountRow = ({
         </td>
         <td className='Layer__table-cell Layer__table-cell--primary'>
           <span className='Layer__table-cell-content Layer__table-cell--amount'>
-            {row.direction === Direction.DEBIT &&
-              `$${centsToDollars(row?.amount || 0)}`}
+            {row.direction === Direction.DEBIT
+            && `$${centsToDollars(row?.amount || 0)}`}
           </span>
         </td>
         <td className='Layer__table-cell Layer__table-cell--primary'>
           <span className='Layer__table-cell-content Layer__table-cell--amount'>
-            {row.direction === Direction.CREDIT &&
-              `$${centsToDollars(row?.amount || 0)}`}
+            {row.direction === Direction.CREDIT
+            && `$${centsToDollars(row?.amount || 0)}`}
           </span>
         </td>
         <td className='Layer__table-cell Layer__table-cell--primary'>
@@ -109,7 +111,8 @@ export const LedgerAccountRow = ({
         onClick={() => {
           if (selectedEntryId === row.entry_id) {
             closeSelectedEntry()
-          } else {
+          }
+          else {
             setSelectedEntryId(row.entry_id)
           }
         }}
@@ -124,7 +127,7 @@ export const LedgerAccountRow = ({
                 weight={TextWeight.normal}
                 className='Layer__ledger_account-table__journal-id'
               >
-                {entryNumber(row)}
+                {lineEntryNumber(row)}
               </Text>
             </div>
             <Text>{row.source?.display_description ?? ''}</Text>
@@ -135,8 +138,8 @@ export const LedgerAccountRow = ({
                 </span>
                 <span className='Layer__ledger_account-table__balances-mobile__value'>
                   {' '}
-                  {row.direction === Direction.DEBIT &&
-                    `$${centsToDollars(row?.amount || 0)}`}
+                  {row.direction === Direction.DEBIT
+                  && `$${centsToDollars(row?.amount || 0)}`}
                 </span>
               </div>
               <div className='Layer__ledger_account-table__balance-item'>
@@ -144,8 +147,8 @@ export const LedgerAccountRow = ({
                   Credit
                 </span>
                 <span className='Layer__ledger_account-table__balances-mobile__value'>
-                  {row.direction === Direction.CREDIT &&
-                    `$${centsToDollars(row?.amount || 0)}`}
+                  {row.direction === Direction.CREDIT
+                  && `$${centsToDollars(row?.amount || 0)}`}
                 </span>
               </div>
               <div className='Layer__ledger_account-table__balance-item'>
@@ -176,7 +179,8 @@ export const LedgerAccountRow = ({
       onClick={() => {
         if (selectedEntryId === row.entry_id) {
           closeSelectedEntry()
-        } else {
+        }
+        else {
           setSelectedEntryId(row.entry_id)
         }
       }}
@@ -187,7 +191,7 @@ export const LedgerAccountRow = ({
         </span>
       </td>
       <td className='Layer__table-cell'>
-        <span className='Layer__table-cell-content'>{entryNumber(row)}</span>
+        <span className='Layer__table-cell-content'>{lineEntryNumber(row)}</span>
       </td>
       <td className='Layer__table-cell'>
         <span className='Layer__table-cell-content'>
@@ -196,14 +200,14 @@ export const LedgerAccountRow = ({
       </td>
       <td className='Layer__table-cell Layer__table-cell--primary'>
         <span className='Layer__table-cell-content Layer__table-cell--amount'>
-          {row.direction === Direction.DEBIT &&
-            `$${centsToDollars(row?.amount || 0)}`}
+          {row.direction === Direction.DEBIT
+          && `$${centsToDollars(row?.amount || 0)}`}
         </span>
       </td>
       <td className='Layer__table-cell Layer__table-cell--primary'>
         <span className='Layer__table-cell-content Layer__table-cell--amount'>
-          {row.direction === Direction.CREDIT &&
-            `$${centsToDollars(row?.amount || 0)}`}
+          {row.direction === Direction.CREDIT
+          && `$${centsToDollars(row?.amount || 0)}`}
         </span>
       </td>
       <td className='Layer__table-cell Layer__table-cell--primary'>

--- a/src/components/LedgerAccountEntryDetails/LedgerAccountEntryDetails.tsx
+++ b/src/components/LedgerAccountEntryDetails/LedgerAccountEntryDetails.tsx
@@ -85,8 +85,8 @@ export const SourceDetailView = ({
           <DetailsListItem
             label={stringOverrides?.counterpartyLabel || 'Counterparty'}
           >
-            {transactionSource.counterparty ||
-              transactionSource.display_description}
+            {transactionSource.counterparty
+            || transactionSource.display_description}
           </DetailsListItem>
         </>
       )
@@ -245,10 +245,11 @@ export const LedgerAccountEntryDetails = ({
   const { totalDebit, totalCredit } = useMemo(() => {
     let totalDebit = 0
     let totalCredit = 0
-    entryData?.line_items?.forEach(item => {
+    entryData?.line_items?.forEach((item) => {
       if (item.direction === Direction.CREDIT) {
         totalCredit += item.amount || 0
-      } else if (item.direction === Direction.DEBIT) {
+      }
+      else if (item.direction === Direction.DEBIT) {
         totalDebit += item.amount || 0
       }
     })
@@ -268,8 +269,8 @@ export const LedgerAccountEntryDetails = ({
           </HeaderCol>
           <HeaderCol className='Layer__show-lg Layer__show-xl'>
             <Heading size={HeadingSize.secondary}>
-              {stringOverrides?.transactionSource?.header ||
-                'Transaction source'}
+              {stringOverrides?.transactionSource?.header
+              || 'Transaction source'}
             </Heading>
           </HeaderCol>
           <HeaderCol className='Layer__show-lg Layer__show-xl'>
@@ -282,7 +283,7 @@ export const LedgerAccountEntryDetails = ({
           stringOverrides?.transactionSource?.header || 'Transaction source'
         }
         titleClassName='Layer__hidden-lg Layer__hidden-xl'
-        actions={
+        actions={(
           <Button
             rightIcon={<XIcon />}
             iconOnly={true}
@@ -290,7 +291,7 @@ export const LedgerAccountEntryDetails = ({
             variant={ButtonVariant.secondary}
             className='Layer__details-list__close-btn'
           />
-        }
+        )}
       >
         <DetailsListItem
           label={
@@ -309,16 +310,16 @@ export const LedgerAccountEntryDetails = ({
         title={
           stringOverrides?.journalEntry?.header
             ? stringOverrides?.journalEntry?.header(
-                entryData ? entryNumber(entryData) : '',
-              )
+              entryData ? entryNumber(entryData) : '',
+            )
             : `Journal Entry ${entryData ? entryNumber(entryData) : ''}`
         }
         className='Layer__border-top'
       >
         <DetailsListItem
           label={
-            stringOverrides?.journalEntry?.details?.entryTypeLabel ||
-            'Entry type'
+            stringOverrides?.journalEntry?.details?.entryTypeLabel
+            || 'Entry type'
           }
           isLoading={isLoadingEntry}
         >
@@ -332,8 +333,8 @@ export const LedgerAccountEntryDetails = ({
         </DetailsListItem>
         <DetailsListItem
           label={
-            stringOverrides?.journalEntry?.details?.creationDateLabel ||
-            'Creation date'
+            stringOverrides?.journalEntry?.details?.creationDateLabel
+            || 'Creation date'
           }
           isLoading={isLoadingEntry}
         >
@@ -342,8 +343,8 @@ export const LedgerAccountEntryDetails = ({
         {entryData?.reversal_id && (
           <DetailsListItem
             label={
-              stringOverrides?.journalEntry?.details?.reversalLabel ||
-              'Reversal'
+              stringOverrides?.journalEntry?.details?.reversalLabel
+              || 'Reversal'
             }
             isLoading={isLoadingEntry}
           >
@@ -352,71 +353,75 @@ export const LedgerAccountEntryDetails = ({
         )}
       </DetailsList>
 
-      {!isLoadingEntry && !errorEntry ? (
-        <div className='Layer__ledger-account__entry-details__line-items'>
-          <Card>
-            <Table
-              componentName='ledger-account__entry-details'
-              borderCollapse='collapse'
-            >
-              <TableHead>
-                <TableRow rowKey='soc-flow-head-row' isHeadRow>
-                  <TableCell>
-                    {stringOverrides?.lineItemsTable?.lineItemsColumnHeader ||
-                      'Line items'}
-                  </TableCell>
-                  <TableCell align={TableCellAlign.RIGHT}>
-                    {stringOverrides?.lineItemsTable?.debitColumnHeader ||
-                      'Debit'}
-                  </TableCell>
-                  <TableCell align={TableCellAlign.RIGHT}>
-                    {stringOverrides?.lineItemsTable?.creditColumnHeader ||
-                      'Credit'}
-                  </TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {entryData?.line_items?.map((item, index) => (
-                  <TableRow
-                    key={`ledger-line-item-${index}`}
-                    rowKey={`ledger-line-item-${index}`}
-                  >
-                    <TableCell>{item.account?.name || ''}</TableCell>
-                    <TableCell align={TableCellAlign.RIGHT}>
-                      {item.direction === Direction.DEBIT && (
-                        <Badge variant={BadgeVariant.WARNING}>
-                          ${centsToDollars(item.amount || 0)}
-                        </Badge>
-                      )}
+      {!isLoadingEntry && !errorEntry
+        ? (
+          <div className='Layer__ledger-account__entry-details__line-items'>
+            <Card>
+              <Table
+                componentName='ledger-account__entry-details'
+                borderCollapse='collapse'
+              >
+                <TableHead>
+                  <TableRow rowKey='soc-flow-head-row' isHeadRow>
+                    <TableCell>
+                      {stringOverrides?.lineItemsTable?.lineItemsColumnHeader
+                      || 'Line items'}
                     </TableCell>
                     <TableCell align={TableCellAlign.RIGHT}>
-                      {item.direction === Direction.CREDIT && (
-                        <Badge variant={BadgeVariant.SUCCESS}>
-                          ${centsToDollars(item.amount || 0)}
-                        </Badge>
-                      )}
+                      {stringOverrides?.lineItemsTable?.debitColumnHeader
+                      || 'Debit'}
+                    </TableCell>
+                    <TableCell align={TableCellAlign.RIGHT}>
+                      {stringOverrides?.lineItemsTable?.creditColumnHeader
+                      || 'Credit'}
                     </TableCell>
                   </TableRow>
-                ))}
-                <TableRow
-                  rowKey='ledger-line-item-summation'
-                  variant='summation'
-                >
-                  <TableCell primary>
-                    {stringOverrides?.lineItemsTable?.totalRowHeader || 'Total'}
-                  </TableCell>
-                  <TableCell isCurrency primary align={TableCellAlign.RIGHT}>
-                    {totalDebit || 0}
-                  </TableCell>
-                  <TableCell isCurrency primary align={TableCellAlign.RIGHT}>
-                    {totalCredit || 0}
-                  </TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </Card>
-        </div>
-      ) : null}
+                </TableHead>
+                <TableBody>
+                  {entryData?.line_items?.map((item, index) => (
+                    <TableRow
+                      key={`ledger-line-item-${index}`}
+                      rowKey={`ledger-line-item-${index}`}
+                    >
+                      <TableCell>{item.account?.name || ''}</TableCell>
+                      <TableCell align={TableCellAlign.RIGHT}>
+                        {item.direction === Direction.DEBIT && (
+                          <Badge variant={BadgeVariant.WARNING}>
+                            $
+                            {centsToDollars(item.amount || 0)}
+                          </Badge>
+                        )}
+                      </TableCell>
+                      <TableCell align={TableCellAlign.RIGHT}>
+                        {item.direction === Direction.CREDIT && (
+                          <Badge variant={BadgeVariant.SUCCESS}>
+                            $
+                            {centsToDollars(item.amount || 0)}
+                          </Badge>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  <TableRow
+                    rowKey='ledger-line-item-summation'
+                    variant='summation'
+                  >
+                    <TableCell primary>
+                      {stringOverrides?.lineItemsTable?.totalRowHeader || 'Total'}
+                    </TableCell>
+                    <TableCell isCurrency primary align={TableCellAlign.RIGHT}>
+                      {totalDebit || 0}
+                    </TableCell>
+                    <TableCell isCurrency primary align={TableCellAlign.RIGHT}>
+                      {totalCredit || 0}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </Card>
+          </div>
+        )
+        : null}
     </div>
   )
 }

--- a/src/types/journal.ts
+++ b/src/types/journal.ts
@@ -56,9 +56,9 @@ export type JournalEntryLineItem = {
     name: string
     subType:
       | {
-          value: string
-          label: string
-        }
+        value: string
+        label: string
+      }
       | undefined
   }
   amount: number

--- a/src/utils/journal.ts
+++ b/src/utils/journal.ts
@@ -23,7 +23,13 @@ export const getAccountIdentifierPayload = (
 }
 
 export const entryNumber = (
-  entry: JournalEntry | LedgerAccountsEntry | LedgerAccountLineItem,
+  entry: JournalEntry | LedgerAccountsEntry,
 ): string => {
   return entry.entry_number?.toString() ?? entry.id.substring(0, 5)
+}
+
+export const lineEntryNumber = (
+  ledgerEntryLine: LedgerAccountLineItem,
+): string => {
+  return ledgerEntryLine.entry_number?.toString() ?? ledgerEntryLine.entry_id.substring(0, 5)
 }


### PR DESCRIPTION
## Description
We had a bug where we were using the _line item id_ and calling it the journal id number by accident, leading to situations like this 
![image](https://github.com/user-attachments/assets/f83b99eb-9a19-4c85-80a0-3ecb16afc177)

Notice the journal id # in the table doesn't match the journal entry number on the right bar!
 
## Changes
I've introduced a dedicated method (and separated out the acceptable argument types so type safety is enforced) to get the _entry_ numbers from line items, not the line item id.
