### PR TITLE
refactor: clean up usage of Layer__tooltip classname

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -71,7 +71,7 @@ export const Badge = ({
     return (
       <Tooltip offset={12}>
         <TooltipTrigger>{content}</TooltipTrigger>
-        <TooltipContent className='Layer__tooltip'>{tooltip}</TooltipContent>
+        <TooltipContent>{tooltip}</TooltipContent>
       </Tooltip>
     )
   }

--- a/src/components/BankTransactionList/BankTransactionProcessingInfo.tsx
+++ b/src/components/BankTransactionList/BankTransactionProcessingInfo.tsx
@@ -4,7 +4,7 @@ import { BookkeepingStatus } from '../BookkeepingStatus/BookkeepingStatus'
 export const BankTransactionProcessingInfo = () => (
   <Tooltip offset={12}>
     <TooltipTrigger><BookkeepingStatus status='IN_PROGRESS_AWAITING_BOOKKEEPER' text='Processing' /></TooltipTrigger>
-    <TooltipContent className='Layer__tooltip' width='md'>
+    <TooltipContent width='md'>
       {'Our team will review and categorize this transaction. We\'ll reach out if we have any questions about it.'}
     </TooltipContent>
   </Tooltip>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -119,9 +119,7 @@ export const Button = ({
         <Tooltip offset={12}>
           <TooltipTrigger>{content}</TooltipTrigger>
           {tooltip && (
-            <TooltipContent className='Layer__tooltip'>
-              {tooltip}
-            </TooltipContent>
+            <TooltipContent>{tooltip}</TooltipContent>
           )}
         </Tooltip>
       ) : (

--- a/src/components/Button/SubmitButton.tsx
+++ b/src/components/Button/SubmitButton.tsx
@@ -52,7 +52,7 @@ const buildRightIcon = ({
         <TooltipTrigger>
           <AlertCircle size={14} />
         </TooltipTrigger>
-        <TooltipContent className='Layer__tooltip'>{error}</TooltipContent>
+        <TooltipContent>{error}</TooltipContent>
       </Tooltip>
     )
   }

--- a/src/components/Input/AmountInput.tsx
+++ b/src/components/Input/AmountInput.tsx
@@ -1,4 +1,3 @@
-
 import classNames from 'classnames'
 import CurrencyInput, { CurrencyInputProps } from 'react-currency-input-field'
 import { Tooltip, TooltipTrigger, TooltipContent } from '../Tooltip'
@@ -44,7 +43,7 @@ export const AmountInput = ({
         />
         {leftText && <span className='Layer__input-left-text'>{leftText}</span>}
       </TooltipTrigger>
-      <TooltipContent className='Layer__tooltip'>{errorMessage}</TooltipContent>
+      <TooltipContent>{errorMessage}</TooltipContent>
     </Tooltip>
   )
 }

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -28,7 +28,7 @@ export const Input = ({
         <input {...props} className={baseClassName} />
         {leftText && <span className='Layer__input-left-text'>{leftText}</span>}
       </TooltipTrigger>
-      <TooltipContent className='Layer__tooltip'>{errorMessage}</TooltipContent>
+      <TooltipContent>{errorMessage}</TooltipContent>
     </Tooltip>
   )
 }

--- a/src/components/Input/InputWithBadge.tsx
+++ b/src/components/Input/InputWithBadge.tsx
@@ -36,7 +36,7 @@ export const InputWithBadge = ({
         </div>
         {leftText && <span className='Layer__input-left-text'>{leftText}</span>}
       </TooltipTrigger>
-      <TooltipContent className='Layer__tooltip'>{errorMessage}</TooltipContent>
+      <TooltipContent>{errorMessage}</TooltipContent>
     </Tooltip>
   )
 }

--- a/src/components/Input/MultiSelect.tsx
+++ b/src/components/Input/MultiSelect.tsx
@@ -74,7 +74,7 @@ export const MultiSelect = <T,>({
           isMulti={true}
         />
       </TooltipTrigger>
-      <TooltipContent className='Layer__tooltip'>{errorMessage}</TooltipContent>
+      <TooltipContent>{errorMessage}</TooltipContent>
     </Tooltip>
   )
 }

--- a/src/components/Input/Select.tsx
+++ b/src/components/Input/Select.tsx
@@ -63,7 +63,7 @@ export const Select = <T,>({
           isDisabled={disabled}
         />
       </TooltipTrigger>
-      <TooltipContent className='Layer__tooltip'>{errorMessage}</TooltipContent>
+      <TooltipContent>{errorMessage}</TooltipContent>
     </Tooltip>
   )
 }

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -49,9 +49,7 @@ export const Tab = ({
             </span>
           </label>
         </TooltipTrigger>
-        <TooltipContent className='Layer__tooltip'>
-          {disabledMessage}
-        </TooltipContent>
+        <TooltipContent>{disabledMessage}</TooltipContent>
       </Tooltip>
     )
   }

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -24,7 +24,7 @@ export const Textarea = ({
       <TooltipTrigger className='Layer__input-tooltip'>
         <textarea {...props} className={baseClassName} />
       </TooltipTrigger>
-      <TooltipContent className='Layer__tooltip'>{errorMessage}</TooltipContent>
+      <TooltipContent>{errorMessage}</TooltipContent>
     </Tooltip>
   )
 }

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -208,9 +208,7 @@ const ToggleOption = ({
             </span>
           </label>
         </TooltipTrigger>
-        <TooltipContent className='Layer__tooltip'>
-          {disabledMessage}
-        </TooltipContent>
+        <TooltipContent>{disabledMessage}</TooltipContent>
       </Tooltip>
     )
   }

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -121,11 +121,6 @@ export const TextWithTooltip = ({
 
   const [hoverStatus, setHover] = useState(false)
 
-  const contentClassName = classNames(
-    'Layer__tooltip',
-    tooltipOptions?.contentClassName,
-  )
-
   return (
     <Tooltip
       disabled={!hoverStatus}
@@ -137,7 +132,7 @@ export const TextWithTooltip = ({
           {children}
         </Component>
       </TooltipTrigger>
-      <TooltipContent className={contentClassName}>{children}</TooltipContent>
+      <TooltipContent className={tooltipOptions?.contentClassName}>{children}</TooltipContent>
     </Tooltip>
   )
 }

--- a/src/components/ui/Checkbox/Checkbox.tsx
+++ b/src/components/ui/Checkbox/Checkbox.tsx
@@ -53,7 +53,7 @@ export function CheckboxWithTooltip({ tooltip, ...props }: CheckboxWithTooltipPr
         <TooltipTrigger className='Layer__input-tooltip'>
           <Checkbox {...props} />
         </TooltipTrigger>
-        <TooltipContent className='Layer__tooltip'>{tooltip}</TooltipContent>
+        <TooltipContent>{tooltip}</TooltipContent>
       </Tooltip>
     </div>
   )


### PR DESCRIPTION
## Description

`.Layer_tooltip` classname was explicitly provided to almost every use of `<TooltipContent />`.
The `feat/categorize-dropdown` branch moves `.Layer_tooltip` to the `TooltipContent`.

## Changes

1. Remove `className='Layer__tooltip'` from everywhere except Tooltip