### PR TITLE
fix: typecheck errors on `Integrations` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.98",
+  "version": "0.1.99-alpha-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.98",
+      "version": "0.1.99-alpha-1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.98",
+  "version": "0.1.99-alpha-1",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/components/Integrations/IntegrationsQuickbooksItemThumb/IntegrationsQuickbooksItemThumbFooter.tsx
+++ b/src/components/Integrations/IntegrationsQuickbooksItemThumb/IntegrationsQuickbooksItemThumbFooter.tsx
@@ -3,9 +3,14 @@ import { BadgeLoader } from '../../BadgeLoader'
 import { HStack, Spacer, VStack } from '../../ui/Stack/Stack'
 import { Text, TextSize } from '../../Typography'
 import { QuickbooksContext } from '../../../contexts/QuickbooksContext/QuickbooksContext'
-import { format } from 'date-fns'
+import { format, isValid } from 'date-fns'
 
-const formatLastSyncedAt = (datetime: string) => `${format(datetime, 'MMMM d, yyyy')}\nat\n${format(datetime, 'h:mm a')}`
+const formatLastSyncedAt = (datetime: string) => {
+  const parsed = new Date(datetime)
+  if (!isValid(parsed)) return ''
+
+  return `${format(parsed, 'MMMM d, yyyy')} at ${format(parsed, 'h:mm a')}`
+}
 
 export const IntegrationsQuickbooksItemThumbFooter = () => {
   const {


### PR DESCRIPTION
## Description
Fix a type error: `format` takes `number | date` and we were passing a `string`.