### PR TITLE
[LAY-1287] fix: a bank transaction can have a null category

### DIFF
--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -54,8 +54,8 @@ type Props = {
 
 export type LastSubmittedForm = 'simple' | 'match' | 'split' | undefined
 
-export const extractDescriptionForSplit = (category: CategoryWithEntries) => {
-  if (!category.entries) {
+export const extractDescriptionForSplit = (category: CategoryWithEntries | null) => {
+  if (!category || !category.entries) {
     return ''
   }
 

--- a/src/components/BankTransactionRow/SplitTooltipDetails.tsx
+++ b/src/components/BankTransactionRow/SplitTooltipDetails.tsx
@@ -6,9 +6,9 @@ export const SplitTooltipDetails = ({
   category,
 }: {
   classNamePrefix: string
-  category: CategoryWithEntries
+  category: CategoryWithEntries | null
 }) => {
-  if (!category.entries) {
+  if (!category || !category.entries) {
     return
   }
 

--- a/src/types/bank_transactions.ts
+++ b/src/types/bank_transactions.ts
@@ -40,7 +40,7 @@ export interface BankTransaction extends Record<string, unknown> {
   amount: number
   direction: Direction
   counterparty_name: string
-  category: CategoryWithEntries
+  category: CategoryWithEntries | null
   categorization_status: CategorizationStatus
   categorization_flow: Categorization | null
   categorization_method: string


### PR DESCRIPTION
## Description

We were seeing an error where a `categorization_status === SPLIT` and `category === null`.