### PR TITLE
[LAY-1253] fix: disable selecting not purchased periods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.92-alpha.1",
+  "version": "0.1.92-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.92-alpha.1",
+      "version": "0.1.92-alpha.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.26.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.92-alpha.1",
+  "version": "0.1.92-alpha.2",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/components/BookkeepingStatus/BookkeepingStatus.tsx
+++ b/src/components/BookkeepingStatus/BookkeepingStatus.tsx
@@ -1,7 +1,7 @@
 import { BookkeepingPeriodStatus } from '../../hooks/bookkeeping/periods/useBookkeepingPeriods'
 import { Text, TextSize } from '../Typography/Text'
 import { toDataProperties } from '../../utils/styleUtils/toDataProperties'
-import { buildStatus } from './utils'
+import { getBookkeepingStatusConfig } from './utils'
 
 type BookkeepingStatusProps = {
   month?: number
@@ -15,8 +15,7 @@ export const BookkeepingStatus = ({ status, month, emphasizeWarning, iconOnly }:
     return
   }
 
-  const statusConfig = buildStatus(status, month)
-
+  const statusConfig = getBookkeepingStatusConfig({ status, month })
   if (!statusConfig) {
     return
   }
@@ -30,7 +29,13 @@ export const BookkeepingStatus = ({ status, month, emphasizeWarning, iconOnly }:
         {statusConfig.icon}
       </span>
       {!iconOnly && (
-        <Text size={TextSize.sm} status={statusConfig.color} invertColor={emphasize}>{statusConfig.label}</Text>
+        <Text
+          size={TextSize.sm}
+          status={statusConfig.color}
+          invertColor={emphasize}
+        >
+          {statusConfig.label}
+        </Text>
       )}
     </span>
   )

--- a/src/components/BookkeepingStatus/BookkeepingStatusDescription.tsx
+++ b/src/components/BookkeepingStatus/BookkeepingStatusDescription.tsx
@@ -1,18 +1,22 @@
 import { BookkeepingPeriodStatus } from '../../hooks/bookkeeping/periods/useBookkeepingPeriods'
 import { Text, TextSize } from '../Typography/Text'
-import { buildStatus } from './utils'
+import { getBookkeepingStatusConfig } from './utils'
 
 type BookkeepingStatusDescriptionProps = {
-  month?: number
-  status?: BookkeepingPeriodStatus
+  month: number
+  status: BookkeepingPeriodStatus
+  incompleteTasksCount: number
 }
 
-export const BookkeepingStatusDescription = ({ month, status }: BookkeepingStatusDescriptionProps) => {
-  if (!status || month === undefined) {
-    return
+export const BookkeepingStatusDescription = ({ month, status, incompleteTasksCount }: BookkeepingStatusDescriptionProps) => {
+  const statusConfig = getBookkeepingStatusConfig({ status, month, incompleteTasksCount })
+  if (!statusConfig) {
+    return null
   }
 
   return (
-    <Text size={TextSize.sm} status='disabled'>{buildStatus(status, month)?.description}</Text>
+    <Text size={TextSize.sm} status='disabled'>
+      {statusConfig.description}
+    </Text>
   )
 }

--- a/src/components/BookkeepingStatus/utils.tsx
+++ b/src/components/BookkeepingStatus/utils.tsx
@@ -6,30 +6,45 @@ import AlertCircle from '../../icons/AlertCircle'
 import Clock from '../../icons/Clock'
 import CheckCircle from '../../icons/CheckCircle'
 import { safeAssertUnreachable } from '../../utils/switch/safeAssertUnreachable'
+import pluralize from 'pluralize'
 
 type InternalStatusConfig = {
   label: string
   description: string
   color: TextStatus
   icon: ReactNode
-} | undefined
+}
 
-export const buildStatus = (status: BookkeepingPeriodStatus, month: number): InternalStatusConfig => {
+type BookkeepingStatusConfigOptions = {
+  status: BookkeepingPeriodStatus
+  month: number
+  incompleteTasksCount?: number
+}
+
+export function getBookkeepingStatusConfig({
+  status,
+  month,
+  incompleteTasksCount,
+}: BookkeepingStatusConfigOptions): InternalStatusConfig | undefined {
   const monthName = getMonthNameFromNumber(month)
+
+  const actionPhrase = incompleteTasksCount !== undefined && incompleteTasksCount > 0
+    ? `Please complete the ${pluralize('open task', incompleteTasksCount, true)}.`
+    : 'No action is needed from you right now.'
 
   switch (status) {
     case 'IN_PROGRESS_AWAITING_BOOKKEEPER':
     case 'NOT_STARTED':
       return {
         label: 'Books in progress',
-        description: `We're working on your ${monthName} books. No action is needed from you right now.`,
-        color: 'info' as TextStatus,
+        description: `We're working on your ${monthName} books. ${actionPhrase}`,
+        color: 'info',
         icon: <Clock size={12} />,
       }
     case 'CLOSING_IN_REVIEW':
       return {
         label: 'Books in review',
-        description: `We're working on your ${monthName} books. No action is needed from you right now.`,
+        description: `We're working on your ${monthName} books. ${actionPhrase}`,
         color: 'info',
         icon: <Clock size={12} />,
       }

--- a/src/components/Tasks/TaskStatusBadge.tsx
+++ b/src/components/Tasks/TaskStatusBadge.tsx
@@ -1,6 +1,6 @@
 import AlertCircle from '../../icons/AlertCircle'
 import Clock from '../../icons/Clock'
-import { Text, TextSize, TextStatus, TextWeight } from '../Typography/Text'
+import { Text, TextSize, TextWeight } from '../Typography/Text'
 import CheckCircle from '../../icons/CheckCircle'
 import { BookkeepingPeriod } from '../../hooks/bookkeeping/periods/useBookkeepingPeriods'
 import pluralize from 'pluralize'
@@ -17,26 +17,28 @@ const buildBadgeConfig = (status: TaskStatusBadgeProps['status'], tasksCount: Ta
     case 'NOT_STARTED':
     case 'CLOSING_IN_REVIEW':
       return {
-        color: 'info' as TextStatus,
+        color: 'info' as const,
         icon: <Clock size={12} />,
+        label: tasksCount ? pluralize('task', tasksCount, true) : undefined,
+        labelShort: tasksCount ? `${tasksCount}` : undefined,
       }
     case 'IN_PROGRESS_AWAITING_CUSTOMER':
       return {
+        color: 'warning' as const,
         label: pluralize('task', tasksCount, true),
         labelShort: `${tasksCount}`,
-        color: 'warning' as TextStatus,
         icon: <AlertCircle size={12} />,
       }
     case 'CLOSED_OPEN_TASKS':
       return {
+        color: 'error' as const,
         label: pluralize('task', tasksCount, true),
         labelShort: `${tasksCount}`,
-        color: 'error' as TextStatus,
         icon: <AlertCircle size={12} />,
       }
     case 'CLOSED_COMPLETE':
       return {
-        color: 'success' as TextStatus,
+        color: 'success' as const,
         icon: <CheckCircle size={12} />,
       }
   }
@@ -66,7 +68,7 @@ export const TaskStatusBadge = ({ status, tasksCount }: TaskStatusBadgeProps) =>
           className='Layer__tasks__badge__label'
           size={TextSize.sm}
           status={badgeConfig.color}
-          invertColor
+          invertColor={badgeConfig.color === 'warning'}
           weight={TextWeight.bold}
         >
           {badgeConfig.label}
@@ -77,7 +79,7 @@ export const TaskStatusBadge = ({ status, tasksCount }: TaskStatusBadgeProps) =>
           className='Layer__tasks__badge__label-short'
           size={TextSize.sm}
           status={badgeConfig.color}
-          invertColor
+          invertColor={badgeConfig.color === 'warning'}
           weight={TextWeight.bold}
         >
           {badgeConfig.labelShort}

--- a/src/components/Tasks/TasksPending.tsx
+++ b/src/components/Tasks/TasksPending.tsx
@@ -86,7 +86,11 @@ export const TasksPending = () => {
         {currentMonthData && (
           <>
             <BookkeepingStatus status={currentMonthData.status} month={currentMonthDate.getMonth()} emphasizeWarning />
-            <BookkeepingStatusDescription status={currentMonthData.status} month={currentMonthDate.getMonth()} />
+            <BookkeepingStatusDescription
+              status={currentMonthData.status}
+              month={currentMonthDate.getMonth()}
+              incompleteTasksCount={incompleteTaskCount}
+            />
           </>
         )}
       </div>


### PR DESCRIPTION
## Description

This fix is instead to supersede #551. It includes a partial fix for LAY-1255, as periods in review will more aggressively prompt with incomplete tasks.