### PR TITLE
fix: when a value is selected in a `ComboBox`, still show all items

### DIFF
--- a/src/hooks/search/useDebouncedSearchQuery.ts
+++ b/src/hooks/search/useDebouncedSearchQuery.ts
@@ -40,6 +40,6 @@ export function useDebouncedSearchInput({
   return {
     inputValue,
     searchQuery,
-    handleInputChange,
+    onInputChange: handleInputChange,
   }
 }


### PR DESCRIPTION
## Description

Once a user has made a ComboBox selection - e.g. they picked a customer - the dropdown should not be filtered to only show their choice. We should present the unfiltered list to them.

### Note

I can't get the special behavior of typing over a result to work without playing bug whack-a-mole. Everything that I do results in an issue in another area.

