### PR TITLE
[LAY-1391] fix: P&L table should not expand for several sections

### DIFF
--- a/src/components/ProfitAndLossTable/ProfitAndLossTableComponent.tsx
+++ b/src/components/ProfitAndLossTable/ProfitAndLossTableComponent.tsx
@@ -142,8 +142,8 @@ export const ProfitAndLossTableComponent = ({
           0,
           'gross_profit',
           2,
-          'revenue',
-          setSidebarScope,
+          undefined,
+          undefined,
           'summation',
         )}
         {renderLineItem(
@@ -163,11 +163,17 @@ export const ProfitAndLossTableComponent = ({
           0,
           'profit_before_taxes',
           4,
-          'revenue',
-          setSidebarScope,
+          undefined,
+          undefined,
           'summation',
         )}
-        {renderLineItem(data.taxes, 0, 'taxes', 5, 'expenses', setSidebarScope)}
+        {renderLineItem(
+          data.taxes,
+          0,
+          'taxes',
+          5,
+          'expenses',
+        )}
         {renderLineItem(
           {
             value: data.net_profit,


### PR DESCRIPTION
## Description

**Linear**: [LAY-1391](https://linear.app/layerfi/issue/LAY-1391/remove-pie-chart-icons-from-specified-rows)

No Longer Expandable:
- Gross Profit
- Profit before Taxes
- Taxes
