### PR TITLE
fix: error as any in swr responses and lint PeriodPicker

### DIFF
--- a/src/components/Journal/download/JournalEntriesDownloadButton.tsx
+++ b/src/components/Journal/download/JournalEntriesDownloadButton.tsx
@@ -24,7 +24,7 @@ export function JournalEntriesDownloadButton({
     <>
       <DownloadButton
         iconOnly={iconOnly}
-        onClick={() => { trigger() }}
+        onClick={() => { void trigger() }}
         isDownloading={isMutating}
         requestFailed={Boolean(error)}
         text='Download CSV'

--- a/src/components/Journal/download/useJournalEntriesDownload.ts
+++ b/src/components/Journal/download/useJournalEntriesDownload.ts
@@ -4,6 +4,7 @@ import { useAuth } from '../../../hooks/useAuth'
 import type { S3PresignedUrl } from '../../../types/general'
 import type { Awaitable } from '../../../types/utility/promises'
 import { getJournalEntriesCSV } from '../../../api/layer/journal'
+import { APIError } from '../../../models/APIError'
 
 function buildKey({
   access_token: accessToken,
@@ -36,6 +37,14 @@ type UseJournalEntriesDownloadOptions = {
   onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>
 }
 
+type MutationParams = () => {
+  accessToken: string
+  apiUrl: string
+  businessId: string
+  startCutoff: Date | undefined
+  endCutoff: Date | undefined
+} | undefined
+
 export function useJournalEntriesDownload({
   startCutoff,
   endCutoff,
@@ -44,7 +53,11 @@ export function useJournalEntriesDownload({
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
 
-  return useSWRMutation(
+  return useSWRMutation<
+    unknown,
+    Error | APIError,
+    MutationParams
+  >(
     () => buildKey({
       ...auth,
       businessId,

--- a/src/components/PeriodPicker/PeriodPicker.tsx
+++ b/src/components/PeriodPicker/PeriodPicker.tsx
@@ -27,9 +27,9 @@ interface PeriodPickerProps {
 }
 
 const periodLabelMap: Record<PeriodPickerOption, string> = {
-  month: 'Month',
-  quarter: 'Quarter',
-  year: 'Year',
+  'month': 'Month',
+  'quarter': 'Quarter',
+  'year': 'Year',
   '2_months': '2 months',
   '3_months': '3 months',
   '6_months': '6 months',
@@ -67,7 +67,7 @@ export const PeriodPicker = ({ onSelect, defaultValue }: PeriodPickerProps) => {
 
   const getStartEndDate = (
     option: PeriodPickerOption,
-  ): { start_date: string; end_date: string } => {
+  ): { start_date: string, end_date: string } => {
     const currentDate = new Date()
     let startDate: Date
     let endDate: Date
@@ -232,8 +232,8 @@ export const PeriodPicker = ({ onSelect, defaultValue }: PeriodPickerProps) => {
 
   const handleClickOutside = (event: MouseEvent) => {
     if (
-      dropdownRef.current &&
-      !dropdownRef.current.contains(event.target as Node)
+      dropdownRef.current
+      && !dropdownRef.current.contains(event.target as Node)
     ) {
       setIsOpen(false)
     }

--- a/src/components/PeriodPicker/index.tsx
+++ b/src/components/PeriodPicker/index.tsx
@@ -1,1 +1,0 @@
-export { PeriodPicker } from './PeriodPicker'


### PR DESCRIPTION
## Description

1. Linting PeriodPicker

2. The `useSWRMutation`'s `error` is `any` in few places what violates [@typescript-eslint/no-unsafe-assignment](https://typescript-eslint.io/rules/no-unsafe-assignment).

`BalanceSheetDownloadButton.tsx:`
![image](https://github.com/user-attachments/assets/97f42d6c-49d0-40a7-b07c-a2718829c13f)

