### PR TITLE
fix: Modal default size is far too small

### DIFF
--- a/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
+++ b/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
@@ -172,6 +172,7 @@ export function OpeningBalanceModal({
     <Modal
       isOpen={shouldShowModal}
       size='lg'
+      flexBlock
       onOpenChange={(isOpen) => {
         if (!isOpen) {
           setAccountsToAddOpeningBalanceInModal([])

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo, type ComponentProps, type PropsWithChildren } from 'react'
+import { forwardRef, type ComponentProps, type PropsWithChildren } from 'react'
 import {
   Dialog as ReactAriaDialog,
   type DialogProps,
@@ -29,9 +29,9 @@ ModalOverlay.displayName = 'ModalOverlay'
 const MODAL_CLASS_NAME = 'Layer__Modal'
 const InternalModal = forwardRef<
   HTMLElementTagNameMap['div'],
-  PropsWithChildren<{ size?: ModalSize }>
->(({ children, size }, ref) => {
-  const dataProperties = useMemo(() => toDataProperties({ size }), [size])
+  PropsWithChildren<{ size?: ModalSize, flexBlock?: boolean }>
+>(({ children, flexBlock, size }, ref) => {
+  const dataProperties = toDataProperties({ size, 'flex-block': flexBlock })
 
   return (
     <ReactAriaModal
@@ -67,7 +67,7 @@ type AllowedModalOverlayProps = Pick<
 >
 type AllowedInternalModalProps = Pick<
   ComponentProps<typeof InternalModal>,
-  'size'
+  'flexBlock' | 'size'
 >
 type AllowedDialogProps = Pick<
   ComponentProps<typeof Dialog>,
@@ -79,12 +79,13 @@ type ModalProps = AllowedModalOverlayProps & AllowedInternalModalProps & Allowed
 export function Modal({
   isOpen,
   size = 'md',
+  flexBlock,
   onOpenChange,
   children,
 }: ModalProps) {
   return (
     <ModalOverlay isOpen={isOpen} onOpenChange={onOpenChange}>
-      <InternalModal size={size}>
+      <InternalModal flexBlock={flexBlock} size={size}>
         <Dialog role='dialog'>
           {children}
         </Dialog>

--- a/src/components/ui/Modal/modal.scss
+++ b/src/components/ui/Modal/modal.scss
@@ -18,8 +18,11 @@
 }
 
 .Layer__Modal {
-  inline-size: min(32rem, 90dvi);
-  block-size: min(32rem, 90dvb);
+  inline-size: min(36rem, 90dvi);
+  max-inline-size: 90dvi;
+
+  block-size: min(42rem, 90dvb);
+  max-block-size: 90dvb;
 
   &[data-entering] {
     animation-duration: 300ms;
@@ -29,10 +32,12 @@
     animation-duration: 300ms;
   }
 
+  &[data-flex-block] {
+    block-size: auto;
+  }
+
   &[data-size='lg'] {
     inline-size: min(42rem, 90dvi);
-    block-size: auto;
-    max-block-size: 90dvb;
   }
 }
 


### PR DESCRIPTION
## Description

It seems like the Modal was unintentionally made especially small.

## Screenshots

This screenshot shows how the modal will appear (embedded within a customer's UI) at the adjusted size.

<img width="1200" alt="Screenshot 2025-03-03 at 4 08 02 PM" src="https://github.com/user-attachments/assets/e1196791-39cc-4c51-a074-1d4bb835ebf4" />
