### PR TITLE
[LAY-1296] fix: remove box shadow from secondary buttons

### DIFF
--- a/src/components/Button/DownloadButton.tsx
+++ b/src/components/Button/DownloadButton.tsx
@@ -1,4 +1,3 @@
-
 import DownloadCloud from '../../icons/DownloadCloud'
 import { Button, ButtonProps, ButtonVariant } from './Button'
 import { RetryButton } from './RetryButton'

--- a/src/components/domain/transactions/searchField/transactionsSearchField.scss
+++ b/src/components/domain/transactions/searchField/transactionsSearchField.scss
@@ -4,7 +4,7 @@
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
 
-  border-radius: var(--border-radius-xs);
+  border-radius: var(--border-radius-2xs);
   border: 1px solid var(--border-color);
   padding-inline-end: var(--spacing-3xs);
 

--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -148,6 +148,8 @@
 .Layer__btn--secondary {
   color: var(--btn-secondary-color);
   background: var(--btn-secondary-bg-color);
+  border: 1px solid var(--border-color);
+  box-shadow: none;
 }
 
 .Layer__btn--tertiary {


### PR DESCRIPTION
## Description

**Linear**: [LAY-1296](https://linear.app/layerfi/issue/LAY-1296/fix-misalignment-of-download-button-and-search-box-in-mobile-view)

The root cause of the issue is the use of a box-shadow. These look good, but they go outside of the border-box model - they  make UIs look misaligned. I think it is easier to manage box shadows if they only apply to interactions states (e.g. data-pressed).

This is a more questionable fix, as I am likely slightly changing the appearance of many secondary buttons across the app.

