### PR TITLE
fix: second resizing of columns in bank transactions feed

### DIFF
--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -158,7 +158,7 @@
       z-index: 2;
       right: 0;
 
-      --width: 520px;
+      --width: 56ch;
 
       width: var(--width);
       min-width: var(--width);
@@ -664,7 +664,7 @@
   position: sticky;
   z-index: 2;
 
-  --right-adjust: 520px;
+  --right-adjust: 56ch;
 
   right: var(--right-adjust);
 
@@ -693,7 +693,7 @@
   box-sizing: border-box;
   position: sticky;
   z-index: 2;
-  right: 520px;
+  right: 56ch;
   width: 0;
   min-width: 0;
   max-width: 0;
@@ -713,7 +713,7 @@
   z-index: 2;
   right: 0;
 
-  --width: 520px;
+  --width: 56ch;
 
   width: var(--width);
   min-width: var(--width);
@@ -733,14 +733,14 @@
 }
 
 .Layer__bank-transactions__tx-text {
-  width: 100%;
+  max-width: 32ch;
 }
 
 .Layer__bank-transactions__account-col {
   box-sizing: border-box;
-  width: 180px;
-  min-width: 125px;
-  max-width: 180px;
+  width: 30ch;
+  min-width: 10ch;
+  max-width: 30ch;
 }
 
 .Layer__bank-transactions__documents-col {
@@ -794,7 +794,6 @@
         box-sizing: border-box;
         display: block;
         overflow: hidden;
-        max-width: 100%;
         text-overflow: ellipsis;
         white-space: nowrap;
       }


### PR DESCRIPTION
## Description

Based on a discussion with Justin, we wanted to make the "Categorize" / "Category" section a bit smaller _and_ give more size to the account section.

These changes come at the expense of spacing for the transaction description.