### PR TITLE
fix: Cannot use `BigInt` literals due to es2016 compilation target for npm

### DIFF
--- a/src/components/Invoices/InvoiceForm/useInvoiceForm.ts
+++ b/src/components/Invoices/InvoiceForm/useInvoiceForm.ts
@@ -4,13 +4,13 @@ import { useAppForm } from '../../../features/forms/hooks/useForm'
 import { UpsertInvoiceSchema, type Invoice, type InvoiceLineItem } from '../../../features/invoices/invoiceSchemas'
 import { useUpsertInvoice, UpsertInvoiceMode } from '../../../features/invoices/api/useUpsertInvoice'
 import { BigDecimal as BD, Schema } from 'effect'
-import { convertBigDecimalToCents, convertCentsToBigDecimal } from '../../../utils/bigDecimalUtils'
+import { BIG_DECIMAL_ONE, convertBigDecimalToCents, convertCentsToBigDecimal } from '../../../utils/bigDecimalUtils'
 
 export const EMPTY_LINE_ITEM = {
   product: '',
   description: '',
   unitPrice: 0,
-  quantity: BD.fromBigInt(1n),
+  quantity: BIG_DECIMAL_ONE,
   amount: 0,
 }
 

--- a/src/utils/bigDecimalUtils.ts
+++ b/src/utils/bigDecimalUtils.ts
@@ -1,6 +1,8 @@
 import { BigDecimal as BD } from 'effect'
 
-export const BIG_DECIMAL_ZERO = BD.fromBigInt(0n)
+export const BIG_DECIMAL_ZERO = BD.fromBigInt(BigInt(0))
+export const BIG_DECIMAL_ONE = BD.fromBigInt(BigInt(1))
+export const BIG_DECIMAL_ONE_HUNDRED = BD.fromBigInt(BigInt(100))
 export const DECIMAL_CHARS_REGEX = /^[\d.,-]+$/
 export const NON_NEGATIVE_DECIMAL_CHARS_REGEX = /^[\d.,]+$/
 
@@ -10,7 +12,7 @@ export const NON_NEGATIVE_DECIMAL_CHARS_REGEX = /^[\d.,]+$/
  */
 export const convertBigDecimalToCents = (amount: BD.BigDecimal): number => {
   // Multiply the amount by 100 to get the value in cents
-  const scaled = BD.multiply(amount, BD.fromBigInt(100n))
+  const scaled = BD.multiply(amount, BIG_DECIMAL_ONE_HUNDRED)
 
   // Round to the nearest whole number (zero decimal places)
   const rounded = BD.round(scaled, { scale: 0 })
@@ -24,7 +26,7 @@ export const convertCentsToBigDecimal = (cents: number): BD.BigDecimal => {
   const decimalCents = BD.fromBigInt(BigInt(cents))
 
   // Divide by 100 to get the dollar amount
-  return BD.unsafeDivide(decimalCents, BD.fromBigInt(100n))
+  return BD.unsafeDivide(decimalCents, BIG_DECIMAL_ONE_HUNDRED)
 }
 
 export function formatBigDecimalToString(


### PR DESCRIPTION
## Description
Cannot publish to npm unless we use the `BigInt` constructor rather than BigInt literals. This is because our package compilation target is es2016 to support older clients and browsers, but BigInt literals were not introduced until es2020.