### PR TITLE
feat: show books in progress when no bookkeeping status for a given month

### DIFF
--- a/src/components/Tasks/TaskMonthTile.tsx
+++ b/src/components/Tasks/TaskMonthTile.tsx
@@ -2,6 +2,9 @@ import { Text, TextSize } from '../Typography'
 import { TaskStatusBadge } from './TaskStatusBadge'
 import { toDataProperties } from '../../utils/styleUtils/toDataProperties'
 import { MonthData } from './types'
+import { useEffectiveBookkeepingStatus } from '../../hooks/bookkeeping/useBookkeepingStatus'
+import { useLayerContext } from '../../contexts/LayerContext'
+import { isBusinessHistoricalMonth } from '../../utils/business'
 
 export type TaskMonthTileProps = {
   data: MonthData
@@ -12,6 +15,12 @@ export type TaskMonthTileProps = {
 
 export const TaskMonthTile = ({ data, onClick, active, disabled }: TaskMonthTileProps) => {
   const dataProperties = toDataProperties({ active, disabled })
+  const bookkeepingStatus = useEffectiveBookkeepingStatus()
+  const { business } = useLayerContext()
+
+  const defaultStatus = isBusinessHistoricalMonth(data.date, business)
+    ? 'IN_PROGRESS_AWAITING_BOOKKEEPER'
+    : undefined
 
   return (
     <div
@@ -22,8 +31,8 @@ export const TaskMonthTile = ({ data, onClick, active, disabled }: TaskMonthTile
       <Text size={TextSize.sm} className='Layer__tasks-month-selector__month__str'>
         {data.monthStr}
       </Text>
-      {data.status && (
-        <TaskStatusBadge status={data.status} tasksCount={data.total - data.completed} />
+      {bookkeepingStatus === 'ACTIVE' && (
+        <TaskStatusBadge status={data.status} defaultStatus={defaultStatus} tasksCount={data.total - data.completed} />
       )}
     </div>
   )

--- a/src/components/Tasks/TaskStatusBadge.tsx
+++ b/src/components/Tasks/TaskStatusBadge.tsx
@@ -7,7 +7,8 @@ import pluralize from 'pluralize'
 import { toDataProperties } from '../../utils/styleUtils/toDataProperties'
 
 type TaskStatusBadgeProps = {
-  status: BookkeepingPeriod['status']
+  status?: BookkeepingPeriod['status']
+  defaultStatus?: BookkeepingPeriod['status']
   tasksCount?: number
 }
 
@@ -40,8 +41,12 @@ const buildBadgeConfig = (status: TaskStatusBadgeProps['status'], tasksCount: Ta
   }
 }
 
-export const TaskStatusBadge = ({ status, tasksCount }: TaskStatusBadgeProps) => {
-  const badgeConfig = buildBadgeConfig(status, tasksCount)
+export const TaskStatusBadge = ({ status, tasksCount, defaultStatus }: TaskStatusBadgeProps) => {
+  if (!status && !defaultStatus) {
+    return
+  }
+
+  const badgeConfig = buildBadgeConfig(status ?? defaultStatus, tasksCount)
 
   if (!badgeConfig) {
     return

--- a/src/components/Tasks/TasksPending.tsx
+++ b/src/components/Tasks/TasksPending.tsx
@@ -8,9 +8,16 @@ import { BookkeepingStatus } from '../BookkeepingStatus/BookkeepingStatus'
 import classNames from 'classnames'
 import { isComplete } from '../../types/tasks'
 import { BookkeepingStatusDescription } from '../BookkeepingStatus/BookkeepingStatusDescription'
+import { useLayerContext } from '../../contexts/LayerContext'
+import { isBusinessHistoricalMonth } from '../../utils/business'
 
 export const TasksPending = () => {
   const { currentMonthData, currentMonthDate } = useTasksContext()
+  const { business } = useLayerContext()
+
+  const defaultStatus = isBusinessHistoricalMonth(currentMonthDate, business)
+    ? 'IN_PROGRESS_AWAITING_BOOKKEEPER'
+    : undefined
 
   const completedTasks = currentMonthData?.tasks?.filter(task => isComplete(task.status)).length
 
@@ -81,12 +88,14 @@ export const TasksPending = () => {
           : null}
       </div>
       <div className='Layer__tasks-pending-main'>
-        {currentMonthData && (
-          <>
-            <BookkeepingStatus status={currentMonthData.status} month={currentMonthDate.getMonth()} emphasizeWarning />
-            <BookkeepingStatusDescription status={currentMonthData.status} month={currentMonthDate.getMonth()} />
-          </>
-        )}
+        {currentMonthData || defaultStatus
+          ? (
+            <>
+              <BookkeepingStatus status={currentMonthData?.status ?? defaultStatus} month={currentMonthDate.getMonth()} emphasizeWarning />
+              <BookkeepingStatusDescription status={currentMonthData?.status ?? defaultStatus} month={currentMonthDate.getMonth()} />
+            </>
+          )
+          : null}
       </div>
     </div>
   )

--- a/src/utils/business.ts
+++ b/src/utils/business.ts
@@ -1,5 +1,5 @@
 import { Business } from '../types'
-import { differenceInCalendarMonths, parseISO, startOfMonth } from 'date-fns'
+import { differenceInCalendarMonths, isAfter, isBefore, parseISO, startOfMonth } from 'date-fns'
 
 export const getActivationDate = (business?: Business) => {
   try {
@@ -36,4 +36,18 @@ export const isDateAllowedToBrowse = (date: Date, business?: Business) => {
   }
 
   return differenceInCalendarMonths(startOfMonth(date), activationDate) >= 0
+}
+
+export const isBusinessHistoricalMonth = (date: Date, business?: Business) => {
+  if (!business) {
+    return false
+  }
+
+  const earliestDateToBrowse = getEarliestDateToBrowse(business)
+
+  if (!earliestDateToBrowse) {
+    return false
+  }
+
+  return !isBefore(startOfMonth(date), earliestDateToBrowse) && !isAfter(startOfMonth(date), startOfMonth(new Date()))
 }


### PR DESCRIPTION
## Description

When Business activation date (ie. April 2023) is earlier than data for Bookkeeping (ie. Jan 2024), we didn't show any status (for months: Apr 2023 - Dec 2023).

With this PR, we show "Books in progress" as default option if no data for a given month is received from API.

## How this has been tested?

The business doesn't have bookkeeping data for 2023.

Before:

![image](https://github.com/user-attachments/assets/960fe02b-7067-4824-893f-5285023e3d35)


After:

![image](https://github.com/user-attachments/assets/c06b4781-cc6b-4ec5-9e74-c1354e9287cd)
