### PR TITLE
fix: filter out `COMPLETED` and `ARCHIVED` at the source

### DIFF
--- a/src/api/layer/tasks.ts
+++ b/src/api/layer/tasks.ts
@@ -1,23 +1,18 @@
 import { FileMetadata } from '../../types/file_upload'
-import { Task } from '../../types/tasks'
+import { RawTask } from '../../types/tasks'
 import { post, postWithFormData } from './authenticated_http'
 
-export const submitResponseToTask = post<{ data: Task }>(
+export const submitResponseToTask = post<{ data: RawTask }>(
   ({ businessId, taskId }) =>
     `/v1/businesses/${businessId}/tasks/${taskId}/user-response`,
 )
 
-export const updateUploadDocumentTaskDescription = post<{ data: Task }>(
+export const updateUploadDocumentTaskDescription = post<{ data: RawTask }>(
   ({ businessId, taskId }) =>
     `/v1/businesses/${businessId}/tasks/${taskId}/upload/update-description`,
 )
 
-export const markTaskAsComplete = post<{ data: Task }>(
-  ({ businessId, taskId }) =>
-    `/v1/businesses/${businessId}/tasks/${taskId}/complete`,
-)
-
-export const deleteTaskUploads = post<{ data: Task }>(
+export const deleteTaskUploads = post<{ data: RawTask }>(
   ({ businessId, taskId }) =>
     `/v1/businesses/${businessId}/tasks/${taskId}/upload/delete`,
 )

--- a/src/components/BookkeepingStatus/BookkeepingStatusReportRow.tsx
+++ b/src/components/BookkeepingStatus/BookkeepingStatusReportRow.tsx
@@ -5,9 +5,9 @@ import { format, getMonth } from 'date-fns'
 import { VStack } from '../ui/Stack/Stack'
 import { Button } from '../Button'
 import pluralize from 'pluralize'
-import { isComplete } from '../../types/tasks'
 import { HeaderRow } from '../Header/HeaderRow'
 import { HeaderCol } from '../Header/HeaderCol'
+import { isIncompleteTask } from '../../utils/bookkeeping/tasks/bookkeepingTasksFilters'
 
 type BookkeepingStatusReportRowProps = {
   currentDate: Date
@@ -21,7 +21,7 @@ export const BookkeepingStatusReportRow = ({ currentDate, onViewBookkeepingTasks
     return null
   }
 
-  const unresolvedTasksCount = data?.tasks.filter(task => !isComplete(task.status)).length
+  const unresolvedTasksCount = data?.tasks.filter(task => isIncompleteTask(task)).length
 
   const buildAction = () => {
     switch (status) {

--- a/src/components/Tasks/TasksListItem.tsx
+++ b/src/components/Tasks/TasksListItem.tsx
@@ -1,26 +1,25 @@
 import { useEffect, useMemo, useState } from 'react'
-import AlertCircle from '../../icons/AlertCircle'
-import Check from '../../icons/Check'
 import ChevronDownFill from '../../icons/ChevronDownFill'
-import { isComplete, Task } from '../../types/tasks'
 import { Button, ButtonVariant } from '../Button'
 import { FileInput } from '../Input'
 import { Textarea } from '../Textarea'
 import { Text, TextSize } from '../Typography'
 import classNames from 'classnames'
 import { useTasksContext } from './TasksContext'
+import { isCompletedTask, type UserVisibleTask } from '../../utils/bookkeeping/tasks/bookkeepingTasksFilters'
+import { getIconForTask } from '../../utils/bookkeeping/tasks/getBookkeepingTaskStatusIcon'
 
 export const TasksListItem = ({
   task,
   goToNextPageIfAllComplete,
   defaultOpen,
 }: {
-  task: Task
-  goToNextPageIfAllComplete: (task: Task) => void
+  task: UserVisibleTask
+  goToNextPageIfAllComplete: (task: UserVisibleTask) => void
   defaultOpen: boolean
 }) => {
   const [isOpen, setIsOpen] = useState(defaultOpen)
-  const [userResponse, setUserResponse] = useState(task.user_response || '')
+  const [userResponse, setUserResponse] = useState(task.user_response ?? '')
   const [selectedFiles, setSelectedFiles] = useState<File[]>()
 
   const {
@@ -31,12 +30,12 @@ export const TasksListItem = ({
   const taskBodyClassName = classNames(
     'Layer__tasks-list-item__body',
     isOpen && 'Layer__tasks-list-item__body--expanded',
-    isComplete(task.status) && 'Layer__tasks-list-item--completed',
+    isCompletedTask(task) && 'Layer__tasks-list-item--completed',
   )
 
   const taskHeadClassName = classNames(
     'Layer__tasks-list-item__head-info',
-    isComplete(task.status)
+    isCompletedTask(task)
       ? 'Layer__tasks-list-item--completed'
       : 'Layer__tasks-list-item--pending',
   )
@@ -134,13 +133,7 @@ export const TasksListItem = ({
         >
           <div className={taskHeadClassName}>
             <div className='Layer__tasks-list-item__head-info__status'>
-              {isComplete(task.status)
-                ? (
-                  <Check size={12} />
-                )
-                : (
-                  <AlertCircle size={12} />
-                )}
+              {getIconForTask(task)}
             </div>
             <Text size={TextSize.md}>{task.title}</Text>
           </div>

--- a/src/components/Tasks/TasksListMobile.tsx
+++ b/src/components/Tasks/TasksListMobile.tsx
@@ -2,16 +2,16 @@ import { Button } from '../Button/Button'
 import { MobilePanel } from '../MobilePanel/MobilePanel'
 import { TextButton } from '../Button'
 import { useState } from 'react'
-import { isComplete, Task } from '../../types/tasks'
 import { TasksListItem } from './TasksListItem'
 import { Pagination } from '../Pagination/Pagination'
+import { getIncompleteTasks, type UserVisibleTask } from '../../utils/bookkeeping/tasks/bookkeepingTasksFilters'
 
 const MOBILE_SHOW_UNRESOLVED_TASKS_COUNT = 2
 
 type TasksListMobileProps = {
   tasksCount: number
-  sortedTasks: Task[]
-  goToNextPage: (task: Task) => void
+  sortedTasks: ReadonlyArray<UserVisibleTask>
+  goToNextPage: (task: UserVisibleTask) => void
   indexFirstIncomplete: number
   currentPage: number
   pageSize: number
@@ -29,7 +29,7 @@ export const TasksListMobile = ({
 }: TasksListMobileProps) => {
   const [showMobilePanel, setShowMobilePanel] = useState(false)
 
-  const unresolvedTasks = sortedTasks?.filter(task => !isComplete(task.status)).slice(0, MOBILE_SHOW_UNRESOLVED_TASKS_COUNT)
+  const unresolvedTasks = getIncompleteTasks(sortedTasks).slice(0, MOBILE_SHOW_UNRESOLVED_TASKS_COUNT)
   const totalTasks = sortedTasks?.length
 
   return (

--- a/src/components/Tasks/TasksMonthSelector.tsx
+++ b/src/components/Tasks/TasksMonthSelector.tsx
@@ -5,7 +5,7 @@ import { TaskMonthTile } from './TaskMonthTile'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { getEarliestDateToBrowse } from '../../utils/business'
 import { useTasksContext } from './TasksContext'
-import { isComplete } from '../../types/tasks'
+import { getCompletedTasks } from '../../utils/bookkeeping/tasks/bookkeepingTasksFilters'
 
 const isCurrentMonth = (period: MonthData, currentDate: Date) =>
   getMonth(currentDate) === period.month - 1 && getYear(currentDate) === period.year
@@ -47,10 +47,10 @@ const TasksMonthSelector = () => {
         monthStr: format(date, 'MMM'),
         date,
         disabled,
-        completed: taskData.tasks?.filter(task => isComplete(task.status)).length,
+        completed: getCompletedTasks(taskData.tasks).length,
         total,
         ...taskData,
-      } as MonthData
+      } satisfies MonthData
     })
   }, [currentYearData, currentMonthDate, minDate])
 

--- a/src/components/Tasks/TasksPending.tsx
+++ b/src/components/Tasks/TasksPending.tsx
@@ -6,27 +6,29 @@ import { Heading, HeadingSize } from '../Typography/Heading'
 import { Text, TextSize } from '../Typography/Text'
 import { BookkeepingStatus } from '../BookkeepingStatus/BookkeepingStatus'
 import classNames from 'classnames'
-import { isComplete } from '../../types/tasks'
 import { BookkeepingStatusDescription } from '../BookkeepingStatus/BookkeepingStatusDescription'
+import { getCompletedTasks, getIncompleteTasks } from '../../utils/bookkeeping/tasks/bookkeepingTasksFilters'
 
 export const TasksPending = () => {
   const { currentMonthData, currentMonthDate } = useTasksContext()
 
-  const completedTasks = currentMonthData?.tasks?.filter(task => isComplete(task.status)).length
+  const totalTaskCount = currentMonthData?.tasks?.length ?? 0
+  const completedTaskCount = getCompletedTasks(currentMonthData?.tasks ?? []).length
+  const incompleteTaskCount = getIncompleteTasks(currentMonthData?.tasks ?? []).length
 
   const chartData = [
     {
       name: 'done',
-      value: completedTasks,
+      value: completedTaskCount,
     },
     {
       name: 'pending',
-      value: currentMonthData?.tasks?.filter(task => !isComplete(task.status)).length,
+      value: incompleteTaskCount,
     },
   ]
 
   const taskStatusClassName = classNames(
-    completedTasks && completedTasks > 0
+    completedTaskCount > 0
       ? 'Layer__tasks-pending-bar__status--done'
       : 'Layer__tasks-pending-bar__status--pending',
   )
@@ -39,9 +41,9 @@ export const TasksPending = () => {
           ? (
             <div className='Layer__tasks-pending-bar'>
               <Text size={TextSize.sm}>
-                <span className={taskStatusClassName}>{completedTasks}</span>
+                <span className={taskStatusClassName}>{completedTaskCount}</span>
                 /
-                {currentMonthData?.tasks?.length}
+                {totalTaskCount}
                 {' '}
                 done
               </Text>

--- a/src/components/Tasks/types.ts
+++ b/src/components/Tasks/types.ts
@@ -1,5 +1,5 @@
 import { BookkeepingPeriodStatus } from '../../hooks/bookkeeping/periods/useBookkeepingPeriods'
-import { Task } from '../../types/tasks'
+import type { UserVisibleTask } from '../../utils/bookkeeping/tasks/bookkeepingTasksFilters'
 
 export type MonthData = {
   monthStr: string
@@ -10,5 +10,5 @@ export type MonthData = {
   completed: number
   status?: BookkeepingPeriodStatus
   disabled?: boolean
-  tasks: Task[]
+  tasks: ReadonlyArray<UserVisibleTask>
 }

--- a/src/hooks/bookkeeping/periods/useBookkeepingPeriods.ts
+++ b/src/hooks/bookkeeping/periods/useBookkeepingPeriods.ts
@@ -5,9 +5,10 @@ import { get } from '../../../api/layer/authenticated_http'
 import {
   useBookkeepingStatus,
 } from '../useBookkeepingStatus'
-import type { Task } from '../../../types/tasks'
+import type { RawTask } from '../../../types/tasks'
 import type { EnumWithUnknownValues } from '../../../types/utility/enumWithUnknownValues'
 import { isActiveOrPausedBookkeepingStatus } from '../../../utils/bookkeeping/bookkeepingStatusFilters'
+import { getUserVisibleTasks } from '../../../utils/bookkeeping/tasks/bookkeepingTasksFilters'
 
 const BOOKKEEPING_PERIOD_STATUSES = [
   'BOOKKEEPING_NOT_PURCHASED',
@@ -39,7 +40,7 @@ type RawBookkeepingPeriod = {
   month: number
   year: number
   status: RawBookkeepingPeriodStatus
-  tasks: ReadonlyArray<Task>
+  tasks: ReadonlyArray<RawTask>
 }
 
 const getBookkeepingPeriods = get<
@@ -97,6 +98,7 @@ export function useBookkeepingPeriods() {
           periods.map(period => ({
             ...period,
             status: constrainToKnownBookkeepingPeriodStatus(period.status),
+            tasks: getUserVisibleTasks(period.tasks),
           })),
       ),
   )

--- a/src/hooks/bookkeeping/periods/useBookkeepingYearsStatus.ts
+++ b/src/hooks/bookkeeping/periods/useBookkeepingYearsStatus.ts
@@ -3,7 +3,7 @@ import { useBookkeepingPeriods } from './useBookkeepingPeriods'
 import { useLayerContext } from '../../../contexts/LayerContext/LayerContext'
 import { getActivationDate } from '../../../utils/business'
 import { getYear } from 'date-fns'
-import { isComplete, Task } from '../../../types/tasks'
+import { isIncompleteTask, type UserVisibleTask } from '../../../utils/bookkeeping/tasks/bookkeepingTasksFilters'
 
 export const useBookkeepingYearsStatus = () => {
   const { business } = useLayerContext()
@@ -19,9 +19,11 @@ export const useBookkeepingYearsStatus = () => {
     return Array.from({ length: count }, (_, index) => ({
       year: startYear + index,
     })).map((d) => {
-      const tasks = data?.filter(period => period.year === d.year).reduce((acc, period) => acc.concat(period.tasks ?? []), [] as Task[])
+      const tasks = data
+        ?.filter(period => period.year === d.year)
+        .reduce((acc, period) => acc.concat(period.tasks), [] as Array<UserVisibleTask>)
 
-      const unresolvedTasks = tasks?.filter(task => !isComplete(task.status)).length
+      const unresolvedTasks = tasks?.filter(task => isIncompleteTask(task)).length
 
       return {
         ...d,

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -5,13 +5,12 @@ type Document = {
   document_type: DocumentType
   file_name: string
   presigned_url: S3PresignedUrl
-  // add the other fields if/when necessary
 }
 
-export type Task = {
+export type RawTask = {
   id: string
   question: string
-  status: TasksStatusType
+  status: TasksStatus
   title: string
   transaction_id: string | null
   type: string
@@ -27,11 +26,12 @@ export type Task = {
   documents: Document[]
 }
 
-export type TasksStatusType = 'COMPLETED' | 'TODO' | 'USER_MARKED_COMPLETED'
+const _TASKS_STATUSES = [
+  'TODO',
+  'USER_MARKED_COMPLETED',
+  'COMPLETED',
+  'ARCHIVED',
+] as const
+
+export type TasksStatus = typeof _TASKS_STATUSES[number]
 export type TasksResponseType = 'FREE_RESPONSE' | 'UPLOAD_DOCUMENT'
-
-const COMPLETED_TASK_TYPES = ['COMPLETED', 'USER_MARKED_COMPLETED']
-
-export function isComplete(taskType: TasksStatusType) {
-  return COMPLETED_TASK_TYPES.includes(taskType)
-}

--- a/src/utils/bookkeeping/tasks/bookkeepingTasksFilters.ts
+++ b/src/utils/bookkeeping/tasks/bookkeepingTasksFilters.ts
@@ -1,0 +1,52 @@
+import type { RawTask, TasksStatus } from '../../../types/tasks'
+
+export function isIncompleteTask<T extends Pick<RawTask, 'status'>>(
+  task: T,
+): task is T & { status: 'TODO' } {
+  const { status } = task
+
+  return status === 'TODO'
+}
+
+export function getIncompleteTasks<T extends Pick<RawTask, 'status'>>(
+  tasks: ReadonlyArray<T>,
+) {
+  return tasks.filter(task => isIncompleteTask(task))
+}
+
+type UserVisibleTaskStatus = Exclude<TasksStatus, 'COMPLETED' | 'ARCHIVED'>
+export type UserVisibleTask = RawTask & { status: UserVisibleTaskStatus }
+
+function isUserVisibleTask<T extends Pick<RawTask, 'status'>>(
+  task: T,
+): task is T & { status: UserVisibleTaskStatus } {
+  const { status } = task
+
+  return status !== 'COMPLETED' && status !== 'ARCHIVED'
+}
+
+export function getUserVisibleTasks<T extends Pick<RawTask, 'status'>>(
+  tasks: ReadonlyArray<T>,
+) {
+  return tasks.filter(task => isUserVisibleTask(task))
+}
+
+type CompletedTaskStatus = Exclude<TasksStatus, 'TODO'>
+
+export function isCompletedTask<T extends Pick<RawTask, 'status'>>(
+  task: T,
+): task is T & { status: CompletedTaskStatus } {
+  const { status } = task
+
+  return (
+    status === 'USER_MARKED_COMPLETED'
+    || status === 'COMPLETED'
+    || status === 'ARCHIVED'
+  )
+}
+
+export function getCompletedTasks<T extends Pick<RawTask, 'status'>>(
+  tasks: ReadonlyArray<T>,
+) {
+  return tasks.filter(task => isCompletedTask(task))
+}

--- a/src/utils/bookkeeping/tasks/getBookkeepingTaskStatusIcon.tsx
+++ b/src/utils/bookkeeping/tasks/getBookkeepingTaskStatusIcon.tsx
@@ -1,0 +1,22 @@
+import AlertCircle from '../../../icons/AlertCircle'
+import Check from '../../../icons/Check'
+import type { RawTask } from '../../../types/tasks'
+
+const STATUS_TO_ICON_MAP = {
+  TODO: {
+    icon: <AlertCircle size={12} />,
+  },
+  USER_MARKED_COMPLETED: {
+    icon: <Check size={12} />,
+  },
+  COMPLETED: {
+    icon: null,
+  },
+  ARCHIVED: {
+    icon: null,
+  },
+} as const
+
+export function getIconForTask(task: Pick<RawTask, 'status'>) {
+  return STATUS_TO_ICON_MAP[task.status].icon
+}


### PR DESCRIPTION
## Description

**Motivation** - the `periods` endpoint is returning `ARCHIVED` tasks. It has not been our attention to show archived tasks.