### PR TITLE
fix: extract `useBankTransactions` into a pure hook

### DIFF
--- a/src/api/layer.ts
+++ b/src/api/layer.ts
@@ -1,6 +1,5 @@
 import { getBalanceSheet } from './layer/balance_sheet'
 import {
-  getBankTransactions,
   categorizeBankTransaction,
   matchBankTransaction,
   getBankTransactionsCsv,
@@ -74,7 +73,6 @@ export const Layer = {
   createAccount,
   updateAccount,
   getBalanceSheet,
-  getBankTransactions,
   getBankTransactionsCsv,
   getBankTransactionMetadata,
   listBankTransactionDocuments,

--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -114,7 +114,6 @@ const BankTransactionsContent = ({
   const categorizeView = categorizeViewProp ?? categorizationEnabled
 
   const {
-    activate,
     data,
     isLoading,
     loadingStatus,
@@ -135,10 +134,6 @@ const BankTransactionsContent = ({
     () => Boolean(linkedAccounts?.some(item => item.is_syncing)),
     [linkedAccounts],
   )
-
-  useEffect(() => {
-    activate()
-  }, [])
 
   useEffect(() => {
     // Reset date range when switching from monthly view to non-monthly view

--- a/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
+++ b/src/components/ProfitAndLossSummaries/ProfitAndLossSummaries.tsx
@@ -10,8 +10,6 @@ import {
   toMiniChartData,
 } from './internal/ProfitAndLossSummariesMiniChart'
 import { ProfitAndLossSummariesSummary } from './internal/ProfitAndLossSummariesSummary'
-import { Button } from '../ui/Button/Button'
-import { HStack } from '../ui/Stack/Stack'
 
 export interface ProfitAndLossSummariesStringOverrides {
   revenueLabel?: string
@@ -73,14 +71,6 @@ export function Internal_ProfitAndLossSummaries({
 
   return (
     <section className={SECTION_CLASS_NAMES}>
-      <HStack gap='sm' pbs='sm' pbe='sm'>
-        <Button isPending>
-          Example
-        </Button>
-        <Button>
-          Example
-        </Button>
-      </HStack>
       <ProfitAndLossSummariesList itemCount={listItemCount}>
         <ProfitAndLossSummariesListItem
           isActive={sidebarScope === 'revenue'}

--- a/src/contexts/BankTransactionsContext/BankTransactionsContext.tsx
+++ b/src/contexts/BankTransactionsContext/BankTransactionsContext.tsx
@@ -16,12 +16,14 @@ export const BankTransactionsContext =
     filters: undefined,
     setFilters: () => {},
     metadata: {
-      pagination: undefined,
+      pagination: {
+        cursor: undefined,
+        has_more: false,
+      },
     },
     updateOneLocal: () => undefined,
     shouldHideAfterCategorize: () => false,
     removeAfterCategorize: () => undefined,
-    activate: () => undefined,
     display: DisplayState.review,
     fetchMore: () => {},
     hasMore: false,

--- a/src/hooks/useBankTransactions/useBankTransactions.ts
+++ b/src/hooks/useBankTransactions/useBankTransactions.ts
@@ -1,0 +1,89 @@
+import useSWRInfinite from 'swr/infinite'
+import { useAuth } from '../useAuth'
+import { useLayerContext } from '../../contexts/LayerContext'
+import { getBankTransactions, type GetBankTransactionsReturn } from '../../api/layer/bankTransactions'
+
+type UseBankTransactionsOptions = {
+  categorized?: boolean
+  direction?: 'INFLOW' | 'OUTFLOW'
+  startDate?: Date
+  endDate?: Date
+  tagFilterQueryString?: string
+}
+
+function keyLoader(
+  previousPageData: GetBankTransactionsReturn | null,
+  {
+    access_token: accessToken,
+    apiUrl,
+    businessId,
+    categorized,
+    direction,
+    startDate,
+    endDate,
+    tagFilterQueryString,
+  }: UseBankTransactionsOptions & {
+    access_token?: string
+    apiUrl?: string
+    businessId: string
+  },
+) {
+  if (accessToken && apiUrl) {
+    return {
+      accessToken,
+      apiUrl,
+      businessId,
+      categorized,
+      cursor: previousPageData ? previousPageData.meta.pagination.cursor : undefined,
+      direction,
+      startDate,
+      endDate,
+      tagFilterQueryString,
+    }
+  }
+}
+
+export function useBankTransactions({
+  categorized,
+  direction,
+  startDate,
+  endDate,
+  tagFilterQueryString,
+}: UseBankTransactionsOptions) {
+  const { data } = useAuth()
+  const { businessId } = useLayerContext()
+
+  return useSWRInfinite(
+    (_index, previousPageData: GetBankTransactionsReturn | null) => keyLoader(
+      previousPageData,
+      {
+        ...data,
+        businessId,
+        categorized,
+        direction,
+        startDate,
+        endDate,
+        tagFilterQueryString,
+      },
+    ),
+    ({ accessToken, apiUrl, businessId, cursor, startDate, endDate, tagFilterQueryString }) => {
+      return getBankTransactions(
+        apiUrl,
+        accessToken,
+        {
+          params: {
+            businessId,
+            cursor,
+            startDate,
+            endDate,
+            tagFilterQueryString,
+          },
+        },
+      )()
+    },
+    {
+      revalidateFirstPage: false,
+      initialSize: 1,
+    },
+  )
+}

--- a/src/utils/request/toDefinedSearchParameters.ts
+++ b/src/utils/request/toDefinedSearchParameters.ts
@@ -35,7 +35,7 @@ export function toDefinedSearchParameters(
 
       return [[key, value]]
     })
-    .filter((entry): entry is Exclude<typeof entry, null> => entry !== null)
+    .filter(([_, value]) => value !== '')
     .map(([key, value]) => [toSnakeCase(key), value])
 
   return new URLSearchParams(definedParameterPairs)


### PR DESCRIPTION
## Description

This is the second step in a series of changes intended to unblock transaction search. In the next PR, I will add the query-parameter required for search.
