### PR TITLE
fix: remove animation on chart `Indicator`

### DIFF
--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -566,8 +566,6 @@ export const ProfitAndLossChart = ({
     )
   }
 
-  const [animateFrom, setAnimateFrom] = useState(-1)
-
   return (
     <div className='Layer__chart-wrapper'>
       <ResponsiveContainer
@@ -726,11 +724,8 @@ export const ProfitAndLossChart = ({
                 <LabelList
                   content={(
                     <Indicator
-                      setCustomCursorSize={(width, height, x) =>
-                        setCustomCursorSize({ width, height, x })}
+                      setCustomCursorSize={(width, height, x) => setCustomCursorSize({ width, height, x })}
                       customCursorSize={customCursorSize}
-                      animateFrom={animateFrom}
-                      setAnimateFrom={setAnimateFrom}
                     />
                   )}
                 />


### PR DESCRIPTION
## Description

The animation logic in the `Indicator` component violates the rules of hooks. This causes a console error in dev mode - `React error: Expected static flag was missing` ([see issue](https://github.com/facebook/react/issues/24391)).  
