### PR TITLE
change order of cashflow report line items

### DIFF
--- a/src/components/StatementOfCashFlow/constants.ts
+++ b/src/components/StatementOfCashFlow/constants.ts
@@ -1,8 +1,8 @@
 export const STATEMENT_OF_CASH_FLOW_ROWS = [
   {
-    name: 'FinancingActivities',
-    displayName: 'Financing Activities',
-    lineItem: 'financing_activities',
+    name: 'OperatingActivities',
+    displayName: 'Operating Activities',
+    lineItem: 'operating_activities',
     type: 'line_item',
     summarize: true,
   },
@@ -14,9 +14,9 @@ export const STATEMENT_OF_CASH_FLOW_ROWS = [
     summarize: true,
   },
   {
-    name: 'OperatingActivities',
-    displayName: 'Operating Activities',
-    lineItem: 'operating_activities',
+    name: 'FinancingActivities',
+    displayName: 'Financing Activities',
+    lineItem: 'financing_activities',
     type: 'line_item',
     summarize: true,
   },
@@ -24,6 +24,13 @@ export const STATEMENT_OF_CASH_FLOW_ROWS = [
     name: 'PeriodNetCashIncrease',
     displayName: 'Net Cash Increase For Period',
     lineItem: 'period_net_cash_increase',
+    type: 'summary_value',
+    summarize: false,
+  },
+  {
+    name: 'CashAtBeginningOfPeriod',
+    displayName: 'Cash at Beginning of Period',
+    lineItem: 'cash_at_beginning_of_period',
     type: 'summary_value',
     summarize: false,
   },


### PR DESCRIPTION
## Description
Changes order of cashflow statement line items and adds the cash at beginning of period section.

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->
