### PR TITLE
fix: broken "amount" input on ledger entry form

### DIFF
--- a/src/components/Input/AmountInput.tsx
+++ b/src/components/Input/AmountInput.tsx
@@ -1,4 +1,4 @@
-
+import { type ReactNode } from 'react'
 import classNames from 'classnames'
 import CurrencyInput, { CurrencyInputProps } from 'react-currency-input-field'
 import { Tooltip, TooltipTrigger, TooltipContent } from '../Tooltip'
@@ -8,6 +8,7 @@ export interface AmountInputProps extends Omit<CurrencyInputProps, 'onChange'> {
   isInvalid?: boolean
   errorMessage?: string
   leftText?: string
+  badge?: ReactNode
 }
 
 export const AmountInput = ({
@@ -16,32 +17,46 @@ export const AmountInput = ({
   leftText,
   errorMessage,
   isInvalid,
+  badge,
   placeholder = '$0.00',
   ...props
 }: AmountInputProps) => {
   const baseClassName = classNames(
     'Layer__input Layer__amount-input',
+    badge ? 'Layer__amount-input--align-left' : 'Layer__amount-input--align-right',
     isInvalid ? 'Layer__input--error' : '',
     leftText ? 'Layer__input--with-left-text' : '',
     className,
   )
 
-  return (
+  const currencyInput = (
+    <CurrencyInput
+      {...props}
+      intlConfig={{
+        locale: 'en-US',
+        currency: 'USD',
+      }}
+      prefix='$'
+      placeholder={placeholder}
+      decimalScale={2}
+      decimalsLimit={2}
+      disableAbbreviations
+      onValueChange={onChange}
+      className={baseClassName}
+    />
+  )
 
+  return (
     <Tooltip disabled={!isInvalid || !errorMessage}>
       <TooltipTrigger className='Layer__input-tooltip'>
-        <CurrencyInput
-          {...props}
-          intlConfig={{
-            locale: 'en-US',
-            currency: 'USD',
-          }}
-          prefix='$'
-          placeholder={placeholder}
-          decimalsLimit={2}
-          onValueChange={onChange}
-          className={baseClassName}
-        />
+        {badge
+          ? (
+            <div className='Layer__input-with-badge'>
+              {currencyInput}
+              {badge}
+            </div>
+          )
+          : currencyInput}
         {leftText && <span className='Layer__input-left-text'>{leftText}</span>}
       </TooltipTrigger>
       <TooltipContent className='Layer__tooltip'>{errorMessage}</TooltipContent>

--- a/src/components/JournalForm/JournalFormEntryLines.tsx
+++ b/src/components/JournalForm/JournalFormEntryLines.tsx
@@ -5,17 +5,16 @@ import { Direction, JournalEntryLineItem } from '../../types'
 import { LedgerAccountBalance } from '../../types/chart_of_accounts'
 import { BaseSelectOption } from '../../types/general'
 import {
-  convertCurrencyToNumber,
-  convertNumberToCurrency,
   humanizeEnum,
 } from '../../utils/format'
-import { BadgeVariant } from '../Badge'
 import { IconButton, TextButton } from '../Button'
-import { InputWithBadge, InputGroup, Select } from '../Input'
+import { InputGroup, Select } from '../Input'
 import { JournalConfig } from '../Journal/Journal'
 import { Text, TextSize } from '../Typography'
 import { useCategories } from '../../hooks/categories/useCategories'
 import { unsafeAssertUnreachable } from '../../utils/switch/assertUnreachable'
+import { AmountInput } from '../Input/AmountInput'
+import { Badge, BadgeVariant } from '../Badge/Badge'
 
 type WithSubCategories = { subCategories: ReadonlyArray<WithSubCategories> | null }
 
@@ -172,25 +171,20 @@ export const JournalFormEntryLines = ({
                   key={direction + '-' + idx}
                 >
                   <InputGroup name={direction} label='Amount' inline={true}>
-                    <InputWithBadge
+                    <AmountInput
                       name={direction}
-                      placeholder='$0.00'
-                      value={convertNumberToCurrency(item.amount)}
+                      onChange={value => changeFormData('amount', value, idx)}
+                      value={item.amount}
                       disabled={sendingForm}
-                      badge={humanizeEnum(direction)}
-                      variant={
-                        item.direction === 'CREDIT'
+                      allowNegativeValue={false}
+                      badge={(
+                        <Badge variant={item.direction === 'CREDIT'
                           ? BadgeVariant.SUCCESS
-                          : BadgeVariant.WARNING
-                      }
-                      onChange={e =>
-                        changeFormData(
-                          'amount',
-                          convertCurrencyToNumber(
-                            (e.target as HTMLInputElement).value,
-                          ),
-                          idx,
-                        )}
+                          : BadgeVariant.WARNING}
+                        >
+                          {humanizeEnum(direction)}
+                        </Badge>
+                      )}
                       isInvalid={Boolean(
                         form?.errors?.lineItems.find(
                           x => x.id === idx && x.field === 'amount',

--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -40,7 +40,13 @@
 }
 
 .Layer__amount-input {
-  text-align: right;
+  &--align-left {
+    text-align: left;
+  }
+
+  &--align-right {
+    text-align: right;
+  }
 }
 
 .Layer__textarea {


### PR DESCRIPTION
This PR fixes a bug where the "amount" input on the ledger entry form did not allow you to enter anything. 

I migrated from the `InputWithBadge` to the AmountInput` component that has stricter input validation around currency values so as to avoid converting values back and forth between numbers and currencies.

I also noticed some issues with tooltips appearing under the drawer due to z-index being less than the drawer, but will separate that work out into another PR because it has a much larger surface area.

See visual here:
<img width="726" alt="Screenshot 2025-06-03 at 11 56 22 AM" src="https://github.com/user-attachments/assets/4be94f1e-ecd5-48e2-b53a-c43127d58383" />