### PR TITLE
fix: remove `revalidateOnFocus` from `useAuth` hook

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -103,7 +103,8 @@ export function useAuth() {
     },
     {
       keepPreviousData: true,
-      revalidateOnFocus: true,
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
       revalidateOnReconnect: true,
       refreshInterval: (latestData) => {
         if (!latestData) {


### PR DESCRIPTION
## Description

This was added by me at one point, but it causes a bit too much flickering in dev mode because we can't ensure a stable result.