### PR TITLE
fix: Reduce z-index on sidebar (again)

### DIFF
--- a/src/styles/panel.scss
+++ b/src/styles/panel.scss
@@ -31,7 +31,7 @@
 
 .Layer__panel__sidebar {
   position: sticky;
-  z-index: 50;
+  z-index: 10;
 
   top: 0;
   overflow-x: hidden;


### PR DESCRIPTION
## Description
Like #699, but down to `z-index: 10` for Dripos who has popovers at 20.
