### PR TITLE
max of 20 splits

### DIFF
--- a/src/components/BankTransactionMobileList/SplitForm.tsx
+++ b/src/components/BankTransactionMobileList/SplitForm.tsx
@@ -26,6 +26,7 @@ import { FileInput, Input } from '../Input'
 import { ErrorText, Text, TextSize, TextWeight } from '../Typography'
 import classNames from 'classnames'
 import { BankTransactionFormFields } from '../../features/bankTransactions/[bankTransactionId]/components/BankTransactionFormFields'
+import { MAX_SPLITS } from '../ExpandedBankTransactionRow/ExpandedBankTransactionRow'
 
 type Split = {
   amount: number
@@ -281,7 +282,7 @@ export const SplitForm = ({
               ))}
               <TextButton
                 onClick={addSplit}
-                disabled={rowState.splits.length > 5 || isLoading}
+                disabled={rowState.splits.length > MAX_SPLITS || isLoading}
                 className='Layer__add-new-split'
               >
                 Add new split

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -37,6 +37,8 @@ import { useEffectiveBookkeepingStatus } from '../../hooks/bookkeeping/useBookke
 import { isCategorizationEnabledForStatus } from '../../utils/bookkeeping/isCategorizationEnabled'
 import { BankTransactionFormFields } from '../../features/bankTransactions/[bankTransactionId]/components/BankTransactionFormFields'
 
+export const MAX_SPLITS = 20
+
 type Props = {
   bankTransaction: BankTransaction
   isOpen?: boolean
@@ -496,7 +498,7 @@ const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
                                 ? (
                                   <TextButton
                                     onClick={addSplit}
-                                    disabled={rowState.splits.length > 5}
+                                    disabled={rowState.splits.length > MAX_SPLITS}
                                   >
                                     Add new split
                                   </TextButton>
@@ -506,7 +508,7 @@ const ExpandedBankTransactionRow = forwardRef<SaveHandle, Props>(
                                     onClick={addSplit}
                                     rightIcon={<Scissors size={14} />}
                                     variant={ButtonVariant.secondary}
-                                    disabled={rowState.splits.length > 5}
+                                    disabled={rowState.splits.length > MAX_SPLITS}
                                   >
                                     Split
                                   </Button>


### PR DESCRIPTION
## Description
Increase max number of splits that we allow to be created to 20, as the previous arbitrary limit (5) was too low. Also centralize this maximum as a const val.

## How this has been tested?
Interactive testing:

<img width="857" height="713" alt="Screenshot 2025-08-04 at 5 31 57 PM" src="https://github.com/user-attachments/assets/4a04e24e-f72f-4c60-9571-0626cf420771" />

<img width="575" height="826" alt="Screenshot 2025-08-04 at 5 31 07 PM" src="https://github.com/user-attachments/assets/847ccdaf-adba-4c8d-9fda-b70b01efe2a7" />


