### PR TITLE
fix: `Filters` label is partially cutoff

### DIFF
--- a/src/styles/profit_and_loss_detailed_charts.scss
+++ b/src/styles/profit_and_loss_detailed_charts.scss
@@ -5,7 +5,7 @@
   align-items: flex-start;
   padding: var(--spacing-xl);
   padding-bottom: var(--spacing-lg);
-  box-shadow: 0px -1px 0px 0px var(--color-base-300) inset;
+  box-shadow: 0 -1px 0 0 var(--color-base-300) inset;
 
   button.Layer__btn.Layer__btn--icon-only {
     width: 32px;
@@ -26,6 +26,7 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
   header.Layer__profit-and-loss-detailed-charts__header {
     display: none;
   }
+
   header.Layer__profit-and-loss-detailed-charts__header--tablet {
     display: flex;
   }
@@ -99,7 +100,9 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
   }
 
   .filters {
-    display: flex;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+
     align-items: center;
     margin: 0 var(--spacing-md);
     padding: var(--spacing-2xs) var(--spacing-xs);
@@ -113,10 +116,10 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
     font-weight: var(--font-weight-normal);
     font-variant-numeric: lining-nums proportional-nums;
     font-feature-settings:
-      'cv10' on,
-      'cv05' on,
-      'cv08' on,
-      'ss03' on;
+      "cv10" on,
+      "cv05" on,
+      "cv08" on,
+      "ss03" on;
     display: inline-flex;
 
     .Layer__select__control {
@@ -125,10 +128,10 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
       font-weight: var(--font-weight-normal);
       font-variant-numeric: lining-nums proportional-nums;
       font-feature-settings:
-        'cv10' on,
-        'cv05' on,
-        'cv08' on,
-        'ss03' on;
+        "cv10" on,
+        "cv05" on,
+        "cv08" on,
+        "ss03" on;
       box-shadow: none;
     }
 
@@ -138,10 +141,10 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
       font-weight: var(--font-weight-normal);
       font-variant-numeric: lining-nums proportional-nums;
       font-feature-settings:
-        'cv10' on,
-        'cv05' on,
-        'cv08' on,
-        'ss03' on;
+        "cv10" on,
+        "cv05" on,
+        "cv08" on,
+        "ss03" on;
     }
 
     .Layer__select__indicator-separator {
@@ -232,15 +235,16 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
       }
 
       .Layer__value-icon--uncategorized {
-        background-image: repeating-linear-gradient(
-          -45deg,
-          var(--color-base-200) 0px,
-          var(--color-base-200) 2px,
-          var(--color-base-500) 2px,
-          var(--color-base-500) 3.5px,
-          var(--color-base-200) 3.5px,
-          var(--color-base-200) 4px
-        );
+        background-image:
+          repeating-linear-gradient(
+            -45deg,
+            var(--color-base-200) 0,
+            var(--color-base-200) 2px,
+            var(--color-base-500) 2px,
+            var(--color-base-500) 3.5px,
+            var(--color-base-200) 3.5px,
+            var(--color-base-200) 4px
+          );
       }
     }
   }
@@ -250,9 +254,7 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
   width: 100%;
 }
 
-.Layer__profit-and-loss
-  .Layer__panel__sidebar
-  .Layer__profit-and-loss-detailed-charts {
+.Layer__profit-and-loss .Layer__panel__sidebar .Layer__profit-and-loss-detailed-charts {
   width: 100%;
 }
 
@@ -285,6 +287,7 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
 
 .Layer__profit-and-loss-detailed-charts__pie {
   transition: fill 1000ms ease-out;
+
   &.inactive {
     fill: var(--color-base-300);
   }
@@ -292,11 +295,6 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
 
 .Layer__profit-and-loss-detailed-charts .header--tablet {
   display: none;
-}
-
-.Layer__profit-and-loss-detailed-charts .chart-field {
-  display: flex;
-  flex-direction: column;
 }
 
 @container (max-width: 1023px) {
@@ -314,6 +312,9 @@ header.Layer__profit-and-loss-detailed-charts__header--tablet {
       justify-content: space-between;
 
       .chart-field {
+        display: flex;
+        flex-direction: column;
+
         max-width: 300px;
       }
 


### PR DESCRIPTION
## Description

I believe that the root cause of the issue is the use of `width: 100%`, but it is easier to force a grid layout and move on.

## Screenshot

<img width="500" alt="Screenshot 2025-05-13 at 4 07 36 PM" src="https://github.com/user-attachments/assets/03fb02f4-e16e-4e68-bd05-1d51cdfcabb4" />

