### PR TITLE
build: when publishing to npm, the default tag is "alpha"

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+tag = "alpha"


### PR DESCRIPTION
## Description

This is a fast follow on an idea from @sarahraines. Now, when we publish "latest" versions, we need to explicitly specify the tag.

### Dev Notes

If you want to see all of the configuration (both defaults and overrides), try this:

```
npm config ls -l
```
