### PR TITLE
fix: revalidate {Bank|External}Accounts when categorizing or matching

### DIFF
--- a/src/api/layer.ts
+++ b/src/api/layer.ts
@@ -1,7 +1,5 @@
 import { getBalanceSheet, getBalanceSheetCSV, getBalanceSheetExcel } from './layer/balance_sheet'
 import {
-  categorizeBankTransaction,
-  matchBankTransaction,
   getBankTransactionMetadata,
   updateBankTransactionMetadata,
   listBankTransactionDocuments,
@@ -29,7 +27,6 @@ import {
   getJournalEntriesCSV,
 } from './layer/journal'
 import {
-  getLinkedAccounts,
   getPlaidLinkToken,
   getPlaidUpdateModeLinkToken,
   exchangePlaidPublicToken,
@@ -62,8 +59,6 @@ import { getVendors } from './layer/vendors'
 
 export const Layer = {
   getBusiness,
-  categorizeBankTransaction,
-  matchBankTransaction,
   createAccount,
   updateAccount,
   createChildAccount,
@@ -90,7 +85,6 @@ export const Layer = {
   getProfitAndLossSummaries,
   getProfitAndLossCsv,
   getProfitAndLossExcel,
-  getLinkedAccounts,
   getJournal,
   getJournalEntriesCSV,
   reverseJournalEntry,

--- a/src/api/layer/bankTransactions.ts
+++ b/src/api/layer/bankTransactions.ts
@@ -70,16 +70,29 @@ export const getBankTransactions = get<
 )
 
 export const categorizeBankTransaction = put<
-  { data: BankTransaction, errors: unknown },
-  CategoryUpdate
+  { data: BankTransaction },
+  CategoryUpdate,
+  {
+    businessId: string
+    bankTransactionId: string
+  }
 >(
   ({ businessId, bankTransactionId }) =>
     `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/categorize`,
 )
 
+export type MatchBankTransactionBody = {
+  match_id: string
+  type: BankTransactionMatchType
+}
+
 export const matchBankTransaction = put<
-  { data: BankTransactionMatch, errors: unknown },
-  { match_id: string, type: BankTransactionMatchType }
+  { data: BankTransactionMatch },
+  MatchBankTransactionBody,
+  {
+    businessId: string
+    bankTransactionId: string
+  }
 >(
   ({ businessId, bankTransactionId }) =>
     `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/match`,

--- a/src/api/layer/linked_accounts.ts
+++ b/src/api/layer/linked_accounts.ts
@@ -38,7 +38,7 @@ export const updateOpeningBalance = post<
     `/v1/businesses/${businessId}/external-accounts/${accountId}/opening-balance`,
 )
 
-export const getLinkedAccounts = get<
+export const listExternalAccounts = get<
   { data: LinkedAccounts },
   {
     businessId: string

--- a/src/hooks/bookkeeping/periods/tasks/useDeleteUploadsOnTask.ts
+++ b/src/hooks/bookkeeping/periods/tasks/useDeleteUploadsOnTask.ts
@@ -59,19 +59,18 @@ export function useDeleteUploadsOnTask() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const result = await originalTrigger(...triggerParameters)
-
-      if (result) {
-        void mutate(key => withSWRKeyTags(
-          key,
-          tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
-        ))
-      }
-
-      return result
-    },
-    [originalTrigger, mutate],
+    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters)
+        .finally(() => {
+          void mutate(key => withSWRKeyTags(
+            key,
+            tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
+          ))
+        }),
+    [
+      originalTrigger,
+      mutate,
+    ],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/bookkeeping/periods/tasks/useDeleteUploadsOnTask.ts
+++ b/src/hooks/bookkeeping/periods/tasks/useDeleteUploadsOnTask.ts
@@ -59,14 +59,16 @@ export function useDeleteUploadsOnTask() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters)
-        .finally(() => {
-          void mutate(key => withSWRKeyTags(
-            key,
-            tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
-          ))
-        }),
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const triggerResult = await originalTrigger(...triggerParameters)
+
+      void mutate(key => withSWRKeyTags(
+        key,
+        tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
+      ))
+
+      return triggerResult
+    },
     [
       originalTrigger,
       mutate,

--- a/src/hooks/bookkeeping/periods/tasks/useSubmitResponseForTask.ts
+++ b/src/hooks/bookkeeping/periods/tasks/useSubmitResponseForTask.ts
@@ -67,19 +67,18 @@ export function useSubmitUserResponseForTask() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const result = await originalTrigger(...triggerParameters)
-
-      if (result) {
-        void mutate(key => withSWRKeyTags(
-          key,
-          tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
-        ))
-      }
-
-      return result
-    },
-    [originalTrigger, mutate],
+    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters)
+        .finally(() => {
+          void mutate(key => withSWRKeyTags(
+            key,
+            tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
+          ))
+        }),
+    [
+      originalTrigger,
+      mutate,
+    ],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/bookkeeping/periods/tasks/useSubmitResponseForTask.ts
+++ b/src/hooks/bookkeeping/periods/tasks/useSubmitResponseForTask.ts
@@ -67,14 +67,16 @@ export function useSubmitUserResponseForTask() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters)
-        .finally(() => {
-          void mutate(key => withSWRKeyTags(
-            key,
-            tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
-          ))
-        }),
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const triggerResult = await originalTrigger(...triggerParameters)
+
+      void mutate(key => withSWRKeyTags(
+        key,
+        tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
+      ))
+
+      return triggerResult
+    },
     [
       originalTrigger,
       mutate,

--- a/src/hooks/bookkeeping/periods/tasks/useUpdateTaskUploadDescription.ts
+++ b/src/hooks/bookkeeping/periods/tasks/useUpdateTaskUploadDescription.ts
@@ -64,19 +64,18 @@ export function useUpdateTaskUploadDescription() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const result = await originalTrigger(...triggerParameters)
-
-      if (result) {
-        void mutate(key => withSWRKeyTags(
-          key,
-          tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
-        ))
-      }
-
-      return result
-    },
-    [originalTrigger, mutate],
+    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters)
+        .finally(() => {
+          void mutate(key => withSWRKeyTags(
+            key,
+            tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
+          ))
+        }),
+    [
+      originalTrigger,
+      mutate,
+    ],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/bookkeeping/periods/tasks/useUpdateTaskUploadDescription.ts
+++ b/src/hooks/bookkeeping/periods/tasks/useUpdateTaskUploadDescription.ts
@@ -64,14 +64,16 @@ export function useUpdateTaskUploadDescription() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters)
-        .finally(() => {
-          void mutate(key => withSWRKeyTags(
-            key,
-            tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
-          ))
-        }),
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const triggerResult = await originalTrigger(...triggerParameters)
+
+      void mutate(key => withSWRKeyTags(
+        key,
+        tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
+      ))
+
+      return triggerResult
+    },
     [
       originalTrigger,
       mutate,

--- a/src/hooks/bookkeeping/periods/tasks/useUploadDocumentsForTask.ts
+++ b/src/hooks/bookkeeping/periods/tasks/useUploadDocumentsForTask.ts
@@ -64,14 +64,16 @@ export function useUploadDocumentsForTask() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters)
-        .finally(() => {
-          void mutate(key => withSWRKeyTags(
-            key,
-            tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
-          ))
-        }),
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const triggerResult = await originalTrigger(...triggerParameters)
+
+      void mutate(key => withSWRKeyTags(
+        key,
+        tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
+      ))
+
+      return triggerResult
+    },
     [
       originalTrigger,
       mutate,

--- a/src/hooks/bookkeeping/periods/tasks/useUploadDocumentsForTask.ts
+++ b/src/hooks/bookkeeping/periods/tasks/useUploadDocumentsForTask.ts
@@ -64,19 +64,18 @@ export function useUploadDocumentsForTask() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const result = await originalTrigger(...triggerParameters)
-
-      if (result) {
-        void mutate(key => withSWRKeyTags(
-          key,
-          tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
-        ))
-      }
-
-      return result
-    },
-    [originalTrigger, mutate],
+    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters)
+        .finally(() => {
+          void mutate(key => withSWRKeyTags(
+            key,
+            tags => tags.includes(BOOKKEEPING_PERIODS_TAG_KEY),
+          ))
+        }),
+    [
+      originalTrigger,
+      mutate,
+    ],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/bookkeeping/useBankAccounts.ts
+++ b/src/hooks/bookkeeping/useBankAccounts.ts
@@ -5,7 +5,7 @@ import { useEnvironment } from '../../providers/Environment/EnvironmentInputProv
 import { get } from '../../api/layer/authenticated_http'
 import { BankAccount } from '../../types/linked_accounts'
 
-const BANK_ACCOUNTS_TAG_KEY = '#bank-accounts'
+export const BANK_ACCOUNTS_TAG_KEY = '#bank-accounts'
 
 const getBankAccounts = get<{ data: BankAccount[] }, { businessId: string }>(
   ({ businessId }) => `/v1/businesses/${businessId}/bank-accounts`,
@@ -50,7 +50,7 @@ export const useBankAccounts = () => {
   )
 
   const disconnectedAccountsRequiringNotification = (data?.data ?? []).filter(
-    account => requiresNotification(account)
+    account => requiresNotification(account),
   ).length
 
   return {

--- a/src/hooks/business/useUpdateBusiness.ts
+++ b/src/hooks/business/useUpdateBusiness.ts
@@ -60,14 +60,16 @@ export function useUpdateBusiness() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters)
-        .finally(() => {
-          void mutate(key => withSWRKeyTags(
-            key,
-            tags => tags.includes(BUSINESS_TAG_KEY),
-          ))
-        }),
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const triggerResult = await originalTrigger(...triggerParameters)
+
+      void mutate(key => withSWRKeyTags(
+        key,
+        tags => tags.includes(BUSINESS_TAG_KEY),
+      ))
+
+      return triggerResult
+    },
     [
       originalTrigger,
       mutate,

--- a/src/hooks/business/useUpdateBusiness.ts
+++ b/src/hooks/business/useUpdateBusiness.ts
@@ -60,19 +60,18 @@ export function useUpdateBusiness() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const result = await originalTrigger(...triggerParameters)
-
-      if (result) {
-        await mutate(key => withSWRKeyTags(
-          key,
-          tags => tags.includes(BUSINESS_TAG_KEY),
-        ))
-      }
-
-      return result
-    },
-    [originalTrigger, mutate],
+    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters)
+        .finally(() => {
+          void mutate(key => withSWRKeyTags(
+            key,
+            tags => tags.includes(BUSINESS_TAG_KEY),
+          ))
+        }),
+    [
+      originalTrigger,
+      mutate,
+    ],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/businessPersonnel/useCreateBusinessPersonnel.ts
+++ b/src/hooks/businessPersonnel/useCreateBusinessPersonnel.ts
@@ -72,19 +72,18 @@ export function useCreateBusinessPersonnel() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const result = await originalTrigger(...triggerParameters)
-
-      if (result) {
-        await mutate(key => withSWRKeyTags(
-          key,
-          tags => tags.includes(BUSINESS_PERSONNEL_TAG_KEY),
-        ))
-      }
-
-      return result
-    },
-    [originalTrigger, mutate],
+    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters)
+        .finally(() => {
+          void mutate(key => withSWRKeyTags(
+            key,
+            tags => tags.includes(BUSINESS_PERSONNEL_TAG_KEY),
+          ))
+        }),
+    [
+      originalTrigger,
+      mutate,
+    ],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/businessPersonnel/useCreateBusinessPersonnel.ts
+++ b/src/hooks/businessPersonnel/useCreateBusinessPersonnel.ts
@@ -72,14 +72,16 @@ export function useCreateBusinessPersonnel() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters)
-        .finally(() => {
-          void mutate(key => withSWRKeyTags(
-            key,
-            tags => tags.includes(BUSINESS_PERSONNEL_TAG_KEY),
-          ))
-        }),
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const triggerResult = await originalTrigger(...triggerParameters)
+
+      void mutate(key => withSWRKeyTags(
+        key,
+        tags => tags.includes(BUSINESS_PERSONNEL_TAG_KEY),
+      ))
+
+      return triggerResult
+    },
     [
       originalTrigger,
       mutate,

--- a/src/hooks/businessPersonnel/useUpdateBusinessPersonnel.ts
+++ b/src/hooks/businessPersonnel/useUpdateBusinessPersonnel.ts
@@ -66,19 +66,18 @@ export function useUpdateBusinessPersonnel({ businessPersonnelId }: { businessPe
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const result = await originalTrigger(...triggerParameters)
-
-      if (result) {
-        await mutate(key => withSWRKeyTags(
-          key,
-          tags => tags.includes(BUSINESS_PERSONNEL_TAG_KEY),
-        ))
-      }
-
-      return result
-    },
-    [originalTrigger, mutate],
+    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters)
+        .finally(() => {
+          void mutate(key => withSWRKeyTags(
+            key,
+            tags => tags.includes(BUSINESS_PERSONNEL_TAG_KEY),
+          ))
+        }),
+    [
+      originalTrigger,
+      mutate,
+    ],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/businessPersonnel/useUpdateBusinessPersonnel.ts
+++ b/src/hooks/businessPersonnel/useUpdateBusinessPersonnel.ts
@@ -66,14 +66,16 @@ export function useUpdateBusinessPersonnel({ businessPersonnelId }: { businessPe
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters)
-        .finally(() => {
-          void mutate(key => withSWRKeyTags(
-            key,
-            tags => tags.includes(BUSINESS_PERSONNEL_TAG_KEY),
-          ))
-        }),
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const triggerResult = await originalTrigger(...triggerParameters)
+
+      void mutate(key => withSWRKeyTags(
+        key,
+        tags => tags.includes(BUSINESS_PERSONNEL_TAG_KEY),
+      ))
+
+      return triggerResult
+    },
     [
       originalTrigger,
       mutate,

--- a/src/hooks/useBankTransactions/useBankTransactions.ts
+++ b/src/hooks/useBankTransactions/useBankTransactions.ts
@@ -3,6 +3,8 @@ import { useAuth } from '../useAuth'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { getBankTransactions, type GetBankTransactionsReturn } from '../../api/layer/bankTransactions'
 
+export const BANK_TRANSACTIONS_TAG_KEY = '#bank-transactions'
+
 export type UseBankTransactionsOptions = {
   categorized?: boolean
   direction?: 'INFLOW' | 'OUTFLOW'
@@ -42,7 +44,7 @@ function keyLoader(
       startDate,
       endDate,
       tagFilterQueryString,
-      tags: ['#bank-transactions'],
+      tags: [BANK_TRANSACTIONS_TAG_KEY],
     } as const
   }
 }

--- a/src/hooks/useBankTransactions/useCategorizeBankTransaction.ts
+++ b/src/hooks/useBankTransactions/useCategorizeBankTransaction.ts
@@ -1,0 +1,115 @@
+import { useCallback } from 'react'
+import { categorizeBankTransaction, type GetBankTransactionsReturn } from '../../api/layer/bankTransactions'
+import { useLayerContext } from '../../contexts/LayerContext'
+import type { CategoryUpdate } from '../../types'
+import { useAuth } from '../useAuth'
+import { useSWRConfig } from 'swr'
+import useSWRMutation from 'swr/mutation'
+import type { SWRInfiniteKeyedMutator } from 'swr/infinite'
+import { withSWRKeyTags } from '../../utils/swr/withSWRKeyTags'
+import { EXTERNAL_ACCOUNTS_TAG_KEY } from '../useLinkedAccounts/useListExternalAccounts'
+import { BANK_ACCOUNTS_TAG_KEY } from '../bookkeeping/useBankAccounts'
+
+const CATEGORIZE_BANK_TRANSACTION_TAG = '#categorize-bank-transaction'
+
+function buildKey({
+  access_token: accessToken,
+  apiUrl,
+  businessId,
+}: {
+  access_token?: string
+  apiUrl?: string
+  businessId: string
+}) {
+  if (accessToken && apiUrl) {
+    return {
+      accessToken,
+      apiUrl,
+      businessId,
+      tags: [CATEGORIZE_BANK_TRANSACTION_TAG],
+    }
+  }
+}
+
+type CategorizeBankTransactionArgs = CategoryUpdate & {
+  bankTransactionId: string
+}
+
+type UseCategorizeBankTransactionOptions = {
+  mutateBankTransactions: SWRInfiniteKeyedMutator<
+    Array<GetBankTransactionsReturn>
+  >
+}
+
+export function useCategorizeBankTransaction({
+  mutateBankTransactions,
+}: UseCategorizeBankTransactionOptions) {
+  const { data: auth } = useAuth()
+  const { businessId } = useLayerContext()
+  const { mutate } = useSWRConfig()
+
+  const mutationResponse = useSWRMutation(
+    () => buildKey({
+      access_token: auth?.access_token,
+      apiUrl: auth?.apiUrl,
+      businessId,
+    }),
+    (
+      { accessToken, apiUrl, businessId },
+      { arg: { bankTransactionId, ...body } }: { arg: CategorizeBankTransactionArgs },
+    ) => categorizeBankTransaction(
+      apiUrl,
+      accessToken,
+      {
+        params: {
+          businessId,
+          bankTransactionId,
+        },
+        body,
+      },
+    ).then(({ data }) => data),
+    {
+      revalidate: false,
+    },
+  )
+
+  const { trigger: originalTrigger } = mutationResponse
+
+  const stableProxiedTrigger = useCallback(
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const result = await originalTrigger(...triggerParameters)
+
+      if (result) {
+        await Promise.all([
+          mutate(key => withSWRKeyTags(
+            key,
+            tags => (
+              tags.includes(BANK_ACCOUNTS_TAG_KEY)
+              || tags.includes(EXTERNAL_ACCOUNTS_TAG_KEY)
+            ),
+          )),
+          /**
+           * SWR does not expose infinite queries through the matcher
+           *
+           * @see https://github.com/vercel/swr/blob/main/src/_internal/utils/mutate.ts#L78
+           */
+          mutateBankTransactions(undefined, { revalidate: true }),
+        ])
+      }
+
+      return result
+    },
+    [originalTrigger, mutate, mutateBankTransactions],
+  )
+
+  return new Proxy(mutationResponse, {
+    get(target, prop) {
+      if (prop === 'trigger') {
+        return stableProxiedTrigger
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return Reflect.get(target, prop)
+    },
+  })
+}

--- a/src/hooks/useBankTransactions/useCategorizeBankTransaction.ts
+++ b/src/hooks/useBankTransactions/useCategorizeBankTransaction.ts
@@ -74,20 +74,22 @@ export function useCategorizeBankTransaction({
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters)
-        .finally(() => {
-          void mutate(key => withSWRKeyTags(
-            key,
-            tags => tags.includes(CATEGORIZE_BANK_TRANSACTION_TAG),
-          ))
-          /**
-           * SWR does not expose infinite queries through the matcher
-           *
-           * @see https://github.com/vercel/swr/blob/main/src/_internal/utils/mutate.ts#L78
-           */
-          void mutateBankTransactions(undefined, { revalidate: true })
-        }),
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const triggerResult = await originalTrigger(...triggerParameters)
+
+      void mutate(key => withSWRKeyTags(
+        key,
+        tags => tags.includes(CATEGORIZE_BANK_TRANSACTION_TAG),
+      ))
+      /**
+       * SWR does not expose infinite queries through the matcher
+       *
+       * @see https://github.com/vercel/swr/blob/main/src/_internal/utils/mutate.ts#L78
+       */
+      void mutateBankTransactions(undefined, { revalidate: true })
+
+      return triggerResult
+    },
     [
       originalTrigger,
       mutate,

--- a/src/hooks/useBankTransactions/useMatchBankTransaction.ts
+++ b/src/hooks/useBankTransactions/useMatchBankTransaction.ts
@@ -1,0 +1,114 @@
+import { useCallback } from 'react'
+import { matchBankTransaction, type GetBankTransactionsReturn, type MatchBankTransactionBody } from '../../api/layer/bankTransactions'
+import { useLayerContext } from '../../contexts/LayerContext'
+import { useAuth } from '../useAuth'
+import { useSWRConfig } from 'swr'
+import useSWRMutation from 'swr/mutation'
+import type { SWRInfiniteKeyedMutator } from 'swr/infinite'
+import { withSWRKeyTags } from '../../utils/swr/withSWRKeyTags'
+import { BANK_ACCOUNTS_TAG_KEY } from '../bookkeeping/useBankAccounts'
+import { EXTERNAL_ACCOUNTS_TAG_KEY } from '../useLinkedAccounts/useListExternalAccounts'
+
+const MATCH_BANK_TRANSACTION_TAG = '#match-bank-transaction'
+
+function buildKey({
+  access_token: accessToken,
+  apiUrl,
+  businessId,
+}: {
+  access_token?: string
+  apiUrl?: string
+  businessId: string
+}) {
+  if (accessToken && apiUrl) {
+    return {
+      accessToken,
+      apiUrl,
+      businessId,
+      tags: [MATCH_BANK_TRANSACTION_TAG],
+    }
+  }
+}
+
+type MatchBankTransactionArgs = MatchBankTransactionBody & {
+  bankTransactionId: string
+}
+
+type UseMatchBankTransactionOptions = {
+  mutateBankTransactions: SWRInfiniteKeyedMutator<
+    Array<GetBankTransactionsReturn>
+  >
+}
+
+export function useMatchBankTransaction({
+  mutateBankTransactions,
+}: UseMatchBankTransactionOptions) {
+  const { data: auth } = useAuth()
+  const { businessId } = useLayerContext()
+  const { mutate } = useSWRConfig()
+
+  const mutationResponse = useSWRMutation(
+    () => buildKey({
+      access_token: auth?.access_token,
+      apiUrl: auth?.apiUrl,
+      businessId,
+    }),
+    (
+      { accessToken, apiUrl, businessId },
+      { arg: { bankTransactionId, ...body } }: { arg: MatchBankTransactionArgs },
+    ) => matchBankTransaction(
+      apiUrl,
+      accessToken,
+      {
+        params: {
+          businessId,
+          bankTransactionId,
+        },
+        body,
+      },
+    ).then(({ data }) => data),
+    {
+      revalidate: false,
+    },
+  )
+
+  const { trigger: originalTrigger } = mutationResponse
+
+  const stableProxiedTrigger = useCallback(
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const result = await originalTrigger(...triggerParameters)
+
+      if (result) {
+        await Promise.all([
+          mutate(key => withSWRKeyTags(
+            key,
+            tags => (
+              tags.includes(BANK_ACCOUNTS_TAG_KEY)
+              || tags.includes(EXTERNAL_ACCOUNTS_TAG_KEY)
+            ),
+          )),
+          /**
+           * SWR does not expose infinite queries through the matcher
+           *
+           * @see https://github.com/vercel/swr/blob/main/src/_internal/utils/mutate.ts#L78
+           */
+          mutateBankTransactions(undefined, { revalidate: true }),
+        ])
+      }
+
+      return result
+    },
+    [originalTrigger, mutate, mutateBankTransactions],
+  )
+
+  return new Proxy(mutationResponse, {
+    get(target, prop) {
+      if (prop === 'trigger') {
+        return stableProxiedTrigger
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return Reflect.get(target, prop)
+    },
+  })
+}

--- a/src/hooks/useBankTransactions/useUpdateBankTransactionMetadata.ts
+++ b/src/hooks/useBankTransactions/useUpdateBankTransactionMetadata.ts
@@ -70,14 +70,16 @@ export function useUpdateBankTransactionMetadata({ bankTransactionId, onSuccess 
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters)
-        .finally(() => {
-          void mutate(key => withSWRKeyTags(
-            key,
-            tags => tags.includes(GET_BANK_TRANSACTION_METADATA_TAG_KEY),
-          ))
-        }),
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const triggerResult = await originalTrigger(...triggerParameters)
+
+      void mutate(key => withSWRKeyTags(
+        key,
+        tags => tags.includes(GET_BANK_TRANSACTION_METADATA_TAG_KEY),
+      ))
+
+      return triggerResult
+    },
     [
       originalTrigger,
       mutate,

--- a/src/hooks/useBankTransactions/useUpdateBankTransactionMetadata.ts
+++ b/src/hooks/useBankTransactions/useUpdateBankTransactionMetadata.ts
@@ -70,19 +70,18 @@ export function useUpdateBankTransactionMetadata({ bankTransactionId, onSuccess 
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const result = await originalTrigger(...triggerParameters)
-
-      if (result) {
-        await mutate(key => withSWRKeyTags(
-          key,
-          tags => tags.includes(GET_BANK_TRANSACTION_METADATA_TAG_KEY),
-        ))
-      }
-
-      return result
-    },
-    [originalTrigger, mutate],
+    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters)
+        .finally(() => {
+          void mutate(key => withSWRKeyTags(
+            key,
+            tags => tags.includes(GET_BANK_TRANSACTION_METADATA_TAG_KEY),
+          ))
+        }),
+    [
+      originalTrigger,
+      mutate,
+    ],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/useChartOfAccounts/useCreateChildAccount.tsx
+++ b/src/hooks/useChartOfAccounts/useCreateChildAccount.tsx
@@ -58,14 +58,16 @@ export function useCreateChildAccount() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters)
-        .finally(() => {
-          void mutate(key => withSWRKeyTags(
-            key,
-            tags => tags.includes(CATEGORIES_TAG_KEY),
-          ))
-        }),
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const triggerResult = await originalTrigger(...triggerParameters)
+
+      void mutate(key => withSWRKeyTags(
+        key,
+        tags => tags.includes(CATEGORIES_TAG_KEY),
+      ))
+
+      return triggerResult
+    },
     [
       originalTrigger,
       mutate,

--- a/src/hooks/useChartOfAccounts/useCreateChildAccount.tsx
+++ b/src/hooks/useChartOfAccounts/useCreateChildAccount.tsx
@@ -58,19 +58,18 @@ export function useCreateChildAccount() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const result = await originalTrigger(...triggerParameters)
-
-      if (result) {
-        await mutate(key => withSWRKeyTags(
-          key,
-          tags => tags.includes(CATEGORIES_TAG_KEY),
-        ))
-      }
-
-      return result
-    },
-    [originalTrigger, mutate],
+    async (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters)
+        .finally(() => {
+          void mutate(key => withSWRKeyTags(
+            key,
+            tags => tags.includes(CATEGORIES_TAG_KEY),
+          ))
+        }),
+    [
+      originalTrigger,
+      mutate,
+    ],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/useLinkedAccounts/useLinkedAccounts.ts
+++ b/src/hooks/useLinkedAccounts/useLinkedAccounts.ts
@@ -5,11 +5,11 @@ import { useLayerContext } from '../../contexts/LayerContext'
 import { DataModel, LoadedStatus } from '../../types/general'
 import { LinkedAccount, AccountSource } from '../../types/linked_accounts'
 import { LINKED_ACCOUNTS_MOCK_DATA } from './mockData'
-import useSWR from 'swr'
 import { useAuth } from '../useAuth'
 import { useEnvironment } from '../../providers/Environment/EnvironmentInputProvider'
 import type { Awaitable } from '../../types/utility/promises'
 import { useAccountConfirmationStoreActions } from '../../providers/AccountConfirmationStoreProvider'
+import { useListExternalAccounts } from './useListExternalAccounts'
 
 export function getAccountsNeedingConfirmation(linkedAccounts: ReadonlyArray<LinkedAccount>) {
   return linkedAccounts.filter(
@@ -69,20 +69,15 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   const queryKey = businessId && auth?.access_token && `linked-accounts-${businessId}`
 
   const {
-    data: responseData,
+    data: externalAccounts,
     isLoading,
     isValidating,
     error: responseError,
     mutate,
-  } = useSWR(
-    queryKey,
-    Layer.getLinkedAccounts(apiUrl, auth?.access_token, {
-      params: { businessId },
-    }),
-  )
+  } = useListExternalAccounts()
 
   useEffect(() => {
-    if (!isLoading && responseData?.data.external_accounts) {
+    if (!isLoading && externalAccounts) {
       setLoadingStatus('complete')
       return
     }
@@ -356,7 +351,7 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   return {
     data: USE_MOCK_RESPONSE_DATA
       ? mockResponseData.data
-      : (responseData?.data.external_accounts ?? []),
+      : (externalAccounts ?? []),
     isLoading,
     loadingStatus,
     isValidating,

--- a/src/hooks/useLinkedAccounts/useListExternalAccounts.ts
+++ b/src/hooks/useLinkedAccounts/useListExternalAccounts.ts
@@ -1,0 +1,48 @@
+import useSWR from 'swr'
+import { useLayerContext } from '../../contexts/LayerContext'
+import { useAuth } from '../useAuth'
+import { useEnvironment } from '../../providers/Environment/EnvironmentInputProvider'
+import { listExternalAccounts } from '../../api/layer/linked_accounts'
+
+export const EXTERNAL_ACCOUNTS_TAG_KEY = '#external-accounts'
+
+function buildKey({
+  access_token: accessToken,
+  apiUrl,
+  businessId,
+}: {
+  access_token?: string
+  apiUrl?: string
+  businessId: string
+}) {
+  if (accessToken && apiUrl) {
+    return {
+      accessToken,
+      apiUrl,
+      businessId,
+      tags: [EXTERNAL_ACCOUNTS_TAG_KEY],
+    } as const
+  }
+}
+
+export function useListExternalAccounts() {
+  const { businessId } = useLayerContext()
+  const { apiUrl } = useEnvironment()
+  const { data: auth } = useAuth()
+
+  return useSWR(
+    () =>
+      buildKey({
+        ...auth,
+        apiUrl,
+        businessId,
+      }),
+    ({ accessToken, apiUrl, businessId }) => listExternalAccounts(
+      apiUrl,
+      accessToken,
+      {
+        params: { businessId },
+      },
+    )().then(({ data }) => data.external_accounts),
+  )
+}


### PR DESCRIPTION
## Description

When we categorize or match a transaction, the ledger account balance at the top of the page should be updated to reflect the change.