### PR TITLE
fix: temporarily hide `CustomerVendorSelector`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.102-alpha.5",
+  "version": "0.1.102-alpha.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.102-alpha.5",
+      "version": "0.1.102-alpha.6",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.102-alpha.5",
+  "version": "0.1.102-alpha.6",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -76,19 +76,17 @@ export interface BankTransactionsProps {
 export interface BankTransactionsWithErrorProps extends BankTransactionsProps {
   onError?: (error: LayerError) => void
   showTags?: boolean
-  showCustomerVendor?: boolean
 }
 
 export const BankTransactions = ({
   onError,
   showTags = false,
-  showCustomerVendor = false,
   mode,
   ...props
 }: BankTransactionsWithErrorProps) => {
   usePreloadTagDimensions({ isEnabled: showTags })
-  usePreloadCustomers({ isEnabled: showCustomerVendor })
-  usePreloadVendors({ isEnabled: showCustomerVendor })
+  usePreloadCustomers({ isEnabled: false })
+  usePreloadVendors({ isEnabled: false })
 
   const contextData = useAugmentedBankTransactions({ monthlyView: props.monthlyView })
 
@@ -97,7 +95,7 @@ export const BankTransactions = ({
       <BankTransactionsContext.Provider value={contextData}>
         <LegacyModeProvider overrideMode={mode}>
           <BankTransactionTagVisibilityProvider showTags={showTags}>
-            <BankTransactionCustomerVendorVisibilityProvider showCustomerVendor={showCustomerVendor}>
+            <BankTransactionCustomerVendorVisibilityProvider showCustomerVendor={false}>
               <BankTransactionsContent {...props} />
             </BankTransactionCustomerVendorVisibilityProvider>
           </BankTransactionTagVisibilityProvider>

--- a/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
+++ b/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
@@ -22,7 +22,6 @@ export interface BankTransactionsWithLinkedAccountsProps {
   showDescriptions?: boolean
   showLedgerBalance?: boolean
   showReceiptUploads?: boolean
-  showCustomerVendor?: boolean
   showTags?: boolean
   showTooltips?: boolean
   showUnlinkItem?: boolean
@@ -45,7 +44,6 @@ export const BankTransactionsWithLinkedAccounts = ({
   showDescriptions = true,
   showLedgerBalance = true,
   showReceiptUploads = true,
-  showCustomerVendor = false,
   showTags = false,
   showTooltips = false,
   showUnlinkItem = false,
@@ -70,7 +68,6 @@ export const BankTransactionsWithLinkedAccounts = ({
         asWidget
         showDescriptions={showDescriptions}
         showReceiptUploads={showReceiptUploads}
-        showCustomerVendor={showCustomerVendor}
         showTags={showTags}
         showTooltips={showTooltips}
         showUploadOptions={showUploadOptions}


### PR DESCRIPTION
## Description

I need to do a major revision on the `CustomerVendorSelector`. These changes effectively hide the current version behind a feature flag.
