### PR TITLE
Remove default elevated behavior on views and sections within views

### DIFF
--- a/src/components/Integrations/Integrations.tsx
+++ b/src/components/Integrations/Integrations.tsx
@@ -11,7 +11,6 @@ import { IntegrationsConnectMenu } from './IntegrationsConnectMenu/IntegrationsC
 const COMPONENT_NAME = 'integrations'
 
 export interface IntegrationsProps {
-  elevated?: boolean
   stringOverrides?: {
     title?: string
   }
@@ -26,14 +25,13 @@ export const Integrations = (props: IntegrationsProps) => {
 }
 
 export const IntegrationsComponent = ({
-  elevated,
   stringOverrides,
 }: IntegrationsProps) => {
   const { quickbooksConnectionStatus } = useContext(QuickbooksContext)
   const isLoading = quickbooksConnectionStatus === undefined
 
   return (
-    <Container name={COMPONENT_NAME} elevated={elevated}>
+    <Container name={COMPONENT_NAME}>
       <Header className='Layer__linked-accounts__header'>
         <Heading
           className='Layer__linked-accounts__title'

--- a/src/components/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/components/LinkedAccounts/LinkedAccounts.tsx
@@ -34,7 +34,7 @@ export const LinkedAccounts = (props: LinkedAccountsProps) => {
 
 export const LinkedAccountsComponent = ({
   asWidget,
-  elevated,
+  elevated = false,
   showLedgerBalance = true,
   showUnlinkItem = false,
   showBreakConnection = false,
@@ -69,7 +69,7 @@ export const LinkedAccountsComponent = ({
             status={DataStateStatus.failed}
             title='Something went wrong'
             description='We couldn’t load your data.'
-            onRefresh={() => refetchAccounts()}
+            onRefresh={() => void refetchAccounts()}
             isLoading={isValidating}
           />
         )

--- a/src/views/AccountingOverview/AccountingOverview.tsx
+++ b/src/views/AccountingOverview/AccountingOverview.tsx
@@ -98,7 +98,6 @@ export const AccountingOverview = ({
         <Container
           name='accounting-overview-profit-and-loss'
           asWidget
-          elevated={true}
         >
           <ProfitAndLoss.Header
             text={stringOverrides?.header || 'Profit & Loss'}

--- a/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
+++ b/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
@@ -38,7 +38,7 @@ export interface BankTransactionsWithLinkedAccountsProps {
 export const BankTransactionsWithLinkedAccounts = ({
   title, // deprecated
   showTitle = true,
-  elevatedLinkedAccounts = true,
+  elevatedLinkedAccounts = false,
   mode,
 
   showBreakConnection = false,

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -88,7 +88,6 @@ export const BookkeepingOverview = ({
           <Container
             name='bookkeeping-overview-profit-and-loss'
             asWidget
-            elevated={true}
             style={{
               position: 'relative',
               zIndex: 2,


### PR DESCRIPTION
## Description
This PR makes it so the default behavior for any section within a view is that it is _not_ elevated (no drop shadow). We still respect when the `elevated` prop is passed by platform customers (e.g., for linked accounts), but will deprecate this in components v0.2.0.

https://linear.app/layerfi/issue/LAY-1539/remove-drop-shadow-from-pandl-chart-and-bank-accounts-components
