### PR TITLE
always allow clicking on months with any tasks

### DIFF
--- a/src/components/TasksMonthSelector/TasksMonthSelector.tsx
+++ b/src/components/TasksMonthSelector/TasksMonthSelector.tsx
@@ -32,11 +32,9 @@ const TasksMonthSelector = ({ tasks, year, currentDate, onClick }: TasksMonthSel
     return Array.from({ length: 12 }, (_, i) => {
       const startDate = set(
         new Date(),
-        { year, month: i, date: 1, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 }
+        { year, month: i, date: 1, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 },
       )
       const endDate = endOfMonth(startDate)
-      const disabled = (minDate && isBefore(startDate, minDate))
-            || isAfter(startDate, startOfMonth(new Date()))
       const taskData = tasks?.find(x => x.month === i && x.year === year) ?? {
         monthStr: format(startDate, 'MMM'),
         year,
@@ -45,12 +43,16 @@ const TasksMonthSelector = ({ tasks, year, currentDate, onClick }: TasksMonthSel
         endDate,
         ...DEFAULT_TASK_DATA,
       }
+
+      const disabled = taskData.total === 0
+        && ((minDate && isBefore(startDate, minDate))
+          || isAfter(startDate, startOfMonth(new Date())))
       return {
         monthStr: format(startDate, 'MMM'),
         startDate,
         endDate,
         disabled,
-        ...taskData
+        ...taskData,
       }
     })
   }, [tasks, year, minDate])
@@ -73,5 +75,3 @@ const TasksMonthSelector = ({ tasks, year, currentDate, onClick }: TasksMonthSel
 }
 
 export { TasksMonthSelector }
-
-


### PR DESCRIPTION
## Description

We had a user reporting that they couldn't click on months with tasks. We have a couple theories on what could have been messed up in the local state to cause this, but safest path forward: if there are tasks in a month, it should always be clickable. Right now, if that month is before activation time or after the current month, you can't!


## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->
