### PR TITLE
fix: (sometimes) hide P&L Summary Chart "Indicator"

### DIFF
--- a/src/components/ProfitAndLoss/ProfitAndLoss.tsx
+++ b/src/components/ProfitAndLoss/ProfitAndLoss.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, createContext } from 'react'
 import { PNLComparisonContext } from '../../contexts/ProfitAndLossComparisonContext'
-import { useProfitAndLoss } from '../../hooks/useProfitAndLoss'
+import { useProfitAndLoss } from '../../hooks/useProfitAndLoss/useProfitAndLoss'
 import { useProfitAndLossComparison } from '../../hooks/useProfitAndLossComparison'
 import { ReportingBasis } from '../../types'
 import { Container } from '../Container'

--- a/src/components/ProfitAndLossChart/Indicator.tsx
+++ b/src/components/ProfitAndLossChart/Indicator.tsx
@@ -36,11 +36,9 @@ export const Indicator = ({
   const { x: animateTo = 0, width = 0 } =
     'x' in viewBox ? viewBox : emptyViewBox
   const margin = width > 12 ? 12 : 6
-  const boxWidth = width + margin
+  const boxWidth = width + (2 * margin)
   const xOffset = boxWidth / 2
   const borderRadius = 6
-  const rectWidth = `${boxWidth}px`
-  const rectHeight = 'calc(100% - 38px)'
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
@@ -75,11 +73,11 @@ export const Indicator = ({
       rx={borderRadius}
       ry={borderRadius}
       style={{
-        width: rectWidth,
-        // @ts-expect-error -- y is fine but x apparently isn't!
-        x: actualX - xOffset / 2 + margin / 4,
-        y: 22,
-        height: rectHeight,
+        width: `${boxWidth}px`,
+        // @ts-expect-error -- "y" is fine but "x" apparently isn't!
+        x: actualX - margin,
+        y: 16,
+        height: 'calc(100% - 30px)',
         opacity: opacityIndicator,
       }}
     />

--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -151,8 +151,10 @@ export const ProfitAndLossChart = ({
 
   const { getColor, business } = useLayerContext()
 
-  const { start, end } = useGlobalDateRange()
+  const { start, end, rangeDisplayMode } = useGlobalDateRange()
   const { setMonth } = useGlobalDateRangeActions()
+
+  const showIndicator = rangeDisplayMode === 'monthPicker'
 
   const dateRange = useMemo(() => ({ startDate: start, endDate: end }), [start, end])
 
@@ -717,17 +719,21 @@ export const ProfitAndLossChart = ({
             xAxisId='revenue'
             stackId='revenue'
           >
-            <LabelList
-              content={(
-                <Indicator
-                  setCustomCursorSize={(width, height, x) =>
-                    setCustomCursorSize({ width, height, x })}
-                  customCursorSize={customCursorSize}
-                  animateFrom={animateFrom}
-                  setAnimateFrom={setAnimateFrom}
+            {showIndicator
+              ? (
+                <LabelList
+                  content={(
+                    <Indicator
+                      setCustomCursorSize={(width, height, x) =>
+                        setCustomCursorSize({ width, height, x })}
+                      customCursorSize={customCursorSize}
+                      animateFrom={animateFrom}
+                      setAnimateFrom={setAnimateFrom}
+                    />
+                  )}
                 />
-              )}
-            />
+              )
+              : null}
             {theData?.map((entry) => {
               return (
                 <Cell

--- a/src/hooks/useProfitAndLoss/index.tsx
+++ b/src/hooks/useProfitAndLoss/index.tsx
@@ -1,1 +1,0 @@
-export { useProfitAndLoss } from './useProfitAndLoss'


### PR DESCRIPTION
## Description

This change is intended to reduce confusion when a custom date range is selected.