### PR TITLE
fix: Set date range from beginning of month on balance sheet date select

### DIFF
--- a/src/providers/GlobalDateStore/GlobalDateStoreProvider.tsx
+++ b/src/providers/GlobalDateStore/GlobalDateStoreProvider.tsx
@@ -34,7 +34,7 @@ function clampToPresentOrPast(date: Date | number, cutoff = endOfDay(new Date())
 
 const RANGE_MODE_LOOKUP = {
   dayPicker: {
-    getStart: ({ start }: { start: Date }) => start,
+    getStart: ({ start }: { start: Date }) => startOfMonth(start),
     getEnd: ({ end }: { end: Date }) => clampToPresentOrPast(endOfDay(end)),
   },
   dayRangePicker: {


### PR DESCRIPTION
## Description
If you select an arbitrary date on the balance sheet (e.g., 2/9), set the global date range to be from the beginning of the same month (e.g., 2/1-2/9) rather than just the single day.

https://layer-financial.slack.com/archives/C06KH7QKS6M/p1753813475803499?thread_ts=1753812311.466079&cid=C06KH7QKS6M