### PR TITLE
fix: direction of `categorizationEnabled` logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.95-alpha",
+  "version": "0.1.95-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.95-alpha",
+      "version": "0.1.95-alpha.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.26.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.95-alpha",
+  "version": "0.1.95-alpha.1",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/components/MatchForm/MatchForm.tsx
+++ b/src/components/MatchForm/MatchForm.tsx
@@ -26,20 +26,20 @@ export const MatchForm = ({
   readOnly = false,
 }: MatchFormProps) => {
   const bookkeepingStatus = useEffectiveBookkeepingStatus()
-  const categorizedEnabled = isCategorizationEnabledForStatus(bookkeepingStatus)
+  const categorizationEnabled = isCategorizationEnabledForStatus(bookkeepingStatus)
 
   const {
     suggested_matches: suggestedMatches = [],
     match,
   } = bankTransaction
 
-  const effectiveSuggestedMatches = categorizedEnabled
-    ? suggestedMatches.filter(
+  const effectiveSuggestedMatches = categorizationEnabled
+    ? suggestedMatches
+    : suggestedMatches.filter(
       ({ details: { id } }) => id === match?.details.id,
     )
-    : suggestedMatches
 
-  if (categorizedEnabled && effectiveSuggestedMatches.length === 0) {
+  if (!categorizationEnabled && effectiveSuggestedMatches.length === 0) {
     return null
   }
 


### PR DESCRIPTION
## Description

I made a mistake in [this commit](https://github.com/Layer-Fi/layer-react/pull/586/commits/d82065c282fbd35d8f7640507d18afd51b6cca0e) and was treating `categorizationEnabled` as the inverse.