### PR TITLE
fix: remove `z-index` on our view headers

### DIFF
--- a/src/styles/view.scss
+++ b/src/styles/view.scss
@@ -2,12 +2,12 @@
   position: relative;
 
   .Layer__view-main {
-    padding: var(--spacing-lg);
+    box-sizing: border-box;
     display: flex;
     flex-direction: column;
     gap: var(--spacing-md);
+    padding: var(--spacing-lg);
     container-type: inline-size;
-    box-sizing: border-box;
 
     .Layer__toggle {
       border-radius: 6px;
@@ -23,16 +23,17 @@
   }
 
   .Layer__view-header {
+    box-sizing: border-box;
+    position: relative;
+
     display: flex;
+    overflow: auto;
     width: 100%;
     max-width: 100%;
-    overflow: auto;
-    container-type: inline-size;
-    position: relative;
-    z-index: 1;
-    border-bottom: 1px solid var(--border-color);
+
     padding: 0 var(--spacing-md);
-    box-sizing: border-box;
+    border-bottom: 1px solid var(--border-color);
+    container-type: inline-size;
 
     .Layer__header__row:last-child {
       border-width: 0;
@@ -44,11 +45,11 @@
   }
 
   .Layer__view-header__title {
-    padding: var(--spacing-md) var(--spacing-sm);
+    display: flex;
+    align-items: center;
     width: 100%;
     min-height: 44px;
-    align-items: center;
-    display: flex;
+    padding: var(--spacing-md) var(--spacing-sm);
   }
 
   .Layer__view-header__content {
@@ -70,8 +71,8 @@
   }
 
   .Layer__view-header__children {
-    width: 100%;
     display: flex;
+    width: 100%;
   }
 
   &.Layer__view--panel {
@@ -81,7 +82,6 @@
 
     .Layer__view-header {
       position: relative;
-      z-index: 1;
       padding: 0;
     }
 


### PR DESCRIPTION
## Description

By arbitrarily increasing the z-index of our headings, we can interfere with items that are intended to overlap the header.

### Example

<img width="300" alt="Screenshot 2025-05-16 at 6 25 22 PM" src="https://github.com/user-attachments/assets/df92b583-eb6c-41c2-ae7e-f21646c89504" />
