### PR TITLE
fix: date picker respects default

### DIFF
--- a/src/components/BalanceSheet/BalanceSheet.tsx
+++ b/src/components/BalanceSheet/BalanceSheet.tsx
@@ -13,6 +13,7 @@ import { View } from '../View'
 import { BALANCE_SHEET_ROWS } from './constants'
 import { BalanceSheetDownloadButton } from './download/BalanceSheetDownloadButton'
 import { useGlobalDate } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
+import { ReportsModeStoreProvider } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 
 export interface BalanceSheetStringOverrides {
   balanceSheetTable?: BalanceSheetTableStringOverrides
@@ -31,6 +32,14 @@ export type BalanceSheetProps = PropsWithChildren<{
 }>
 
 const COMPONENT_NAME = 'balance-sheet'
+
+export const StandaloneBalanceSheet = (props: BalanceSheetProps) => {
+  return (
+    <ReportsModeStoreProvider initialModes={{ BalanceSheet: 'dayPicker' }}>
+      <BalanceSheet {...props} />
+    </ReportsModeStoreProvider>
+  )
+}
 
 export const BalanceSheet = (props: BalanceSheetProps) => {
   return (

--- a/src/components/BalanceSheet/index.tsx
+++ b/src/components/BalanceSheet/index.tsx
@@ -1,1 +1,1 @@
-export { BalanceSheet } from './BalanceSheet'
+export { BalanceSheet, StandaloneBalanceSheet } from './BalanceSheet'

--- a/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
+++ b/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
@@ -1,11 +1,11 @@
 import { DatePicker } from '../DatePicker'
 import { useGlobalDate, useGlobalDateActions } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
-import { ReportKey, useReportMode } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
+import { ReportKey, useReportModeWithFallback } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 
 export function BalanceSheetDatePicker() {
   const { date } = useGlobalDate()
   const { setDate } = useGlobalDateActions()
-  const displayMode = useReportMode(ReportKey.BalanceSheet)
+  const displayMode = useReportModeWithFallback(ReportKey.BalanceSheet, 'dayPicker')
 
   return (
     <DatePicker

--- a/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
+++ b/src/components/BalanceSheetDatePicker/BalanceSheetDatePicker.tsx
@@ -1,16 +1,18 @@
 import { DatePicker } from '../DatePicker'
 import { useGlobalDate, useGlobalDateActions } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
+import { ReportKey, useReportMode } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 
 export function BalanceSheetDatePicker() {
-  const { date, displayMode } = useGlobalDate()
-  const { set } = useGlobalDateActions()
+  const { date } = useGlobalDate()
+  const { setDate } = useGlobalDateActions()
+  const displayMode = useReportMode(ReportKey.BalanceSheet)
 
   return (
     <DatePicker
       selected={date}
       onChange={(date) => {
         if (date instanceof Date) {
-          set({ date })
+          setDate({ date })
         }
       }}
       displayMode={displayMode}

--- a/src/components/ProfitAndLoss/ProfitAndLoss.tsx
+++ b/src/components/ProfitAndLoss/ProfitAndLoss.tsx
@@ -10,11 +10,12 @@ import { ProfitAndLossDatePicker } from '../ProfitAndLossDatePicker'
 import { ProfitAndLossDetailedCharts } from '../ProfitAndLossDetailedCharts'
 import { ProfitAndLossDownloadButton } from '../ProfitAndLossDownloadButton'
 import { ProfitAndLossHeader } from '../ProfitAndLossHeader'
-import { StandaloneProfitAndLossReport } from '../ProfitAndLossReport/ProfitAndLossReport'
+import { ProfitAndLossReport } from '../ProfitAndLossReport/ProfitAndLossReport'
 import { ProfitAndLossSummaries } from '../ProfitAndLossSummaries/ProfitAndLossSummaries'
 import { ProfitAndLossTable } from '../ProfitAndLossTable'
 import { endOfMonth, startOfMonth } from 'date-fns'
 import { ProfitAndLossCompareConfig } from '../../types/profit_and_loss'
+import { ReportsModeStoreProvider } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 
 type PNLContextType = ReturnType<typeof useProfitAndLoss>
 const PNLContext = createContext<PNLContextType>({
@@ -50,9 +51,10 @@ type Props = PropsWithChildren & {
   comparisonConfig?: ProfitAndLossCompareConfig
   reportingBasis?: ReportingBasis
   asContainer?: boolean
+  withReportsModeProvider?: boolean
 }
 
-const ProfitAndLoss = ({
+const ProfitAndLossWithoutReportsModeProvider = ({
   children,
   tagFilter,
   comparisonConfig,
@@ -77,6 +79,19 @@ const ProfitAndLoss = ({
   )
 }
 
+const ProfitAndLossWithReportsModeProvider = (props: Props) => {
+  return (
+    <ReportsModeStoreProvider initialModes={{ ProfitAndLoss: 'monthPicker' }}>
+      <ProfitAndLossWithoutReportsModeProvider {...props} />
+    </ReportsModeStoreProvider>
+  )
+}
+
+const ProfitAndLoss = ({ withReportsModeProvider = true, ...restProps }: Props) => {
+  if (withReportsModeProvider) return <ProfitAndLossWithReportsModeProvider {...restProps} />
+  return <ProfitAndLossWithoutReportsModeProvider {...restProps} />
+}
+
 ProfitAndLoss.Chart = ProfitAndLossChart
 ProfitAndLoss.Context = PNLContext
 ProfitAndLoss.ComparisonContext = PNLComparisonContext
@@ -86,6 +101,6 @@ ProfitAndLoss.Summaries = ProfitAndLossSummaries
 ProfitAndLoss.Table = ProfitAndLossTable
 ProfitAndLoss.DetailedCharts = ProfitAndLossDetailedCharts
 ProfitAndLoss.Header = ProfitAndLossHeader
-ProfitAndLoss.Report = StandaloneProfitAndLossReport
+ProfitAndLoss.Report = ProfitAndLossReport
 ProfitAndLoss.DownloadButton = ProfitAndLossDownloadButton
 export { ProfitAndLoss }

--- a/src/components/ProfitAndLoss/ProfitAndLoss.tsx
+++ b/src/components/ProfitAndLoss/ProfitAndLoss.tsx
@@ -10,7 +10,7 @@ import { ProfitAndLossDatePicker } from '../ProfitAndLossDatePicker'
 import { ProfitAndLossDetailedCharts } from '../ProfitAndLossDetailedCharts'
 import { ProfitAndLossDownloadButton } from '../ProfitAndLossDownloadButton'
 import { ProfitAndLossHeader } from '../ProfitAndLossHeader'
-import { ProfitAndLossReport } from '../ProfitAndLossReport/ProfitAndLossReport'
+import { StandaloneProfitAndLossReport } from '../ProfitAndLossReport/ProfitAndLossReport'
 import { ProfitAndLossSummaries } from '../ProfitAndLossSummaries/ProfitAndLossSummaries'
 import { ProfitAndLossTable } from '../ProfitAndLossTable'
 import { endOfMonth, startOfMonth } from 'date-fns'
@@ -86,6 +86,6 @@ ProfitAndLoss.Summaries = ProfitAndLossSummaries
 ProfitAndLoss.Table = ProfitAndLossTable
 ProfitAndLoss.DetailedCharts = ProfitAndLossDetailedCharts
 ProfitAndLoss.Header = ProfitAndLossHeader
-ProfitAndLoss.Report = ProfitAndLossReport
+ProfitAndLoss.Report = StandaloneProfitAndLossReport
 ProfitAndLoss.DownloadButton = ProfitAndLossDownloadButton
 export { ProfitAndLoss }

--- a/src/components/ProfitAndLoss/ProfitAndLoss.tsx
+++ b/src/components/ProfitAndLoss/ProfitAndLoss.tsx
@@ -30,7 +30,6 @@ const PNLContext = createContext<PNLContextType>({
     startDate: startOfMonth(new Date()),
     endDate: endOfMonth(new Date()),
   },
-  changeDateRange: () => {},
   refetch: () => {},
   sidebarScope: undefined,
   setSidebarScope: () => {},

--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -41,6 +41,7 @@ import {
   useGlobalDateRange,
   useGlobalDateRangeActions,
 } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
+import { ReportKey, useReportModeWithFallback } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 
 const getChartWindow = ({
   chartWindow,
@@ -151,7 +152,8 @@ export const ProfitAndLossChart = ({
 
   const { getColor, business } = useLayerContext()
 
-  const { start, end, rangeDisplayMode } = useGlobalDateRange()
+  const rangeDisplayMode = useReportModeWithFallback(ReportKey.ProfitAndLoss, 'monthPicker')
+  const { start, end } = useGlobalDateRange({ displayMode: rangeDisplayMode })
   const { setMonth } = useGlobalDateRangeActions()
 
   const showIndicator = rangeDisplayMode === 'monthPicker'

--- a/src/components/ProfitAndLossCompareOptions/ProfitAndLossCompareOptions.tsx
+++ b/src/components/ProfitAndLossCompareOptions/ProfitAndLossCompareOptions.tsx
@@ -2,8 +2,9 @@ import { useContext, useMemo } from 'react'
 import { MultiSelect, Select } from '../Input'
 import { ProfitAndLoss } from '../ProfitAndLoss/ProfitAndLoss'
 import type { StylesConfig } from 'react-select'
-import { DateRangePickerMode, useGlobalDateRange } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
+import { DateRangePickerMode } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 import { TagComparisonOption } from '../../types/profit_and_loss'
+import { ReportKey, useReportModeWithFallback } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 
 const selectStyles = {
   valueContainer: (styles) => {
@@ -48,7 +49,7 @@ export const ProfitAndLossCompareOptions = () => {
     comparisonConfig,
   } = useContext(ProfitAndLoss.ComparisonContext)
 
-  const { rangeDisplayMode } = useGlobalDateRange()
+  const rangeDisplayMode = useReportModeWithFallback(ReportKey.ProfitAndLoss, 'monthPicker')
 
   const periods = useMemo<number>(
     () => comparePeriods !== 0 ? comparePeriods : 1,

--- a/src/components/ProfitAndLossDatePicker/ProfitAndLossDatePicker.tsx
+++ b/src/components/ProfitAndLossDatePicker/ProfitAndLossDatePicker.tsx
@@ -1,11 +1,11 @@
+import { useCallback, useEffect, useRef } from 'react'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { getEarliestDateToBrowse } from '../../utils/business'
 import type { TimeRangePickerConfig } from '../../views/Reports/reportTypes'
 import { DatePicker } from '../DatePicker'
 import { DatePickerModeSelector } from '../DatePicker/ModeSelector/DatePickerModeSelector'
-import { getAllowedDateRangePickerModes, useGlobalDateRangePicker } from '../../providers/GlobalDateStore/useGlobalDateRangePicker'
+import { getAllowedDateRangePickerModes, getInitialDateRangePickerMode, useGlobalDateRangePicker } from '../../providers/GlobalDateStore/useGlobalDateRangePicker'
 import { ReportKey, useReportModeActions, useReportModeWithFallback } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
-import { useCallback } from 'react'
 import { type DateRangePickerMode } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 
 export type ProfitAndLossDatePickerProps = TimeRangePickerConfig
@@ -15,6 +15,7 @@ export const ProfitAndLossDatePicker = ({
   customDateRanges,
   defaultDatePickerMode,
 }: ProfitAndLossDatePickerProps) => {
+  const isMounted = useRef(false)
   const { business } = useLayerContext()
 
   const displayMode = useReportModeWithFallback(ReportKey.ProfitAndLoss, 'monthPicker')
@@ -24,6 +25,14 @@ export const ProfitAndLossDatePicker = ({
   const setDisplayMode = useCallback((mode: DateRangePickerMode) => {
     setModeForReport(ReportKey.ProfitAndLoss, mode)
   }, [setModeForReport])
+
+  useEffect(() => {
+    const initialDatePickerMode = getInitialDateRangePickerMode({ allowedDatePickerModes, defaultDatePickerMode })
+    if (!isMounted.current && displayMode !== initialDatePickerMode) {
+      setDisplayMode(initialDatePickerMode)
+    }
+    isMounted.current = true
+  }, [allowedDatePickerModes, defaultDatePickerMode, displayMode, setDisplayMode])
 
   const cleanedAllowedModes = getAllowedDateRangePickerModes({ allowedDatePickerModes, defaultDatePickerMode })
 

--- a/src/components/ProfitAndLossDatePicker/ProfitAndLossDatePicker.tsx
+++ b/src/components/ProfitAndLossDatePicker/ProfitAndLossDatePicker.tsx
@@ -4,7 +4,7 @@ import type { TimeRangePickerConfig } from '../../views/Reports/reportTypes'
 import { DatePicker } from '../DatePicker'
 import { DatePickerModeSelector } from '../DatePicker/ModeSelector/DatePickerModeSelector'
 import { getAllowedDateRangePickerModes, useGlobalDateRangePicker } from '../../providers/GlobalDateStore/useGlobalDateRangePicker'
-import { ReportKey, useReportMode, useReportModeActions } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
+import { ReportKey, useReportModeActions, useReportModeWithFallback } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 import { useCallback } from 'react'
 import { type DateRangePickerMode } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 
@@ -17,7 +17,8 @@ export const ProfitAndLossDatePicker = ({
 }: ProfitAndLossDatePickerProps) => {
   const { business } = useLayerContext()
 
-  const displayMode = useReportMode(ReportKey.ProfitAndLoss)
+  const displayMode = useReportModeWithFallback(ReportKey.ProfitAndLoss, 'monthPicker')
+
   const { setModeForReport } = useReportModeActions()
 
   const setDisplayMode = useCallback((mode: DateRangePickerMode) => {

--- a/src/components/ProfitAndLossReport/ProfitAndLossReport.tsx
+++ b/src/components/ProfitAndLossReport/ProfitAndLossReport.tsx
@@ -5,8 +5,6 @@ import type { TimeRangePickerConfig } from '../../views/Reports/reportTypes'
 import { Header, HeaderCol, HeaderRow } from '../Header'
 import { ProfitAndLoss } from '../ProfitAndLoss'
 import { View } from '../View'
-import { ReportsModeStoreProvider } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
-import { getInitialDateRangePickerMode } from '../../providers/GlobalDateStore/useGlobalDateRangePicker'
 
 type ViewBreakpoint = ViewType | undefined
 
@@ -14,16 +12,6 @@ export type ProfitAndLossReportProps = {
   stringOverrides?: ReportsStringOverrides
   view?: ViewBreakpoint
 } & TimeRangePickerConfig
-
-export const StandaloneProfitAndLossReport = (props: ProfitAndLossReportProps) => {
-  const initialModeForProfitAndLossReport = getInitialDateRangePickerMode(props)
-
-  return (
-    <ReportsModeStoreProvider initialModes={{ ProfitAndLoss: initialModeForProfitAndLossReport }}>
-      <ProfitAndLossReport {...props} />
-    </ReportsModeStoreProvider>
-  )
-}
 
 export const ProfitAndLossReport = ({
   stringOverrides,

--- a/src/components/ProfitAndLossReport/ProfitAndLossReport.tsx
+++ b/src/components/ProfitAndLossReport/ProfitAndLossReport.tsx
@@ -5,6 +5,8 @@ import type { TimeRangePickerConfig } from '../../views/Reports/reportTypes'
 import { Header, HeaderCol, HeaderRow } from '../Header'
 import { ProfitAndLoss } from '../ProfitAndLoss'
 import { View } from '../View'
+import { ReportsModeStoreProvider } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
+import { getInitialDateRangePickerMode } from '../../providers/GlobalDateStore/useGlobalDateRangePicker'
 
 type ViewBreakpoint = ViewType | undefined
 
@@ -12,6 +14,16 @@ export type ProfitAndLossReportProps = {
   stringOverrides?: ReportsStringOverrides
   view?: ViewBreakpoint
 } & TimeRangePickerConfig
+
+export const StandaloneProfitAndLossReport = (props: ProfitAndLossReportProps) => {
+  const initialModeForProfitAndLossReport = getInitialDateRangePickerMode(props)
+
+  return (
+    <ReportsModeStoreProvider initialModes={{ ProfitAndLoss: initialModeForProfitAndLossReport }}>
+      <ProfitAndLossReport {...props} />
+    </ReportsModeStoreProvider>
+  )
+}
 
 export const ProfitAndLossReport = ({
   stringOverrides,

--- a/src/components/ProfitAndLossTable/ProfitAndLossCompareTable.tsx
+++ b/src/components/ProfitAndLossTable/ProfitAndLossCompareTable.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useContext, useEffect } from 'react'
+import { Fragment, useContext, useEffect, useMemo } from 'react'
 import { useTableExpandRow } from '../../hooks/useTableExpandRow'
 import { LineItem } from '../../types'
 import { ProfitAndLossComparisonPnl } from '../../types/profit_and_loss'
@@ -16,6 +16,7 @@ import { useGlobalDateRange } from '../../providers/GlobalDateStore/GlobalDateSt
 import { useBookkeepingPeriods } from '../../hooks/bookkeeping/periods/useBookkeepingPeriods'
 import { BookkeepingStatus } from '../BookkeepingStatus/BookkeepingStatus'
 import { HStack } from '../ui/Stack/Stack'
+import { ReportKey, useReportModeWithFallback } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 
 interface ProfilAndLostCompareTableProps {
   stringOverrides?: ProfitAndLossTableStringOverrides
@@ -24,7 +25,6 @@ interface ProfilAndLostCompareTableProps {
 export const ProfitAndLossCompareTable = ({
   stringOverrides,
 }: ProfilAndLostCompareTableProps) => {
-  const { dateRange } = useContext(ProfitAndLoss.Context)
   const {
     data: comparisonData,
     isLoading,
@@ -32,8 +32,11 @@ export const ProfitAndLossCompareTable = ({
     selectedCompareOptions,
   } = useContext(ProfitAndLoss.ComparisonContext)
   const { isOpen, setIsOpen } = useTableExpandRow()
-  const { rangeDisplayMode } = useGlobalDateRange()
   const { data: bookkeepingPeriods } = useBookkeepingPeriods()
+
+  const rangeDisplayMode = useReportModeWithFallback(ReportKey.ProfitAndLoss, 'monthPicker')
+  const { start, end } = useGlobalDateRange({ displayMode: rangeDisplayMode })
+  const dateRange = useMemo(() => ({ startDate: start, endDate: end }), [start, end])
 
   useEffect(() => {
     setIsOpen(['income', 'cost_of_goods_sold', 'expenses'])
@@ -154,9 +157,9 @@ export const ProfitAndLossCompareTable = ({
                   {option.displayName}
                 </TableCell>
                 {comparePeriods
-                && Array.from({ length: comparePeriods - 1 }, (_, index) => (
-                  <TableCell key={option.displayName + '-' + index} isHeaderCell />
-                ))}
+                  && Array.from({ length: comparePeriods - 1 }, (_, index) => (
+                    <TableCell key={option.displayName + '-' + index} isHeaderCell />
+                  ))}
               </Fragment>
             ))}
           </TableRow>

--- a/src/components/ProfitAndLossView/ProfitAndLossView.tsx
+++ b/src/components/ProfitAndLossView/ProfitAndLossView.tsx
@@ -47,11 +47,11 @@ const ProfitAndLossPanel = ({
 
   return (
     <Panel
-      sidebar={
+      sidebar={(
         <ProfitAndLossDetailedCharts
           stringOverrides={stringOverrides?.profitAndLossDetailedCharts}
         />
-      }
+      )}
       sidebarIsOpen={Boolean(sidebarScope)}
       parentRef={containerRef}
     >

--- a/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
+++ b/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
@@ -11,7 +11,8 @@ import { useElementViewSize } from '../../hooks/useElementViewSize/useElementVie
 import { useGlobalDateRange } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 import { StatementOfCashFlowDatePicker } from './datePicker/StatementOfCashFlowDatePicker'
 import { useStatementOfCashFlow } from '../../hooks/useStatementOfCashFlow/useStatementOfCashFlow'
-import { ReportKey, useReportMode } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
+import { ReportKey, ReportsModeStoreProvider, useReportMode } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
+import { getInitialDateRangePickerMode } from '../../providers/GlobalDateStore/useGlobalDateRangePicker'
 
 const COMPONENT_NAME = 'statement-of-cash-flow'
 
@@ -21,6 +22,16 @@ export interface StatementOfCashFlowStringOverrides {
 
 export type StatementOfCashFlowProps = TimeRangePickerConfig & {
   stringOverrides?: StatementOfCashFlowStringOverrides
+}
+
+export const StandaloneStatementOfCashFlow = (props: StatementOfCashFlowProps) => {
+  const initialModeForStatementOfCashFlows = getInitialDateRangePickerMode(props)
+
+  return (
+    <ReportsModeStoreProvider initialModes={{ StatementOfCashFlows: initialModeForStatementOfCashFlows }}>
+      <StatementOfCashFlow {...props} />
+    </ReportsModeStoreProvider>
+  )
 }
 
 export const StatementOfCashFlow = (props: StatementOfCashFlowProps) => {
@@ -33,7 +44,7 @@ type StatementOfCashFlowViewProps = TimeRangePickerConfig & {
   stringOverrides?: StatementOfCashFlowStringOverrides
 }
 
-const StatementOfCashFlowView = ({
+export const StatementOfCashFlowView = ({
   stringOverrides,
   allowedDatePickerModes,
   defaultDatePickerMode,

--- a/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
+++ b/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
@@ -11,6 +11,7 @@ import { useElementViewSize } from '../../hooks/useElementViewSize/useElementVie
 import { useGlobalDateRange } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 import { StatementOfCashFlowDatePicker } from './datePicker/StatementOfCashFlowDatePicker'
 import { useStatementOfCashFlow } from '../../hooks/useStatementOfCashFlow/useStatementOfCashFlow'
+import { ReportKey, useReportMode } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 
 const COMPONENT_NAME = 'statement-of-cash-flow'
 
@@ -35,9 +36,11 @@ type StatementOfCashFlowViewProps = TimeRangePickerConfig & {
 const StatementOfCashFlowView = ({
   stringOverrides,
   allowedDatePickerModes,
+  defaultDatePickerMode,
   customDateRanges,
 }: StatementOfCashFlowViewProps) => {
-  const { start, end } = useGlobalDateRange()
+  const displayMode = useReportMode(ReportKey.StatementOfCashFlows)
+  const { start, end } = useGlobalDateRange({ displayMode })
   const { data, isLoading } = useStatementOfCashFlow({ startDate: start, endDate: end })
   const { view, containerRef } = useElementViewSize<HTMLDivElement>()
 
@@ -52,6 +55,7 @@ const StatementOfCashFlowView = ({
               <HeaderCol>
                 <StatementOfCashFlowDatePicker
                   allowedDatePickerModes={allowedDatePickerModes}
+                  defaultDatePickerMode={defaultDatePickerMode}
                   customDateRanges={customDateRanges}
                 />
               </HeaderCol>

--- a/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
+++ b/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
@@ -44,7 +44,7 @@ type StatementOfCashFlowViewProps = TimeRangePickerConfig & {
   stringOverrides?: StatementOfCashFlowStringOverrides
 }
 
-export const StatementOfCashFlowView = ({
+const StatementOfCashFlowView = ({
   stringOverrides,
   allowedDatePickerModes,
   defaultDatePickerMode,

--- a/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
+++ b/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
@@ -11,7 +11,7 @@ import { useElementViewSize } from '../../hooks/useElementViewSize/useElementVie
 import { useGlobalDateRange } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 import { StatementOfCashFlowDatePicker } from './datePicker/StatementOfCashFlowDatePicker'
 import { useStatementOfCashFlow } from '../../hooks/useStatementOfCashFlow/useStatementOfCashFlow'
-import { ReportKey, ReportsModeStoreProvider, useReportMode } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
+import { ReportKey, ReportsModeStoreProvider, useReportModeWithFallback } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 import { getInitialDateRangePickerMode } from '../../providers/GlobalDateStore/useGlobalDateRangePicker'
 
 const COMPONENT_NAME = 'statement-of-cash-flow'
@@ -50,7 +50,7 @@ export const StatementOfCashFlowView = ({
   defaultDatePickerMode,
   customDateRanges,
 }: StatementOfCashFlowViewProps) => {
-  const displayMode = useReportMode(ReportKey.StatementOfCashFlows)
+  const displayMode = useReportModeWithFallback(ReportKey.StatementOfCashFlows, 'monthPicker')
   const { start, end } = useGlobalDateRange({ displayMode })
   const { data, isLoading } = useStatementOfCashFlow({ startDate: start, endDate: end })
   const { view, containerRef } = useElementViewSize<HTMLDivElement>()

--- a/src/components/StatementOfCashFlow/datePicker/StatementOfCashFlowDatePicker.tsx
+++ b/src/components/StatementOfCashFlow/datePicker/StatementOfCashFlowDatePicker.tsx
@@ -3,7 +3,10 @@ import type { TimeRangePickerConfig } from '../../../views/Reports/reportTypes'
 import { DatePicker } from '../../DatePicker'
 import { useLayerContext } from '../../../contexts/LayerContext'
 import { getEarliestDateToBrowse } from '../../../utils/business'
-import { useGlobalDateRangePicker } from '../../../providers/GlobalDateStore/useGlobalDateRangePicker'
+import { getAllowedDateRangePickerModes, useGlobalDateRangePicker } from '../../../providers/GlobalDateStore/useGlobalDateRangePicker'
+import { ReportKey, useReportMode, useReportModeActions } from '../../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
+import { useCallback } from 'react'
+import type { DateRangePickerMode } from '../../../providers/GlobalDateStore/GlobalDateStoreProvider'
 
 type StatementOfCashFlowDatePickerProps = Pick<
   TimeRangePickerConfig,
@@ -17,38 +20,32 @@ export function StatementOfCashFlowDatePicker({
 }: StatementOfCashFlowDatePickerProps) {
   const { business } = useLayerContext()
 
+  const displayMode = useReportMode(ReportKey.StatementOfCashFlows)
+  const { setModeForReport } = useReportModeActions()
+
+  const setDisplayMode = useCallback((mode: DateRangePickerMode) => {
+    setModeForReport(ReportKey.StatementOfCashFlows, mode)
+  }, [setModeForReport])
+
   const {
-    allowedDateRangePickerModes,
     dateFormat,
     rangeDisplayMode,
-    selected,
-    setRangeDisplayMode,
-    setSelected,
-  } = useGlobalDateRangePicker({ allowedDatePickerModes, defaultDatePickerMode })
+    onChangeMode,
+    dateOrDateRange,
+    onChangeDateOrDateRange,
+  } = useGlobalDateRangePicker({ displayMode, setDisplayMode })
+
+  const cleanedAllowedModes = getAllowedDateRangePickerModes({ allowedDatePickerModes, defaultDatePickerMode })
 
   const minDate = getEarliestDateToBrowse(business)
 
   return (
     <DatePicker
-      selected={selected}
-      onChange={(dates) => {
-        if (dates instanceof Date) {
-          setSelected({ start: dates, end: dates })
-
-          return
-        }
-
-        const [start, end] = dates
-
-        setSelected({ start, end: end ?? start })
-      }}
+      selected={dateOrDateRange}
+      onChange={onChangeDateOrDateRange}
       displayMode={rangeDisplayMode}
-      allowedModes={allowedDateRangePickerModes}
-      onChangeMode={(rangeDisplayMode) => {
-        if (rangeDisplayMode !== 'dayPicker') {
-          setRangeDisplayMode({ rangeDisplayMode })
-        }
-      }}
+      allowedModes={cleanedAllowedModes}
+      onChangeMode={onChangeMode}
       slots={{
         ModeSelector: DatePickerModeSelector,
       }}

--- a/src/components/StatementOfCashFlow/datePicker/StatementOfCashFlowDatePicker.tsx
+++ b/src/components/StatementOfCashFlow/datePicker/StatementOfCashFlowDatePicker.tsx
@@ -4,7 +4,7 @@ import { DatePicker } from '../../DatePicker'
 import { useLayerContext } from '../../../contexts/LayerContext'
 import { getEarliestDateToBrowse } from '../../../utils/business'
 import { getAllowedDateRangePickerModes, useGlobalDateRangePicker } from '../../../providers/GlobalDateStore/useGlobalDateRangePicker'
-import { ReportKey, useReportMode, useReportModeActions } from '../../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
+import { ReportKey, useReportModeActions, useReportModeWithFallback } from '../../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 import { useCallback } from 'react'
 import type { DateRangePickerMode } from '../../../providers/GlobalDateStore/GlobalDateStoreProvider'
 
@@ -20,7 +20,7 @@ export function StatementOfCashFlowDatePicker({
 }: StatementOfCashFlowDatePickerProps) {
   const { business } = useLayerContext()
 
-  const displayMode = useReportMode(ReportKey.StatementOfCashFlows)
+  const displayMode = useReportModeWithFallback(ReportKey.StatementOfCashFlows, 'monthPicker')
   const { setModeForReport } = useReportModeActions()
 
   const setDisplayMode = useCallback((mode: DateRangePickerMode) => {

--- a/src/components/StatementOfCashFlow/index.tsx
+++ b/src/components/StatementOfCashFlow/index.tsx
@@ -1,1 +1,1 @@
-export { StatementOfCashFlow } from './StatementOfCashFlow'
+export { StatementOfCashFlow, StandaloneStatementOfCashFlow } from './StatementOfCashFlow'

--- a/src/hooks/useProfitAndLoss/useProfitAndLoss.tsx
+++ b/src/hooks/useProfitAndLoss/useProfitAndLoss.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
   ReportingBasis,
   SortDirection,
-  type DateRange,
 } from '../../types'
 import {
   collectExpensesItems,
@@ -12,9 +11,10 @@ import {
 import { useProfitAndLossLTM } from './useProfitAndLossLTM'
 import { useProfitAndLossQuery } from './useProfitAndLossQuery'
 import {
+  DateRangePickerMode,
   useGlobalDateRange,
-  useGlobalDateRangeActions,
 } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
+import { ReportKey, useReportModeWithFallback } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 
 export type Scope = 'expenses' | 'revenue'
 
@@ -28,6 +28,7 @@ export type PnlTagFilter = {
 type UseProfitAndLossOptions = {
   tagFilter?: PnlTagFilter
   reportingBasis?: ReportingBasis
+  initialDateRangePickerMode?: DateRangePickerMode
 }
 
 type ProfitAndLossFilter = {
@@ -45,14 +46,9 @@ export const useProfitAndLoss = ({
   tagFilter,
   reportingBasis,
 }: UseProfitAndLossOptions) => {
-  const { start, end } = useGlobalDateRange()
-  const { setRange } = useGlobalDateRangeActions()
-
+  const rangeDisplayMode = useReportModeWithFallback(ReportKey.ProfitAndLoss, 'monthPicker')
+  const { start, end } = useGlobalDateRange({ displayMode: rangeDisplayMode })
   const dateRange = useMemo(() => ({ startDate: start, endDate: end }), [start, end])
-  const changeDateRange = useCallback(
-    ({ startDate: start, endDate: end }: DateRange) => setRange({ start, end }),
-    [setRange],
-  )
 
   const [filters, setFilters] = useState<ProfitAndLossFilters>({
     expenses: undefined,
@@ -233,8 +229,6 @@ export const useProfitAndLoss = ({
     isLoading,
     isValidating,
     error: error,
-    dateRange,
-    changeDateRange,
     refetch,
     sidebarScope,
     setSidebarScope,
@@ -242,5 +236,6 @@ export const useProfitAndLoss = ({
     filters,
     setFilterTypes,
     tagFilter,
+    dateRange,
   }
 }

--- a/src/hooks/useProfitAndLoss/useProfitAndLoss.tsx
+++ b/src/hooks/useProfitAndLoss/useProfitAndLoss.tsx
@@ -11,7 +11,6 @@ import {
 import { useProfitAndLossLTM } from './useProfitAndLossLTM'
 import { useProfitAndLossQuery } from './useProfitAndLossQuery'
 import {
-  DateRangePickerMode,
   useGlobalDateRange,
 } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 import { ReportKey, useReportModeWithFallback } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
@@ -28,7 +27,6 @@ export type PnlTagFilter = {
 type UseProfitAndLossOptions = {
   tagFilter?: PnlTagFilter
   reportingBasis?: ReportingBasis
-  initialDateRangePickerMode?: DateRangePickerMode
 }
 
 type ProfitAndLossFilter = {

--- a/src/hooks/useProfitAndLossComparison/useProfitAndLossComparison.tsx
+++ b/src/hooks/useProfitAndLossComparison/useProfitAndLossComparison.tsx
@@ -10,6 +10,7 @@ import useSWR from 'swr'
 import { MultiValue } from 'react-select'
 import { ProfitAndLossCompareConfig, ProfitAndLossComparisonTags, TagComparisonOption, type ProfitAndLossComparisonRequestBody } from '../../types/profit_and_loss'
 import { ReadonlyArrayWithAtLeastOne } from '../../utils/array/getArrayWithAtLeastOneOrFallback'
+import { ReportKey, useReportModeWithFallback } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 
 export type Scope = 'expenses' | 'revenue'
 
@@ -64,8 +65,10 @@ export function useProfitAndLossComparison({
   const [selectedCompareOptions, setSelectedCompareOptionsState] = useState<TagComparisonOption[]>(
     comparisonConfig?.defaultTagFilter ? [comparisonConfig?.defaultTagFilter] : [],
   )
-  const { rangeDisplayMode, start, end } = useGlobalDateRange()
-  const dateRange = { startDate: start, endDate: end }
+
+  const rangeDisplayMode = useReportModeWithFallback(ReportKey.ProfitAndLoss, 'monthPicker')
+  const { start, end } = useGlobalDateRange({ displayMode: rangeDisplayMode })
+  const dateRange = useMemo(() => ({ startDate: start, endDate: end }), [start, end])
 
   const isPeriodsSelectEnabled = COMPARE_MODES_SUPPORTING_MULTI_PERIOD.includes(rangeDisplayMode)
   const effectiveComparePeriods = isPeriodsSelectEnabled

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,9 +23,10 @@ export { ProfitAndLoss } from './components/ProfitAndLoss'
  * - Summaries
  * - Table
  * - DetailedCharts
+ * - Report
  */
-export { BalanceSheet } from './components/BalanceSheet'
-export { StatementOfCashFlow } from './components/StatementOfCashFlow'
+export { StandaloneBalanceSheet as BalanceSheet } from './components/BalanceSheet'
+export { StandaloneStatementOfCashFlow as StatementOfCashFlow } from './components/StatementOfCashFlow'
 
 /* ------------------ Ledger ------------------ */
 export { ChartOfAccounts } from './components/ChartOfAccounts'

--- a/src/providers/ReportsModeStoreProvider/ReportsModeStoreProvider.tsx
+++ b/src/providers/ReportsModeStoreProvider/ReportsModeStoreProvider.tsx
@@ -1,0 +1,90 @@
+import { useState, createContext, type PropsWithChildren, useContext } from 'react'
+import { createStore, useStore } from 'zustand'
+import type { DatePickerMode, DateRangePickerMode } from '../GlobalDateStore/GlobalDateStoreProvider'
+
+export enum ReportKey {
+  ProfitAndLoss = 'ProfitAndLoss',
+  BalanceSheet = 'BalanceSheet',
+  StatementOfCashFlows = 'StatementOfCashFlows',
+}
+
+export type ReportModes = {
+  [ReportKey.ProfitAndLoss]: DateRangePickerMode
+  [ReportKey.BalanceSheet]: DatePickerMode
+  [ReportKey.StatementOfCashFlows]: DateRangePickerMode
+}
+type MutableReportKey = Exclude<ReportKey, ReportKey.BalanceSheet>
+
+type ReportsModeStoreShape = {
+  modeByReport: ReportModes
+  actions: {
+    setModeForReport: <K extends MutableReportKey>(report: K, mode: ReportModes[K]) => void
+  }
+}
+
+const ReportsModeStoreContext = createContext(
+  createStore<ReportsModeStoreShape>(() => ({
+    modeByReport: {
+      [ReportKey.ProfitAndLoss]: 'monthPicker',
+      // This one should never change, but is included for completeness
+      [ReportKey.BalanceSheet]: 'dayPicker',
+      [ReportKey.StatementOfCashFlows]: 'monthPicker',
+    },
+    actions: {
+      setModeForReport: () => {},
+    },
+  })),
+)
+
+export function useReportMode<K extends ReportKey>(report: K): ReportModes[K] {
+  const store = useContext(ReportsModeStoreContext)
+  return useStore(store, state => state.modeByReport[report])
+}
+
+export function useReportModeActions() {
+  const store = useContext(ReportsModeStoreContext)
+  const setModeForReport = useStore(store, s => s.actions.setModeForReport)
+
+  return { setModeForReport }
+}
+
+export function useReportModeWithFallback<K extends ReportKey>(
+  report: K,
+  fallback: ReportModes[K],
+): ReportModes[K] {
+  const context = useContext(ReportsModeStoreContext)
+
+  const mode = useReportMode(report)
+
+  return context ? mode : fallback
+}
+
+type ReportsModeStoreProviderProps = PropsWithChildren<{
+  initialModes: ReportModes
+}>
+
+export function ReportsModeStoreProvider({
+  children,
+  initialModes,
+}: ReportsModeStoreProviderProps) {
+  const [store] = useState(() =>
+    createStore<ReportsModeStoreShape>(set => ({
+      modeByReport: initialModes,
+      actions: {
+        setModeForReport: (report, mode) =>
+          set(state => ({
+            modeByReport: {
+              ...state.modeByReport,
+              [report]: mode,
+            },
+          })),
+      },
+    })),
+  )
+
+  return (
+    <ReportsModeStoreContext.Provider value={store}>
+      {children}
+    </ReportsModeStoreContext.Provider>
+  )
+}

--- a/src/providers/ReportsModeStoreProvider/ReportsModeStoreProvider.tsx
+++ b/src/providers/ReportsModeStoreProvider/ReportsModeStoreProvider.tsx
@@ -31,14 +31,14 @@ const defaultModeByReport: ReportModes = {
 
 const ReportsModeStoreContext = createContext(
   createStore<ReportsModeStoreShape>(() => ({
-    modeByReport: defaultModeByReport,
+    modeByReport: {} as ReportModes,
     actions: {
       setModeForReport: () => {},
     },
   })),
 )
 
-export function useReportMode<K extends ReportKey>(report: K): ReportModes[K] {
+export function useReportMode<K extends ReportKey>(report: K): ReportModes[K] | undefined {
   const store = useContext(ReportsModeStoreContext)
   return useStore(store, state => state.modeByReport[report])
 }
@@ -54,13 +54,9 @@ export function useReportModeWithFallback<K extends ReportKey>(
   report: K,
   fallback: ReportModes[K],
 ): ReportModes[K] {
-  const context = useContext(ReportsModeStoreContext)
-  console.error(context)
-
   const mode = useReportMode(report)
-  console.error(mode)
 
-  return context ? mode : fallback
+  return mode ?? fallback
 }
 
 type ReportsModeStoreProviderProps = PropsWithChildren<{

--- a/src/providers/ReportsModeStoreProvider/ReportsModeStoreProvider.tsx
+++ b/src/providers/ReportsModeStoreProvider/ReportsModeStoreProvider.tsx
@@ -22,14 +22,16 @@ type ReportsModeStoreShape = {
   }
 }
 
+const defaultModeByReport: ReportModes = {
+  [ReportKey.ProfitAndLoss]: 'monthPicker',
+  // This one should never change, but is included for completeness
+  [ReportKey.BalanceSheet]: 'dayPicker',
+  [ReportKey.StatementOfCashFlows]: 'monthPicker',
+}
+
 const ReportsModeStoreContext = createContext(
   createStore<ReportsModeStoreShape>(() => ({
-    modeByReport: {
-      [ReportKey.ProfitAndLoss]: 'monthPicker',
-      // This one should never change, but is included for completeness
-      [ReportKey.BalanceSheet]: 'dayPicker',
-      [ReportKey.StatementOfCashFlows]: 'monthPicker',
-    },
+    modeByReport: defaultModeByReport,
     actions: {
       setModeForReport: () => {},
     },
@@ -53,14 +55,16 @@ export function useReportModeWithFallback<K extends ReportKey>(
   fallback: ReportModes[K],
 ): ReportModes[K] {
   const context = useContext(ReportsModeStoreContext)
+  console.error(context)
 
   const mode = useReportMode(report)
+  console.error(mode)
 
   return context ? mode : fallback
 }
 
 type ReportsModeStoreProviderProps = PropsWithChildren<{
-  initialModes: ReportModes
+  initialModes: Partial<ReportModes>
 }>
 
 export function ReportsModeStoreProvider({
@@ -69,7 +73,7 @@ export function ReportsModeStoreProvider({
 }: ReportsModeStoreProviderProps) {
   const [store] = useState(() =>
     createStore<ReportsModeStoreShape>(set => ({
-      modeByReport: initialModes,
+      modeByReport: { ...defaultModeByReport, ...initialModes },
       actions: {
         setModeForReport: (report, mode) =>
           set(state => ({

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
-import { BalanceSheet } from '../../components/BalanceSheet'
+import { BalanceSheet as EmbeddedBalanceSheet } from '../../components/BalanceSheet'
 import { BalanceSheetStringOverrides } from '../../components/BalanceSheet/BalanceSheet'
 import { Container } from '../../components/Container'
 import { ProfitAndLoss } from '../../components/ProfitAndLoss'
 import { ProfitAndLossDetailedChartsStringOverrides } from '../../components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts'
 import { PnLDownloadButtonStringOverrides } from '../../components/ProfitAndLossDownloadButton'
 import { ProfitAndLossTableStringOverrides } from '../../components/ProfitAndLossTable'
-import { StatementOfCashFlow } from '../../components/StatementOfCashFlow'
+import { StatementOfCashFlow as EmbeddedStatementOfCashFlow } from '../../components/StatementOfCashFlow'
 import { StatementOfCashFlowStringOverrides } from '../../components/StatementOfCashFlow/StatementOfCashFlow'
 import { Toggle } from '../../components/Toggle'
 import { View } from '../../components/View'
@@ -16,6 +16,7 @@ import type { TimeRangePickerConfig } from './reportTypes'
 import { ProfitAndLossCompareConfig } from '../../types/profit_and_loss'
 import { ReportKey, ReportsModeStoreProvider, type ReportModes } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
 import { getInitialDateRangePickerMode } from '../../providers/GlobalDateStore/useGlobalDateRangePicker'
+import { ProfitAndLossReport as EmbeddedProfitAndLossReport } from '../../components/ProfitAndLossReport/ProfitAndLossReport'
 
 type ViewBreakpoint = ViewType | undefined
 
@@ -89,7 +90,7 @@ export const Reports = ({
   const defaultTitle =
     enabledReports.length > 1
       ? 'Reports'
-      : options.find(option => (option.value = enabledReports[0]))?.label
+      : options.find(option => (option.value === enabledReports[0]))?.label
 
   const initialModeForProfitAndLoss = profitAndLossConfig ? getInitialDateRangePickerMode(profitAndLossConfig) : 'monthPicker'
   const initialModeForStatementOfCashFlows = statementOfCashFlowConfig ? getInitialDateRangePickerMode(statementOfCashFlowConfig) : 'monthPicker'
@@ -142,17 +143,17 @@ const ReportsPanel = ({
   return (
     <>
       {openReport === 'profitAndLoss' && (
-        <ProfitAndLoss.Report
+        <EmbeddedProfitAndLossReport
           stringOverrides={stringOverrides}
           view={view}
           {...profitAndLossConfig}
         />
       )}
       {openReport === 'balanceSheet' && (
-        <BalanceSheet stringOverrides={stringOverrides?.balanceSheet} />
+        <EmbeddedBalanceSheet stringOverrides={stringOverrides?.balanceSheet} />
       )}
       {openReport === 'statementOfCashFlow' && (
-        <StatementOfCashFlow
+        <EmbeddedStatementOfCashFlow
           stringOverrides={stringOverrides?.statementOfCashflow}
           {...statementOfCashFlowConfig}
         />

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -14,6 +14,8 @@ import { useElementViewSize } from '../../hooks/useElementViewSize/useElementVie
 import { View as ViewType } from '../../types/general'
 import type { TimeRangePickerConfig } from './reportTypes'
 import { ProfitAndLossCompareConfig } from '../../types/profit_and_loss'
+import { ReportKey, ReportsModeStoreProvider, type ReportModes } from '../../providers/ReportsModeStoreProvider/ReportsModeStoreProvider'
+import { getInitialDateRangePickerMode } from '../../providers/GlobalDateStore/useGlobalDateRangePicker'
 
 type ViewBreakpoint = ViewType | undefined
 
@@ -89,6 +91,15 @@ export const Reports = ({
       ? 'Reports'
       : options.find(option => (option.value = enabledReports[0]))?.label
 
+  const initialModeForProfitAndLoss = profitAndLossConfig ? getInitialDateRangePickerMode(profitAndLossConfig) : 'monthPicker'
+  const initialModeForStatementOfCashFlows = statementOfCashFlowConfig ? getInitialDateRangePickerMode(statementOfCashFlowConfig) : 'monthPicker'
+
+  const initialModes: ReportModes = {
+    [ReportKey.ProfitAndLoss]: initialModeForProfitAndLoss,
+    [ReportKey.BalanceSheet]: 'dayPicker',
+    [ReportKey.StatementOfCashFlows]: initialModeForStatementOfCashFlows,
+  }
+
   return (
     <View
       title={stringOverrides?.title || title || defaultTitle}
@@ -105,15 +116,17 @@ export const Reports = ({
         </div>
       )}
       <Container name='reports' ref={containerRef}>
-        <ProfitAndLoss asContainer={false} comparisonConfig={comparisonConfig}>
-          <ReportsPanel
-            openReport={activeTab}
-            stringOverrides={stringOverrides}
-            profitAndLossConfig={profitAndLossConfig}
-            statementOfCashFlowConfig={statementOfCashFlowConfig}
-            view={view}
-          />
-        </ProfitAndLoss>
+        <ReportsModeStoreProvider initialModes={initialModes}>
+          <ProfitAndLoss asContainer={false} comparisonConfig={comparisonConfig}>
+            <ReportsPanel
+              openReport={activeTab}
+              stringOverrides={stringOverrides}
+              profitAndLossConfig={profitAndLossConfig}
+              statementOfCashFlowConfig={statementOfCashFlowConfig}
+              view={view}
+            />
+          </ProfitAndLoss>
+        </ReportsModeStoreProvider>
       </Container>
     </View>
   )

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -118,7 +118,7 @@ export const Reports = ({
       )}
       <Container name='reports' ref={containerRef}>
         <ReportsModeStoreProvider initialModes={initialModes}>
-          <ProfitAndLoss asContainer={false} comparisonConfig={comparisonConfig}>
+          <ProfitAndLoss asContainer={false} comparisonConfig={comparisonConfig} withReportsModeProvider={false}>
             <ReportsPanel
               openReport={activeTab}
               stringOverrides={stringOverrides}


### PR DESCRIPTION
## Description
This PR fixes the date picker so that it honors defaults passed by the platform for P&L and SOCF.

It also makes the following design changes:
1. [Old] All dates are still global, and all date pickers still set the global state.
2. [New] What is _shown_ on the date picker is what is filtered. E.g., if the global date range is 4/15-4/29 but a month picker is shown, then the effective date range on that view is 4/1-4/30.
3. [New] If you navigate away from a report, we remember what mode you were on for that report. E.g., if you are looking at a month picker on P&L and then go to a date picker on SOCF, going back to P&L shows the month picker again.