### PR TITLE
feat: add `last_synced_at` field to `quickbooks/connection-status` fetcher

### DIFF
--- a/src/api/layer/quickbooks.ts
+++ b/src/api/layer/quickbooks.ts
@@ -1,4 +1,4 @@
-import { StatusOfSyncFromQuickbooks } from '../../types/quickbooks'
+import type { StatusOfQuickbooksConnection, StatusOfSyncFromQuickbooks } from '../../types/quickbooks'
 import { get, post } from './authenticated_http'
 
 export const syncFromQuickbooks = post<
@@ -37,9 +37,7 @@ export const unlinkQuickbooksConnection = post<
  */
 export const statusOfQuickbooksConnection = get<
   {
-    data: {
-      is_connected: boolean
-    }
+    data: StatusOfQuickbooksConnection
   },
   { businessId: string }
 >(

--- a/src/components/Quickbooks/Quickbooks.tsx
+++ b/src/components/Quickbooks/Quickbooks.tsx
@@ -21,7 +21,7 @@ const Quickbooks = () => {
             : 'not connected'}
       </div>
       <br />
-      {quickbooksIsConnected === null && 'Loading...'}
+      {quickbooksIsConnected === undefined && 'Loading...'}
       {quickbooksIsConnected === false && (
         <button
           onClick={async () => {

--- a/src/components/Quickbooks/Quickbooks.tsx
+++ b/src/components/Quickbooks/Quickbooks.tsx
@@ -4,7 +4,7 @@ const Quickbooks = () => {
   const {
     syncFromQuickbooks,
     isSyncingFromQuickbooks,
-    quickbooksIsLinked,
+    quickbooksIsConnected,
     linkQuickbooks,
     unlinkQuickbooks,
   } = useQuickbooks()
@@ -14,15 +14,15 @@ const Quickbooks = () => {
       <div>
         Quickbooks OAuth connection status:
         {' '}
-        {quickbooksIsLinked === undefined
+        {quickbooksIsConnected === undefined
           ? ''
-          : quickbooksIsLinked
+          : quickbooksIsConnected
             ? 'established'
             : 'not connected'}
       </div>
       <br />
-      {quickbooksIsLinked === null && 'Loading...'}
-      {quickbooksIsLinked === false && (
+      {quickbooksIsConnected === null && 'Loading...'}
+      {quickbooksIsConnected === false && (
         <button
           onClick={async () => {
             const authorizationUrl = await linkQuickbooks()
@@ -32,7 +32,7 @@ const Quickbooks = () => {
           Link Quickbooks
         </button>
       )}
-      {quickbooksIsLinked === true
+      {quickbooksIsConnected === true
       && (isSyncingFromQuickbooks
         ? (
           'Syncing data from Quickbooks...'

--- a/src/hooks/useQuickbooks/useQuickbooks.ts
+++ b/src/hooks/useQuickbooks/useQuickbooks.ts
@@ -39,13 +39,15 @@ export const useQuickbooks: UseQuickbooks = () => {
         params: { businessId },
       })()
     ).data.is_syncing
+    const wasSyncing = wasSyncingFromQuickbooksRef.current
+    
+    wasSyncingFromQuickbooksRef.current = isSyncing
     setIsSyncingFromQuickbooks(isSyncing)
 
     // If we completed the sync, fetch a fresh Quickbooks connection status
-    if (!isSyncing && wasSyncingFromQuickbooksRef.current) {
+    if (!isSyncing && wasSyncing) {
       await fetchQuickbooksConnectionStatus()
     }
-    wasSyncingFromQuickbooksRef.current = isSyncing
   }, [apiUrl, auth?.access_token, businessId, setIsSyncingFromQuickbooks, fetchQuickbooksConnectionStatus])
 
   // Poll the server to determine when the Quickbooks sync is complete

--- a/src/types/quickbooks.ts
+++ b/src/types/quickbooks.ts
@@ -1,3 +1,8 @@
+export type StatusOfQuickbooksConnection = {
+  is_connected: boolean
+  last_synced_at: string | null
+}
+
 export type StatusOfSyncFromQuickbooks = {
   is_syncing: boolean
 }


### PR DESCRIPTION
## Description
We added a new field to the `quickbooks/connection-status` API get the last time we synced with Quickbooks. This PR adds it to the API call, and returns this value from the `useQuickbooks` hook as `quickbooksLastSyncedAt`. 

Along the way, I refactored `useQuickbooks` to remove disabled lint rules around non-exhaustive `useEffect` dependencies and wrap all of the functions in `useCallback` so as to prevent them from causing unnecessary re-renders.