### PR TITLE
[LAY-1295] Hide suggested matches + suggested categorization when in bookkeeping mode

### DIFF
--- a/src/components/BookkeepingStatus/utils.tsx
+++ b/src/components/BookkeepingStatus/utils.tsx
@@ -5,7 +5,7 @@ import { TextStatus } from '../Typography/Text'
 import AlertCircle from '../../icons/AlertCircle'
 import Clock from '../../icons/Clock'
 import CheckCircle from '../../icons/CheckCircle'
-import { safeAssertUnreachable } from '../../utils/switch/safeAssertUnreachable'
+import { safeAssertUnreachable } from '../../utils/switch/assertUnreachable'
 import pluralize from 'pluralize'
 
 type InternalStatusConfig = {
@@ -64,7 +64,11 @@ export function getBookkeepingStatusConfig({
       return
     }
     default: {
-      return safeAssertUnreachable(status, 'Unexpected bookkeeping status in BookkeepingStatus')
+      return safeAssertUnreachable({
+        value: status,
+        message: 'Unexpected bookkeeping status in BookkeepingStatus',
+        fallbackValue: undefined,
+      })
     }
   }
 }

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -149,7 +149,6 @@ const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
     const [height, setHeight] = useState<string | number>(0)
     const [isOver, setOver] = useState(false)
     const bodyRef = useRef<HTMLSpanElement>(null)
-    const [isLoaded, setIsLoaded] = useState(false)
 
     const defaultCategory =
       bankTransaction.category
@@ -378,6 +377,10 @@ const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
     const bookkeepingStatus = useEffectiveBookkeepingStatus()
     const categorizationEnabled = isCategorizationEnabledForStatus(bookkeepingStatus)
 
+    const effectiveSplits = categorizationEnabled
+      ? rowState.splits
+      : []
+
     const className = 'Layer__expanded-bank-transaction-row'
     const shouldHide = !isOpen && isOver
 
@@ -462,7 +465,7 @@ const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
                   >
                     <div className={`${className}__content-panel-container`}>
                       <div className={`${className}__splits-inputs`}>
-                        {rowState.splits.map((split, index) => (
+                        {effectiveSplits.map((split, index) => (
                           <div
                             className={`${className}__table-cell--split-entry`}
                             key={`split-${index}`}
@@ -511,13 +514,13 @@ const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
                       </div>
                       {splitFormError && <ErrorText>{splitFormError}</ErrorText>}
                       <div className={`${className}__total-and-btns`}>
-                        {rowState.splits.length > 1 && (
+                        {effectiveSplits.length > 1 && (
                           <Input
                             disabled={true}
                             leftText='Total'
                             inputMode='numeric'
                             value={`$${formatMoney(
-                              rowState.splits.reduce(
+                              effectiveSplits.reduce(
                                 (x, { amount }) => x + amount,
                                 0,
                               ),
@@ -527,7 +530,7 @@ const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
                         {categorizationEnabled
                           ? (
                             <div className={`${className}__splits-buttons`}>
-                              {rowState.splits.length > 1
+                              {effectiveSplits.length > 1
                                 ? (
                                   <TextButton
                                     onClick={addSplit}

--- a/src/components/JournalForm/JournalFormEntryLines.tsx
+++ b/src/components/JournalForm/JournalFormEntryLines.tsx
@@ -15,7 +15,7 @@ import { InputWithBadge, InputGroup, Select } from '../Input'
 import { JournalConfig } from '../Journal/Journal'
 import { Text, TextSize } from '../Typography'
 import { useAllCategories } from '../../hooks/categories/useAllCategories'
-import { safeAssertUnreachable } from '../../utils/switch/safeAssertUnreachable'
+import { unsafeAssertUnreachable } from '../../utils/switch/assertUnreachable'
 
 type WithSubCategories = { subCategories: ReadonlyArray<WithSubCategories> | null }
 
@@ -76,7 +76,10 @@ export const JournalFormEntryLines = ({
               value: account.id,
             }
           default:
-            safeAssertUnreachable(account, 'Unexpected account type')
+            unsafeAssertUnreachable({
+              value: account,
+              message: 'Unexpected account type',
+            })
         }
       })
 
@@ -87,16 +90,19 @@ export const JournalFormEntryLines = ({
     lineItemIndex,
     value,
   }: { lineItemIndex: number, value: BaseSelectOption }) => {
-    const relevantCategory = flattenedCategories.find((x) => {
-      switch (x.type) {
+    const relevantCategory = flattenedCategories.find((category) => {
+      switch (category.type) {
         case 'AccountNested':
-          return x.id === value.value
+          return category.id === value.value
         case 'OptionalAccountNested':
-          return x.stable_name === value.value
+          return category.stable_name === value.value
         case 'ExclusionNested':
-          return x.id === value.value
+          return category.id === value.value
         default:
-          safeAssertUnreachable(x, 'Unexpected account type')
+          unsafeAssertUnreachable({
+            value: category,
+            message: 'Unexpected account type',
+          })
       }
     })
 

--- a/src/components/Tasks/TaskStatusBadge.tsx
+++ b/src/components/Tasks/TaskStatusBadge.tsx
@@ -5,7 +5,7 @@ import CheckCircle from '../../icons/CheckCircle'
 import { BookkeepingPeriod } from '../../hooks/bookkeeping/periods/useBookkeepingPeriods'
 import pluralize from 'pluralize'
 import { toDataProperties } from '../../utils/styleUtils/toDataProperties'
-import { safeAssertUnreachable } from '../../utils/switch/safeAssertUnreachable'
+import { safeAssertUnreachable } from '../../utils/switch/assertUnreachable'
 
 type TaskStatusBadgeProps = {
   status: BookkeepingPeriod['status']
@@ -43,7 +43,11 @@ const buildBadgeConfig = (status: TaskStatusBadgeProps['status'], tasksCount: Ta
       return
     }
     default: {
-      safeAssertUnreachable(status, 'Unexpected bookkeeping status in TaskStatusBadge')
+      return safeAssertUnreachable({
+        value: status,
+        message: 'Unexpected bookkeeping status in `TaskStatusBadge`',
+        fallbackValue: undefined,
+      })
     }
   }
 }

--- a/src/providers/GlobalDateStore/GlobalDateStoreProvider.tsx
+++ b/src/providers/GlobalDateStore/GlobalDateStoreProvider.tsx
@@ -15,7 +15,7 @@ import {
 } from 'date-fns'
 import { useState, createContext, type PropsWithChildren, useContext } from 'react'
 import { createStore, useStore } from 'zustand'
-import { safeAssertUnreachable } from '../../utils/switch/safeAssertUnreachable'
+import { safeAssertUnreachable } from '../../utils/switch/assertUnreachable'
 import { useStoreWithDateSelected } from '../../utils/zustand/useStoreWithDateSelected'
 
 const _DATE_PICKER_MODES = [
@@ -187,7 +187,10 @@ function buildStore() {
           setYear({ start })
           break
         default:
-          safeAssertUnreachable(rangeDisplayMode, 'Invalid range displayMode')
+          safeAssertUnreachable({
+            value: rangeDisplayMode,
+            message: 'Invalid `rangeDisplayMode`',
+          })
       }
     }
 

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -413,6 +413,10 @@
   flex-direction: column;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) 0;
+
+  &:empty {
+    display: none;
+  }
 }
 
 .Layer__bank-transaction-row__table-cell--amount-credit,

--- a/src/utils/bookkeeping/isCategorizationEnabled.ts
+++ b/src/utils/bookkeeping/isCategorizationEnabled.ts
@@ -1,11 +1,19 @@
 import type { BookkeepingStatus } from '../../hooks/bookkeeping/useBookkeepingStatus'
+import { safeAssertUnreachable } from '../switch/assertUnreachable'
 
 export function isCategorizationEnabledForStatus(status: BookkeepingStatus) {
   switch (status) {
     case 'NOT_PURCHASED':
+    case 'ONBOARDING':
     case 'BOOKKEEPING_PAUSED':
       return true
     case 'ACTIVE':
       return false
+    default:
+      return safeAssertUnreachable({
+        value: status,
+        message: 'Unexpected bookkeeping status in `isCategorizationEnabledForStatus`',
+        fallbackValue: true,
+      })
   }
 }

--- a/src/utils/switch/assertUnreachable.ts
+++ b/src/utils/switch/assertUnreachable.ts
@@ -1,0 +1,27 @@
+export function safeAssertUnreachable<T>({
+  value,
+  message,
+  fallbackValue,
+}: {
+  value: never
+  message?: string
+  fallbackValue?: T
+}) {
+  console.error(
+    message ?? 'Unexpected value encountered in exhaustive check:',
+    value,
+  )
+
+  return fallbackValue
+}
+
+export function unsafeAssertUnreachable({
+  message,
+}: {
+  value: never
+  message?: string
+}): never {
+  throw new Error(
+    message ?? 'Unexpected value encountered in exhaustive check',
+  )
+}

--- a/src/utils/switch/safeAssertUnreachable.ts
+++ b/src/utils/switch/safeAssertUnreachable.ts
@@ -1,8 +1,0 @@
-export function safeAssertUnreachable(value: never, message?: string): never {
-  console.error(
-    message ?? 'Unexpected value encountered in exhaustive check:',
-    value,
-  )
-
-  return undefined as never
-}


### PR DESCRIPTION
## Description

**Linear**: [LAY-1295](https://linear.app/layerfi/issue/LAY-1295/fix-suggested-category-display-in-expanded-processing-row)

Bookkeeping users should not see extra information related to categorization.