### PR TITLE
feat: add upload transactions by CSV to bank transactions header menu

### DIFF
--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -60,6 +60,7 @@ export interface BankTransactionsProps {
   showDescriptions?: boolean
   showReceiptUploads?: boolean
   showTooltips?: boolean
+  showUploadOptions?: boolean
 
   monthlyView?: boolean
   categorizeView?: boolean
@@ -104,6 +105,7 @@ const BankTransactionsContent = ({
   showDescriptions = true,
   showReceiptUploads = true,
   showTooltips = false,
+  showUploadOptions = false,
 
   monthlyView = false,
   categorizeView: categorizeViewProp,
@@ -309,6 +311,7 @@ const BankTransactionsContent = ({
           stringOverrides={stringOverrides?.bankTransactionsHeader}
           isDataLoading={isLoadingWithoutData}
           isSyncing={isSyncing}
+          withUploadMenu={showUploadOptions}
         />
       )}
 

--- a/src/components/BankTransactions/BankTransactionsHeader.tsx
+++ b/src/components/BankTransactions/BankTransactionsHeader.tsx
@@ -16,7 +16,7 @@ import { useBankTransactionsContext } from '../../contexts/BankTransactionsConte
 import { useDebounce } from '../../hooks/useDebounce/useDebounce'
 import { TransactionsSearchField } from '../domain/transactions/searchField/TransactionsSearchField'
 import { TransactionsActions } from '../domain/transactions/actions/TransactionsActions'
-import { VStack } from '../ui/Stack/Stack'
+import { HStack, VStack } from '../ui/Stack/Stack'
 import { useBankTransactionsDownload } from '../../hooks/useBankTransactions/useBankTransactionsDownload'
 import InvisibleDownload, { useInvisibleDownload } from '../utility/InvisibleDownload'
 import { bankTransactionFiltersToHookOptions } from '../../hooks/useBankTransactions/useAugmentedBankTransactions'
@@ -171,7 +171,7 @@ export const BankTransactionsHeader = ({
           )
           : null}
       </div>
-      <TransactionsActions withUploadMenu={withUploadMenu}>
+      <TransactionsActions>
         {(!categorizedOnly && categorizeView) && (
           <VStack slot='toggle' justify='center'>
             <Toggle
@@ -191,17 +191,13 @@ export const BankTransactionsHeader = ({
           </VStack>
         )}
         <TransactionsSearch slot='search' />
-        <VStack slot='download' justify='center'>
+        <HStack slot='download-upload' justify='center' gap='xs'>
           <DownloadButton
             downloadButtonTextOverride={stringOverrides?.downloadButton}
             iconOnly={listView}
           />
-        </VStack>
-        {withUploadMenu && (
-          <VStack slot='upload' justify='center'>
-            <BankTransactionsUploadMenu iconOnly={listView} />
-          </VStack>
-        )}
+          {withUploadMenu && <BankTransactionsUploadMenu iconOnly={listView} />}
+        </HStack>
       </TransactionsActions>
     </Header>
   )

--- a/src/components/BankTransactions/BankTransactionsHeader.tsx
+++ b/src/components/BankTransactions/BankTransactionsHeader.tsx
@@ -37,6 +37,7 @@ export interface BankTransactionsHeaderProps {
   isSyncing?: boolean
   setDateRange?: (value: DateRange) => void
   stringOverrides?: BankTransactionsHeaderStringOverrides
+  withUploadMenu?: boolean
 }
 
 export interface BankTransactionsHeaderStringOverrides {
@@ -121,6 +122,7 @@ export const BankTransactionsHeader = ({
   setDateRange,
   stringOverrides,
   isSyncing,
+  withUploadMenu,
 }: BankTransactionsHeaderProps) => {
   const { business } = useLayerContext()
 
@@ -169,7 +171,7 @@ export const BankTransactionsHeader = ({
           )
           : null}
       </div>
-      <TransactionsActions>
+      <TransactionsActions withUploadMenu={withUploadMenu}>
         {(!categorizedOnly && categorizeView) && (
           <VStack slot='toggle' justify='center'>
             <Toggle
@@ -195,9 +197,11 @@ export const BankTransactionsHeader = ({
             iconOnly={listView}
           />
         </VStack>
-        <VStack slot='manage' justify='center'>
-          <BankTransactionsUploadMenu iconOnly={listView} />
-        </VStack>
+        {withUploadMenu && (
+          <VStack slot='upload' justify='center'>
+            <BankTransactionsUploadMenu iconOnly={listView} />
+          </VStack>
+        )}
       </TransactionsActions>
     </Header>
   )

--- a/src/components/BankTransactions/BankTransactionsHeader.tsx
+++ b/src/components/BankTransactions/BankTransactionsHeader.tsx
@@ -20,6 +20,7 @@ import { VStack } from '../ui/Stack/Stack'
 import { useBankTransactionsDownload } from '../../hooks/useBankTransactions/useBankTransactionsDownload'
 import InvisibleDownload, { useInvisibleDownload } from '../utility/InvisibleDownload'
 import { bankTransactionFiltersToHookOptions } from '../../hooks/useBankTransactions/useAugmentedBankTransactions'
+import { BankTransactionsUploadMenu } from './BankTransactionsUploadMenu'
 
 export interface BankTransactionsHeaderProps {
   shiftStickyHeader: number
@@ -193,6 +194,9 @@ export const BankTransactionsHeader = ({
             downloadButtonTextOverride={stringOverrides?.downloadButton}
             iconOnly={listView}
           />
+        </VStack>
+        <VStack slot='manage' justify='center'>
+          <BankTransactionsUploadMenu iconOnly={listView} />
         </VStack>
       </TransactionsActions>
     </Header>

--- a/src/components/BankTransactions/BankTransactionsUploadMenu.tsx
+++ b/src/components/BankTransactions/BankTransactionsUploadMenu.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
 import { DropdownMenu, Heading, MenuList, MenuItem } from '../ui/DropdownMenu/DropdownMenu'
 import { Text, TextSize } from '../Typography'
 import { Button } from '../ui/Button/Button'
@@ -16,14 +16,11 @@ const MenuTriggerButton = ({ iconOnly }: { iconOnly?: boolean }) => (
 
 export const BankTransactionsUploadMenu = ({ iconOnly }: { iconOnly?: boolean }) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const onModalOpenChange = useCallback((isOpen: boolean) => {
-    setIsModalOpen(isOpen)
-  }, [])
 
   return (
     <>
       <DropdownMenu
-        ariaLabel='Manage transactions'
+        ariaLabel='Upload transactions'
         slots={{ Trigger: () => <MenuTriggerButton iconOnly={iconOnly} /> }}
         slotProps={{
           Dialog: { width: '18rem' },
@@ -31,7 +28,7 @@ export const BankTransactionsUploadMenu = ({ iconOnly }: { iconOnly?: boolean })
       >
         <Heading>Choose how to upload transactions</Heading>
         <MenuList>
-          <MenuItem key='upload-txns' onClick={() => onModalOpenChange(true)}>
+          <MenuItem key='upload-txns' onClick={() => setIsModalOpen(true)}>
             <VStack className='Layer__bank-transactions__header-menu__upload-transactions-icon'>
               <UploadCloud size={16} />
             </VStack>
@@ -43,7 +40,7 @@ export const BankTransactionsUploadMenu = ({ iconOnly }: { iconOnly?: boolean })
           </MenuItem>
         </MenuList>
       </DropdownMenu>
-      <BankTransactionsUploadModal isOpen={isModalOpen} onOpenChange={onModalOpenChange} />
+      <BankTransactionsUploadModal isOpen={isModalOpen} onOpenChange={setIsModalOpen} />
     </>
   )
 }

--- a/src/components/BankTransactions/BankTransactionsUploadMenu.tsx
+++ b/src/components/BankTransactions/BankTransactionsUploadMenu.tsx
@@ -1,0 +1,49 @@
+import { useCallback, useState } from 'react'
+import { DropdownMenu, Heading, MenuList, MenuItem } from '../ui/DropdownMenu/DropdownMenu'
+import { Text, TextSize } from '../Typography'
+import { Button } from '../ui/Button/Button'
+import { Spacer, VStack } from '../ui/Stack/Stack'
+import { ChevronRight } from 'lucide-react'
+import UploadCloud from '../../icons/UploadCloud'
+import { BankTransactionsUploadModal } from './BankTransactionsUploadModal/BankTransactionsUploadModal'
+
+const MenuTriggerButton = ({ iconOnly }: { iconOnly?: boolean }) => (
+  <Button variant='ghost' {...(iconOnly && { icon: true })} persistentBorder={iconOnly}>
+    {!iconOnly && 'Upload'}
+    <UploadCloud size={12} />
+  </Button>
+)
+
+export const BankTransactionsUploadMenu = ({ iconOnly }: { iconOnly?: boolean }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const onModalOpenChange = useCallback((isOpen: boolean) => {
+    setIsModalOpen(isOpen)
+  }, [])
+
+  return (
+    <>
+      <DropdownMenu
+        ariaLabel='Manage transactions'
+        slots={{ Trigger: () => <MenuTriggerButton iconOnly={iconOnly} /> }}
+        slotProps={{
+          Dialog: { width: '18rem' },
+        }}
+      >
+        <Heading>Choose how to upload transactions</Heading>
+        <MenuList>
+          <MenuItem key='upload-txns' onClick={() => onModalOpenChange(true)}>
+            <VStack className='Layer__bank-transactions__header-menu__upload-transactions-icon'>
+              <UploadCloud size={16} />
+            </VStack>
+            <Text size={TextSize.sm}>
+              Upload transactions manually
+            </Text>
+            <Spacer />
+            <ChevronRight size={12} />
+          </MenuItem>
+        </MenuList>
+      </DropdownMenu>
+      <BankTransactionsUploadModal isOpen={isModalOpen} onOpenChange={onModalOpenChange} />
+    </>
+  )
+}

--- a/src/components/BankTransactions/BankTransactionsUploadModal/BankTransactionsUploadModal.tsx
+++ b/src/components/BankTransactions/BankTransactionsUploadModal/BankTransactionsUploadModal.tsx
@@ -1,0 +1,21 @@
+import { Modal, ModalProps } from '../../ui/Modal/Modal'
+import { ModalContextBar } from '../../ui/Modal/ModalSlots'
+import { UploadTransactions } from '../../UploadTransactions/UploadTransactions'
+
+function BankTransactionsUploadModalContent({ onClose }: { onClose: () => void }) {
+  return (
+    <>
+      <ModalContextBar onClose={onClose} />
+      <UploadTransactions onComplete={onClose} />
+    </>
+  )
+}
+
+type BankTransactionsUploadModalProps = Pick<ModalProps, 'isOpen' | 'onOpenChange'>
+export function BankTransactionsUploadModal({ isOpen, onOpenChange }: BankTransactionsUploadModalProps) {
+  return (
+    <Modal flexBlock isOpen={isOpen} onOpenChange={onOpenChange} size='lg'>
+      {({ close }) => <BankTransactionsUploadModalContent onClose={close} />}
+    </Modal>
+  )
+}

--- a/src/components/CsvUpload/CopyTemplateHeadersButtonGroup.tsx
+++ b/src/components/CsvUpload/CopyTemplateHeadersButtonGroup.tsx
@@ -1,6 +1,7 @@
 import { CopyIcon } from 'lucide-react'
 import { HStack } from '../ui/Stack/Stack'
 import { Button, ButtonVariant } from '../Button/Button'
+import classNames from 'classnames'
 
 const copyTextToClipboard = (text: string) => {
   navigator.clipboard.writeText(text).catch(() => {})
@@ -8,11 +9,12 @@ const copyTextToClipboard = (text: string) => {
 
 interface CopyTemplateHeadersButtonGroupProps {
   headers: Record<string, string>
+  className?: string
 }
 
-export const CopyTemplateHeadersButtonGroup = ({ headers }: CopyTemplateHeadersButtonGroupProps) => {
+export const CopyTemplateHeadersButtonGroup = ({ headers, className }: CopyTemplateHeadersButtonGroupProps) => {
   return (
-    <HStack gap='3xs' className='Layer__csv-upload__copy-template-headers-button-group'>
+    <HStack gap='3xs' className={classNames('Layer__csv-upload__copy-template-headers-button-group', className)}>
       {Object.keys(headers).map(key => (
         <Button
           key={key}

--- a/src/components/CsvUpload/ValidateCsvTable.tsx
+++ b/src/components/CsvUpload/ValidateCsvTable.tsx
@@ -13,7 +13,7 @@ import { PreviewCsv, PreviewRow } from './types'
 import { useVirtualizer, VirtualItem, Virtualizer } from '@tanstack/react-virtual'
 
 const ROW_HEIGHT = 52
-const MAX_NUM_ROWS = 10
+const MAX_NUM_ROWS = 8
 const HEADER_HEIGHT = 41
 const CONTAINER_HEIGHT = ROW_HEIGHT * MAX_NUM_ROWS + HEADER_HEIGHT - 1
 

--- a/src/components/CsvUpload/csvUpload.scss
+++ b/src/components/CsvUpload/csvUpload.scss
@@ -52,9 +52,14 @@
 }
 
 .Layer__csv-upload__copy-template-headers-button-group {
+  box-sizing: border-box;
   padding: var(--spacing-3xs);
   border-radius: var(--border-radius-3xs);
   background-color: var(--color-base-200);
+
+  .Layer__btn {
+    flex: 1 1 auto;
+  }
 }
 
 .Layer__csv-upload__validate-csv-table__container {

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
@@ -177,13 +177,13 @@ function LinkedAccountsConfirmationModalContent({ onClose }: { onClose: () => vo
                 <P size='sm'>
                   No data will be synced until you confirm.
                 </P>
-                <Button size='lg' onPress={close}>
+                <Button onPress={close}>
                   Close
                 </Button>
               </>
             )
             : (
-              <Button size='lg' onPress={() => { void handleFinish() }} isPending={isMutating}>
+              <Button onPress={() => { void handleFinish() }} isPending={isMutating}>
                 {buttonLabel}
               </Button>
             )}

--- a/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
+++ b/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
@@ -143,7 +143,7 @@ function LinkedAccountsOpeningBalanceModalContent({
       </ModalContent>
       <ModalActions>
         <VStack gap='md'>
-          <Button size='lg' onPress={() => void trigger()} isPending={isMutating}>
+          <Button onPress={() => void trigger()} isPending={isMutating}>
             {stringOverrides?.buttonText ?? 'Submit'}
           </Button>
         </VStack>

--- a/src/components/UploadTransactions/UploadTransactions.tsx
+++ b/src/components/UploadTransactions/UploadTransactions.tsx
@@ -78,7 +78,7 @@ export function UploadTransactions({ onComplete }: UploadTransactionsProps) {
   }, [])
 
   return (
-    <section className='Layer__component'>
+    <section className='Layer__component Layer__upload-transactions'>
       <Wizard
         Header={<UploadTransactionsHeader currentStep={currentStep} isValid={isValid} />}
         Footer={null}

--- a/src/components/UploadTransactions/UploadTransactionsUploadCsvStep.tsx
+++ b/src/components/UploadTransactions/UploadTransactionsUploadCsvStep.tsx
@@ -149,12 +149,15 @@ export function UploadTransactionsUploadCsvStep(
       <Separator />
       <VStack gap='xs' className='Layer__upload-transactions__template-section'>
         <P size='sm'>Click to copy the required column headers</P>
-        <HStack align='center' gap='xs'>
-          <CopyTemplateHeadersButtonGroup headers={templateHeaders} />
-          <Spacer />
+        <HStack align='center' gap='xs' className='Layer__upload-transactions__template-section__button-row'>
+          <CopyTemplateHeadersButtonGroup
+            headers={templateHeaders}
+            className='Layer__upload-transactions__template-section__button-row-item'
+          />
           <DownloadCsvTemplateButton
             fileName='upload_transactions.csv'
             csvProps={{ headers: templateHeaders, rows: templateExampleTransactions }}
+            className='Layer__upload-transactions__template-section__button-row-item'
           >
             Download template
           </DownloadCsvTemplateButton>

--- a/src/components/UploadTransactions/uploadTransactions.scss
+++ b/src/components/UploadTransactions/uploadTransactions.scss
@@ -1,71 +1,90 @@
-.Layer__upload-transactions__select-account-name-field {
-  >.Layer__input-tooltip {
-    flex: auto;
-  }
-}
-
-.Layer__upload-transactions__select-account-name-input {
-  .Layer__select__control {
-    width: 24rem;
-    min-height: 44px;
+.Layer__upload-transactions {
+  container-type: inline-size;
+  
+  .Layer__upload-transactions__select-account-name-field {
+    >.Layer__input-tooltip {
+      flex: auto;
+    }
   }
 
-  &--error {
+  .Layer__upload-transactions__select-account-name-input {
     .Layer__select__control {
-      box-shadow:
-        0 0 0 1px var(--color-base-300),
-        0 0 0 2px var(--color-danger);
-    }
-    
-    .Layer__select__placeholder {
-      color: var(--color-danger);
-    }
-  }
-}
-
-.Layer__upload-transactions__create-account-form {
-  border-radius: var(--border-radius-3xs);
-  padding: var(--spacing-xs);
-  background: var(--color-base-100);
-}
-
-.Layer__upload-transactions__parse-csv-error-message {
-  max-width: 29rem;
-}
-
-.Layer__upload-transactions__template-section {
-  border-radius: var(--border-radius-3xs);
-  border: 1px solid var(--color-base-400);
-  padding: var(--spacing-md);
-}
-
-.Layer__upload-transactions__confirmation-step__data-state {
-  .Layer__data-state__description {
-    margin-bottom: 0;
-  }
-}
-
-.Layer__upload-transactions__preview_table {
-  .Layer__csv-upload__validate-csv-table__cell--date,
-  .Layer__csv-upload__validate-csv-table__header-cell--date {
-    min-width: 120px;
-  }
-
-  .Layer__csv-upload__validate-csv-table__cell--amount,
-  .Layer__csv-upload__validate-csv-table__header-cell--amount {
-    min-width: 120px;
-    
-    .Layer__csv-upload__validate-csv-table__header-cell-content {
-      margin-left: auto;
+      width: 24rem;
+      min-height: 44px;
     }
 
-    .Layer__csv-upload__validate-csv-table__cell-content {
-      text-align: right;
+    &--error {
+      .Layer__select__control {
+        box-shadow:
+          0 0 0 1px var(--color-base-300),
+          0 0 0 2px var(--color-danger);
+      }
+      
+      .Layer__select__placeholder {
+        color: var(--color-danger);
+      }
     }
   }
 
-  .Layer__csv-upload__validate-csv-table__cell--description,
-  .Layer__csv-upload__validate-csv-table__header-cell--description {
-    flex: 3 1 0;
+  .Layer__upload-transactions__create-account-form {
+    border-radius: var(--border-radius-3xs);
+    padding: var(--spacing-xs);
+    background: var(--color-base-100);
+  }
+
+  .Layer__upload-transactions__parse-csv-error-message {
+    max-width: 29rem;
+  }
+
+  .Layer__upload-transactions__template-section {
+    border-radius: var(--border-radius-3xs);
+    border: 1px solid var(--color-base-400);
+    padding: var(--spacing-md);
+  }
+
+  .Layer__upload-transactions__template-section__button-row {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  @container (max-width: 576px) {
+    .Layer__upload-transactions__template-section__button-row {
+      flex-direction: column;
+
+      >.Layer__upload-transactions__template-section__button-row-item {
+        width: 100%
+      }
+    }
+  }
+
+  .Layer__upload-transactions__confirmation-step__data-state {
+    .Layer__data-state__description {
+      margin-bottom: 0;
+    }
+  }
+
+  .Layer__upload-transactions__preview_table {
+    .Layer__csv-upload__validate-csv-table__cell--date,
+    .Layer__csv-upload__validate-csv-table__header-cell--date {
+      min-width: 120px;
+    }
+
+    .Layer__csv-upload__validate-csv-table__cell--amount,
+    .Layer__csv-upload__validate-csv-table__header-cell--amount {
+      min-width: 120px;
+      
+      .Layer__csv-upload__validate-csv-table__header-cell-content {
+        margin-left: auto;
+      }
+
+      .Layer__csv-upload__validate-csv-table__cell-content {
+        text-align: right;
+      }
+    }
+
+    .Layer__csv-upload__validate-csv-table__cell--description,
+    .Layer__csv-upload__validate-csv-table__header-cell--description {
+      flex: 3 1 0;
+    }
   }
 }

--- a/src/components/UploadTransactions/uploadTransactions.scss
+++ b/src/components/UploadTransactions/uploadTransactions.scss
@@ -52,7 +52,7 @@
       flex-direction: column;
 
       >.Layer__upload-transactions__template-section__button-row-item {
-        width: 100%
+        width: 100%;
       }
     }
   }

--- a/src/components/domain/transactions/actions/TransactionsActions.tsx
+++ b/src/components/domain/transactions/actions/TransactionsActions.tsx
@@ -1,10 +1,15 @@
+import classNames from 'classnames'
 import type { PropsWithChildren } from 'react'
 
 const CLASS_NAME = 'Layer__TransactionsActions'
+const UPLOAD_MENU_CLASS_NAME = `${CLASS_NAME}--with-upload-menu`
 
-export function TransactionsActions({ children }: PropsWithChildren) {
+type TransactionsActionsProps = PropsWithChildren<{
+  withUploadMenu?: boolean
+}>
+export function TransactionsActions({ children, withUploadMenu }: TransactionsActionsProps) {
   return (
-    <div className={CLASS_NAME}>
+    <div className={classNames(CLASS_NAME, withUploadMenu && UPLOAD_MENU_CLASS_NAME)}>
       {children}
     </div>
   )

--- a/src/components/domain/transactions/actions/TransactionsActions.tsx
+++ b/src/components/domain/transactions/actions/TransactionsActions.tsx
@@ -1,15 +1,10 @@
-import classNames from 'classnames'
 import type { PropsWithChildren } from 'react'
 
 const CLASS_NAME = 'Layer__TransactionsActions'
-const UPLOAD_MENU_CLASS_NAME = `${CLASS_NAME}--with-upload-menu`
 
-type TransactionsActionsProps = PropsWithChildren<{
-  withUploadMenu?: boolean
-}>
-export function TransactionsActions({ children, withUploadMenu }: TransactionsActionsProps) {
+export function TransactionsActions({ children }: PropsWithChildren) {
   return (
-    <div className={classNames(CLASS_NAME, withUploadMenu && UPLOAD_MENU_CLASS_NAME)}>
+    <div className={CLASS_NAME}>
       {children}
     </div>
   )

--- a/src/components/domain/transactions/actions/transactionsActions.scss
+++ b/src/components/domain/transactions/actions/transactionsActions.scss
@@ -1,25 +1,47 @@
 .Layer__TransactionsActions {
   display: grid;
 
-  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   gap: var(--spacing-xs);
   grid-template-areas:
-    "toggle . download manage"
-    "search search search search";
+    "toggle . download"
+    "search search search";
+
+  &--with-upload-menu {
+    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    grid-template-areas:
+      "toggle . download upload"
+      "search search search search";
+  }
 
   @container (min-width: 640px) {
-    grid-template-columns: auto minmax(0, 2fr) minmax(0, 3fr) auto auto;
-    grid-template-areas: "toggle . search download manage";
+    grid-template-columns: auto minmax(0, 2fr) minmax(0, 3fr) auto;
+    grid-template-areas: "toggle . search download";
+    
+    &--with-upload-menu {
+      grid-template-columns: auto minmax(0, 2fr) minmax(0, 3fr) auto auto;
+      grid-template-areas: "toggle . search download upload";
+    }
   }
 
   @container (min-width: 780px) {
-    grid-template-columns: auto minmax(0, 3fr) minmax(0, 2fr) auto auto;
-    grid-template-areas: "toggle . search download manage";
+    grid-template-columns: auto minmax(0, 3fr) minmax(0, 2fr) auto;
+    grid-template-areas: "toggle . search download";
+
+    &--with-upload-menu {
+      grid-template-columns: auto minmax(0, 3fr) minmax(0, 2fr) auto auto;
+      grid-template-areas: "toggle . search download upload";
+    }
   }
 
   @container (min-width: 1024px) {
-    grid-template-columns: auto minmax(0, 3fr) minmax(0, 1fr) auto auto;
-    grid-template-areas: "toggle . search download manage";
+    grid-template-columns: auto minmax(0, 3fr) minmax(0, 1fr) auto;
+    grid-template-areas: "toggle . search download";
+
+    &--with-upload-menu {
+      grid-template-columns: auto minmax(0, 3fr) minmax(0, 1fr) auto auto;
+      grid-template-areas: "toggle . search download upload";
+    }
   }
 
   > [slot="toggle"] {
@@ -34,7 +56,7 @@
     grid-area: download;
   }
 
-  > [slot="manage"] {
-    grid-area: manage;
+  > [slot="upload"] {
+    grid-area: upload;
   }
 }

--- a/src/components/domain/transactions/actions/transactionsActions.scss
+++ b/src/components/domain/transactions/actions/transactionsActions.scss
@@ -1,47 +1,26 @@
 .Layer__TransactionsActions {
   display: grid;
+  grid-template-areas:
+    "toggle . download-upload"
+    "search search search";
 
   grid-template-columns: auto minmax(0, 1fr) auto;
   gap: var(--spacing-xs);
-  grid-template-areas:
-    "toggle . download"
-    "search search search";
-
-  &--with-upload-menu {
-    grid-template-columns: auto minmax(0, 1fr) auto auto;
-    grid-template-areas:
-      "toggle . download upload"
-      "search search search search";
-  }
+  align-items: center;
 
   @container (min-width: 640px) {
-    grid-template-columns: auto minmax(0, 2fr) minmax(0, 3fr) auto;
-    grid-template-areas: "toggle . search download";
-    
-    &--with-upload-menu {
-      grid-template-columns: auto minmax(0, 2fr) minmax(0, 3fr) auto auto;
-      grid-template-areas: "toggle . search download upload";
-    }
+    grid-template-areas: "toggle . search download-upload";
+    grid-template-columns: auto minmax(0, 2fr) minmax(15rem, 3fr) auto;
   }
 
   @container (min-width: 780px) {
-    grid-template-columns: auto minmax(0, 3fr) minmax(0, 2fr) auto;
-    grid-template-areas: "toggle . search download";
-
-    &--with-upload-menu {
-      grid-template-columns: auto minmax(0, 3fr) minmax(0, 2fr) auto auto;
-      grid-template-areas: "toggle . search download upload";
-    }
+    grid-template-areas: "toggle . search download-upload";
+    grid-template-columns: auto minmax(0, 3fr) minmax(15rem, 2fr) auto;
   }
 
   @container (min-width: 1024px) {
-    grid-template-columns: auto minmax(0, 3fr) minmax(0, 1fr) auto;
-    grid-template-areas: "toggle . search download";
-
-    &--with-upload-menu {
-      grid-template-columns: auto minmax(0, 3fr) minmax(0, 1fr) auto auto;
-      grid-template-areas: "toggle . search download upload";
-    }
+    grid-template-areas: "toggle . search download-upload";
+    grid-template-columns: auto minmax(0, 3fr) minmax(15rem, 1fr) auto;
   }
 
   > [slot="toggle"] {
@@ -52,11 +31,7 @@
     grid-area: search;
   }
 
-  > [slot="download"] {
-    grid-area: download;
-  }
-
-  > [slot="upload"] {
-    grid-area: upload;
+  > [slot="download-upload"] {
+    grid-area: download-upload;
   }
 }

--- a/src/components/domain/transactions/actions/transactionsActions.scss
+++ b/src/components/domain/transactions/actions/transactionsActions.scss
@@ -1,25 +1,25 @@
 .Layer__TransactionsActions {
   display: grid;
 
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
   gap: var(--spacing-xs);
   grid-template-areas:
-    "toggle . download"
-    "search search search";
+    "toggle . download manage"
+    "search search search search";
 
   @container (min-width: 640px) {
-    grid-template-columns: auto minmax(0, 2fr) minmax(0, 3fr) auto;
-    grid-template-areas: "toggle . search download";
+    grid-template-columns: auto minmax(0, 2fr) minmax(0, 3fr) auto auto;
+    grid-template-areas: "toggle . search download manage";
   }
 
   @container (min-width: 780px) {
-    grid-template-columns: auto minmax(0, 3fr) minmax(0, 2fr) auto;
-    grid-template-areas: "toggle . search download";
+    grid-template-columns: auto minmax(0, 3fr) minmax(0, 2fr) auto auto;
+    grid-template-areas: "toggle . search download manage";
   }
 
   @container (min-width: 1024px) {
-    grid-template-columns: auto minmax(0, 3fr) minmax(0, 1fr) auto;
-    grid-template-areas: "toggle . search download";
+    grid-template-columns: auto minmax(0, 3fr) minmax(0, 1fr) auto auto;
+    grid-template-areas: "toggle . search download manage";
   }
 
   > [slot="toggle"] {
@@ -32,5 +32,9 @@
 
   > [slot="download"] {
     grid-area: download;
+  }
+
+  > [slot="manage"] {
+    grid-area: manage;
   }
 }

--- a/src/components/domain/transactions/searchField/transactionsSearchField.scss
+++ b/src/components/domain/transactions/searchField/transactionsSearchField.scss
@@ -3,11 +3,12 @@
   grid-template-areas: "icon search";
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
-
-  background: var(--color-base-0);
+  height: 2.25rem;
 
   border-radius: var(--border-radius-2xs);
   border: 1px solid var(--border-color);
+
+  background: var(--color-base-0);
   padding-inline-end: var(--spacing-3xs);
 
   &[data-focus-within] {
@@ -16,8 +17,8 @@
 
   & > [slot="icon"] {
     grid-area: icon;
-    inline-size: 2rem;
     block-size: 2rem;
+    inline-size: 2rem;
   }
 
   & > [slot="search"] {

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -37,6 +37,7 @@ const Button = forwardRef<
     icon?: true
     size?: ButtonSize
     variant?: ButtonVariant
+    persistentBorder?: boolean
   }
 >((
   {
@@ -44,6 +45,7 @@ const Button = forwardRef<
     icon,
     size = 'md',
     variant = 'solid',
+    persistentBorder = false,
     ...restProps
   },
   ref,
@@ -53,6 +55,7 @@ const Button = forwardRef<
     icon,
     size,
     variant,
+    'persistent-border': persistentBorder,
   })
 
   return (

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -14,7 +14,7 @@ function ButtonSpinner({ size }: { size: ButtonSize }) {
 
   return (
     <div {...dataProperties} className={BUTTON_CLASS_NAMES.SPINNER_CONTAINER}>
-      <LoadingSpinner size={size === 'lg' ? 20 : 16} />
+      <LoadingSpinner size={16} />
     </div>
   )
 }
@@ -28,7 +28,7 @@ function ButtonTransparentContent({ children }: PropsWithChildren) {
 }
 
 type ButtonVariant = 'solid' | 'ghost'
-type ButtonSize = 'sm' | 'md' | 'lg'
+type ButtonSize = 'sm' | 'md'
 
 const BUTTON_CLASS_NAME = 'Layer__UI__Button'
 const Button = forwardRef<

--- a/src/components/ui/Button/button.scss
+++ b/src/components/ui/Button/button.scss
@@ -91,17 +91,13 @@
 
   &[data-disabled] {
     background-color: var(--button-bg-disabled);
-    cursor: not-allowed;
     color: var(--button-fg-disabled);
+    cursor: not-allowed;
   }
 
   &[data-pending] {
     background-color: var(--button-bg-disabled);
-
-    &[data-variant="ghost"] {
-      background-color: transparent;
-    }
-
+    color: var(--button-fg-disabled);
     cursor: progress;
   }
 }

--- a/src/components/ui/Button/button.scss
+++ b/src/components/ui/Button/button.scss
@@ -49,7 +49,7 @@
     color: var(--button-fg-ghost);
     border: 1px solid transparent;
 
-    &[data-icon]:not([data-pressed]) {
+    &[data-persistent-border]:not([data-pressed]) {
       border-color: var(--button-border-color-ghost)
     }
 

--- a/src/components/ui/Button/button.scss
+++ b/src/components/ui/Button/button.scss
@@ -22,35 +22,40 @@
     padding-inline: 0;
   }
 
+  &[data-focus-visible] {
+    outline: 1px auto -webkit-focus-ring-color;
+  }
+
+  &[data-hovered]:not([data-pressed]):not([data-focus-visible]) {
+    outline: 1px solid var(--outline-default)
+  }
+
   &[data-variant="solid"] {
     background-color: var(--button-bg-default);
     color: var(--button-fg-default);
 
-    &[data-hovered] {
+    &[data-hovered]:not([data-pressed]) {
       background-color: var(--button-bg-active);
     }
-  }
 
-  &[data-focus-visible] {
-    outline-style: solid;
-    outline-offset: 0.12rem;
-    outline-color: var(--button-bg-default);
+    &[data-pressed] {
+      background-color: var(--button-bg-active);
+      outline: 2px solid var(--outline-default)
+    }
   }
 
   &[data-variant="ghost"] {
-    background-color: transparent;
+    background-color: var(--button-bg-ghost);
     color: var(--button-fg-ghost);
     border: 1px solid transparent;
 
-    &[data-hovered] {
-      background-color: var(--button-bg-ghost-active);
-      color: var(--button-fg-ghost-active);
-      border-color: var(--button-outline-ghost-active);
+    &[data-icon]:not([data-pressed]) {
+      border-color: var(--button-border-color-ghost)
     }
 
-    &[data-focus-visible] {
-      outline-style: solid;
-      outline-color: var(--button-outline-ghost-active);
+    &[data-pressed] {
+      border-color: var(--button-border-color-ghost-active);
+      outline: 2px solid var(--outline-default)
     }
   }
 
@@ -70,7 +75,7 @@
   }
 
   &[data-size="md"] {
-    --min-size: 2rem;
+    --min-size: 2.25rem;
 
     min-block-size: var(--min-size);
     font-size: var(--text-md);
@@ -81,21 +86,6 @@
 
     &:not([data-icon]) {
       padding-inline: var(--spacing-md);
-    }
-  }
-
-  &[data-size="lg"] {
-    --min-size: 2.25rem;
-
-    min-block-size: var(--min-size);
-    font-size: var(--text-lg);
-
-    &[data-icon] {
-      min-inline-size: var(--min-size);
-    }
-
-    &:not([data-icon]) {
-      padding-inline: var(--spacing-lg);
     }
   }
 

--- a/src/components/ui/Button/button.scss
+++ b/src/components/ui/Button/button.scss
@@ -27,7 +27,7 @@
   }
 
   &[data-hovered]:not([data-pressed]):not([data-focus-visible]) {
-    outline: 1px solid var(--outline-default)
+    outline: 1px solid var(--outline-default);
   }
 
   &[data-variant="solid"] {
@@ -50,12 +50,12 @@
     border: 1px solid transparent;
 
     &[data-persistent-border]:not([data-pressed]) {
-      border-color: var(--button-border-color-ghost)
+      border-color: var(--button-border-color-ghost);
     }
 
     &[data-pressed] {
       border-color: var(--button-border-color-ghost-active);
-      outline: 2px solid var(--outline-default)
+      outline: 2px solid var(--outline-default);
     }
   }
 

--- a/src/components/ui/Button/button.scss
+++ b/src/components/ui/Button/button.scss
@@ -26,7 +26,7 @@
     outline: 1px auto -webkit-focus-ring-color;
   }
 
-  &[data-hovered]:not([data-pressed]):not([data-focus-visible]) {
+  &[data-hovered]:not([data-pressed], [data-focus-visible]) {
     outline: 1px solid var(--outline-default);
   }
 
@@ -38,22 +38,22 @@
       background-color: var(--button-bg-active);
     }
 
-    &[data-pressed]&:not([data-focus-visible]) {
-      background-color: var(--button-bg-active);
+    &[data-pressed]:not([data-focus-visible]) {
       outline: 2px solid var(--outline-default);
+      background-color: var(--button-bg-active);
     }
   }
 
   &[data-variant="ghost"] {
+    border: 1px solid transparent;
     background-color: var(--button-bg-ghost);
     color: var(--button-fg-ghost);
-    border: 1px solid transparent;
 
     &[data-persistent-border]:not([data-pressed]) {
       border-color: var(--button-border-color-ghost);
     }
 
-    &[data-pressed]&:not([data-focus-visible]) {
+    &[data-pressed]:not([data-focus-visible]) {
       border-color: var(--button-border-color-ghost-active);
       outline: 2px solid var(--outline-default);
     }
@@ -91,14 +91,14 @@
 
   &[data-disabled] {
     background-color: var(--button-bg-disabled);
-    color: var(--button-fg-disabled);
     cursor: not-allowed;
+    color: var(--button-fg-disabled);
   }
 
   &[data-pending] {
     background-color: var(--button-bg-disabled);
-    color: var(--button-fg-disabled);
     cursor: progress;
+    color: var(--button-fg-disabled);
   }
 }
 

--- a/src/components/ui/Button/button.scss
+++ b/src/components/ui/Button/button.scss
@@ -38,9 +38,9 @@
       background-color: var(--button-bg-active);
     }
 
-    &[data-pressed] {
+    &[data-pressed]&:not([data-focus-visible]) {
       background-color: var(--button-bg-active);
-      outline: 2px solid var(--outline-default)
+      outline: 2px solid var(--outline-default);
     }
   }
 
@@ -53,7 +53,7 @@
       border-color: var(--button-border-color-ghost);
     }
 
-    &[data-pressed] {
+    &[data-pressed]&:not([data-focus-visible]) {
       border-color: var(--button-border-color-ghost-active);
       outline: 2px solid var(--outline-default);
     }

--- a/src/components/ui/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu/DropdownMenu.tsx
@@ -10,7 +10,7 @@ type DropdownMenuProps = PropsWithChildren<{
   }
   slotProps?: {
     Dialog?: {
-      width?: number
+      width?: number | string
     }
   }
 }>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,6 @@ export { Onboarding } from './components/Onboarding'
 
 /* ------------------ Bank Accounts & Transactions ------------------ */
 export { LinkedAccounts } from './components/LinkedAccounts'
-export { UploadTransactions as unstable_UploadTransactions } from './components/UploadTransactions/UploadTransactions'
 export { BankTransactions } from './components/BankTransactions/BankTransactions'
 export { Integrations } from './components/Integrations/Integrations'
 

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -114,6 +114,13 @@
   margin-right: 4px;
 }
 
+.Layer__bank-transactions__header-menu__upload-transactions-icon {
+  color: var(--color-base-500);
+  background: var(--color-base-200);
+  border-radius: var(--spacing-3xs);
+  padding: var(--spacing-3xs);
+}
+
 .Layer__bank-transaction-row {
   transition: all var(--transition-speed) ease-in-out;
   opacity: 0.3;

--- a/src/styles/internal_variables.scss
+++ b/src/styles/internal_variables.scss
@@ -30,8 +30,8 @@
   
   --button-bg-active: var(--color-base-800);
 
-  --button-fg-disabled: var(--color-base-200);
-  --button-bg-disabled: var(--color-base-700);
+  --button-fg-disabled: var(--color-base-500);
+  --button-bg-disabled: var(--color-base-200);
 
   --button-bg-ghost: var(--color-base-0);
   --button-fg-ghost: var(--color-base-800);

--- a/src/styles/internal_variables.scss
+++ b/src/styles/internal_variables.scss
@@ -12,7 +12,7 @@
   /*
    * Foreground
    */
-  --fg-default: var(--color-base-900);
+  --fg-default: var(--color-base-800);
   --fg-subtle: var(--color-base-500);
 
   /*
@@ -25,15 +25,19 @@
   /*
    * Buttons
    */
-  --button-bg-default: var(--color-base-900);
-  --button-bg-active: var(--color-base-1000);
-  --button-bg-disabled: var(--color-base-700);
+  --button-bg-default: var(--color-base-1000);
   --button-fg-default: var(--color-base-0);
+  
+  --button-bg-active: var(--color-base-800);
+
   --button-fg-disabled: var(--color-base-200);
-  --button-bg-ghost-active: var(--color-base-50);
-  --button-outline-ghost-active: var(--color-base-100);
-  --button-fg-ghost: var(--color-base-900);
-  --button-fg-ghost-active: var(--color-base-1000);
+  --button-bg-disabled: var(--color-base-700);
+
+  --button-bg-ghost: var(--color-base-0);
+  --button-fg-ghost: var(--color-base-800);
+
+  --button-border-color-ghost: var(--color-base-300);
+  --button-border-color-ghost-active: var(--color-base-800);
 
   /*
    * Checkbox

--- a/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
+++ b/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
@@ -25,6 +25,7 @@ export interface BankTransactionsWithLinkedAccountsProps {
   showTags?: boolean
   showTooltips?: boolean
   showUnlinkItem?: boolean
+  showUploadOptions?: boolean
   /**
    * @deprecated `mode` can be inferred from the bookkeeping configuration of a business
    */
@@ -46,6 +47,7 @@ export const BankTransactionsWithLinkedAccounts = ({
   showTags = false,
   showTooltips = false,
   showUnlinkItem = false,
+  showUploadOptions = false,
 
   mobileComponent,
   stringOverrides,
@@ -68,6 +70,7 @@ export const BankTransactionsWithLinkedAccounts = ({
         showReceiptUploads={showReceiptUploads}
         showTags={showTags}
         showTooltips={showTooltips}
+        showUploadOptions={showUploadOptions}
         mobileComponent={mobileComponent}
         mode={mode}
         stringOverrides={stringOverrides?.bankTransactions}


### PR DESCRIPTION
## Description
This PR adds the CSV upload component in a menu that you can trigger from the bank transactions table. Along the way, I ended up doing some work on button styles to create relative parity between the old and new buttons.
