### PR TITLE
upgrade: `recharts` on latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-datepicker": "^6.9.0",
         "react-plaid-link": "^3.5.1",
         "react-select": "^5.8.0",
-        "recharts": "^2.10.1",
+        "recharts": "^2.15.2",
         "swr": "^2.2.4",
         "zustand": "^5.0.1"
       },
@@ -8056,15 +8056,16 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.0.tgz",
-      "integrity": "sha512-cIvMxDfpAmqAmVgc4yb7pgm/O1tmmkl/CjrvXuW+62/+7jj/iF9Ykm+hb/UJt42TREHMyd3gb+pkgoa2MxgDIw==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.2.tgz",
+      "integrity": "sha512-xv9lVztv3ingk7V3Jf05wfAZbM9Q2umJzu5t/cfnAK7LUslNrGT7LPBr74G+ok8kSCeFMaePmWMg0rcYOnczTw==",
+      "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.21",
         "react-is": "^18.3.1",
-        "react-smooth": "^4.0.0",
+        "react-smooth": "^4.0.4",
         "recharts-scale": "^0.4.4",
         "tiny-invariant": "^1.3.1",
         "victory-vendor": "^36.6.8"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "react-datepicker": "^6.9.0",
     "react-plaid-link": "^3.5.1",
     "react-select": "^5.8.0",
-    "recharts": "^2.10.1",
+    "recharts": "^2.15.2",
     "swr": "^2.2.4",
     "zustand": "^5.0.1"
   }


### PR DESCRIPTION
## Description

This is motivated by fixing a customer issue with `recharts` loading. It is still unclear if the version upgrade will have any notable effect.