### PR TITLE
refactor!: decouple the default `categories` from the LayerContext

### DIFF
--- a/src/api/layer/categories.ts
+++ b/src/api/layer/categories.ts
@@ -2,6 +2,8 @@ import { toDefinedSearchParameters } from '../../utils/request/toDefinedSearchPa
 import { Category } from '../../types'
 import { get } from './authenticated_http'
 
+export type CategoriesListMode = 'ALL' | 'EXPENSES' | 'DEFAULT'
+
 export const getCategories = get<
   {
     data: {
@@ -11,7 +13,7 @@ export const getCategories = get<
   },
   {
     businessId: string
-    mode?: 'ALL'
+    mode?: CategoriesListMode
   }
 >(({ businessId, mode }) => {
   const parameters = toDefinedSearchParameters({ mode })

--- a/src/components/BankTransactionMobileList/BusinessCategories.tsx
+++ b/src/components/BankTransactionMobileList/BusinessCategories.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
-import { useLayerContext } from '../../contexts/LayerContext'
 import { ActionableList } from '../ActionableList'
 import { Text, TextWeight } from '../Typography'
 import { Option, flattenCategories } from './utils'
+import { useCategories } from '../../hooks/categories/useCategories'
 
 export interface BusinessCategoriesProps {
   select: (category: Option) => void
@@ -15,10 +15,10 @@ export const BusinessCategories = ({
   selectedId,
   showTooltips,
 }: BusinessCategoriesProps) => {
-  const { categories } = useLayerContext()
+  const { data: categories } = useCategories()
 
   const categoryOptions = flattenCategories(
-    categories.filter(category => category.type != 'ExclusionNested'),
+    (categories ?? []).filter(category => category.type != 'ExclusionNested'),
   )
 
   const [optionsToShow, setOptionsToShow] = useState(categoryOptions)

--- a/src/components/CategorySelect/CategorySelect.tsx
+++ b/src/components/CategorySelect/CategorySelect.tsx
@@ -6,7 +6,6 @@ import Select, {
   components,
 } from 'react-select'
 import { DATE_FORMAT } from '../../config/general'
-import { useLayerContext } from '../../contexts/LayerContext'
 import Check from '../../icons/Check'
 import ChevronDown from '../../icons/ChevronDown'
 import InfoIcon from '../../icons/InfoIcon'
@@ -21,6 +20,7 @@ import { Text, TextSize } from '../Typography'
 import { CategorySelectDrawer } from './CategorySelectDrawer'
 import classNames from 'classnames'
 import { parseISO, format as formatTime } from 'date-fns'
+import { useCategories } from '../../hooks/categories/useCategories'
 
 type Props = {
   name?: string
@@ -258,7 +258,7 @@ export const CategorySelect = ({
   excludeMatches = false,
   asDrawer = false,
 }: Props) => {
-  const { categories } = useLayerContext()
+  const { data: categories } = useCategories()
 
   const matchOptions =
     !excludeMatches && bankTransaction?.suggested_matches
@@ -295,7 +295,7 @@ export const CategorySelect = ({
       ]
       : []
 
-  const categoryOptions = flattenCategories(categories)
+  const categoryOptions = flattenCategories(categories ?? [])
 
   const options = [
     ...matchOptions,

--- a/src/components/JournalForm/JournalFormEntryLines.tsx
+++ b/src/components/JournalForm/JournalFormEntryLines.tsx
@@ -14,7 +14,7 @@ import { IconButton, TextButton } from '../Button'
 import { InputWithBadge, InputGroup, Select } from '../Input'
 import { JournalConfig } from '../Journal/Journal'
 import { Text, TextSize } from '../Typography'
-import { useAllCategories } from '../../hooks/categories/useAllCategories'
+import { useCategories } from '../../hooks/categories/useCategories'
 import { unsafeAssertUnreachable } from '../../utils/switch/assertUnreachable'
 
 type WithSubCategories = { subCategories: ReadonlyArray<WithSubCategories> | null }
@@ -50,11 +50,11 @@ export const JournalFormEntryLines = ({
   sendingForm: boolean
   config: JournalConfig
 }) => {
-  const { data } = useAllCategories()
+  const { data: categories } = useCategories({ mode: 'ALL' })
   const { form } = useContext(JournalContext)
 
   const { flattenedCategories, parentOptions } = useMemo(() => {
-    const flattenedCategories = recursiveFlattenCategories(data ?? [])
+    const flattenedCategories = recursiveFlattenCategories(categories ?? [])
 
     const parentOptions = [...flattenedCategories]
       .sort((a, b) => (a.display_name.localeCompare(b.display_name)))
@@ -84,7 +84,7 @@ export const JournalFormEntryLines = ({
       })
 
     return { flattenedCategories, parentOptions }
-  }, [data])
+  }, [categories])
 
   const handleChangeParent = ({
     lineItemIndex,

--- a/src/contexts/LayerContext/LayerContext.tsx
+++ b/src/contexts/LayerContext/LayerContext.tsx
@@ -12,7 +12,6 @@ export const LayerContext = createContext<
 >({
       businessId: '',
       business: undefined,
-      categories: [],
       theme: undefined,
       colors: {},
       setTheme: () => undefined,

--- a/src/hooks/categories/useCategories.ts
+++ b/src/hooks/categories/useCategories.ts
@@ -1,7 +1,10 @@
 import useSWR from 'swr'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { useAuth } from '../useAuth'
-import { getCategories } from '../../api/layer/categories'
+import {
+  getCategories,
+  type CategoriesListMode,
+} from '../../api/layer/categories'
 
 export const CATEGORIES_TAG_KEY = '#categories'
 
@@ -14,7 +17,7 @@ function buildKey({
   access_token?: string
   apiUrl?: string
   businessId: string
-  mode?: 'ALL'
+  mode?: CategoriesListMode
 }) {
   if (accessToken && apiUrl) {
     return {
@@ -28,7 +31,7 @@ function buildKey({
 }
 
 type UseCategoriesOptions = {
-  mode?: 'ALL'
+  mode?: CategoriesListMode
 }
 
 export function useCategories({ mode }: UseCategoriesOptions = {}) {

--- a/src/hooks/categories/useCategories.ts
+++ b/src/hooks/categories/useCategories.ts
@@ -4,27 +4,34 @@ import { useAuth } from '../useAuth'
 import { getCategories } from '../../api/layer/categories'
 
 export const CATEGORIES_TAG_KEY = '#categories'
+
 function buildKey({
   access_token: accessToken,
   apiUrl,
   businessId,
+  mode,
 }: {
   access_token?: string
   apiUrl?: string
   businessId: string
+  mode?: 'ALL'
 }) {
   if (accessToken && apiUrl) {
     return {
       accessToken,
       apiUrl,
       businessId,
-      mode: 'ALL',
+      mode,
       tags: [CATEGORIES_TAG_KEY],
     } as const
   }
 }
 
-export function useAllCategories() {
+type UseCategoriesOptions = {
+  mode?: 'ALL'
+}
+
+export function useCategories({ mode }: UseCategoriesOptions = {}) {
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
 
@@ -32,6 +39,7 @@ export function useAllCategories() {
     () => buildKey({
       ...auth,
       businessId,
+      mode,
     }),
     ({ accessToken, apiUrl, businessId, mode }) => getCategories(
       apiUrl,

--- a/src/hooks/useChartOfAccounts/useCreateChildAccount.tsx
+++ b/src/hooks/useChartOfAccounts/useCreateChildAccount.tsx
@@ -6,7 +6,7 @@ import { useSWRConfig } from 'swr'
 import { withSWRKeyTags } from '../../utils/swr/withSWRKeyTags'
 import { useCallback } from 'react'
 import { NewChildAccount } from '../../types/chart_of_accounts'
-import { CATEGORIES_TAG_KEY } from '../categories/useAllCategories'
+import { CATEGORIES_TAG_KEY } from '../categories/useCategories'
 
 function buildKey({
   access_token: accessToken,

--- a/src/providers/BusinessProvider/BusinessProvider.tsx
+++ b/src/providers/BusinessProvider/BusinessProvider.tsx
@@ -32,7 +32,6 @@ const reducer: Reducer<LayerContextValues, LayerContextAction> = (
 ) => {
   switch (action.type) {
     case Action.setBusiness:
-    case Action.setCategories:
     case Action.setTheme:
     case Action.setOnboardingStep:
     case Action.setColors:
@@ -82,7 +81,6 @@ export const BusinessProvider = ({
   const [state, dispatch] = useReducer(reducer, {
     businessId,
     business: undefined,
-    categories: [],
     theme,
     colors,
     onboardingStep: undefined,
@@ -101,33 +99,6 @@ export const BusinessProvider = ({
 
   const { apiUrl } = useEnvironment()
   const { data: auth } = useAuth()
-
-  const { data: categoriesData } = useSWR(
-    businessId && auth?.access_token && `categories-${businessId}`,
-    Layer.getCategories(apiUrl, auth?.access_token, {
-      params: { businessId },
-    }),
-    {
-      ...DEFAULT_SWR_CONFIG,
-      provider: () => new Map(),
-      onSuccess: (response) => {
-        if (response?.data?.categories?.length) {
-          dispatch({
-            type: Action.setCategories,
-            payload: { categories: response.data.categories || [] },
-          })
-        }
-      },
-    },
-  )
-  useEffect(() => {
-    if (categoriesData?.data?.categories?.length) {
-      dispatch({
-        type: Action.setCategories,
-        payload: { categories: categoriesData.data.categories || [] },
-      })
-    }
-  }, [categoriesData])
 
   const { data: businessData } = useSWR(
     businessId && auth?.access_token && `business-${businessId}`,

--- a/src/types/layer_context.ts
+++ b/src/types/layer_context.ts
@@ -1,13 +1,12 @@
 import { ToastProps } from '../components/Toast/Toast'
 import { LayerError } from '../models/ErrorHandler'
 import { EventCallbacks } from '../providers/LayerProvider/LayerProvider'
-import { Business, Category } from '../types'
+import { Business } from '../types'
 import { DataModel } from './general'
 
 export type LayerContextValues = {
   businessId: string
   business?: Business
-  categories: Category[]
   theme?: LayerThemeConfig
   colors: ColorsPalette
   onboardingStep?: OnboardingStep
@@ -85,7 +84,6 @@ export type OnboardingStep = undefined | 'connectAccount' | 'complete'
 
 export enum LayerContextActionName {
   setBusiness = 'LayerContext.setBusiness',
-  setCategories = 'LayerContext.setCategories',
   setTheme = 'LayerContext.setTheme',
   setOnboardingStep = 'LayerContext.setOnboardingStep',
   setColors = 'LayerContext.setColors',
@@ -98,10 +96,6 @@ export type LayerContextAction =
   | {
     type: LayerContextActionName.setBusiness
     payload: { business: LayerContextValues['business'] }
-  }
-  | {
-    type: LayerContextActionName.setCategories
-    payload: { categories: LayerContextValues['categories'] }
   }
   | {
     type: LayerContextActionName.setTheme


### PR DESCRIPTION
## Description

This is a fast-follow to #602 which will invalidate any query tagged with `#categories`.

This is (technically) a breaking change because `useLayerContext` is exposed at the top-level. We are moving away from exposing hook and contexts at the top-level already.
