### PR TITLE
fix: use ISO `full-date` when transforming search parameters

### DIFF
--- a/src/utils/request/toDefinedSearchParameters.ts
+++ b/src/utils/request/toDefinedSearchParameters.ts
@@ -1,3 +1,4 @@
+import { formatISO } from 'date-fns'
 import { isStringArray } from '../array/isStringArray'
 
 function toSnakeCase(input: string) {
@@ -21,7 +22,7 @@ export function toDefinedSearchParameters(
       }
 
       if (value instanceof Date) {
-        return [[key, value.toISOString()]]
+        return [[key, formatISO(value, { representation: 'date' })]]
       }
 
       if (isStringArray(value)) {


### PR DESCRIPTION
## Description

This change is inspired by #519. It will influence our cashflow statement and balance sheet queries. 