### PR TITLE
fix: `BOOKKEEPING_PAUSED` should allow users to categorize

### DIFF
--- a/src/utils/bookkeeping/isCategorizationEnabled.ts
+++ b/src/utils/bookkeeping/isCategorizationEnabled.ts
@@ -3,10 +3,9 @@ import type { BookkeepingStatus } from '../../hooks/bookkeeping/useBookkeepingSt
 export function isCategorizationEnabledForStatus(status: BookkeepingStatus) {
   switch (status) {
     case 'NOT_PURCHASED':
+    case 'BOOKKEEPING_PAUSED':
       return true
     case 'ACTIVE':
-      return false
-    case 'BOOKKEEPING_PAUSED':
       return false
   }
 }


### PR DESCRIPTION
## Description

This is a fast-follow based on an internal testing session. When bookkeeping is paused, this is the equivalent of a user no longer being enrolled in the service (and they should have full control).