### PR TITLE
fix: prevent jumping layout in bookkeeping overview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.92-alpha.3",
+  "version": "0.1.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.92-alpha.3",
+      "version": "0.1.92",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.26.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.92-alpha.3",
+  "version": "0.1.92",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/hooks/useKeepInMobileViewport.tsx
+++ b/src/hooks/useKeepInMobileViewport.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef } from 'react'
+
+export const useKeepInMobileViewport = () => {
+  const upperContentRef = useRef<HTMLDivElement>(null)
+  const targetElementRef = useRef<HTMLDivElement>(null)
+  const lastKnownSizeRef = useRef<number | null>(null)
+  const lastKnownTargetPositionRef = useRef<number | null>(null)
+  const upperElementInFocus = useRef<boolean | null>(false)
+
+  useEffect(() => {
+    if (!upperContentRef.current || !targetElementRef.current) return
+
+    lastKnownSizeRef.current = upperContentRef.current.getBoundingClientRect().height
+    lastKnownTargetPositionRef.current = targetElementRef.current.getBoundingClientRect().top
+
+    // Use observer to detect upper element content changes
+    const resizeObserver = new ResizeObserver(() => {
+      if (!upperContentRef.current || !targetElementRef.current) return
+
+      const currentSize = upperContentRef.current.getBoundingClientRect().height
+      const currentTargetPosition = targetElementRef.current.getBoundingClientRect().top
+
+      if (lastKnownSizeRef.current !== null && lastKnownTargetPositionRef.current !== null) {
+        const sizeDelta = currentSize - lastKnownSizeRef.current
+
+        // Only adjust if size actually changed and we're scrolled down enough
+        // that the target element is in or near the viewport
+        if (sizeDelta !== 0 && currentTargetPosition < window.innerHeight) {
+          const positionDelta = currentTargetPosition - lastKnownTargetPositionRef.current
+
+          // Adjust scroll to maintain target element position but only if the upper element is not in "focus"
+          if (upperElementInFocus.current === false) {
+            window.scrollBy(0, positionDelta)
+          }
+
+          // After scroll adjustment, update the target position reference
+          requestAnimationFrame(() => {
+            if (targetElementRef.current) {
+              lastKnownTargetPositionRef.current = targetElementRef.current.getBoundingClientRect().top
+            }
+          })
+        }
+      }
+
+      lastKnownSizeRef.current = currentSize
+    })
+
+    if (upperContentRef.current) {
+      resizeObserver.observe(upperContentRef.current)
+    }
+
+    // Observe scroll events to update our target position reference
+    const handleScroll = () => {
+      if (targetElementRef.current) {
+        lastKnownTargetPositionRef.current = targetElementRef.current.getBoundingClientRect().top
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true })
+
+    return () => {
+      if (upperContentRef.current) {
+        resizeObserver.unobserve(upperContentRef.current)
+      }
+      window.removeEventListener('scroll', handleScroll)
+    }
+  }, [])
+
+  return {
+    upperContentRef,
+    targetElementRef,
+    upperElementInFocus,
+  }
+}

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -10,7 +10,7 @@ import { useWindowSize } from '../../hooks/useWindowSize'
 import { Variants } from '../../utils/styleUtils/sizeVariants'
 import { BookkeepingProfitAndLossSummariesContainer } from './internal/BookkeepingProfitAndLossSummariesContainer'
 import classNames from 'classnames'
-import { useKeepInMobileViewport } from '../../hooks/useKeepInMobileViewport'
+import { useKeepInMobileViewport } from './useKeepInMobileViewport'
 
 export interface BookkeepingOverviewProps {
   showTitle?: boolean
@@ -60,12 +60,12 @@ export const BookkeepingOverview = ({
         sidebar={<Tasks stringOverrides={stringOverrides?.tasks} />}
         showHeader={showTitle}
       >
-        <div ref={upperContentRef} onPointerEnter={() => upperElementInFocus.current = true}>
+        <div ref={upperContentRef} onClick={() => upperElementInFocus.current = true}>
           {width <= 1100 && (
             <Tasks mobile stringOverrides={stringOverrides?.tasks} />
           )}
         </div>
-        <div ref={targetElementRef} onPointerEnter={() => upperElementInFocus.current = false}>
+        <div ref={targetElementRef} onClick={() => upperElementInFocus.current = false}>
           <Container
             name='bookkeeping-overview-profit-and-loss'
             asWidget

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -10,6 +10,7 @@ import { useWindowSize } from '../../hooks/useWindowSize'
 import { Variants } from '../../utils/styleUtils/sizeVariants'
 import { BookkeepingProfitAndLossSummariesContainer } from './internal/BookkeepingProfitAndLossSummariesContainer'
 import classNames from 'classnames'
+import { useKeepInMobileViewport } from '../../hooks/useKeepInMobileViewport'
 
 export interface BookkeepingOverviewProps {
   showTitle?: boolean
@@ -48,6 +49,12 @@ export const BookkeepingOverview = ({
 
   const profitAndLossSummariesVariants = slotProps?.profitAndLoss?.summaries?.variants
 
+  const {
+    upperContentRef,
+    targetElementRef,
+    upperElementInFocus,
+  } = useKeepInMobileViewport()
+
   return (
     <ProfitAndLoss asContainer={false}>
       <View
@@ -57,27 +64,45 @@ export const BookkeepingOverview = ({
         sidebar={<Tasks stringOverrides={stringOverrides?.tasks} />}
         showHeader={showTitle}
       >
-        {width <= 1100 && (
-          <Tasks mobile stringOverrides={stringOverrides?.tasks} />
-        )}
-        <Container
-          name='bookkeeping-overview-profit-and-loss'
-          asWidget
-          elevated={true}
+        <div
+          ref={upperContentRef}
+          onTouchStart={() => upperElementInFocus.current = true}
+          onMouseLeave={() => upperElementInFocus.current = true}
+          onClick={() => upperElementInFocus.current = true}
         >
-          <ProfitAndLoss.Header
-            text={stringOverrides?.profitAndLoss?.header || 'Profit & Loss'}
-            withDatePicker
-            withStatus
-          />
-          <BookkeepingProfitAndLossSummariesContainer>
-            <ProfitAndLoss.Summaries
-              stringOverrides={stringOverrides?.profitAndLoss?.summaries}
-              variants={profitAndLossSummariesVariants}
+          {width <= 1100 && (
+            <Tasks mobile stringOverrides={stringOverrides?.tasks} />
+          )}
+        </div>
+        <div
+          ref={targetElementRef}
+          onTouchStart={() => upperElementInFocus.current = false}
+          onMouseLeave={() => upperElementInFocus.current = false}
+          onClick={() => upperElementInFocus.current = false}
+        >
+          <Container
+            name='bookkeeping-overview-profit-and-loss'
+            asWidget
+            elevated={true}
+            style={{
+              position: 'relative',
+              zIndex: 2,
+            }}
+          >
+            <ProfitAndLoss.Header
+              text={stringOverrides?.profitAndLoss?.header || 'Profit & Loss'}
+              withDatePicker
+              withStatus
             />
-          </BookkeepingProfitAndLossSummariesContainer>
-          <ProfitAndLoss.Chart />
-        </Container>
+            <BookkeepingProfitAndLossSummariesContainer>
+              <ProfitAndLoss.Summaries
+                stringOverrides={stringOverrides?.profitAndLoss?.summaries}
+                variants={profitAndLossSummariesVariants}
+              />
+            </BookkeepingProfitAndLossSummariesContainer>
+            <ProfitAndLoss.Chart />
+          </Container>
+        </div>
         <div className='Layer__bookkeeping-overview-profit-and-loss-charts'>
           <Toggle
             name='pnl-detailed-charts'

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -49,11 +49,7 @@ export const BookkeepingOverview = ({
 
   const profitAndLossSummariesVariants = slotProps?.profitAndLoss?.summaries?.variants
 
-  const {
-    upperContentRef,
-    targetElementRef,
-    upperElementInFocus,
-  } = useKeepInMobileViewport()
+  const { upperContentRef, targetElementRef, upperElementInFocus } = useKeepInMobileViewport()
 
   return (
     <ProfitAndLoss asContainer={false}>
@@ -64,22 +60,12 @@ export const BookkeepingOverview = ({
         sidebar={<Tasks stringOverrides={stringOverrides?.tasks} />}
         showHeader={showTitle}
       >
-        <div
-          ref={upperContentRef}
-          onTouchStart={() => upperElementInFocus.current = true}
-          onMouseLeave={() => upperElementInFocus.current = true}
-          onClick={() => upperElementInFocus.current = true}
-        >
+        <div ref={upperContentRef} onPointerEnter={() => upperElementInFocus.current = true}>
           {width <= 1100 && (
             <Tasks mobile stringOverrides={stringOverrides?.tasks} />
           )}
         </div>
-        <div
-          ref={targetElementRef}
-          onTouchStart={() => upperElementInFocus.current = false}
-          onMouseLeave={() => upperElementInFocus.current = false}
-          onClick={() => upperElementInFocus.current = false}
-        >
+        <div ref={targetElementRef} onPointerEnter={() => upperElementInFocus.current = false}>
           <Container
             name='bookkeeping-overview-profit-and-loss'
             asWidget

--- a/src/views/BookkeepingOverview/useKeepInMobileViewport.tsx
+++ b/src/views/BookkeepingOverview/useKeepInMobileViewport.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from 'react'
 
+const TASKS_MOBILE_VIEWPORT_WIDTH = 1100
+
 export const useKeepInMobileViewport = () => {
   const upperContentRef = useRef<HTMLDivElement>(null)
   const targetElementRef = useRef<HTMLDivElement>(null)
@@ -25,11 +27,12 @@ export const useKeepInMobileViewport = () => {
 
         // Only adjust if size actually changed and we're scrolled down enough
         // that the target element is in or near the viewport
-        if (sizeDelta !== 0 && currentTargetPosition < window.innerHeight) {
+        if (sizeDelta !== 0 && window.innerWidth <= TASKS_MOBILE_VIEWPORT_WIDTH) {
           const positionDelta = currentTargetPosition - lastKnownTargetPositionRef.current
 
           // Adjust scroll to maintain target element position but only if the upper element is not in "focus"
           if (upperElementInFocus.current === false) {
+            console.log('scroll', positionDelta)
             window.scrollBy(0, positionDelta)
           }
 

--- a/src/views/BookkeepingOverview/useKeepInMobileViewport.tsx
+++ b/src/views/BookkeepingOverview/useKeepInMobileViewport.tsx
@@ -32,7 +32,6 @@ export const useKeepInMobileViewport = () => {
 
           // Adjust scroll to maintain target element position but only if the upper element is not in "focus"
           if (upperElementInFocus.current === false) {
-            console.log('scroll', positionDelta)
             window.scrollBy(0, positionDelta)
           }
 


### PR DESCRIPTION
## Description

This PR adds hook observing `upper` element size and adjusts the page scroll to keep the `target` in the same spot of the viewport.


The usage:

```tsx
const { upperContentRef, targetElementRef, upperElementInFocus } = useKeepInMobileViewport()

return (
  <>
   <div ref={upperContentRef} onPointerEnter={() => upperElementInFocus.current = true}>
    {...}
   </div>

    <div ref={targetElementRef} onPointerEnter={() => upperElementInFocus.current = false}>
       {...} 
    </div>
  </>
)
```

---

To discuss:

We can leverage this into more reusable component, something like this:

```tsx
import { StickyMobileScroll } from '../components/StickyMobileScroll'

return (
   <StickyMobileScroll upperElement={<div>...</div>}>
      <div>Target element</div>
  </StickyMobileScroll>
}
```

...and add prop for which we disable behavior.

However, making this as a local hook dedicated just for Bookkeeping Overview also makes sense to me at this point, because I don't foresee other use cases.


## How this has been tested?



https://github.com/user-attachments/assets/473b3cac-46af-4b83-9d9e-7b09e3181402



