### PR TITLE
[LAY-1254] fix: add an empty state for business not enrolled in bookkeeping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.92-alpha",
+  "version": "0.1.92-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.92-alpha",
+      "version": "0.1.92-alpha.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.26.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.92-alpha",
+  "version": "0.1.92-alpha.1",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/components/Tasks/Tasks.tsx
+++ b/src/components/Tasks/Tasks.tsx
@@ -11,6 +11,11 @@ import { TasksPanelNotification } from './TasksPanelNotification'
 import { TasksYearsTabs } from './TasksYearsTabs'
 import { TasksContext, useTasksContext } from './TasksContext'
 import { useTasks } from '../../hooks/useTasks'
+import { ConditionalBlock } from '../utility/ConditionalBlock'
+import { TasksEmptyContainer } from './container/TasksEmptyContainer'
+import { P } from '../ui/Typography/Text'
+import { Heading } from '../ui/Typography/Heading'
+import { VStack } from '../ui/Stack/Stack'
 
 export interface TasksStringOverrides {
   header?: string
@@ -64,13 +69,28 @@ export const TasksComponent = ({
           !open && 'Layer__tasks__content--collapsed',
         )}
       >
-        {isLoading || !data
-          ? (
-            <div className='Layer__tasks__loader-container'>
+        <ConditionalBlock
+          data={data}
+          isLoading={isLoading}
+          Loading={(
+            <TasksEmptyContainer>
               <Loader />
-            </div>
-          )
-          : (
+            </TasksEmptyContainer>
+          )}
+          Inactive={(
+            <TasksEmptyContainer>
+              <VStack gap='sm' align='center'>
+                <Heading size='xs' level={4}>
+                  Not Enrolled in Bookkeeping
+                </Heading>
+                <P>
+                  If you believe this is an error, please contact support.
+                </P>
+              </VStack>
+            </TasksEmptyContainer>
+          )}
+        >
+          {() => (
             <>
               <TasksYearsTabs />
               <TasksMonthSelector />
@@ -78,6 +98,7 @@ export const TasksComponent = ({
               <TasksList mobile={mobile} />
             </>
           )}
+        </ConditionalBlock>
       </div>
     </div>
   )

--- a/src/components/Tasks/container/TasksEmptyContainer.tsx
+++ b/src/components/Tasks/container/TasksEmptyContainer.tsx
@@ -1,0 +1,11 @@
+import type { PropsWithChildren } from 'react'
+
+const CLASS_NAME = 'Layer__TasksEmptyContainer'
+
+export function TasksEmptyContainer({ children }: PropsWithChildren) {
+  return (
+    <div className={CLASS_NAME}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/Tasks/container/tasksEmptyContainer.scss
+++ b/src/components/Tasks/container/tasksEmptyContainer.scss
@@ -1,0 +1,5 @@
+.Layer__TasksEmptyContainer {
+  display: grid;
+  place-items: center;
+  min-block-size: 20rem;
+}

--- a/src/components/Tasks/tasks.scss
+++ b/src/components/Tasks/tasks.scss
@@ -1,3 +1,5 @@
+@forward './container/tasksEmptyContainer';
+
 .Layer__tasks-component {
   display: flex;
   flex-direction: column;

--- a/src/components/utility/ConditionalBlock.tsx
+++ b/src/components/utility/ConditionalBlock.tsx
@@ -1,0 +1,42 @@
+type ConditionalBlockProps<T> = {
+  data: T | undefined
+  children: React.FC<{ data: T }>
+} & ({
+  isLoading: boolean
+  Loading: React.ReactNode
+  Inactive: React.ReactNode
+} | {
+  isLoading?: never
+  Loading?: never
+  Inactive?: never
+}) & ({
+  isError: boolean
+  Error: React.ReactNode
+} | {
+  isError?: never
+  Error?: never
+})
+
+export function ConditionalBlock<T>({
+  data,
+  children,
+  isLoading,
+  Loading,
+  Inactive,
+  isError,
+  Error,
+}: ConditionalBlockProps<T>) {
+  if (isError) {
+    return Error
+  }
+
+  if (!data && isLoading) {
+    return Loading
+  }
+
+  if (!data) {
+    return Inactive
+  }
+
+  return children({ data })
+}

--- a/src/hooks/bookkeeping/periods/useBookkeepingPeriods.ts
+++ b/src/hooks/bookkeeping/periods/useBookkeepingPeriods.ts
@@ -3,11 +3,11 @@ import { useLayerContext } from '../../../contexts/LayerContext'
 import { useAuth } from '../../useAuth'
 import { get } from '../../../api/layer/authenticated_http'
 import {
-  isActiveBookkeepingStatus,
   useBookkeepingStatus,
 } from '../useBookkeepingStatus'
 import type { Task } from '../../../types/tasks'
 import type { EnumWithUnknownValues } from '../../../types/utility/enumWithUnknownValues'
+import { isActiveOrPausedBookkeepingStatus } from '../../../utils/bookkeeping/bookkeepingStatusFilters'
 
 const BOOKKEEPING_PERIOD_STATUSES = [
   'BOOKKEEPING_NOT_PURCHASED',
@@ -57,14 +57,14 @@ function buildKey({
   access_token: accessToken,
   apiUrl,
   businessId,
-  isActive,
+  isActiveOrPaused,
 }: {
   access_token?: string
   apiUrl?: string
   businessId: string
-  isActive: boolean
+  isActiveOrPaused: boolean
 }) {
-  if (accessToken && apiUrl && isActive) {
+  if (accessToken && apiUrl && isActiveOrPaused) {
     return {
       accessToken,
       apiUrl,
@@ -79,13 +79,13 @@ export function useBookkeepingPeriods() {
   const { businessId } = useLayerContext()
 
   const { data } = useBookkeepingStatus()
-  const isActive = data ? isActiveBookkeepingStatus(data.status) : false
+  const isActiveOrPaused = data ? isActiveOrPausedBookkeepingStatus(data.status) : false
 
   return useSWR(
     () => buildKey({
       ...auth,
       businessId,
-      isActive,
+      isActiveOrPaused,
     }),
     ({ accessToken, apiUrl, businessId }) => getBookkeepingPeriods(
       apiUrl,

--- a/src/hooks/bookkeeping/useBookkeepingStatus.ts
+++ b/src/hooks/bookkeeping/useBookkeepingStatus.ts
@@ -15,10 +15,6 @@ const BOOKKEEPING_STATUSES = [
 export type BookkeepingStatus = typeof BOOKKEEPING_STATUSES[number]
 type RawBookkeepingStatus = EnumWithUnknownValues<BookkeepingStatus>
 
-export function isActiveBookkeepingStatus(status: BookkeepingStatus) {
-  return status === 'ACTIVE' || status === 'ONBOARDING'
-}
-
 function constrainToKnownBookkeepingStatus(status: string): BookkeepingStatus {
   if (BOOKKEEPING_STATUSES.includes(status as BookkeepingStatus)) {
     return status as BookkeepingStatus

--- a/src/utils/bookkeeping/bookkeepingStatusFilters.ts
+++ b/src/utils/bookkeeping/bookkeepingStatusFilters.ts
@@ -1,0 +1,11 @@
+import type { BookkeepingStatus } from '../../hooks/bookkeeping/useBookkeepingStatus'
+
+type ActiveBookkeepingStatus = 'ACTIVE' | 'ONBOARDING'
+export function isActiveBookkeepingStatus(status: BookkeepingStatus): status is ActiveBookkeepingStatus {
+  return status === 'ACTIVE' || status === 'ONBOARDING'
+}
+
+type ActiveOrPausedBookkeepingStatus = ActiveBookkeepingStatus | 'BOOKKEEPING_PAUSED'
+export function isActiveOrPausedBookkeepingStatus(status: BookkeepingStatus): status is ActiveOrPausedBookkeepingStatus {
+  return isActiveBookkeepingStatus(status) || status === 'BOOKKEEPING_PAUSED'
+}


### PR DESCRIPTION
## Description

The `Bookkeeping Tasks` section appears to hang for businesses that are not enrolled in bookkeeping.

This fix has two major components:
- Churned bookkeeping businesses can still view their old tasks
- If a business is not enrolled, they will receive a reasonable inactive state.
