### PR TITLE
Daniel/export excels by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.92",
+  "version": "0.1.93-alpha",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/api/layer.ts
+++ b/src/api/layer.ts
@@ -1,8 +1,9 @@
-import { getBalanceSheet } from './layer/balance_sheet'
+import { getBalanceSheet, getBalanceSheetCSV, getBalanceSheetExcel } from './layer/balance_sheet'
 import {
   categorizeBankTransaction,
   matchBankTransaction,
   getBankTransactionsCsv,
+  getBankTransactionsExcel,
   getBankTransactionMetadata,
   updateBankTransactionMetadata,
   listBankTransactionDocuments,
@@ -46,6 +47,7 @@ import {
   getProfitAndLoss,
   getProfitAndLossSummaries,
   getProfitAndLossCsv,
+  getProfitAndLossExcel,
   compareProfitAndLoss,
   profitAndLossComparisonCsv,
 } from './layer/profit_and_loss'
@@ -66,7 +68,10 @@ export const Layer = {
   createAccount,
   updateAccount,
   getBalanceSheet,
+  getBalanceSheetCSV,
+  getBalanceSheetExcel,
   getBankTransactionsCsv,
+  getBankTransactionsExcel,
   getBankTransactionMetadata,
   listBankTransactionDocuments,
   getBankTransactionDocument,
@@ -86,6 +91,7 @@ export const Layer = {
   getProfitAndLoss,
   getProfitAndLossSummaries,
   getProfitAndLossCsv,
+  getProfitAndLossExcel,
   getLinkedAccounts,
   getJournal,
   getJournalEntriesCSV,

--- a/src/api/layer/balance_sheet.ts
+++ b/src/api/layer/balance_sheet.ts
@@ -29,3 +29,14 @@ export const getBalanceSheetCSV = get<
     return `/v1/businesses/${businessId}/reports/balance-sheet/exports/csv?${parameters}`
   },
 )
+
+export const getBalanceSheetExcel = get<
+  { data: S3PresignedUrl },
+  GetBalanceSheetParams
+>(
+  ({ businessId, effectiveDate }) => {
+    const parameters = toDefinedSearchParameters({ effectiveDate })
+
+    return `/v1/businesses/${businessId}/reports/balance-sheet/exports/excel?${parameters}`
+  },
+)

--- a/src/api/layer/bankTransactions.ts
+++ b/src/api/layer/bankTransactions.ts
@@ -81,7 +81,7 @@ export const matchBankTransaction = put<
     `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/match`,
 )
 
-export interface GetBankTransactionsCsvParams
+export interface GetBankTransactionsExportParams
   extends Record<string, string | undefined> {
   businessId: string
   startDate?: string
@@ -97,8 +97,23 @@ export const getBankTransactionsCsv = get<{
   error?: unknown
 }>((params: Record<string, string | undefined>) => {
   const { businessId, startDate, endDate, categorized, category, month, year } =
-    params as GetBankTransactionsCsvParams // Type assertion here for clarity
+    params as GetBankTransactionsExportParams // Type assertion here for clarity
   return `/v1/businesses/${businessId}/reports/transactions/exports/csv?${
+    startDate ? `start_date=${encodeURIComponent(startDate)}&` : ''
+  }${endDate ? `end_date=${encodeURIComponent(endDate)}&` : ''}${
+    month ? `month=${encodeURIComponent(month)}&` : ''
+  }${year ? `year=${encodeURIComponent(year)}&` : ''}${
+    categorized ? `categorized=${categorized}&` : ''
+  }${category ? `category=${encodeURIComponent(category)}&` : ''}`
+})
+
+export const getBankTransactionsExcel = get<{
+  data?: S3PresignedUrl
+  error?: unknown
+}>((params: Record<string, string | undefined>) => {
+  const { businessId, startDate, endDate, categorized, category, month, year } =
+    params as GetBankTransactionsExportParams // Type assertion here for clarity
+  return `/v1/businesses/${businessId}/reports/transactions/exports/excel?${
     startDate ? `start_date=${encodeURIComponent(startDate)}&` : ''
   }${endDate ? `end_date=${encodeURIComponent(endDate)}&` : ''}${
     month ? `month=${encodeURIComponent(month)}&` : ''

--- a/src/api/layer/profit_and_loss.ts
+++ b/src/api/layer/profit_and_loss.ts
@@ -96,6 +96,24 @@ export const getProfitAndLossCsv = (apiUrl: string, accessToken: string | undefi
   )(apiUrl, accessToken, { params: { businessId } })
 }
 
+export const getProfitAndLossExcel = (apiUrl: string, accessToken: string | undefined, params: GetProfitAndLossCsvParams) => {
+  const { businessId, startDate, endDate, month, year, tagKey, tagValues, reportingBasis, moneyFormat } = params
+  return get<{
+    data?: S3PresignedUrl
+    error?: unknown
+  }>(({ businessId }) =>
+    `/v1/businesses/${businessId}/reports/profit-and-loss/exports/excel?${
+      startDate ? `start_date=${encodeURIComponent(toLocalDateString(startDate))}` : ''
+    }${endDate ? `&end_date=${encodeURIComponent(toLocalDateString(endDate))}` : ''}${
+      month ? `&month=${month}` : ''
+    }${year ? `&year=${year}` : ''}${
+      reportingBasis ? `&reporting_basis=${reportingBasis}` : ''
+    }${tagKey ? `&tag_key=${tagKey}` : ''}${
+      tagValues ? `&tag_values=${tagValues}` : ''
+    }${moneyFormat ? `&money_format=${moneyFormat}` : ''}`,
+  )(apiUrl, accessToken, { params: { businessId } })
+}
+
 export const profitAndLossComparisonCsv = post<{
   data?: S3PresignedUrl
   error?: unknown

--- a/src/components/BalanceSheet/download/useBalanceSheetDownload.ts
+++ b/src/components/BalanceSheet/download/useBalanceSheetDownload.ts
@@ -1,7 +1,7 @@
 import useSWRMutation from 'swr/mutation'
 import { useLayerContext } from '../../../contexts/LayerContext'
 import { useAuth } from '../../../hooks/useAuth'
-import { getBalanceSheetCSV } from '../../../api/layer/balance_sheet'
+import { getBalanceSheetExcel } from '../../../api/layer/balance_sheet'
 import type { S3PresignedUrl } from '../../../types/general'
 import type { Awaitable } from '../../../types/utility/promises'
 
@@ -22,7 +22,7 @@ function buildKey({
       apiUrl,
       businessId,
       effectiveDate,
-      tags: ['#balance-sheet', '#exports', '#csv'],
+      tags: ['#balance-sheet', '#exports', '#excel'],
     }
   }
 }
@@ -45,7 +45,7 @@ export function useBalanceSheetDownload({
       businessId,
       effectiveDate,
     }),
-    ({ accessToken, apiUrl, businessId, effectiveDate }) => getBalanceSheetCSV(
+    ({ accessToken, apiUrl, businessId, effectiveDate }) => getBalanceSheetExcel(
       apiUrl,
       accessToken,
       {

--- a/src/components/BankTransactions/BankTransactionsHeader.tsx
+++ b/src/components/BankTransactions/BankTransactionsHeader.tsx
@@ -54,7 +54,7 @@ const DownloadButton = ({
   const handleClick = async () => {
     setIsDownloading(true)
     const currentYear = new Date().getFullYear().toString()
-    const getBankTransactionsCsv = Layer.getBankTransactionsCsv(
+    const getBankTransactionsExcel = Layer.getBankTransactionsExcel(
       apiUrl,
       auth?.access_token,
       {
@@ -65,7 +65,7 @@ const DownloadButton = ({
       },
     )
     try {
-      const result = await getBankTransactionsCsv()
+      const result = await getBankTransactionsExcel()
       if (result?.data?.presignedUrl) {
         window.location.href = result.data.presignedUrl
         setRequestFailed(false)

--- a/src/components/ProfitAndLossDownloadButton/ProfitAndLossDownloadButton.tsx
+++ b/src/components/ProfitAndLossDownloadButton/ProfitAndLossDownloadButton.tsx
@@ -42,7 +42,7 @@ export const ProfitAndLossDownloadButton = ({
 
   const handleClick = async () => {
     setIsDownloading(true)
-    const getProfitAndLossCsv = Layer.getProfitAndLossCsv(
+    const getProfitAndLossExcel = Layer.getProfitAndLossExcel(
       apiUrl,
       auth?.access_token,
       {
@@ -63,7 +63,7 @@ export const ProfitAndLossDownloadButton = ({
     try {
       const result = useComparisonPnl
         ? await getProfitAndLossComparisonCsv(dateRange, moneyFormat)
-        : await getProfitAndLossCsv()
+        : await getProfitAndLossExcel()
       if (result?.data?.presignedUrl) {
         window.location.href = result.data.presignedUrl
         setRequestFailed(false)


### PR DESCRIPTION
## Description
Change the behavior of the download buttons in the Transactions, P&L and Balance Sheet components to produce excel spreadsheets instead of CSVs.

I did _not_
  - Make this a configurable option. This is the right default until we...
  - Add multiple download types option. Would be nice, but not biting off yet.
  - Update exports for the GL (this just needs a little more backend attention first, not a customer ask right now)

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->
