### PR TITLE
[LAY-1299] fix: improve alignment of transaction card + header for mobile view

### DIFF
--- a/src/components/domain/transactions/searchField/TransactionsSearchField.tsx
+++ b/src/components/domain/transactions/searchField/TransactionsSearchField.tsx
@@ -21,6 +21,7 @@ export function TransactionsSearchField({ slot, ...restProps }: TransactionsSear
         {...restProps}
         slot='search'
         placeholder='Search transactions'
+        aria-label='Search transactions'
       />
     </Group>
   )

--- a/src/components/domain/transactions/searchField/transactionsSearchField.scss
+++ b/src/components/domain/transactions/searchField/transactionsSearchField.scss
@@ -1,8 +1,10 @@
 .Layer__TransactionsSearchField {
   display: grid;
-  grid-template-areas: 'icon search';
+  grid-template-areas: "icon search";
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
+
+  background: var(--color-base-0);
 
   border-radius: var(--border-radius-2xs);
   border: 1px solid var(--border-color);
@@ -12,12 +14,13 @@
     outline: 2px solid var(--outline-subtle);
   }
 
-  & > [slot=icon] {
+  & > [slot="icon"] {
     grid-area: icon;
     inline-size: 2rem;
     block-size: 2rem;
   }
-  & > [slot=search] {
+
+  & > [slot="search"] {
     grid-area: search;
   }
 }

--- a/src/components/ui/SearchField/minimalSearchField.scss
+++ b/src/components/ui/SearchField/minimalSearchField.scss
@@ -6,8 +6,10 @@
 
   border: none;
 
-  & > [slot=input] {
+  & > [slot="input"] {
     grid-area: input;
+
+    font-family: var(--font-family);
 
     border: none;
     outline: none;
@@ -23,17 +25,19 @@
 
     &::-webkit-search-cancel-button,
     &::-webkit-search-decoration {
-      -webkit-appearance: none;
+      appearance: none;
     }
   }
-  &[data-empty] > [slot=input] {
+
+  &[data-empty] > [slot="input"] {
     grid-column: 1 / -1;
   }
 
-  & > [slot=clear-button] {
+  & > [slot="clear-button"] {
     grid-area: clear-button;
   }
-  &[data-empty] > [slot=clear-button] {
+
+  &[data-empty] > [slot="clear-button"] {
     display: none;
   }
 }

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -106,13 +106,11 @@
   flex-direction: column;
 
   .Layer__bank-transactions__header__content {
-    width: 100%;
     padding-left: var(--spacing-3xs);
   }
 }
 
-.Layer__bank-transactions__header--with-date-picker.Layer__bank-transactions__header--mobile
-.Layer__datepicker__wrapper {
+.Layer__bank-transactions__header--with-date-picker.Layer__bank-transactions__header--mobile .Layer__datepicker__wrapper {
   margin-right: 4px;
 }
 
@@ -204,7 +202,8 @@
   overflow: hidden;
   position: relative;
   background-color: var(--bg-element-focus);
-  transition: background-color var(--transition-speed) ease-in-out,
+  transition:
+    background-color var(--transition-speed) ease-in-out,
     height var(--transition-speed) ease-in-out;
 }
 
@@ -224,8 +223,7 @@
   }
 }
 
-.Layer__bank-transaction-row:hover
-.Layer__bank-transaction__submit-btn:not([disabled]) {
+.Layer__bank-transaction-row:hover .Layer__bank-transaction__submit-btn:not([disabled]) {
   color: var(--btn-color-hover);
   background: var(--btn-bg-color-hover);
 
@@ -243,8 +241,7 @@
   }
 }
 
-.Layer__expanded-bank-transaction-row
-.Layer__expanded-bank-transaction-row__wrapper {
+.Layer__expanded-bank-transaction-row .Layer__expanded-bank-transaction-row__wrapper {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-sm);
@@ -302,7 +299,8 @@
 .Layer__expanded-bank-transaction-row__content-panel {
   max-width: 0;
   opacity: 0;
-  transition: max-width 150ms ease-out,
+  transition:
+    max-width 150ms ease-out,
     opacity 300ms ease-out;
   overflow: hidden;
   flex: 1;
@@ -511,7 +509,8 @@
   .Layer__bank-transaction-list-item__base-row {
     max-height: 60px;
     opacity: 1;
-    transition: max-height 350ms ease-out,
+    transition:
+      max-height 350ms ease-out,
       opacity 200ms ease-out;
     justify-content: flex-end;
   }
@@ -671,8 +670,7 @@
   }
 }
 
-.Layer__table.Layer__bank-transactions__table
-.Layer__bank-transactions__documents-col {
+.Layer__table.Layer__bank-transactions__table .Layer__bank-transactions__documents-col {
   position: sticky;
   right: 430px;
   box-sizing: border-box;
@@ -798,14 +796,15 @@
     border-left: 1px solid var(--border-color);
 
     &::after {
-      content: '';
+      content: "";
       width: 50px;
       height: 100%;
-      background: linear-gradient(
-        90deg,
-        rgb(255 255 255 / 0%) 0%,
-        rgb(255 255 255 / 100%) 120%
-      );
+      background:
+        linear-gradient(
+          90deg,
+          rgb(255 255 255 / 0%) 0%,
+          rgb(255 255 255 / 100%) 120%
+        );
       position: absolute;
       left: -51px;
       top: 0;
@@ -1170,8 +1169,7 @@
 }
 
 @container (max-width: 760px) {
-  .Layer__expanded-bank-transaction-row__match-table
-  .Layer__expanded-bank-transaction-row__match-table__header {
+  .Layer__expanded-bank-transaction-row__match-table .Layer__expanded-bank-transaction-row__match-table__header {
     display: none;
   }
 
@@ -1298,10 +1296,7 @@
 }
 
 @container (max-width: 500px) {
-  .Layer__expanded-bank-transaction-row__content-toggle
-  .Layer__toggle-option
-  input
-  + span {
+  .Layer__expanded-bank-transaction-row__content-toggle .Layer__toggle-option input + span {
     font-size: var(--text-xs);
   }
 
@@ -1368,7 +1363,8 @@
     cursor: pointer;
 
     &:hover .Layer__bank-transactions__notification-content {
-      box-shadow: 0 0 3px 0 var(--base-transparent-12),
+      box-shadow:
+        0 0 3px 0 var(--base-transparent-12),
         0 0 0 1px var(--color-base-200);
     }
   }
@@ -1381,7 +1377,8 @@
     gap: var(--spacing-sm);
     border-radius: var(--border-radius-3xs);
     background: var(--color-base-0);
-    box-shadow: 0 0 12px 0 var(--base-transparent-12),
+    box-shadow:
+      0 0 12px 0 var(--base-transparent-12),
       0 0 0 1px var(--color-base-200);
   }
 
@@ -1395,7 +1392,8 @@
     border-radius: var(--border-radius-3xs);
     background: var(--color-base-0);
     color: var(--color-danger);
-    box-shadow: 0 1px 2px 0 var(--base-transparent-6),
+    box-shadow:
+      0 1px 2px 0 var(--base-transparent-6),
       0 0 0 1px var(--color-base-300);
   }
 
@@ -1489,8 +1487,7 @@
 
 @container (min-width: 401px) {
   .Layer__expanded-bank-transaction-row__total-and-btns .Layer__input-tooltip,
-  .Layer__expanded-bank-transaction-row__table-cell--split-entry
-  .Layer__input-tooltip {
+  .Layer__expanded-bank-transaction-row__table-cell--split-entry .Layer__input-tooltip {
     max-width: 200px;
     flex: 1;
 

--- a/src/styles/bank_transactions_mobile_list.scss
+++ b/src/styles/bank_transactions_mobile_list.scss
@@ -4,7 +4,6 @@
   flex-direction: column;
   list-style: none;
   overflow: hidden;
-  max-width: 414px;
   margin: auto;
 }
 
@@ -12,7 +11,8 @@
   padding: 0;
   margin: var(--spacing-2xs) var(--spacing-md);
   background: var(--color-base-0);
-  box-shadow: 0 2px 2px 0 var(--color-base-200),
+  box-shadow:
+    0 2px 2px 0 var(--color-base-200),
     0 4px 4px 0 var(--color-base-100);
   border-radius: var(--border-radius-sm);
   opacity: 0;
@@ -31,7 +31,8 @@
 
   &.show.Layer__bank-transaction-row--removing {
     opacity: 0;
-    transition: all 500ms ease-in-out,
+    transition:
+      all 500ms ease-in-out,
       opacity 80ms ease-out;
     overflow: hidden;
     margin-top: 0;


### PR DESCRIPTION
## Description

**Linear**: [LAY-1299](https://linear.app/layerfi/issue/LAY-1299/transactions-on-mobile-or-cards-and-search-box-are-not-aligned)

The bank transactions cards are arbitrarily fixed to a maximum width. This makes them makes them misaligned with their (flexible) header.

### Screenshot (Fixed)

<img width="340" alt="Screenshot 2025-04-25 at 11 51 08 AM" src="https://github.com/user-attachments/assets/63b12c33-b9bf-46ae-829e-6247e064ca35" />
