### PR TITLE
fix: delete outlined button special hover state

### DIFF
--- a/src/components/ui/Button/button.scss
+++ b/src/components/ui/Button/button.scss
@@ -85,10 +85,6 @@
       color: var(--button-fg-disabled);
     }
 
-    &[data-hovered]:not([data-pressed]) {
-      border-color: var(--button-border-color-ghost-active);
-    }
-
     &[data-pressed]:not([data-focus-visible]) {
       border-color: var(--button-border-color-ghost-active);
       outline: 2px solid var(--outline-default);

--- a/src/components/ui/Button/button.scss
+++ b/src/components/ui/Button/button.scss
@@ -1,4 +1,5 @@
 .Layer__UI__Button {
+  all: unset;
   display: inline-grid;
 
   grid-template-rows: minmax(0, 1fr);


### PR DESCRIPTION
## Description
Fixes [LAY-1488](https://linear.app/layerfi/issue/LAY-1488/fix-hover-state-outline-for-txn-upload-button)

I think the ghost and outlined buttons should have the same hover state, even if it is more subtle for the outlined button.
