### PR TITLE
fix: remove `revalidateOnMount: false`

### DIFF
--- a/src/utils/swr/defaultSWRConfig.ts
+++ b/src/utils/swr/defaultSWRConfig.ts
@@ -5,5 +5,4 @@ export const DEFAULT_SWR_CONFIG = {
   revalidateIfStale: true,
   revalidateOnFocus: false,
   revalidateOnReconnect: false,
-  revalidateOnMount: false,
 } as const satisfies SWRConfiguration


### PR DESCRIPTION
## Description

For some reason, not revalidating on mount results in nothing loading 🙃 .

