### PR TITLE
[LAY-1266] fix: prevent pinning to unreachable pages in bookkeeping tasks component

### DIFF
--- a/src/components/Tasks/TasksListMobile.tsx
+++ b/src/components/Tasks/TasksListMobile.tsx
@@ -30,7 +30,6 @@ export const TasksListMobile = ({
   const [showMobilePanel, setShowMobilePanel] = useState(false)
 
   const unresolvedTasks = getIncompleteTasks(sortedTasks).slice(0, MOBILE_SHOW_UNRESOLVED_TASKS_COUNT)
-  const totalTasks = sortedTasks?.length
 
   return (
     <div className='Layer__tasks-list'>
@@ -42,19 +41,19 @@ export const TasksListMobile = ({
           defaultOpen={index === indexFirstIncomplete}
         />
       ))}
-      {unresolvedTasks.length === 0 && totalTasks > 0
+      {unresolvedTasks.length === 0 && tasksCount > 0
         ? (
           <div style={{ textAlign: 'center', padding: '12px 24px' }}>
             <TextButton onClick={() => setShowMobilePanel(true)}>Show completed tasks</TextButton>
           </div>
         )
         : null}
-      {unresolvedTasks.length !== 0 && totalTasks > unresolvedTasks.length
+      {unresolvedTasks.length !== 0 && tasksCount > unresolvedTasks.length
         ? (
           <div style={{ textAlign: 'center', padding: '12px 24px' }}>
             <Button onClick={() => setShowMobilePanel(true)} fullWidth>
               Show all tasks (
-              {totalTasks}
+              {tasksCount}
               )
             </Button>
           </div>
@@ -76,7 +75,7 @@ export const TasksListMobile = ({
                 defaultOpen={index === indexFirstIncomplete}
               />
             ))}
-            {tasksCount >= 10 && (
+            {tasksCount > pageSize && (
               <Pagination
                 currentPage={currentPage}
                 totalCount={tasksCount}

--- a/src/hooks/array/usePaginatedList.ts
+++ b/src/hooks/array/usePaginatedList.ts
@@ -1,0 +1,42 @@
+import { useCallback, useMemo, useState } from 'react'
+
+export function usePaginatedList<T>(list: ReadonlyArray<T>, pageSize: number) {
+  const [internalPageIndex, setInternalPageIndex] = useState(0)
+
+  const pageCount = Math.max(0, Math.ceil(list.length / pageSize))
+  const effectivePageIndex = Math.max(0, Math.min(internalPageIndex, pageCount - 1))
+
+  const pageItems = useMemo(() => {
+    return list.slice(
+      effectivePageIndex * pageSize,
+      (effectivePageIndex + 1) * pageSize,
+    ) as ReadonlyArray<T>
+  }, [list, effectivePageIndex, pageSize])
+
+  const next = useCallback(() => {
+    setInternalPageIndex(Math.min(effectivePageIndex + 1, pageCount - 1))
+  }, [effectivePageIndex, pageCount])
+
+  const set = useCallback((pageIndex: number) => {
+    setInternalPageIndex(Math.max(0, Math.min(pageIndex, pageCount - 1)))
+  }, [pageCount])
+
+  const previous = useCallback(() => {
+    setInternalPageIndex(Math.max(effectivePageIndex - 1, 0))
+  }, [effectivePageIndex])
+
+  const reset = useCallback(() => {
+    setInternalPageIndex(0)
+  }, [])
+
+  return {
+    pageCount,
+    pageIndex: effectivePageIndex,
+    pageItems,
+    pageSize,
+    next,
+    set,
+    previous,
+    reset,
+  }
+}


### PR DESCRIPTION
## Description

The pagination of the tasks lists need to anticipate a dynamic list size. This occurs most often when switching between active periods (as the list component is not unmounted and remounted on this change).