### PR TITLE
fix: remove `revalidateAll` behavior from transactions SWR

### DIFF
--- a/src/features/bankTransactions/[bankTransactionId]/metadata/api/useSetMetadataOnBankTransaction.ts
+++ b/src/features/bankTransactions/[bankTransactionId]/metadata/api/useSetMetadataOnBankTransaction.ts
@@ -109,10 +109,20 @@ export function useSetMetadataOnBankTransaction({
           return {
             ...bankTransaction,
             customer: customer
-              ? encodeCustomer(customer)
+              ? encodeCustomer({
+                ...customer,
+                _local: {
+                  isOptimistic: true,
+                },
+              })
               : null,
             vendor: vendor
-              ? encodeVendor(vendor)
+              ? encodeVendor({
+                ...vendor,
+                _local: {
+                  isOptimistic: true,
+                },
+              })
               : null,
           }
         }
@@ -121,7 +131,11 @@ export function useSetMetadataOnBankTransaction({
       })
 
       return triggerResultPromise
-        .finally(() => { void debouncedInvalidateBankTransactions() })
+        .finally(() => {
+          void debouncedInvalidateBankTransactions({
+            withPrecedingOptimisticUpdate: true,
+          })
+        })
     },
     [
       bankTransactionId,

--- a/src/features/bankTransactions/[bankTransactionId]/tags/api/useRemoveTagFromBankTransaction.ts
+++ b/src/features/bankTransactions/[bankTransactionId]/tags/api/useRemoveTagFromBankTransaction.ts
@@ -104,7 +104,11 @@ export function useRemoveTagFromBankTransaction({ bankTransactionId }: RemoveTag
       })
 
       return triggerResultPromise
-        .finally(() => { void debouncedInvalidateBankTransactions() })
+        .finally(() => {
+          void debouncedInvalidateBankTransactions({
+            withPrecedingOptimisticUpdate: true,
+          })
+        })
     },
     [
       bankTransactionId,

--- a/src/features/bankTransactions/[bankTransactionId]/tags/api/useTagBankTransaction.ts
+++ b/src/features/bankTransactions/[bankTransactionId]/tags/api/useTagBankTransaction.ts
@@ -127,7 +127,11 @@ export function useTagBankTransaction({ bankTransactionId }: TagBankTransactionO
       })
 
       return triggerResultPromise
-        .finally(() => { void debouncedInvalidateBankTransactions() })
+        .finally(() => {
+          void debouncedInvalidateBankTransactions({
+            withPrecedingOptimisticUpdate: true,
+          })
+        })
     },
     [
       bankTransactionId,

--- a/src/features/customers/api/useListCustomers.ts
+++ b/src/features/customers/api/useListCustomers.ts
@@ -147,7 +147,7 @@ export function useListCustomers({ query, isEnabled = true }: UseListCustomersPa
     )().then(Schema.decodeUnknownPromise(ListCustomersRawResultSchema)),
     {
       keepPreviousData: true,
-      revalidateAll: true,
+      revalidateFirstPage: false,
       initialSize: 1,
     },
   )

--- a/src/features/invoices/api/useListInvoices.tsx
+++ b/src/features/invoices/api/useListInvoices.tsx
@@ -163,7 +163,7 @@ export function useListInvoices({
     )().then(Schema.decodeUnknownPromise(ListInvoicesReturnSchema)),
     {
       keepPreviousData: true,
-      revalidateAll: true,
+      revalidateFirstPage: false,
       initialSize: 1,
     },
   )

--- a/src/features/ledger/accounts/[ledgerAccountId]/api/useListLedgerAccountLines.ts
+++ b/src/features/ledger/accounts/[ledgerAccountId]/api/useListLedgerAccountLines.ts
@@ -40,18 +40,18 @@ export const listLedgerAccountLines = get<
   ListLedgerAccountLinesReturn,
   GetLedgerAccountLinesParams
 >(({
-     businessId,
-     accountId,
-     include_entries_before_activation,
-     include_child_account_lines,
-     start_date,
-     end_date,
-     sort_by,
-     sort_order,
-     cursor,
-     limit,
-     show_total_count
-   }) => {
+  businessId,
+  accountId,
+  include_entries_before_activation,
+  include_child_account_lines,
+  start_date,
+  end_date,
+  sort_by,
+  sort_order,
+  cursor,
+  limit,
+  show_total_count,
+}) => {
   const parameters = toDefinedSearchParameters({
     include_entries_before_activation,
     include_child_account_lines,
@@ -145,7 +145,7 @@ export function useListLedgerAccountLines({
   const { data: auth } = useAuth()
 
   return useSWRInfinite(
-    (index, previousPageData: ListLedgerAccountLinesReturn | null) => keyLoader(
+    (_index, previousPageData: ListLedgerAccountLinesReturn | null) => keyLoader(
       previousPageData,
       {
         ...auth,
@@ -163,20 +163,20 @@ export function useListLedgerAccountLines({
       },
     ),
     ({
-       accessToken,
-       apiUrl,
-       businessId,
-       accountId,
-       cursor,
-       include_entries_before_activation,
-       include_child_account_lines,
-       start_date,
-       end_date,
-       sort_by,
-       sort_order,
-       limit,
-       show_total_count,
-     }) => listLedgerAccountLines(
+      accessToken,
+      apiUrl,
+      businessId,
+      accountId,
+      cursor,
+      include_entries_before_activation,
+      include_child_account_lines,
+      start_date,
+      end_date,
+      sort_by,
+      sort_order,
+      limit,
+      show_total_count,
+    }) => listLedgerAccountLines(
       apiUrl,
       accessToken,
       {
@@ -197,7 +197,6 @@ export function useListLedgerAccountLines({
     )(),
     {
       keepPreviousData: true,
-      revalidateAll: false,
       revalidateFirstPage: false,
       initialSize: 1,
     },

--- a/src/features/ledger/entries/api/useListLedgerEntries.ts
+++ b/src/features/ledger/entries/api/useListLedgerEntries.ts
@@ -99,7 +99,7 @@ export function useListLedgerEntries({
   const { data: auth } = useAuth()
 
   return useSWRInfinite(
-    (index, previousPageData: ListLedgerEntriesReturn | null) => keyLoader(
+    (_index, previousPageData: ListLedgerEntriesReturn | null) => keyLoader(
       previousPageData,
       {
         ...auth,
@@ -136,7 +136,6 @@ export function useListLedgerEntries({
     )(),
     {
       keepPreviousData: true,
-      revalidateAll: false,
       revalidateFirstPage: false,
       initialSize: 1,
     },

--- a/src/features/vendors/api/useListVendors.ts
+++ b/src/features/vendors/api/useListVendors.ts
@@ -146,7 +146,7 @@ export function useListVendors({ query, isEnabled = true }: UseListVendorsParame
     )().then(Schema.decodeUnknownPromise(ListVendorsRawResultSchema)),
     {
       keepPreviousData: true,
-      revalidateAll: true,
+      revalidateFirstPage: false,
       initialSize: 1,
     },
   )

--- a/src/hooks/useBankTransactions/useBankTransactions.ts
+++ b/src/hooks/useBankTransactions/useBankTransactions.ts
@@ -110,7 +110,7 @@ export function useBankTransactions({
     },
     {
       keepPreviousData: true,
-      revalidateAll: true,
+      revalidateFirstPage: false,
       initialSize: 1,
     },
   )
@@ -121,11 +121,18 @@ const INVALIDATION_DEBOUNCE_OPTIONS = {
   maxWait: 3000,
 }
 
+type BankTransactionsInvalidateOptions = {
+  withPrecedingOptimisticUpdate?: boolean
+}
+
 export function useBankTransactionsInvalidator() {
   const { invalidate } = useGlobalInvalidator()
 
   const invalidateBankTransactions = useCallback(
-    () => invalidate(tags => tags.includes(BANK_TRANSACTIONS_TAG_KEY)),
+    (invalidateOptions?: BankTransactionsInvalidateOptions) => invalidate(
+      tags => tags.includes(BANK_TRANSACTIONS_TAG_KEY),
+      invalidateOptions,
+    ),
     [invalidate],
   )
 


### PR DESCRIPTION
## Description

I may have made a mistake when I switched us over to `revalidateAll: true`, based on information from [this thread](https://github.com/vercel/swr/issues/1670#issuecomment-1625977770).

I believe we no longer need `revalidateAll: true` (and can `revalidateFirstPage: false`) because we are making an optimistic update in most situations.

However, the default assumption will be that we are _not_ doing an optimistic update, so we'll revalidate every page of an infinite query.
