### PR TITLE
[LAY-1294] fix: downloading bank transactions should respect filters

### DIFF
--- a/src/api/layer.ts
+++ b/src/api/layer.ts
@@ -2,8 +2,6 @@ import { getBalanceSheet, getBalanceSheetCSV, getBalanceSheetExcel } from './lay
 import {
   categorizeBankTransaction,
   matchBankTransaction,
-  getBankTransactionsCsv,
-  getBankTransactionsExcel,
   getBankTransactionMetadata,
   updateBankTransactionMetadata,
   listBankTransactionDocuments,
@@ -70,8 +68,6 @@ export const Layer = {
   getBalanceSheet,
   getBalanceSheetCSV,
   getBalanceSheetExcel,
-  getBankTransactionsCsv,
-  getBankTransactionsExcel,
   getBankTransactionMetadata,
   listBankTransactionDocuments,
   getBankTransactionDocument,

--- a/src/hooks/useBankTransactions/useBankTransactions.ts
+++ b/src/hooks/useBankTransactions/useBankTransactions.ts
@@ -3,7 +3,7 @@ import { useAuth } from '../useAuth'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { getBankTransactions, type GetBankTransactionsReturn } from '../../api/layer/bankTransactions'
 
-type UseBankTransactionsOptions = {
+export type UseBankTransactionsOptions = {
   categorized?: boolean
   direction?: 'INFLOW' | 'OUTFLOW'
   descriptionFilter?: string
@@ -92,6 +92,7 @@ export function useBankTransactions({
             businessId,
             categorized,
             cursor,
+            limit: 200,
             descriptionFilter,
             direction,
             startDate,

--- a/src/hooks/useBankTransactions/useBankTransactionsDownload.ts
+++ b/src/hooks/useBankTransactions/useBankTransactionsDownload.ts
@@ -1,0 +1,76 @@
+import useSWRMutation from 'swr/mutation'
+import { useAuth } from '../useAuth'
+import { useLayerContext } from '../../contexts/LayerContext'
+import { getBankTransactionsExcel } from '../../api/layer/bankTransactions'
+import type { UseBankTransactionsOptions } from './useBankTransactions'
+
+function buildKey({
+  access_token: accessToken,
+  apiUrl,
+  businessId,
+}: {
+  access_token?: string
+  apiUrl?: string
+  businessId: string
+},
+) {
+  if (accessToken && apiUrl) {
+    return {
+      accessToken,
+      apiUrl,
+      businessId,
+      tags: ['#bank-transactions-download-excel'],
+    } as const
+  }
+}
+
+type UseBankTransactionsDownloadOptions = UseBankTransactionsOptions
+
+export function useBankTransactionsDownload() {
+  const { data } = useAuth()
+  const { businessId } = useLayerContext()
+
+  return useSWRMutation(
+    () => buildKey({
+      ...data,
+      businessId,
+    }),
+    (
+      {
+        accessToken,
+        apiUrl,
+        businessId,
+      },
+      {
+        arg: {
+          categorized,
+          direction,
+          descriptionFilter,
+          startDate,
+          endDate,
+          tagFilterQueryString,
+        },
+      }: { arg: UseBankTransactionsDownloadOptions },
+    ) => {
+      return getBankTransactionsExcel(
+        apiUrl,
+        accessToken,
+        {
+          params: {
+            businessId,
+            categorized,
+            descriptionFilter,
+            direction,
+            startDate,
+            endDate,
+            tagFilterQueryString,
+          },
+        },
+      )().then(({ data }) => data)
+    },
+    {
+      revalidate: false,
+      throwOnError: false,
+    },
+  )
+}


### PR DESCRIPTION
## Description

**Linear**: [LAY-1294](https://linear.app/layerfi/issue/LAY-1294/txn-export-not-respecting-search-filters-applied)

The download was not receiving any of the selected filters properly. This is still not a complete fix because the server does not respect all query parameters for a download.
