### PR TITLE
[LAY-1392] fix: cashflow date picker behavior should match P&L date picker

### DIFF
--- a/src/components/StatementOfCashFlow/datePicker/StatementOfCashFlowDatePicker.tsx
+++ b/src/components/StatementOfCashFlow/datePicker/StatementOfCashFlowDatePicker.tsx
@@ -33,9 +33,7 @@ export function StatementOfCashFlowDatePicker({
       selected={selected}
       onChange={(dates) => {
         if (dates instanceof Date) {
-          if (rangeDisplayMode === 'monthPicker') {
-            setSelected({ start: dates, end: dates })
-          }
+          setSelected({ start: dates, end: dates })
 
           return
         }


### PR DESCRIPTION
## Description

**Linear**: [LAY-1392](https://linear.app/layerfi/issue/LAY-1392/fix-date-selector-issue-for-statement-of-cash-flow)

The statement of cashflow `rangeDisplayMode` can be shifted to `dayRange` when the users moves the balance sheet date around. But, it can still be a `monthPicker` mode internally since this is the only allowed mode.

(See `ProfitAndLossDatePicker` for the [correct behavior](https://github.com/Layer-Fi/layer-react/blob/ea3616df3e30d5acaadf12243bb2d1b36d67850a/src/components/ProfitAndLossDatePicker/ProfitAndLossDatePicker.tsx#L35))