### PR TITLE
fix: primary and accent color contrast

### DIFF
--- a/src/components/Tasks/tasks.scss
+++ b/src/components/Tasks/tasks.scss
@@ -3,50 +3,50 @@
 .Layer__tasks-component {
   display: flex;
   flex-direction: column;
-  height: 100%;
   overflow-y: auto;
+  height: 100%;
   border-radius: 8px;
   box-shadow: 0 0 0 1px var(--color-base-300);
   background-color: var(--color-base-0);
 }
 
 .Layer__tasks-pending {
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
+  gap: var(--spacing-xs);
   align-items: center;
   justify-content: flex-start;
-  box-sizing: border-box;
-  border-top: 1px solid var(--color-base-300);
   padding: var(--spacing-md);
-  gap: var(--spacing-xs);
+  border-top: 1px solid var(--color-base-300);
 
   .Layer__tasks-pending-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
     box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     min-height: 36px;
+    width: 100%;
   }
 
   .Layer__tasks-pending-main {
+    box-sizing: border-box;
     display: flex;
     flex-direction: column;
+    gap: var(--spacing-2xs);
     align-items: flex-start;
     justify-content: center;
-    gap: var(--spacing-2xs);
-    box-sizing: border-box;
     width: 100%;
   }
 
   .Layer__tasks-pending-bar {
     display: flex;
-    align-items: center;
     gap: var(--spacing-xs);
-    font-weight: 540;
+    align-items: center;
     padding: var(--spacing-3xs) var(--spacing-xs);
-    background-color: var(--color-base-50);
     border-radius: 8px;
+    background-color: var(--color-base-50);
+    font-weight: 540;
 
     .mini-chart {
       transform: rotate(90deg);
@@ -63,11 +63,11 @@
 }
 
 .Layer__tasks-header {
-  min-height: 36px;
   display: flex;
+  gap: var(--spacing-md);
   align-items: center;
   justify-content: space-between;
-  gap: var(--spacing-md);
+  min-height: 36px;
   padding: var(--spacing-md);
   container-type: inline-size;
 }
@@ -75,7 +75,8 @@
 .Layer__tasks__content {
   max-height: 1000px;
   opacity: 1;
-  transition: max-height 0.18s ease-out,
+  transition:
+    max-height 0.18s ease-out,
     opacity 0.2s ease-out;
 }
 
@@ -85,8 +86,8 @@
 }
 
 .Layer__tasks-list {
-  background-color: var(--color-base-0);
   box-shadow: 0 0 0 1px var(--color-base-300);
+  background-color: var(--color-base-0);
 
   .Layer__tasks-list-item-wrapper {
     padding: var(--spacing-2xs);
@@ -102,22 +103,22 @@
 
       &:hover,
       &.Layer__tasks-list-item__expanded {
-        background: var(--color-base-50);
         border-radius: 6px;
+        background: var(--color-base-50);
       }
 
       .Layer__tasks-list-item__head {
         display: flex;
+        gap: var(--spacing-xs);
         align-items: center;
         justify-content: space-between;
-        gap: var(--spacing-xs);
         padding: var(--spacing-md);
         cursor: pointer;
 
         .Layer__tasks-list-item__head-info {
           display: flex;
-          align-items: center;
           gap: var(--spacing-xs);
+          align-items: center;
 
           .Layer__tasks-list-item__head-info__status {
             display: flex;
@@ -136,22 +137,21 @@
             }
           }
 
-          &.Layer__tasks-list-item--pending
-          .Layer__tasks-list-item__head-info__status {
-            color: var(--color-info-warning-fg);
+          &.Layer__tasks-list-item--pending .Layer__tasks-list-item__head-info__status {
             background: var(--color-info-warning-bg);
+            color: var(--color-info-warning-fg);
           }
         }
       }
 
       .Layer__tasks-list-item__body {
+        overflow: hidden;
+        height: 0;
         padding-right: var(--spacing-md);
+        padding-bottom: 0;
         padding-left: var(--spacing-3xl);
         margin-left: var(--spacing-3xs);
-        padding-bottom: 0;
-        height: 0;
         opacity: 0;
-        overflow: hidden;
         transition: all 0.2s ease-out;
 
         .Layer__tasks-list-item__body-info {
@@ -175,13 +175,13 @@
           }
 
           .Layer__tasks-list-item__link {
-            color: var(--color-primary);
             font-size: var(--text-sm);
+            color: var(--color-primary);
           }
 
           .Layer__tasks-list__links-list {
-            margin: 0;
             padding: var(--spacing-3xs) 0 var(--spacing-sm) var(--spacing-md);
+            margin: 0;
           }
         }
 
@@ -190,8 +190,8 @@
         }
 
         &.Layer__tasks-list-item__body--expanded {
-          padding-bottom: var(--spacing-sm);
           height: auto;
+          padding-bottom: var(--spacing-sm);
           opacity: 1;
         }
       }
@@ -201,11 +201,11 @@
   .Layer__tasks-empty-state {
     display: flex;
     flex-direction: column;
+    gap: var(--spacing-md);
     align-items: center;
     justify-content: center;
-    gap: var(--spacing-md);
-    text-align: center;
     padding: var(--spacing-md);
+    text-align: center;
     color: var(--color-base-500);
   }
 }
@@ -221,25 +221,25 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
   height: 32px;
+  width: 32px;
   border-radius: 4px;
-  background-color: var(--color-base-50);
   box-shadow: 0 0 0 1px var(--color-base-300);
+  background-color: var(--color-base-50);
 }
 
 .Layer__tasks__expand-icon {
-  transition: transform 150ms ease-out;
-  color: var(--color-base-600);
   margin-left: -15px;
+  color: var(--color-base-600);
+  transition: transform 150ms ease-out;
 }
 
 @container (width <= 400px) {
   .Layer__tasks-component {
     .Layer__tasks-pending {
       flex-direction: column;
-      align-items: stretch;
       gap: var(--spacing-xs);
+      align-items: stretch;
 
       .Layer__tasks-pending-bar {
         justify-content: space-between;
@@ -270,43 +270,55 @@
 .Layer__tasks-header__notification {
   display: flex;
   flex-wrap: wrap;
+  gap: var(--spacing-xs);
   align-items: center;
   justify-content: space-between;
-  gap: var(--spacing-xs);
   padding: var(--spacing-xs) var(--spacing-xs) var(--spacing-2xs) var(--spacing-md);
-  background: linear-gradient(0deg, var(--base-transparent-10) 0%, var(--base-transparent-10) 100%), var(--color-info-warning);
-  
-  &[data-status="error"] {
-    background: linear-gradient(0deg, var(--base-transparent-10) 0%, var(--base-transparent-10) 100%), var(--color-info-error);
+  background:
+    linear-gradient(
+      0deg,
+      var(--base-transparent-10) 0%,
+      var(--base-transparent-10) 100%
+    ),
+    var(--color-info-warning);
+
+  &[data-status='error'] {
+    background:
+      linear-gradient(
+        0deg,
+        var(--base-transparent-10) 0%,
+        var(--base-transparent-10) 100%
+      ),
+      var(--color-info-error);
     color: var(--color-info-error-bg);
   }
 }
 
 .Layer__tasks-header__notification__text {
   display: flex;
+  gap: var(--spacing-xs);
   align-items: center;
   justify-content: center;
-  gap: var(--spacing-xs);
   white-space: nowrap;
 }
 
 .Layer__tasks-header__notification__button {
-  background: var(--color-info-warning-fg);
-  color: var(--color-info-warning-bg);
-  border: none;
+  display: flex;
+  gap: var(--spacing-xs);
+  align-items: center;
   padding: var(--spacing-3xs) var(--spacing-xs);
   border-radius: 4px;
+  border: none;
+  background: var(--color-info-warning-fg);
   cursor: pointer;
   font-size: var(--text-sm);
   font-weight: var(--font-weight-bold);
+  color: var(--color-info-warning-bg);
   font-variation-settings: 'wght' var(--font-weight-bold);
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-xs);
   transition: all 0.12s ease-in-out;
   white-space: nowrap;
 
-  .Layer__tasks-header__notification[data-status="error"] & {
+  .Layer__tasks-header__notification[data-status='error'] & {
     background: var(--color-info-error-fg);
     color: var(--color-info-error-bg);
   }
@@ -318,13 +330,13 @@
 
 .Layer__tasks__badge {
   display: flex;
+  gap: var(--spacing-3xs);
   align-items: center;
-  font-size: var(--text-xs);
-  background: var(--color-info-warning);
-  color: var(--color-info-warning-bg);
   padding: var(--spacing-3xs) var(--border-radius-2xs);
   border-radius: var(--border-radius-3xs);
-  gap: var(--spacing-3xs);
+  background: var(--color-info-warning);
+  font-size: var(--text-xs);
+  color: var(--color-info-warning-bg);
   white-space: nowrap;
 
   .Layer__tasks__badge__label-short {
@@ -342,11 +354,11 @@
   }
 
   &[data-icononly] {
-    border-radius: 50%;
     gap: 0;
-    padding: 0;
-    width: 16px;
     height: 16px;
+    width: 16px;
+    padding: 0;
+    border-radius: 50%;
   }
 
   .Layer__text {
@@ -354,31 +366,31 @@
   }
 
   .Layer__tasks__badge__icon-wrapper {
-    border-radius: 50%;
-    width: 16px;
-    height: 16px;
     display: flex;
     align-items: center;
     justify-content: center;
+    height: 16px;
+    width: 16px;
+    border-radius: 50%;
   }
 
   &[data-status='info'] {
-    color: var(--color-info-fg);
     background: var(--color-info-bg);
+    color: var(--color-info-fg);
   }
 
   &[data-status='warning'] {
-    color: var(--color-info-warning-bg);
     background: var(--color-info-warning);
+    color: var(--color-info-warning-bg);
   }
 
   &[data-status='success'] {
-    color: var(--color-info-success-fg);
     background: var(--color-info-success-bg);
+    color: var(--color-info-success-fg);
   }
 
   &[data-status='error'] {
-    color: var(--color-info-error);
     background: var(--color-info-error-bg);
+    color: var(--color-info-error);
   }
 }

--- a/src/components/Tasks/tasks.scss
+++ b/src/components/Tasks/tasks.scss
@@ -176,7 +176,7 @@
 
           .Layer__tasks-list-item__link {
             font-size: var(--text-sm);
-            color: var(--color-primary);
+            color: var(--color-base-900);
           }
 
           .Layer__tasks-list__links-list {

--- a/src/styles/badge.scss
+++ b/src/styles/badge.scss
@@ -1,27 +1,31 @@
 .Layer__badge {
+  box-sizing: border-box;
   display: inline-flex;
   gap: var(--spacing-3xs);
-  border-radius: var(--border-radius-5xl);
-  background-color: var(--badge-bg-color);
-  color: var(--badge-color);
-  padding: var(--spacing-3xs) var(--spacing-xs);
-  font-size: var(--text-sm);
   align-items: center;
-  transition: all var(--transition-speed) ease-in-out;
-  box-sizing: border-box;
   height: 27px;
 
+  padding: var(--spacing-3xs) var(--spacing-xs);
+  border-radius: var(--border-radius-5xl);
+
+  background-color: var(--badge-bg-color);
+
+  font-size: var(--text-sm);
+  color: var(--badge-color);
+
+  transition: all var(--transition-speed) ease-in-out;
+
   &.Layer__badge--small {
-    font-size: var(--text-xs);
-    padding: var(--spacing-3xs) var(--spacing-xs);
-    line-height: 1.1;
     height: 21px;
+    padding: var(--spacing-3xs) var(--spacing-xs);
+    font-size: var(--text-xs);
+    line-height: 1.1;
   }
 
   &.Layer__badge--clickable {
-    cursor: pointer;
     min-height: 21px;
     border-width: 0;
+    cursor: pointer;
   }
 
   .Layer__badge__icon {

--- a/src/styles/pagination.scss
+++ b/src/styles/pagination.scss
@@ -1,9 +1,9 @@
 .Layer__pagination-container {
+  position: sticky;
+  left: 0;
   display: flex;
   justify-content: flex-end;
   padding: var(--spacing-md);
-  position: sticky;
-  left: 0;
 
   @container (min-width: 1400px) {
     display: flex;
@@ -14,45 +14,46 @@
 
 .Layer__pagination {
   display: inline-flex;
-  list-style-type: none;
-  padding: var(--spacing-4xs);
-  background: var(--color-base-50);
-  box-shadow: 0 0 0 1px var(--color-base-300);
-  border-radius: var(--border-radius-2xs);
   gap: 2px;
+  padding: var(--spacing-4xs);
+  border-radius: var(--border-radius-2xs);
+  box-shadow: 0 0 0 1px var(--color-base-300);
   margin: 0;
+  background: var(--color-base-50);
+  list-style-type: none;
 
   .Layer__pagination-item {
-    display: flex;
     box-sizing: border-box;
-    height: 32px;
-    width: 32px;
-    text-align: center;
+    display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: var(--border-radius-3xs);
-    color: var(--color-base-700);
-    font-size: var(--text-md);
+    height: 32px;
+    width: 32px;
     min-width: 32px;
+    border-radius: var(--border-radius-3xs);
     border: 1px solid transparent;
+    font-size: var(--text-md);
+    text-align: center;
+    color: var(--color-base-700);
 
     &.Layer__pagination-dots:hover {
-      background-color: transparent;
-      color: var(--color-base-700);
       box-shadow: none;
+      background-color: transparent;
       cursor: default;
+      color: var(--color-base-700);
     }
 
     &:hover {
-      background-color: var(--color-base-0);
-      color: var(--color-base-900);
       box-shadow: 0 0 0 1px var(--color-base-300);
+      background-color: var(--color-base-0);
       cursor: pointer;
+      color: var(--color-base-900);
     }
 
     &.selected {
-      background-color: var(--color-base-400);
-      color: var(--color-base-900);
+      background-color: var(--bg-brand-accent, var(--color-accent));
+      color: var(--fg-brand-accent, var(--color-primary));
+
       border-color: var(--base-transparent-6);
     }
 

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -116,11 +116,15 @@
   --color-primary: var(--color-dark);
   --color-accent: var(--color-light);
 
-  --bg-brand-primary: var(--color-primary);
-  --fg-brand-primary: var(--color-white);
-
-  --bg-brand-accent: var(--color-accent);
-  --fg-brand-accent: var(--color-white);
+  /*
+   * The variables are not defined; they must explicitly overridden.
+   *
+   * --bg-brand-primary
+   * --fg-brand-primary
+   *
+   * --bg-brand-accent
+   * --fg-brand-accent
+   */
 
   // Other Colors
   --color-secondary: var(--color-base);
@@ -187,19 +191,25 @@
   --btn-bg-color: var(--color-white);
   --btn-color-primary: var(--color-white);
   --btn-bg-color-primary: var(--color-black);
-  --btn-color-hover: var(--color-white);
-  --btn-bg-color-hover: var(--color-base-1000);
+
+  --btn-color-hover: var(--fg-brand-primary, var(--color-white));
+  --btn-bg-color-hover: var(--bg-brand-primary, var(--color-primary));
+
   --btn-color-icon: var(--color-black);
   --btn-bg-color-icon: var(--color-base-50);
-  --btn-color-icon-hover: var(--color-base-1000);
-  --btn-bg-color-icon-hover: var(--color-base-0);
+
+  --btn-color-icon-hover: var(--fg-brand-accent, var(--color-primary));
+  --btn-bg-color-icon-hover: var(--bg-brand-accent, var(--color-accent));
+
   --btn-secondary-color: var(--color-black);
   --btn-secondary-bg-color: var(--color-white);
   --btn-tertiary-color: var(--color-black);
   --btn-tertiary-bg-color: var(--color-white);
-  --badge-color: var(--color-base-900);
-  --badge-fg-color: var(--color-base-900);
-  --badge-bg-color: var(--color-base-400);
+
+  --badge-color: var(--fg-brand-accent, var(--color-primary));
+  --badge-fg-color: var(--fg-brand-accent, var(--color-primary));
+  --badge-bg-color: var(--bg-brand-accent, var(--color-accent));
+
   --badge-color-info: var(--color-info);
   --badge-fg-color-info: var(--color-info-fg);
   --badge-bg-color-info: var(--color-info-bg);

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -113,9 +113,16 @@
       var(--color-light-l) / 16%
     );
 
-  // Customization
   --color-primary: var(--color-dark);
   --color-accent: var(--color-light);
+
+  --bg-brand-primary: var(--color-primary);
+  --fg-brand-primary: var(--color-white);
+
+  --bg-brand-accent: var(--color-accent);
+  --fg-brand-accent: var(--color-white);
+
+  // Other Colors
   --color-secondary: var(--color-base);
   --color-success: var(--color-info-success);
   --color-danger: var(--color-info-error);
@@ -181,11 +188,11 @@
   --btn-color-primary: var(--color-white);
   --btn-bg-color-primary: var(--color-black);
   --btn-color-hover: var(--color-white);
-  --btn-bg-color-hover: var(--color-primary);
+  --btn-bg-color-hover: var(--color-base-1000);
   --btn-color-icon: var(--color-black);
   --btn-bg-color-icon: var(--color-base-50);
-  --btn-color-icon-hover: var(--color-primary);
-  --btn-bg-color-icon-hover: var(--color-accent);
+  --btn-color-icon-hover: var(--color-base-1000);
+  --btn-bg-color-icon-hover: var(--color-base-0);
   --btn-secondary-color: var(--color-black);
   --btn-secondary-bg-color: var(--color-white);
   --btn-tertiary-color: var(--color-black);


### PR DESCRIPTION
## Description

This PR introduces 4 undefined CSS variables that must be explicitly set by the platform:

```
--bg-brand-primary
--fg-brand-primary
 
--bg-brand-accent
--fg-brand-accent
```

When these variables are set, they will override the use of `color-primary` (think: "dark") and `color-accent` (think: "light") in two (2) key areas:
- The hovered state of some solid buttons
- The default badge color