### PR TITLE
feat: create date, invoice no, invoice terms fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",
-        "@tanstack/react-form": "^1.9.1",
+        "@internationalized/date": "^3.8.2",
+        "@tanstack/react-form": "^1.15.2",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.9",
         "classnames": "^2.5.1",
@@ -1186,9 +1187,9 @@
       }
     },
     "node_modules/@internationalized/date": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
-      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.2.tgz",
+      "integrity": "sha512-/wENk7CbvLbkUvX1tu0mwq49CVkkWpkXubGel6birjRPyo6uQ4nQpnq5xZu823zRCwwn82zgHrvgF1vZyvmVgA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -3594,12 +3595,12 @@
       }
     },
     "node_modules/@tanstack/form-core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/form-core/-/form-core-1.9.1.tgz",
-      "integrity": "sha512-v/bz3UB7EHfxDUkzGZm44NhlbRqR8x26xozTIWR/0UfuQBtp6CDGIL/kQArWIrKkWV2zX2KZ7vR9XTsNdzHMgQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/form-core/-/form-core-1.15.1.tgz",
+      "integrity": "sha512-Z8+29KhaGko5VSmnt0iUpB7wlFqOsLCSL3EhC2F/xm/qMq6BzR0yJVpeunN8pwfnlVnkUAO7I8yxT9VS/7ncBA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/store": "^0.7.0"
+        "@tanstack/store": "^0.7.2"
       },
       "funding": {
         "type": "github",
@@ -3607,13 +3608,13 @@
       }
     },
     "node_modules/@tanstack/react-form": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-form/-/react-form-1.9.1.tgz",
-      "integrity": "sha512-DGJXpAGoCVJUsuzFqtvuBNre86tr53QQsJxK1IivckYsqz8jOZCQfGYudnqoiPeC0azQPgTp1ezifxdslSrHbw==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-form/-/react-form-1.15.2.tgz",
+      "integrity": "sha512-mNW3xixPM99jIuU0moxatZ97B0J8YWlM9ROXLlyuEA4QabLjw7dtWpd1Rq3HVftNbAOneFxb/LwoNywb9pabXw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/form-core": "1.9.1",
-        "@tanstack/react-store": "^0.7.0",
+        "@tanstack/form-core": "1.15.1",
+        "@tanstack/react-store": "^0.7.3",
         "decode-formdata": "^0.9.0",
         "devalue": "^5.1.1"
       },
@@ -3636,13 +3637,13 @@
       }
     },
     "node_modules/@tanstack/react-form/node_modules/@tanstack/react-store": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.7.0.tgz",
-      "integrity": "sha512-S/Rq17HaGOk+tQHV/yrePMnG1xbsKZIl/VsNWnNXt4XW+tTY8dTlvpJH2ZQ3GRALsusG5K6Q3unAGJ2pd9W/Ng==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.7.3.tgz",
+      "integrity": "sha512-3Dnqtbw9P2P0gw8uUM8WP2fFfg8XMDSZCTsywRPZe/XqqYW8PGkXKZTvP0AHkE4mpqP9Y43GpOg9vwO44azu6Q==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/store": "0.7.0",
-        "use-sync-external-store": "^1.4.0"
+        "@tanstack/store": "0.7.2",
+        "use-sync-external-store": "^1.5.0"
       },
       "funding": {
         "type": "github",
@@ -3691,9 +3692,9 @@
       }
     },
     "node_modules/@tanstack/store": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.0.tgz",
-      "integrity": "sha512-CNIhdoUsmD2NolYuaIs8VfWM467RK6oIBAW4nPEKZhg1smZ+/CwtCdpURgp7nxSqOaV9oKkzdWD80+bC66F/Jg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.2.tgz",
+      "integrity": "sha512-RP80Z30BYiPX2Pyo0Nyw4s1SJFH2jyM6f9i3HfX4pA+gm5jsnYryscdq2aIQLnL4TaGuQMO+zXmN9nh1Qck+Pg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -10683,9 +10684,10 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
-      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
   },
   "dependencies": {
     "@floating-ui/react": "^0.27.8",
-    "@tanstack/react-form": "^1.9.1",
+    "@internationalized/date": "^3.8.2",
+    "@tanstack/react-form": "^1.15.2",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.9",
     "classnames": "^2.5.1",

--- a/src/components/Invoices/InvoiceForm/InvoiceForm.tsx
+++ b/src/components/Invoices/InvoiceForm/InvoiceForm.tsx
@@ -68,7 +68,6 @@ export const InvoiceForm = (props: InvoiceFormProps) => {
     const dueAtChanged = getDueAtChanged(lastDueAtRef.current, newDueAt)
 
     if (dueAtChanged) {
-      const newDueAt = sentAt.add({ days: duration })
       form.setFieldValue('dueAt', newDueAt)
       lastDueAtRef.current = newDueAt
     }
@@ -186,7 +185,7 @@ export const InvoiceForm = (props: InvoiceFormProps) => {
                         const nextAmount = BD.multiply(unitPrice, quantity)
 
                         if (!BD.equals(amount, nextAmount)) {
-                          form.setFieldValue(`lineItems[${index}].amount`, withForceUpdate(amount))
+                          form.setFieldValue(`lineItems[${index}].amount`, withForceUpdate(nextAmount))
                         }
                       },
                     }}
@@ -202,7 +201,7 @@ export const InvoiceForm = (props: InvoiceFormProps) => {
                         const nextAmount = BD.multiply(unitPrice, quantity)
 
                         if (!BD.equals(amount, nextAmount)) {
-                          form.setFieldValue(`lineItems[${index}].amount`, withForceUpdate(amount))
+                          form.setFieldValue(`lineItems[${index}].amount`, withForceUpdate(nextAmount))
                         }
                       },
                     }}

--- a/src/components/Invoices/InvoiceForm/InvoiceForm.tsx
+++ b/src/components/Invoices/InvoiceForm/InvoiceForm.tsx
@@ -1,4 +1,6 @@
-import { EMPTY_LINE_ITEM, useInvoiceForm } from './useInvoiceForm'
+import { useCallback, useRef, type PropsWithChildren } from 'react'
+import classNames from 'classnames'
+import { getEmptyLineItem, useInvoiceForm } from './useInvoiceForm'
 import type { Invoice } from '../../../features/invoices/invoiceSchemas'
 import { UpsertInvoiceMode } from '../../../features/invoices/api/useUpsertInvoice'
 import { Form } from '../../ui/Form/Form'
@@ -10,8 +12,9 @@ import { CustomerSelector } from '../../../features/customers/components/Custome
 import { convertBigDecimalToCents, safeDivide, negate } from '../../../utils/bigDecimalUtils'
 import { Span } from '../../ui/Typography/Text'
 import { convertCentsToCurrency } from '../../../utils/format'
-import type { PropsWithChildren } from 'react'
-import classNames from 'classnames'
+import { getDurationInDaysFromTerms, InvoiceTermsComboBox, InvoiceTermsValues } from '../InvoiceTermsComboBox/InvoiceTermsComboBox'
+import { type ZonedDateTime } from '@internationalized/date'
+import { withForceUpdate } from '../../../features/forms/components/FormBigDecimalField'
 
 const INVOICE_FORM_CSS_PREFIX = 'Layer__InvoiceForm'
 const INVOICE_FORM_FIELD_CSS_PREFIX = `${INVOICE_FORM_CSS_PREFIX}__Field`
@@ -20,6 +23,11 @@ type InvoiceFormTotalRowProps = PropsWithChildren<{
   label: string
   value: BD.BigDecimal
 }>
+
+const getDueAtChanged = (dueAt: ZonedDateTime | null, previousDueAt: ZonedDateTime | null) =>
+  (dueAt === null && previousDueAt !== null)
+  || (dueAt !== null && previousDueAt === null)
+  || (dueAt !== null && previousDueAt !== null && dueAt.compare(previousDueAt) !== 0)
 
 const InvoiceFormTotalRow = ({ label, value, children }: InvoiceFormTotalRowProps) => {
   const className = classNames(
@@ -48,41 +56,121 @@ export const InvoiceForm = (props: InvoiceFormProps) => {
   const { form, subtotal, additionalDiscount, taxableSubtotal, taxes, grandTotal } = useInvoiceForm(
     { onSuccess, ...(mode === UpsertInvoiceMode.Update ? { mode, invoice: props.invoice } : { mode }) },
   )
+  const lastDueAtRef = useRef<ZonedDateTime | null>(form.getFieldValue('dueAt'))
+
+  const updateDueAtFromTermsAndSentAt = useCallback((terms: InvoiceTermsValues, sentAt: ZonedDateTime | null) => {
+    if (sentAt == null) return
+
+    const duration = getDurationInDaysFromTerms(terms)
+    if (!duration) return
+
+    const newDueAt = sentAt.add({ days: duration })
+    const dueAtChanged = getDueAtChanged(lastDueAtRef.current, newDueAt)
+
+    if (dueAtChanged) {
+      const newDueAt = sentAt.add({ days: duration })
+      form.setFieldValue('dueAt', newDueAt)
+      lastDueAtRef.current = newDueAt
+    }
+  }, [form])
 
   return (
     <Form className={INVOICE_FORM_CSS_PREFIX}>
-      <VStack className={`${INVOICE_FORM_CSS_PREFIX}__Terms`} gap='xs'>
-        <form.Field
-          name='customer'
-          listeners={{
-            onChange: ({ value: customer }) => {
-              form.setFieldValue('email', customer?.email || '')
-              form.setFieldValue('address', customer?.addressString || '')
-            },
-          }}
-        >
-          {field => (
-            <CustomerSelector
-              className={`${INVOICE_FORM_FIELD_CSS_PREFIX}__Customer`}
-              selectedCustomer={field.state.value}
-              onSelectedCustomerChange={field.handleChange}
-              inline
-            />
-          )}
-        </form.Field>
-        <form.AppField name='email'>
-          {field => <field.FormTextField label='Email' inline className={`${INVOICE_FORM_FIELD_CSS_PREFIX}__Email`} />}
-        </form.AppField>
-        <form.AppField name='address'>
-          {field => <field.FormTextAreaField label='Billing address' inline className={`${INVOICE_FORM_FIELD_CSS_PREFIX}__Address`} />}
-        </form.AppField>
-      </VStack>
+      <HStack gap='xl' className={`${INVOICE_FORM_CSS_PREFIX}__Terms`}>
+        <VStack gap='xs'>
+          <form.Field
+            name='customer'
+            listeners={{
+              onChange: ({ value: customer }) => {
+                form.setFieldValue('email', customer?.email || '')
+                form.setFieldValue('address', customer?.addressString || '')
+              },
+            }}
+          >
+            {field => (
+              <CustomerSelector
+                className={`${INVOICE_FORM_FIELD_CSS_PREFIX}__Customer`}
+                selectedCustomer={field.state.value}
+                onSelectedCustomerChange={field.handleChange}
+                inline
+              />
+            )}
+          </form.Field>
+          <form.AppField name='email'>
+            {field => <field.FormTextField label='Email' inline className={`${INVOICE_FORM_FIELD_CSS_PREFIX}__Email`} />}
+          </form.AppField>
+          <form.AppField name='address'>
+            {field => <field.FormTextAreaField label='Billing address' inline className={`${INVOICE_FORM_FIELD_CSS_PREFIX}__Address`} />}
+          </form.AppField>
+        </VStack>
+        <VStack gap='xs'>
+          <form.AppField name='invoiceNumber'>
+            {field => <field.FormTextField label='Invoice number' inline className={`${INVOICE_FORM_FIELD_CSS_PREFIX}__InvoiceNo`} />}
+          </form.AppField>
+          <form.Field
+            name='terms'
+            listeners={{
+              onChange: ({ value: terms }) => {
+                const sentAt = form.getFieldValue('sentAt')
+                updateDueAtFromTermsAndSentAt(terms, sentAt)
+              },
+            }}
+          >
+            {field => (
+              <InvoiceTermsComboBox
+                value={field.state.value}
+                onValueChange={(value: InvoiceTermsValues | null) => {
+                  if (value !== null) {
+                    field.handleChange(value)
+                  }
+                }}
+              />
+            )}
+          </form.Field>
+          <form.AppField
+            name='sentAt'
+            listeners={{
+              onBlur: ({ value: sentAt }) => {
+                const terms = form.getFieldValue('terms')
+                updateDueAtFromTermsAndSentAt(terms, sentAt)
+              },
+            }}
+          >
+            {field => <field.FormDateField label='Invoice date' inline className={`${INVOICE_FORM_FIELD_CSS_PREFIX}__SentAt`} />}
+          </form.AppField>
+          <form.AppField
+            name='dueAt'
+            listeners={{
+              onBlur: ({ value: dueAt }) => {
+                const terms = form.getFieldValue('terms')
+                const previousDueAt = lastDueAtRef.current
+
+                const dueAtChanged = getDueAtChanged(dueAt, previousDueAt)
+
+                if (terms !== InvoiceTermsValues.Custom && dueAtChanged) {
+                  form.setFieldValue('terms', InvoiceTermsValues.Custom)
+                  lastDueAtRef.current = dueAt
+                }
+              },
+            }}
+          >
+            {field => <field.FormDateField label='Due date' inline className={`${INVOICE_FORM_FIELD_CSS_PREFIX}__DueAt`} />}
+          </form.AppField>
+        </VStack>
+      </HStack>
       <VStack className={`${INVOICE_FORM_CSS_PREFIX}__LineItems`} gap='md'>
-        <form.AppField name='lineItems' mode='array'>
+        <form.Field name='lineItems' mode='array'>
           {field => (
             <VStack gap='xs' align='baseline'>
-              {field.state.value.map((_, index) => (
-                <HStack key={`lineItems[${index}]`} gap='xs' align='end' className={`${INVOICE_FORM_CSS_PREFIX}__LineItem`}>
+              {field.state.value.map((_value, index) => (
+                /**
+                 * A more correct implementation would use a UUID as the key for this HStack. Specifically, it is an antipattern in
+                 * React to use array indices as keys. However, there are some ongoing issues with @tanstack/react-form related to
+                 * deleting an element from an array field. In particular, the form values for the remaining array items may become
+                 * momentarily undefined as they re-render due to re-indexing. Thus, we use indices here for now.
+                 * See here for more information: https://github.com/TanStack/form/issues/1518.
+                 */
+                <HStack key={index} gap='xs' align='end' className={`${INVOICE_FORM_CSS_PREFIX}__LineItem`}>
                   <form.AppField name={`lineItems[${index}].product`}>
                     {innerField => <innerField.FormTextField label='Product' showLabel={index === 0} />}
                   </form.AppField>
@@ -93,10 +181,13 @@ export const InvoiceForm = (props: InvoiceFormProps) => {
                     name={`lineItems[${index}].quantity`}
                     listeners={{
                       onBlur: ({ value: quantity }) => {
+                        const amount = form.getFieldValue(`lineItems[${index}].amount`)
                         const unitPrice = form.getFieldValue(`lineItems[${index}].unitPrice`)
                         const nextAmount = BD.multiply(unitPrice, quantity)
 
-                        form.setFieldValue(`lineItems[${index}].amount`, nextAmount)
+                        if (!BD.equals(amount, nextAmount)) {
+                          form.setFieldValue(`lineItems[${index}].amount`, withForceUpdate(amount))
+                        }
                       },
                     }}
                   >
@@ -106,10 +197,13 @@ export const InvoiceForm = (props: InvoiceFormProps) => {
                     name={`lineItems[${index}].unitPrice`}
                     listeners={{
                       onBlur: ({ value: unitPrice }) => {
+                        const amount = form.getFieldValue(`lineItems[${index}].amount`)
                         const quantity = form.getFieldValue(`lineItems[${index}].quantity`)
                         const nextAmount = BD.multiply(unitPrice, quantity)
 
-                        form.setFieldValue(`lineItems[${index}].amount`, nextAmount)
+                        if (!BD.equals(amount, nextAmount)) {
+                          form.setFieldValue(`lineItems[${index}].amount`, withForceUpdate(amount))
+                        }
                       },
                     }}
                   >
@@ -119,10 +213,13 @@ export const InvoiceForm = (props: InvoiceFormProps) => {
                     name={`lineItems[${index}].amount`}
                     listeners={{
                       onBlur: ({ value: amount }) => {
+                        const unitPrice = form.getFieldValue(`lineItems[${index}].unitPrice`)
                         const quantity = form.getFieldValue(`lineItems[${index}].quantity`)
                         const nextUnitPrice = safeDivide(amount, quantity)
 
-                        form.setFieldValue(`lineItems[${index}].unitPrice`, nextUnitPrice)
+                        if (!BD.equals(unitPrice, nextUnitPrice)) {
+                          form.setFieldValue(`lineItems[${index}].unitPrice`, withForceUpdate(nextUnitPrice))
+                        }
                       },
                     }}
                   >
@@ -134,13 +231,13 @@ export const InvoiceForm = (props: InvoiceFormProps) => {
                   <Button variant='outlined' icon aria-label='Delete line item' onClick={() => field.removeValue(index)}><Trash size={16} /></Button>
                 </HStack>
               ))}
-              <Button variant='outlined' onClick={() => field.pushValue(EMPTY_LINE_ITEM)}>
+              <Button variant='outlined' onClick={() => field.pushValue(getEmptyLineItem())}>
                 Add line item
                 <Plus size={16} />
               </Button>
             </VStack>
           )}
-        </form.AppField>
+        </form.Field>
         <VStack className={`${INVOICE_FORM_CSS_PREFIX}__Metadata`} pbs='md'>
           <HStack justify='space-between' gap='xl'>
             <VStack className={`${INVOICE_FORM_CSS_PREFIX}__AdditionalTextFields`}>

--- a/src/components/Invoices/InvoiceForm/invoiceForm.scss
+++ b/src/components/Invoices/InvoiceForm/invoiceForm.scss
@@ -1,10 +1,17 @@
 .Layer__InvoiceForm {
-  min-width: 32rem;
-
   .Layer__InvoiceForm__Field__Customer,
   .Layer__InvoiceForm__Field__Email,
   .Layer__InvoiceForm__Field__Address {
-    grid-template-columns: 8rem 24rem;
+    grid-template-columns: 8rem auto;
+    width: clamp(28rem, 100%, 44rem);
+  }
+
+  .Layer__InvoiceForm__Field__InvoiceNo,
+  .Layer__InvoiceForm__Field__Terms,
+  .Layer__InvoiceForm__Field__SentAt,
+  .Layer__InvoiceForm__Field__DueAt {
+    grid-template-columns: 8rem auto;
+    width: clamp(16rem, 100%, 24rem);
   }
 
   .Layer__InvoiceForm__LineItem {
@@ -19,11 +26,16 @@
       auto;
 
     width: 100%;
-    min-width: 45rem;
   }
+
+  min-width: 54rem;
 }
 
 .Layer__InvoiceForm__Terms {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+
+  max-width: 64rem;
   padding: var(--spacing-lg) var(--spacing-2xl);
 }
 
@@ -58,4 +70,9 @@
       7.5rem
       minmax(6rem, 0.8fr);
   }
+}
+
+.Layer__InvoiceForm__TermsComboBox {
+  display: grid;
+  align-items: center;
 }

--- a/src/components/Invoices/InvoiceForm/utils.ts
+++ b/src/components/Invoices/InvoiceForm/utils.ts
@@ -1,17 +1,11 @@
 import { BigDecimal as BD } from 'effect'
-import type { UpsertInvoiceLineItem, InvoiceLineItem } from '../../../features/invoices/invoiceSchemas'
+import type { InvoiceFormLineItem } from '../../../features/invoices/invoiceSchemas'
 import { BIG_DECIMAL_ZERO, roundDecimalToCents } from '../../../utils/bigDecimalUtils'
 
-type AugmentedInvoiceLineItem = (Omit<UpsertInvoiceLineItem | InvoiceLineItem, 'unitPrice'>) & {
-  unitPrice: BD.BigDecimal
-  amount: BD.BigDecimal
-  isTaxable: boolean
-}
-
-export const computeSubtotal = (lineItems: AugmentedInvoiceLineItem[]): BD.BigDecimal =>
+export const computeSubtotal = (lineItems: InvoiceFormLineItem[]): BD.BigDecimal =>
   lineItems.reduce((sum, item) => BD.sum(sum, item.amount), BIG_DECIMAL_ZERO)
 
-export const computeRawTaxableSubtotal = (lineItems: AugmentedInvoiceLineItem[]): BD.BigDecimal =>
+export const computeRawTaxableSubtotal = (lineItems: InvoiceFormLineItem[]): BD.BigDecimal =>
   lineItems
     .filter(item => item.isTaxable)
     .reduce((sum, item) => BD.sum(sum, item.amount), BIG_DECIMAL_ZERO)

--- a/src/components/Invoices/InvoiceTermsComboBox/InvoiceTermsComboBox.tsx
+++ b/src/components/Invoices/InvoiceTermsComboBox/InvoiceTermsComboBox.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useId } from 'react'
+import { ComboBox } from '../../ui/ComboBox/ComboBox'
+import { ZonedDateTime } from '@internationalized/date'
+import { differenceInDays, startOfDay } from 'date-fns'
+import { HStack } from '../../ui/Stack/Stack'
+import { Label } from '../../ui/Typography/Text'
+
+export enum InvoiceTermsValues {
+  Net10 = 'Net10',
+  Net15 = 'Net15',
+  Net30 = 'Net30',
+  Net60 = 'Net60',
+  Net90 = 'Net90',
+  Custom = 'Custom',
+}
+
+type InvoiceTermsOption = {
+  label: string
+  value: InvoiceTermsValues
+}
+const InvoiceStatusOptionConfig = {
+  [InvoiceTermsValues.Net10]: { label: 'Net 10', value: InvoiceTermsValues.Net10 },
+  [InvoiceTermsValues.Net15]: { label: 'Net 15', value: InvoiceTermsValues.Net15 },
+  [InvoiceTermsValues.Net30]: { label: 'Net 30', value: InvoiceTermsValues.Net30 },
+  [InvoiceTermsValues.Net60]: { label: 'Net 60', value: InvoiceTermsValues.Net60 },
+  [InvoiceTermsValues.Net90]: { label: 'Net 90', value: InvoiceTermsValues.Net90 },
+  [InvoiceTermsValues.Custom]: { label: 'Custom', value: InvoiceTermsValues.Custom },
+}
+const options = Object.values(InvoiceStatusOptionConfig)
+
+export const getDurationInDaysFromTerms = (terms: InvoiceTermsValues) => {
+  switch (terms) {
+    case InvoiceTermsValues.Net10:
+      return 10
+    case InvoiceTermsValues.Net15:
+      return 15
+    case InvoiceTermsValues.Net30:
+      return 30
+    case InvoiceTermsValues.Net60:
+      return 60
+    case InvoiceTermsValues.Net90:
+      return 90
+    case InvoiceTermsValues.Custom:
+    default:
+      return undefined
+  }
+}
+
+export const getInvoiceTermsFromDates = (sentAt: ZonedDateTime | null, dueAt: ZonedDateTime | null): InvoiceTermsValues => {
+  if (!sentAt || !dueAt) return InvoiceTermsValues.Custom
+
+  const days = differenceInDays(
+    startOfDay(dueAt.toDate()),
+    startOfDay(sentAt.toDate()),
+  )
+
+  switch (days) {
+    case 10:
+      return InvoiceTermsValues.Net10
+    case 15:
+      return InvoiceTermsValues.Net15
+    case 30:
+      return InvoiceTermsValues.Net30
+    case 60:
+      return InvoiceTermsValues.Net60
+    case 90:
+      return InvoiceTermsValues.Net90
+    default:
+      return InvoiceTermsValues.Custom
+  }
+}
+
+type InvoiceTermsComboBoxProps = {
+  value: InvoiceTermsValues
+  onValueChange: (value: InvoiceTermsValues | null) => void
+}
+
+export const InvoiceTermsComboBox = ({ value, onValueChange }: InvoiceTermsComboBoxProps) => {
+  const selectedOption = InvoiceStatusOptionConfig[value]
+  const onSelectedValueChange = useCallback((option: InvoiceTermsOption | null) => {
+    onValueChange(option?.value || null)
+  }, [onValueChange])
+
+  const inputId = useId()
+
+  return (
+    <HStack className='Layer__InvoiceForm__TermsComboBox Layer__InvoiceForm__Field__Terms'>
+      <Label size='sm' htmlFor={inputId}>
+        Terms
+      </Label>
+      <ComboBox
+        options={options}
+        onSelectedValueChange={onSelectedValueChange}
+        selectedValue={selectedOption}
+        isSearchable={false}
+        isClearable={false}
+        inputId={inputId}
+      />
+    </HStack>
+  )
+}

--- a/src/components/Invoices/InvoiceTermsComboBox/InvoiceTermsComboBox.tsx
+++ b/src/components/Invoices/InvoiceTermsComboBox/InvoiceTermsComboBox.tsx
@@ -18,7 +18,7 @@ type InvoiceTermsOption = {
   label: string
   value: InvoiceTermsValues
 }
-const InvoiceStatusOptionConfig = {
+const InvoiceTermsOptionConfig = {
   [InvoiceTermsValues.Net10]: { label: 'Net 10', value: InvoiceTermsValues.Net10 },
   [InvoiceTermsValues.Net15]: { label: 'Net 15', value: InvoiceTermsValues.Net15 },
   [InvoiceTermsValues.Net30]: { label: 'Net 30', value: InvoiceTermsValues.Net30 },
@@ -26,7 +26,7 @@ const InvoiceStatusOptionConfig = {
   [InvoiceTermsValues.Net90]: { label: 'Net 90', value: InvoiceTermsValues.Net90 },
   [InvoiceTermsValues.Custom]: { label: 'Custom', value: InvoiceTermsValues.Custom },
 }
-const options = Object.values(InvoiceStatusOptionConfig)
+const options = Object.values(InvoiceTermsOptionConfig)
 
 export const getDurationInDaysFromTerms = (terms: InvoiceTermsValues) => {
   switch (terms) {
@@ -76,7 +76,7 @@ type InvoiceTermsComboBoxProps = {
 }
 
 export const InvoiceTermsComboBox = ({ value, onValueChange }: InvoiceTermsComboBoxProps) => {
-  const selectedOption = InvoiceStatusOptionConfig[value]
+  const selectedOption = InvoiceTermsOptionConfig[value]
   const onSelectedValueChange = useCallback((option: InvoiceTermsOption | null) => {
     onValueChange(option?.value || null)
   }, [onValueChange])

--- a/src/components/ui/Date/Date.scss
+++ b/src/components/ui/Date/Date.scss
@@ -1,0 +1,13 @@
+.Layer__UI__DateSegment {
+  padding: 1px;
+  border-radius: var(--border-radius-4xs);
+
+  &[data-focused] {
+    outline: none;
+    background-color: var(--color-base-400);
+  }
+
+  &[data-hovered] {
+    background-color: var(--color-base-400);
+  }
+}

--- a/src/components/ui/Date/Date.tsx
+++ b/src/components/ui/Date/Date.tsx
@@ -1,0 +1,67 @@
+import { forwardRef } from 'react'
+import classNames from 'classnames'
+import type { ZonedDateTime } from '@internationalized/date'
+import {
+  DateField as ReactAriaDateField,
+  type DateFieldProps as ReactAriaDateFieldProps,
+  DateSegment as ReactAriaDateSegment,
+  type DateSegmentProps as ReactAriaDateSegmentProps,
+  DateInput as ReactAriaDateInput,
+  type DateInputProps as ReactAriaDateInputProps,
+} from 'react-aria-components'
+import { toDataProperties } from '../../../utils/styleUtils/toDataProperties'
+
+const DATE_FIELD_CLASS_NAME = 'Layer__UI__DateField'
+type DateFieldProps = ReactAriaDateFieldProps<ZonedDateTime> & {
+  inline?: boolean
+}
+
+export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
+  function DateField({ inline, className, ...restProps }, ref) {
+    const dataProperties = toDataProperties({ inline })
+
+    return (
+      <ReactAriaDateField
+        {...dataProperties}
+        {...restProps}
+        className={classNames(DATE_FIELD_CLASS_NAME, className)}
+        ref={ref}
+      />
+    )
+  },
+)
+
+const DATE_INPUT_CLASS_NAME = 'Layer__UI__DateInput'
+type DateInputProps = Omit<ReactAriaDateInputProps, 'className'> & {
+  inset?: true
+}
+
+export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
+  function DateInput({ inset, ...restProps }, ref) {
+    const dataProperties = toDataProperties({ inset })
+
+    return (
+      <ReactAriaDateInput
+        {...dataProperties}
+        {...restProps}
+        className={classNames(DATE_INPUT_CLASS_NAME)}
+        ref={ref}
+      />
+    )
+  },
+)
+
+const DATE_SEGMENT_CLASS_NAME = 'Layer__UI__DateSegment'
+type DateSegmentProps = Omit<ReactAriaDateSegmentProps, 'className'>
+
+export const DateSegment = forwardRef<HTMLDivElement, DateSegmentProps>(
+  function DateSegment(props, ref) {
+    return (
+      <ReactAriaDateSegment
+        {...props}
+        className={DATE_SEGMENT_CLASS_NAME}
+        ref={ref}
+      />
+    )
+  },
+)

--- a/src/components/ui/Form/form.scss
+++ b/src/components/ui/Form/form.scss
@@ -5,7 +5,8 @@
   color: var(--color-danger);
 }
 
-.Layer__UI__TextField {
+.Layer__UI__TextField,
+.Layer__UI__DateField {
   display: grid;
 
   grid-template-areas:

--- a/src/components/ui/Input/input.scss
+++ b/src/components/ui/Input/input.scss
@@ -1,4 +1,5 @@
-.Layer__UI__Input {
+.Layer__UI__Input,
+.Layer__UI__DateInput {
   min-inline-size: 0;
   padding-inline: var(--spacing-xs);
 

--- a/src/components/ui/index.scss
+++ b/src/components/ui/index.scss
@@ -1,6 +1,7 @@
 @forward './Button/button';
 @forward './Checkbox/checkbox';
 @forward './ComboBox/comboBox';
+@forward './Date/date';
 @forward './DropdownMenu/dropdownMenu';
 @forward './Form/form';
 @forward './Input/input';

--- a/src/features/forms/components/BaseFormTextField.tsx
+++ b/src/features/forms/components/BaseFormTextField.tsx
@@ -2,29 +2,23 @@ import type { PropsWithChildren } from 'react'
 import { FieldError, TextField, type TextFieldProps } from '../../../components/ui/Form/Form'
 import { Label } from '../../../components/ui/Typography/Text'
 import { useFieldContext } from '../hooks/useForm'
+import type { CommonFormFieldProps } from '../types'
 
-export type BaseFormTextFieldProps = Omit<InternalBaseFormTextFieldProps, 'isTextArea'>
-
-interface InternalBaseFormTextFieldProps {
-  label: string
-  className?: string
-  inline?: boolean
-  showLabel?: boolean
-  showFieldError?: boolean
+export type BaseFormTextFieldProps = CommonFormFieldProps & {
   inputMode?: TextFieldProps['inputMode']
   isTextArea?: boolean
 }
 
-export function BaseFormTextField<TData>({
+export function BaseFormTextField({
   label,
-  className,
   inline = false,
   showLabel = true,
   showFieldError = true,
   isTextArea = false,
+  className,
   children,
-}: PropsWithChildren<InternalBaseFormTextFieldProps>) {
-  const field = useFieldContext<TData>()
+}: PropsWithChildren<BaseFormTextFieldProps>) {
+  const field = useFieldContext<string>()
 
   const { name, state } = field
   const { meta } = state
@@ -35,7 +29,14 @@ export function BaseFormTextField<TData>({
 
   const additionalAriaProps = !showLabel && { 'aria-label': label }
   return (
-    <TextField name={name} isInvalid={!isValid} inline={inline} className={className} textarea={isTextArea} {...additionalAriaProps}>
+    <TextField
+      name={name}
+      isInvalid={!isValid}
+      inline={inline}
+      className={className}
+      textarea={isTextArea}
+      {...additionalAriaProps}
+    >
       {showLabel && <Label size='sm' htmlFor={name} {...(!inline && { pbe: '3xs' })}>{label}</Label>}
       {children}
       {shouldShowErrorMessage && <FieldError>{errorMessage}</FieldError>}

--- a/src/features/forms/components/FormBigDecimalField.tsx
+++ b/src/features/forms/components/FormBigDecimalField.tsx
@@ -6,7 +6,7 @@ import { Input } from '../../../components/ui/Input/Input'
 import { BIG_DECIMAL_ZERO, buildDecimalCharRegex, convertPercentToDecimal, formatBigDecimalToString } from '../../../utils/bigDecimalUtils'
 import { BaseFormTextField, type BaseFormTextFieldProps } from './BaseFormTextField'
 
-type FormBigDecimalFieldProps = Omit<BaseFormTextFieldProps, 'inputMode'> & {
+type FormBigDecimalFieldProps = Omit<BaseFormTextFieldProps, 'inputMode' | 'isTextArea'> & {
   maxValue?: number
   minDecimalPlaces?: number
   maxDecimalPlaces?: number
@@ -18,6 +18,23 @@ const DEFAULT_MAX_VALUE = 10_000_000
 const DEFAULT_MIN_DECIMAL_PLACES = 0
 const DEFAULT_MAX_DECIMAL_PLACES = 3
 const DECORATOR_CHARS_REGEX = /[,%$]/g
+
+/**
+ * This is some crazy nonsense to make BigDecimal play nicely with TanStack form. TanStack form checks deep equality for
+ * object form fields all the way down to determine if they've changed. BigDecimal has a `normalized` param, which is a
+ * BigDecimal that is the "normalized" form of itself (i.e., lowest absolute scale). Therefore, when determining if two
+ * BigDecimals values are equal, we do an infinite recursion comparing their normalized forms.
+ *
+ * To remediate this, before updating a BigDecimal field, we check the new value is equal (per BigDecimal.equal) outside,
+ * and if not, only then call the onChange handler with the value wrapped with withForceUpdate, which adds a unique symbol
+ * to the BigDecimal and short-circuits any potential infinite recursion on comparing normalized values all the way down.
+ *
+ * Doing either the equality check or forced update to cause inequality is sufficient, but we do both to cover our bases.
+ */
+export const withForceUpdate = (value: BD.BigDecimal): BD.BigDecimal => ({
+  ...value,
+  __forceUpdate: Symbol(),
+} as BD.BigDecimal)
 
 export function FormBigDecimalField({
   mode = 'decimal',
@@ -61,11 +78,13 @@ export function FormBigDecimalField({
     const normalized = BD.normalize(adjustedForPercent)
     const clamped = BD.min(normalized, maxBigDecimalValue)
 
-    handleChange(clamped)
+    if (!BD.equals(clamped, value)) {
+      handleChange(withForceUpdate(clamped))
+    }
     handleBlur()
 
     setInputValue(formatBigDecimalToString(clamped, formattingProps))
-  }, [inputValue, mode, maxBigDecimalValue, handleChange, handleBlur, formattingProps])
+  }, [inputValue, mode, maxBigDecimalValue, value, handleBlur, formattingProps, handleChange])
 
   // Don't allow the user to type anything other than numeric characters, commas, decimals, etc
   const allowedChars = useMemo(() =>

--- a/src/features/forms/components/FormCheckboxField.tsx
+++ b/src/features/forms/components/FormCheckboxField.tsx
@@ -1,25 +1,19 @@
-import { useCallback, type PropsWithChildren } from 'react'
+import { type PropsWithChildren } from 'react'
 import { useFieldContext } from '../hooks/useForm'
 import { CheckboxWithTooltip } from '../../../components/ui/Checkbox/Checkbox'
 import { Label } from '../../../components/ui/Typography/Text'
 import classNames from 'classnames'
+import type { CommonFormFieldProps } from '../types'
 
-export interface FormCheckboxField {
-  label: string
-  className?: string
-  inline?: boolean
-  showLabel?: boolean
-  showErrorInTooltip?: boolean
-}
-
+export type FormCheckboxFieldProps = CommonFormFieldProps
 const FORM_CHECKBOX_FIELD_CLASSNAME = 'Layer__FormCheckboxField'
 export function FormCheckboxField({
   label,
   className,
   inline = false,
   showLabel = true,
-  showErrorInTooltip = true,
-}: PropsWithChildren<FormCheckboxField>) {
+  showFieldError = true,
+}: PropsWithChildren<FormCheckboxFieldProps>) {
   const field = useFieldContext<boolean>()
 
   const { name, state, handleChange, handleBlur } = field
@@ -27,7 +21,7 @@ export function FormCheckboxField({
   const { errors, isValid } = meta
 
   const errorMessage = errors.length !== 0 ? (errors[0] as string) : undefined
-  const tooltipProps = showErrorInTooltip ? { tooltip: errorMessage } : {}
+  const tooltipProps = showFieldError ? { tooltip: errorMessage } : {}
 
   const additionalAriaProps = !showLabel && { 'aria-label': label }
 
@@ -37,16 +31,12 @@ export function FormCheckboxField({
     className,
   )
 
-  const onChange = useCallback((isSelected: boolean) => {
-    handleChange(isSelected)
-  }, [handleChange])
-
   return (
     <CheckboxWithTooltip
       className={checkboxClassNames}
       isSelected={value}
       isInvalid={!isValid}
-      onChange={onChange}
+      onChange={handleChange}
       onBlur={handleBlur}
       name={name}
       value={name}

--- a/src/features/forms/components/FormDateField.tsx
+++ b/src/features/forms/components/FormDateField.tsx
@@ -1,0 +1,61 @@
+import { useState, useEffect, type PropsWithChildren, useCallback } from 'react'
+import { useFieldContext } from '../hooks/useForm'
+import { Label } from '../../../components/ui/Typography/Text'
+import { DateField, DateInput, DateSegment } from '../../../components/ui/Date/Date'
+import { FieldError } from '../../../components/ui/Form/Form'
+import type { CommonFormFieldProps } from '../types'
+import type { ZonedDateTime } from '@internationalized/date'
+import { InputGroup } from '../../../components/ui/Input/InputGroup'
+import { isZonedDateTime } from '../../../utils/time/timeUtils'
+
+export type FormDateFieldProps = CommonFormFieldProps
+export function FormDateField({
+  label,
+  className,
+  inline = false,
+  showLabel = true,
+  showFieldError = true,
+}: PropsWithChildren<FormDateFieldProps>) {
+  const field = useFieldContext<ZonedDateTime | null>()
+
+  const { name, state, handleChange, handleBlur } = field
+  const { meta, value } = state
+  const { errors, isValid } = meta
+  const [localDate, setLocalDate] = useState(value)
+
+  useEffect(() => {
+    setLocalDate(value)
+  }, [value])
+
+  const onBlur = useCallback(() => {
+    const nextDate = isZonedDateTime(localDate) ? localDate : null
+    handleChange(nextDate)
+    handleBlur()
+  }, [handleBlur, handleChange, localDate])
+
+  const errorMessage = errors.length !== 0 ? (errors[0] as string) : undefined
+  const shouldShowErrorMessage = showFieldError && errorMessage
+
+  const additionalAriaProps = !showLabel && { 'aria-label': label }
+  return (
+    <DateField
+      name={name}
+      granularity='day'
+      value={localDate}
+      isInvalid={!isValid}
+      inline={inline}
+      className={className}
+      {...additionalAriaProps}
+      onChange={setLocalDate}
+      onBlur={onBlur}
+    >
+      {showLabel && <Label size='sm' htmlFor={name} {...(!inline && { pbe: '3xs' })}>{label}</Label>}
+      <InputGroup>
+        <DateInput inset>
+          {segment => <DateSegment segment={segment} />}
+        </DateInput>
+      </InputGroup>
+      {shouldShowErrorMessage && <FieldError>{errorMessage}</FieldError>}
+    </DateField>
+  )
+}

--- a/src/features/forms/components/FormTextAreaField.tsx
+++ b/src/features/forms/components/FormTextAreaField.tsx
@@ -3,8 +3,7 @@ import { TextArea } from '../../../components/ui/Input/TextArea'
 import { useFieldContext } from '../hooks/useForm'
 import { BaseFormTextField, type BaseFormTextFieldProps } from './BaseFormTextField'
 
-type FormTextAreaFieldProps = BaseFormTextFieldProps
-
+type FormTextAreaFieldProps = Omit<BaseFormTextFieldProps, 'isTextArea'>
 export function FormTextAreaField(props: FormTextAreaFieldProps) {
   const field = useFieldContext<string>()
 

--- a/src/features/forms/components/FormTextField.tsx
+++ b/src/features/forms/components/FormTextField.tsx
@@ -4,7 +4,7 @@ import { useFieldContext } from '../hooks/useForm'
 import { InputGroup } from '../../../components/ui/Input/InputGroup'
 import { BaseFormTextField, type BaseFormTextFieldProps } from './BaseFormTextField'
 
-type FormTextFieldProps = BaseFormTextFieldProps
+type FormTextFieldProps = Omit<BaseFormTextFieldProps, 'isTextArea'>
 export function FormTextField(props: FormTextFieldProps) {
   const field = useFieldContext<string>()
 

--- a/src/features/forms/hooks/useForm.tsx
+++ b/src/features/forms/hooks/useForm.tsx
@@ -1,18 +1,26 @@
-import { createFormHookContexts, createFormHook } from '@tanstack/react-form'
+import {
+  createFormHookContexts,
+  createFormHook,
+  type FormOptions,
+  type FormValidateOrFn,
+  type FormAsyncValidateOrFn,
+} from '@tanstack/react-form'
 import { BaseFormTextField } from '../components/BaseFormTextField'
 import { FormBigDecimalField } from '../components/FormBigDecimalField'
 import { FormCheckboxField } from '../components/FormCheckboxField'
+import { FormDateField } from '../components/FormDateField'
 import { FormTextAreaField } from '../components/FormTextAreaField'
 import { FormTextField } from '../components/FormTextField'
 
 export const { fieldContext, useFieldContext, formContext, useFormContext } =
   createFormHookContexts()
 
-export const { useAppForm, withForm } = createFormHook({
+const { useAppForm: useInternalAppForm } = createFormHook({
   fieldComponents: {
     BaseFormTextField,
     FormBigDecimalField,
     FormCheckboxField,
+    FormDateField,
     FormTextAreaField,
     FormTextField,
   },
@@ -22,3 +30,18 @@ export const { useAppForm, withForm } = createFormHook({
   fieldContext,
   formContext,
 })
+
+export function useAppForm<T>(props: FormOptions<
+  T,
+  FormValidateOrFn<T>,
+  FormValidateOrFn<T>,
+  FormAsyncValidateOrFn<T>,
+  FormValidateOrFn<T>,
+  FormAsyncValidateOrFn<T>,
+  FormValidateOrFn<T>,
+  FormAsyncValidateOrFn<T>,
+  FormAsyncValidateOrFn<T>,
+  unknown
+>) {
+  return useInternalAppForm(props)
+}

--- a/src/features/forms/types.ts
+++ b/src/features/forms/types.ts
@@ -1,0 +1,7 @@
+export interface CommonFormFieldProps {
+  label: string
+  className?: string
+  inline?: boolean
+  showLabel?: boolean
+  showFieldError?: boolean
+}

--- a/src/features/invoices/invoiceSchemas.ts
+++ b/src/features/invoices/invoiceSchemas.ts
@@ -1,5 +1,7 @@
 import { Schema, pipe } from 'effect'
 import { CustomerSchema } from '../customers/customersSchemas'
+import { ZonedDateTimeFromSelf } from '../../utils/schema/utils'
+import { InvoiceTermsValues } from '../../components/Invoices/InvoiceTermsComboBox/InvoiceTermsComboBox'
 
 export enum InvoiceStatus {
   Voided = 'VOIDED',
@@ -215,3 +217,47 @@ export const UpsertInvoiceSchema = Schema.Struct({
   ),
 })
 export type UpsertInvoice = typeof UpsertInvoiceSchema.Type
+
+export const InvoiceFormLineItemSchema = Schema.Struct({
+  description: Schema.String,
+
+  product: Schema.String,
+
+  unitPrice: Schema.BigDecimal,
+
+  quantity: Schema.BigDecimal,
+
+  amount: Schema.BigDecimal,
+
+  isTaxable: Schema.Boolean,
+})
+export type InvoiceFormLineItem = typeof InvoiceFormLineItemSchema.Type
+
+const InvoiceTermsValuesSchema = Schema.Enums(InvoiceTermsValues)
+export const InvoiceFormSchema = Schema.Struct({
+  terms: InvoiceTermsValuesSchema,
+
+  sentAt: Schema.NullOr(ZonedDateTimeFromSelf),
+
+  dueAt: Schema.NullOr(ZonedDateTimeFromSelf),
+
+  invoiceNumber: Schema.String,
+
+  customer: Schema.NullOr(CustomerSchema),
+
+  email: Schema.String,
+
+  address: Schema.String,
+
+  lineItems: Schema.Array(InvoiceFormLineItemSchema),
+
+  discountRate: Schema.BigDecimal,
+
+  taxRate: Schema.BigDecimal,
+
+  memo: Schema.String,
+})
+export type InvoiceForm = Omit<typeof InvoiceFormSchema.Type, 'lineItems'> & {
+  // Purposefully allow lineItems to be mutable for `field.pushValue` in the form
+  lineItems: InvoiceFormLineItem[]
+}

--- a/src/utils/schema/utils.ts
+++ b/src/utils/schema/utils.ts
@@ -1,0 +1,6 @@
+import { Schema } from 'effect'
+import { ZonedDateTime } from '@internationalized/date'
+
+export const ZonedDateTimeFromSelf = Schema.declare(
+  (input: unknown): input is ZonedDateTime => input instanceof ZonedDateTime,
+)

--- a/src/utils/time/timeUtils.ts
+++ b/src/utils/time/timeUtils.ts
@@ -1,4 +1,5 @@
 import { differenceInDays, formatISO } from 'date-fns'
+import { ZonedDateTime } from '@internationalized/date'
 
 export const toLocalDateString = (date: Date): string => formatISO(date.valueOf(), { representation: 'date' })
 
@@ -10,4 +11,8 @@ export function getDueDifference(dueDate: Date): number {
   normalizedDue.setHours(0, 0, 0, 0)
 
   return differenceInDays(normalizedDue, today)
+}
+
+export function isZonedDateTime(val: unknown): val is ZonedDateTime {
+  return val instanceof ZonedDateTime
 }


### PR DESCRIPTION
## Description
1. Creates a canonical DateField for the form, as well as implements two date fields for sent/due date.
2. Implements a terms dropdown that affects the date fields (e.g., net 10, net 30, etc.)
3. Adds an invoice number field.
4. Adds `@internationalized/date` as a dependency, and upgrades `@tanstack/react-form`
5. Creates an `InvoiceForm` schema that will help us down the road with converting the form to an API request
6. Fixes some infinite recursion issues with form validation.

<img width="929" height="575" alt="Screenshot 2025-08-04 at 3 49 39 PM" src="https://github.com/user-attachments/assets/5aad26a7-8b44-4f63-b351-c958913424b0" />