### PR TITLE
fix: if there is no incomplete task on a page, none should default open

### DIFF
--- a/src/components/Tasks/TasksList.tsx
+++ b/src/components/Tasks/TasksList.tsx
@@ -49,7 +49,7 @@ export function TasksList({ pageSize = 8, mobile }: TasksListProps) {
 
   const { pageItems, pageIndex, set } = usePaginatedList(sortedTasks, pageSize)
 
-  const indexFirstIncomplete = sortedTasks?.findIndex(task => isIncompleteTask(task))
+  const indexFirstIncomplete = pageItems?.findIndex(task => isIncompleteTask(task))
 
   if (mobile) {
     return (


### PR DESCRIPTION
## Description

This look like an existing issue that [I carried over here](https://github.com/Layer-Fi/layer-react/pull/564/files#diff-dab11e5898b5c6ec9c07f30e72b6c3b4e1998b2d45a942462884218c06d37629L75-R52) in #564.