### PR TITLE
fix: prefer `id`-based keys in bookkeeping tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.95",
+  "version": "0.1.96-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.95",
+      "version": "0.1.96-alpha",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.26.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.95",
+  "version": "0.1.96-alpha",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/components/Tasks/TasksList.tsx
+++ b/src/components/Tasks/TasksList.tsx
@@ -72,7 +72,7 @@ export function TasksList({ pageSize = 8, mobile }: TasksListProps) {
           <>
             {pageItems.map((task, index) => (
               <TasksListItem
-                key={index}
+                key={task.id}
                 task={task}
                 goToNextPageIfAllComplete={next}
                 defaultOpen={index === indexFirstIncomplete}


### PR DESCRIPTION
## Description

This test needs to be tried in production mode.
