### PR TITLE
fix: regression in dismissing account confirmation modal

### DIFF
--- a/src/components/LinkedAccountPill/LinkedAccountPill.tsx
+++ b/src/components/LinkedAccountPill/LinkedAccountPill.tsx
@@ -21,7 +21,6 @@ export function LinkedAccountPill({ label, items }: LinkedAccountPillProps) {
       <Pill
         status='error'
         onPress={() => setIsOpen(true)}
-        onHoverStart={() => setIsOpen(true)}
       >
         <AlertCircle size={14} />
         {label}

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
@@ -56,8 +56,9 @@ function useLinkedAccountsConfirmationModal() {
     actions: { dismiss: dismissAccountConfirmation, reset: resetAccountConfirmation },
   } = useAccountConfirmationStore()
 
-  const preloadIsOpen = visibility === 'PRELOADED'
-  const mainIsOpen = accountsNeedingConfirmation.length > 0
+  const isDismissed = visibility === 'DISMISSED'
+  const preloadIsOpen = !isDismissed && visibility === 'PRELOADED'
+  const mainIsOpen = !isDismissed && accountsNeedingConfirmation.length > 0
 
   const baseInfo = {
     accounts: accountsNeedingConfirmation,


### PR DESCRIPTION
## Description

I was not properly respecting the dismissed state as overriding the other two statuses. This looks like a regression, as I've included this logic in the past.
