### PR TITLE
fix: categorization must invalidate bank account tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.99-alpha.3",
+  "version": "0.1.99",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.99-alpha.3",
+      "version": "0.1.99",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.99-alpha.3",
+  "version": "0.1.99",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/hooks/useBankTransactions/useCategorizeBankTransaction.ts
+++ b/src/hooks/useBankTransactions/useCategorizeBankTransaction.ts
@@ -7,6 +7,8 @@ import { useSWRConfig } from 'swr'
 import useSWRMutation from 'swr/mutation'
 import type { SWRInfiniteKeyedMutator } from 'swr/infinite'
 import { withSWRKeyTags } from '../../utils/swr/withSWRKeyTags'
+import { BANK_ACCOUNTS_TAG_KEY } from '../bookkeeping/useBankAccounts'
+import { EXTERNAL_ACCOUNTS_TAG_KEY } from '../useLinkedAccounts/useListExternalAccounts'
 
 const CATEGORIZE_BANK_TRANSACTION_TAG = '#categorize-bank-transaction'
 
@@ -79,7 +81,8 @@ export function useCategorizeBankTransaction({
 
       void mutate(key => withSWRKeyTags(
         key,
-        tags => tags.includes(CATEGORIZE_BANK_TRANSACTION_TAG),
+        tags => tags.includes(BANK_ACCOUNTS_TAG_KEY)
+          || tags.includes(EXTERNAL_ACCOUNTS_TAG_KEY),
       ))
       /**
        * SWR does not expose infinite queries through the matcher


### PR DESCRIPTION
## Description

I made a [bad change here](https://github.com/Layer-Fi/layer-react/pull/615/files#diff-8e8abec8c4e071254eb9be7d2bd419ed2463aa86cd0cb3e7d64af9f84cddf0eaR82) (autocomplete-related) on a previous PR.
