### PR TITLE
include negative values in table and total, but not in percentages and pie chart

### DIFF
--- a/src/components/ProfitAndLossDetailedCharts/DetailedChart.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedChart.tsx
@@ -41,7 +41,7 @@ export const DetailedChart = ({
     if (!filteredData) {
       return []
     }
-    return filteredData.map(x => {
+    return filteredData.map((x) => {
       if (x.hidden) {
         return {
           ...x,
@@ -53,7 +53,7 @@ export const DetailedChart = ({
       return {
         ...x,
         name: x.display_name,
-        value: x.value,
+        value: x.value > 0 ? x.value : 0,
         type: x.type,
       }
     })
@@ -97,272 +97,279 @@ export const DetailedChart = ({
                 <rect width='1' height='1' opacity={0.56} />
               </pattern>
             </defs>
-            {!isLoading && !noValue ? (
-              <Pie
-                data={chartData}
-                dataKey='value'
-                nameKey='name'
-                cx='50%'
-                cy='50%'
-                innerRadius={'91%'}
-                outerRadius={'100%'}
-                paddingAngle={0.5}
-                fill='#8884d8'
-                animationDuration={200}
-                animationEasing='ease-in-out'
-              >
-                {chartData.map((entry, index) => {
-                  let fill: string | undefined = typeColorMapping[index].color
-                  let active = true
-                  if (hoveredItem && entry.name !== hoveredItem) {
-                    active = false
-                    fill = undefined
-                  }
+            {!isLoading && !noValue
+              ? (
+                <Pie
+                  data={chartData}
+                  dataKey='value'
+                  nameKey='name'
+                  cx='50%'
+                  cy='50%'
+                  innerRadius='91%'
+                  outerRadius='100%'
+                  paddingAngle={0.5}
+                  fill='#8884d8'
+                  animationDuration={200}
+                  animationEasing='ease-in-out'
+                >
+                  {chartData.map((entry, index) => {
+                    let fill: string | undefined = typeColorMapping[index].color
+                    let active = true
+                    if (hoveredItem && entry.name !== hoveredItem) {
+                      active = false
+                      fill = undefined
+                    }
 
-                  return (
-                    <Cell
-                      key={`cell-${index}`}
-                      className={classNames(
-                        'Layer__profit-and-loss-detailed-charts__pie',
-                        hoveredItem && active ? 'active' : 'inactive',
-                        entry.type === 'Uncategorized' &&
-                          'Layer__profit-and-loss-detailed-charts__pie--border',
-                      )}
-                      style={{
-                        fill:
+                    return (
+                      <Cell
+                        key={`cell-${index}`}
+                        className={classNames(
+                          'Layer__profit-and-loss-detailed-charts__pie',
+                          hoveredItem && active ? 'active' : 'inactive',
+                          entry.type === 'Uncategorized'
+                          && 'Layer__profit-and-loss-detailed-charts__pie--border',
+                        )}
+                        style={{
+                          fill:
                           entry.type === 'Uncategorized' && fill
                             ? 'url(#layer-pie-dots-pattern)'
                             : fill,
-                      }}
-                      opacity={typeColorMapping[index].opacity}
-                      onMouseEnter={() => setHoveredItem(entry.name)}
-                      onMouseLeave={() => setHoveredItem(undefined)}
-                    />
-                  )
-                })}
-                <Label
-                  position='center'
-                  value='Total'
-                  className='pie-center-label-title'
-                  content={props => {
-                    const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
-                      cx: 0,
-                      cy: 0,
-                    }
-                    const positioningProps = {
-                      x: cx,
-                      y: (cy || 0) - 15,
-                      textAnchor: 'middle' as
-                        | 'start'
-                        | 'middle'
-                        | 'end'
-                        | 'inherit',
-                      verticalAnchor: 'middle' as 'start' | 'middle' | 'end',
-                    }
-
-                    let text = 'Total'
-
-                    if (hoveredItem) {
-                      text = hoveredItem
-                    }
-
-                    return (
-                      <ChartText
-                        {...positioningProps}
-                        className='pie-center-label__title'
-                      >
-                        {text}
-                      </ChartText>
+                        }}
+                        opacity={typeColorMapping[index].opacity}
+                        onMouseEnter={() => setHoveredItem(entry.name)}
+                        onMouseLeave={() => setHoveredItem(undefined)}
+                      />
                     )
-                  }}
-                />
-
-                <Label
-                  position='center'
-                  value='Total'
-                  className='pie-center-label-title'
-                  content={props => {
-                    const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
-                      cx: 0,
-                      cy: 0,
-                    }
-                    const positioningProps = {
-                      x: cx,
-                      y: (cy || 0) + 5,
-                      textAnchor: 'middle' as
+                  })}
+                  <Label
+                    position='center'
+                    value='Total'
+                    className='pie-center-label-title'
+                    content={(props) => {
+                      const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
+                        cx: 0,
+                        cy: 0,
+                      }
+                      const positioningProps = {
+                        x: cx,
+                        y: (cy || 0) - 15,
+                        textAnchor: 'middle' as
                         | 'start'
                         | 'middle'
                         | 'end'
                         | 'inherit',
-                      verticalAnchor: 'middle' as 'start' | 'middle' | 'end',
-                    }
+                        verticalAnchor: 'middle' as 'start' | 'middle' | 'end',
+                      }
 
-                    let value = filteredTotal
-                    if (hoveredItem) {
-                      value = filteredData.find(
-                        x => x.display_name === hoveredItem,
-                      )?.value
-                    }
+                      let text = 'Total'
 
-                    return (
-                      <ChartText
-                        {...positioningProps}
-                        className='pie-center-label__value'
-                      >
-                        {`$${formatMoney(value)}`}
-                      </ChartText>
-                    )
-                  }}
-                />
+                      if (hoveredItem) {
+                        text = hoveredItem
+                      }
 
-                <Label
-                  position='center'
-                  value='Total'
-                  className='pie-center-label-title'
-                  content={props => {
-                    const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
-                      cx: 0,
-                      cy: 0,
-                    }
-                    const positioningProps = {
-                      x: cx,
-                      y: (cy || 0) + 25,
-                      height: 20,
-                      textAnchor: 'middle' as
-                        | 'start'
-                        | 'middle'
-                        | 'end'
-                        | 'inherit',
-                      verticalAnchor: 'middle' as 'start' | 'middle' | 'end',
-                    }
-
-                    if (hoveredItem) {
                       return (
                         <ChartText
                           {...positioningProps}
-                          className='pie-center-label__share'
+                          className='pie-center-label__title'
                         >
-                          {`${formatPercent(
-                            filteredData.find(
-                              x => x.display_name === hoveredItem,
-                            )?.share,
-                          )}%`}
+                          {text}
                         </ChartText>
                       )
-                    }
+                    }}
+                  />
 
-                    return null
-                  }}
-                />
-              </Pie>
-            ) : null}
-
-            {!isLoading && noValue ? (
-              <Pie
-                data={[{ name: 'Total', value: 1 }]}
-                dataKey='value'
-                nameKey='name'
-                cx='50%'
-                cy='50%'
-                innerRadius={'91%'}
-                outerRadius={'100%'}
-                paddingAngle={0}
-                fill='#F8F8FA'
-                animationDuration={200}
-                animationEasing='ease-in-out'
-              >
-                <Label
-                  position='center'
-                  value='Total'
-                  className='pie-center-label-title'
-                  content={props => {
-                    const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
-                      cx: 0,
-                      cy: 0,
-                    }
-                    const positioningProps = {
-                      x: cx,
-                      y: (cy || 0) - 15,
-                      textAnchor: 'middle' as
+                  <Label
+                    position='center'
+                    value='Total'
+                    className='pie-center-label-title'
+                    content={(props) => {
+                      const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
+                        cx: 0,
+                        cy: 0,
+                      }
+                      const positioningProps = {
+                        x: cx,
+                        y: (cy || 0) + 5,
+                        textAnchor: 'middle' as
                         | 'start'
                         | 'middle'
                         | 'end'
                         | 'inherit',
-                      verticalAnchor: 'middle' as 'start' | 'middle' | 'end',
-                    }
+                        verticalAnchor: 'middle' as 'start' | 'middle' | 'end',
+                      }
 
-                    let text = 'Total'
+                      let value = filteredTotal
+                      if (hoveredItem) {
+                        value = filteredData.find(
+                          x => x.display_name === hoveredItem,
+                        )?.value
+                      }
 
-                    if (hoveredItem) {
-                      text = hoveredItem
-                    }
+                      return (
+                        <ChartText
+                          {...positioningProps}
+                          className='pie-center-label__value'
+                        >
+                          {`$${formatMoney(value)}`}
+                        </ChartText>
+                      )
+                    }}
+                  />
 
-                    return (
-                      <ChartText
-                        {...positioningProps}
-                        className='pie-center-label__title'
-                      >
-                        {text}
-                      </ChartText>
-                    )
-                  }}
-                />
-
-                <Label
-                  position='center'
-                  value='Total'
-                  className='pie-center-label-title'
-                  content={props => {
-                    const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
-                      cx: 0,
-                      cy: 0,
-                    }
-                    const positioningProps = {
-                      x: cx,
-                      y: (cy || 0) + 5,
-                      textAnchor: 'middle' as
+                  <Label
+                    position='center'
+                    value='Total'
+                    className='pie-center-label-title'
+                    content={(props) => {
+                      const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
+                        cx: 0,
+                        cy: 0,
+                      }
+                      const positioningProps = {
+                        x: cx,
+                        y: (cy || 0) + 25,
+                        height: 20,
+                        textAnchor: 'middle' as
                         | 'start'
                         | 'middle'
                         | 'end'
                         | 'inherit',
-                      verticalAnchor: 'middle' as 'start' | 'middle' | 'end',
-                    }
+                        verticalAnchor: 'middle' as 'start' | 'middle' | 'end',
+                      }
 
-                    let value = filteredTotal
-                    if (hoveredItem) {
-                      value = filteredData.find(
-                        x => x.display_name === hoveredItem,
-                      )?.value
-                    }
+                      if (hoveredItem) {
+                        const item = filteredData.find(
+                          x => x.display_name === hoveredItem,
+                        )
+                        const positiveTotal = chartData.reduce((sum, x) => sum + x.value, 0)
+                        const share = item?.value > 0 ? item.value / positiveTotal : 0
+                        return (
+                          <ChartText
+                            {...positioningProps}
+                            className='pie-center-label__share'
+                          >
+                            {`${formatPercent(share)}%`}
+                          </ChartText>
+                        )
+                      }
 
-                    return (
-                      <ChartText
-                        {...positioningProps}
-                        className='pie-center-label__value'
-                      >
-                        {`$${formatMoney(value)}`}
-                      </ChartText>
-                    )
-                  }}
+                      return null
+                    }}
+                  />
+                </Pie>
+              )
+              : null}
+
+            {!isLoading && noValue
+              ? (
+                <Pie
+                  data={[{ name: 'Total', value: 1 }]}
+                  dataKey='value'
+                  nameKey='name'
+                  cx='50%'
+                  cy='50%'
+                  innerRadius='91%'
+                  outerRadius='100%'
+                  paddingAngle={0}
+                  fill='#F8F8FA'
+                  animationDuration={200}
+                  animationEasing='ease-in-out'
+                >
+                  <Label
+                    position='center'
+                    value='Total'
+                    className='pie-center-label-title'
+                    content={(props) => {
+                      const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
+                        cx: 0,
+                        cy: 0,
+                      }
+                      const positioningProps = {
+                        x: cx,
+                        y: (cy || 0) - 15,
+                        textAnchor: 'middle' as
+                        | 'start'
+                        | 'middle'
+                        | 'end'
+                        | 'inherit',
+                        verticalAnchor: 'middle' as 'start' | 'middle' | 'end',
+                      }
+
+                      let text = 'Total'
+
+                      if (hoveredItem) {
+                        text = hoveredItem
+                      }
+
+                      return (
+                        <ChartText
+                          {...positioningProps}
+                          className='pie-center-label__title'
+                        >
+                          {text}
+                        </ChartText>
+                      )
+                    }}
+                  />
+
+                  <Label
+                    position='center'
+                    value='Total'
+                    className='pie-center-label-title'
+                    content={(props) => {
+                      const { cx, cy } = (props.viewBox as PolarViewBox) ?? {
+                        cx: 0,
+                        cy: 0,
+                      }
+                      const positioningProps = {
+                        x: cx,
+                        y: (cy || 0) + 5,
+                        textAnchor: 'middle' as
+                        | 'start'
+                        | 'middle'
+                        | 'end'
+                        | 'inherit',
+                        verticalAnchor: 'middle' as 'start' | 'middle' | 'end',
+                      }
+
+                      let value = filteredTotal
+                      if (hoveredItem) {
+                        value = filteredData.find(
+                          x => x.display_name === hoveredItem,
+                        )?.value
+                      }
+
+                      return (
+                        <ChartText
+                          {...positioningProps}
+                          className='pie-center-label__value'
+                        >
+                          {`$${formatMoney(value)}`}
+                        </ChartText>
+                      )
+                    }}
+                  />
+                </Pie>
+              )
+              : null}
+
+            {isLoading
+              ? (
+                <Pie
+                  data={[{ name: 'loading...', value: 1 }]}
+                  dataKey='value'
+                  nameKey='name'
+                  cx='50%'
+                  cy='50%'
+                  innerRadius='91%'
+                  outerRadius='100%'
+                  paddingAngle={0}
+                  fill='#F8F8FA'
+                  animationDuration={200}
+                  animationEasing='ease-in-out'
                 />
-              </Pie>
-            ) : null}
-
-            {isLoading ? (
-              <Pie
-                data={[{ name: 'loading...', value: 1 }]}
-                dataKey='value'
-                nameKey='name'
-                cx='50%'
-                cy='50%'
-                innerRadius={'91%'}
-                outerRadius={'100%'}
-                paddingAngle={0}
-                fill='#F8F8FA'
-                animationDuration={200}
-                animationEasing='ease-in-out'
-              />
-            ) : null}
+              )
+              : null}
           </PieChart>
         </ResponsiveContainer>
       </div>

--- a/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/DetailedTable.tsx
@@ -144,6 +144,9 @@ export const DetailedTable = ({
   }
 
   const typeColorMapping = mapTypesToColors(filteredData, chartColorsList)
+  const positiveTotal = filteredData
+    .filter(x => !x.hidden && x.value > 0)
+    .reduce((sum, x) => sum + x.value, 0)
 
   return (
     <div className='details-container'>
@@ -182,6 +185,7 @@ export const DetailedTable = ({
             {filteredData
               .filter(x => !x.hidden)
               .map((item, idx) => {
+                const share = item.value > 0 ? item.value / positiveTotal : 0
                 return (
                   <tr
                     key={`pl-side-table-item-${idx}`}
@@ -202,8 +206,7 @@ export const DetailedTable = ({
                     </td>
                     <td className='share-col'>
                       <span className='share-cell-content'>
-                        {formatPercent(item.share)}
-                        %
+                        {item.value < 0 ? '-' : `${formatPercent(share)}%`}
                         <ValueIcon
                           item={item}
                           typeColorMapping={typeColorMapping}

--- a/src/utils/profitAndLossUtils.ts
+++ b/src/utils/profitAndLossUtils.ts
@@ -4,13 +4,11 @@ import { ProfitAndLoss } from '../types/profit_and_loss'
 
 const doesLineItemQualifies = (item: LineItem) => {
   return !(
-    item.is_contra ||
-    item.value === undefined ||
-    item.value === null ||
-    isNaN(item.value) ||
-    item.value === -Infinity ||
-    item.value === Infinity ||
-    item.value < 0
+    item.value === undefined
+    || item.value === null
+    || isNaN(item.value)
+    || item.value === -Infinity
+    || item.value === Infinity
   )
 }
 
@@ -21,12 +19,12 @@ const collectSubItems = (type: string, item?: LineItem | null) => {
 
   const items: LineBaseItem[] = []
 
-  item?.line_items?.forEach(item => {
+  item?.line_items?.forEach((item) => {
     if (doesLineItemQualifies(item)) {
       items.push({
         name: item.name,
         display_name: item.display_name,
-        value: item.value || 0,
+        value: item.is_contra ? -(item.value || 0) : (item.value || 0),
         type,
       })
     }
@@ -64,7 +62,7 @@ export const applyShare = (
   items: LineBaseItem[],
   total: number,
 ): LineBaseItem[] => {
-  return items.map(item => {
+  return items.map((item) => {
     if (total === 0) {
       return item
     }


### PR DESCRIPTION
## Description
Previously we dropped negative values entirely out of the detail charts.
Now, we're going to include the negative values in the detail charts so they affect the total and show up in the table, but exclude them from percentage calculations so we don't have nonsensical numbers.
<img width="801" alt="image" src="https://github.com/user-attachments/assets/a6f74c1c-72c6-4073-bdd1-791ae720399f" />


## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->
