### PR TITLE
fix: completing a task should not switch the page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.96",
+  "version": "0.1.97-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.96",
+      "version": "0.1.97-alpha",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.26.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.96",
+  "version": "0.1.97-alpha",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/components/Tasks/TasksList.tsx
+++ b/src/components/Tasks/TasksList.tsx
@@ -47,7 +47,7 @@ export function TasksList({ pageSize = 8, mobile }: TasksListProps) {
       })
   }, [activePeriod?.tasks])
 
-  const { pageItems, pageIndex, next, set } = usePaginatedList(sortedTasks, pageSize)
+  const { pageItems, pageIndex, set } = usePaginatedList(sortedTasks, pageSize)
 
   const indexFirstIncomplete = sortedTasks?.findIndex(task => isIncompleteTask(task))
 
@@ -56,7 +56,6 @@ export function TasksList({ pageSize = 8, mobile }: TasksListProps) {
       <TasksListMobile
         tasksCount={sortedTasks.length}
         sortedTasks={pageItems}
-        goToNextPage={next}
         indexFirstIncomplete={indexFirstIncomplete}
         currentPage={pageIndex + 1}
         pageSize={pageSize}
@@ -74,7 +73,6 @@ export function TasksList({ pageSize = 8, mobile }: TasksListProps) {
               <TasksListItem
                 key={task.id}
                 task={task}
-                goToNextPageIfAllComplete={next}
                 defaultOpen={index === indexFirstIncomplete}
               />
             ))}

--- a/src/components/Tasks/TasksListItem.tsx
+++ b/src/components/Tasks/TasksListItem.tsx
@@ -14,11 +14,9 @@ import { useUpdateTaskUploadDescription } from '../../hooks/bookkeeping/periods/
 
 export const TasksListItem = ({
   task,
-  goToNextPageIfAllComplete,
   defaultOpen,
 }: {
   task: UserVisibleTask
-  goToNextPageIfAllComplete: (task: UserVisibleTask) => void
   defaultOpen: boolean
 }) => {
   const [isOpen, setIsOpen] = useState(defaultOpen)
@@ -64,7 +62,6 @@ export const TasksListItem = ({
     })
 
     setIsOpen(false)
-    goToNextPageIfAllComplete(task)
     setSelectedFiles(undefined)
   }
 
@@ -204,7 +201,6 @@ export const TasksListItem = ({
                       void handleSubmitUserResponseForTask({ taskId: task.id, userResponse })
                         .then(() => {
                           setIsOpen(false)
-                          goToNextPageIfAllComplete(task)
                         })
                     }}
                   >

--- a/src/components/Tasks/TasksListMobile.tsx
+++ b/src/components/Tasks/TasksListMobile.tsx
@@ -11,7 +11,6 @@ const MOBILE_SHOW_UNRESOLVED_TASKS_COUNT = 2
 type TasksListMobileProps = {
   tasksCount: number
   sortedTasks: ReadonlyArray<UserVisibleTask>
-  goToNextPage: (task: UserVisibleTask) => void
   indexFirstIncomplete: number
   currentPage: number
   pageSize: number
@@ -21,7 +20,6 @@ type TasksListMobileProps = {
 export const TasksListMobile = ({
   tasksCount,
   sortedTasks,
-  goToNextPage,
   indexFirstIncomplete,
   currentPage,
   pageSize,
@@ -37,7 +35,6 @@ export const TasksListMobile = ({
         <TasksListItem
           key={index}
           task={task}
-          goToNextPageIfAllComplete={goToNextPage}
           defaultOpen={index === indexFirstIncomplete}
         />
       ))}
@@ -71,7 +68,6 @@ export const TasksListMobile = ({
               <TasksListItem
                 key={index}
                 task={task}
-                goToNextPageIfAllComplete={goToNextPage}
                 defaultOpen={index === indexFirstIncomplete}
               />
             ))}


### PR DESCRIPTION
## Description

This was an issue caused by [me over here](https://github.com/Layer-Fi/layer-react/pull/564/files#diff-dab11e5898b5c6ec9c07f30e72b6c3b4e1998b2d45a942462884218c06d37629L77-L87) on #564 (while fixing another bug).

### Why Remove Advancing Entirely?

We already display a sorted task list with incomplete tasks shown first. When we complete a task, we should expect some re-ordering... but going to the next page is nonsensical.