### PR TITLE
fix pnl chart- not missing data

### DIFF
--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -202,7 +202,9 @@ export const ProfitAndLossChart = ({
           || x.operatingExpenses !== 0
           || x.profitBeforeTaxes !== 0
           || x.taxes !== 0
-          || x.totalExpenses !== 0,
+          || x.totalExpenses !== 0
+          || x.uncategorizedInflows !== 0
+          || x.uncategorizedOutflows !== 0,
       ),
     )
   }, [data])


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->
If the only data you had were uncategorized transactions, the pnl summaries chart would display 'No data yet', because `anyData` wasn't counting uncategorized inflows/outflows

## Changes
<!-- [Optional] List the main changes made in this PR. -->
now it is counting uncategorized inflows/outflows

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

