### PR TITLE
fix: temporarily revert color 900 -> 700

### DIFF
--- a/src/components/ui/Typography/money_text.scss
+++ b/src/components/ui/Typography/money_text.scss
@@ -1,5 +1,5 @@
 .Layer__MoneyText {
-  color: var(--color-base-900);
+  color: var(--color-base-700);
   overflow-x: hidden;
   text-overflow: ellipsis;
 

--- a/src/styles/ledger_account.scss
+++ b/src/styles/ledger_account.scss
@@ -104,7 +104,7 @@
 
   .Layer__ledger_account-table__balances-mobile__value {
     font-weight: var(--font-weight-bold);
-    color: var(--color-base-900);
+    color: var(--color-base-700);
   }
 }
 

--- a/src/styles/table.scss
+++ b/src/styles/table.scss
@@ -320,7 +320,7 @@
 
 .Layer__table-cell--primary,
 .Layer__table-cell--primary .Layer__table-cell-content {
-  color: var(--color-base-900);
+  color: var(--color-base-700);
   font-weight: var(--font-weight-bold);
 }
 


### PR DESCRIPTION
## Description

Root cause is that we set `--color-900: var(--color-dark)` (reference). This is a huge footgun that needs to be addressed more comprehensively.

### Screenshot (w/ Colored Text)

<img width="1200" alt="Screenshot 2025-04-24 at 7 05 07 PM" src="https://github.com/user-attachments/assets/cb9ec465-4730-4d05-8b9e-6fee78c271e1" />

