### PR TITLE
Include optional fields in example csv

### DIFF
--- a/src/components/CsvUpload/DownloadCsvTemplateButton.tsx
+++ b/src/components/CsvUpload/DownloadCsvTemplateButton.tsx
@@ -14,14 +14,14 @@ interface DownloadCsvTemplateButtonProps<T> {
 export const DownloadCsvTemplateButton = <T extends { [K in keyof T]: string | number | null | undefined }>({ children, className, csvProps, fileName = 'template.csv' }: PropsWithChildren<DownloadCsvTemplateButtonProps<T>>) => {
   const { headers, rows = [] } = csvProps
   const handleDownload = () => {
-    const csvData: string[][] = [
+    const csvData: (string | undefined)[][] = [
       Object.values(headers),
       ...rows.map((row: T) =>
         (Object.keys(headers) as (keyof T)[])
-          .map(header => row[header] ? String(row[header]) : ''),
+          .map(header => row[header] != null ? String(row[header]) : undefined),
       ),
     ]
-    const csvContent = csvData.map(row => row.map(value => `"${value.replace(/"/g, '""')}"`).join(',')).join('\n')
+    const csvContent = csvData.map(row => row.map(value => value !== undefined ? `"${value.replace(/"/g, '""')}"` : '').join(',')).join('\n')
 
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8' })
     const url = URL.createObjectURL(blob)

--- a/src/components/CsvUpload/DownloadCsvTemplateButton.tsx
+++ b/src/components/CsvUpload/DownloadCsvTemplateButton.tsx
@@ -18,10 +18,10 @@ export const DownloadCsvTemplateButton = <T extends { [K in keyof T]: string | n
       Object.values(headers),
       ...rows.map((row: T) =>
         (Object.keys(headers) as (keyof T)[])
-          .map(header => row[header] != null ? String(row[header]) : undefined),
+          .map(header => row[header] ? String(row[header]) : ''),
       ),
     ]
-    const csvContent = csvData.map(row => row.map(value => value !== undefined ? `"${value.replace(/"/g, '""')}"` : '').join(',')).join('\n')
+    const csvContent = csvData.map(row => row.map(value => value ? `"${value.replace(/"/g, '""')}"` : '').join(',')).join('\n')
 
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8' })
     const url = URL.createObjectURL(blob)

--- a/src/components/JournalForm/JournalFormEntryLines.tsx
+++ b/src/components/JournalForm/JournalFormEntryLines.tsx
@@ -134,6 +134,7 @@ export const JournalFormEntryLines = ({
       [
         {
           ...baseFields,
+          is_deletable: false,
           name: relevantCategory.display_name,
           sub_accounts: [],
           balance: 0,

--- a/src/components/UploadTransactions/UploadTransactionsUploadCsvStep.tsx
+++ b/src/components/UploadTransactions/UploadTransactionsUploadCsvStep.tsx
@@ -12,7 +12,7 @@ import { Separator } from '../Separator/Separator'
 import { DownloadCsvTemplateButton } from '../CsvUpload/DownloadCsvTemplateButton'
 import { CopyTemplateHeadersButtonGroup } from '../CsvUpload/CopyTemplateHeadersButtonGroup'
 import { type CustomAccountParseCsvResponse, useCustomAccountParseCsv } from '../../hooks/customAccounts/useCustomAccountParseCsv'
-import { templateHeaders, templateExampleTransactions } from './template'
+import { templateHeaders, allHeaders, templateExampleTransactions } from './template'
 import { humanizeEnum } from '../../utils/format'
 import { useWizard } from '../Wizard/Wizard'
 import type { FormatOptionLabelMeta } from 'react-select'
@@ -168,7 +168,7 @@ export function UploadTransactionsUploadCsvStep(
                 />
                 <DownloadCsvTemplateButton
                   fileName='upload_transactions.csv'
-                  csvProps={{ headers: templateHeaders, rows: templateExampleTransactions }}
+                  csvProps={{ headers: allHeaders, rows: templateExampleTransactions }}
                   className='Layer__upload-transactions__template-section__button-row-item'
                 >
                   Download template

--- a/src/components/UploadTransactions/UploadTransactionsValidateCsvStep.tsx
+++ b/src/components/UploadTransactions/UploadTransactionsValidateCsvStep.tsx
@@ -27,7 +27,7 @@ const formatters = {
   amount: (parsed: number) => convertCentsToCurrency(parsed) ?? '',
 }
 
-const generateDynamicHeaders = (transactionsPreview: PreviewCsv<CustomAccountTransactionRow>): { [K in keyof CustomAccountTransactionRow]: string } => {
+const generateDynamicHeaders = (transactionsPreview: PreviewCsv<CustomAccountTransactionRow>) => {
   const hasExternalId = transactionsPreview.some(transaction =>
     transaction.external_id?.parsed != null,
   )

--- a/src/components/UploadTransactions/UploadTransactionsValidateCsvStep.tsx
+++ b/src/components/UploadTransactions/UploadTransactionsValidateCsvStep.tsx
@@ -27,7 +27,7 @@ const formatters = {
   amount: (parsed: number) => convertCentsToCurrency(parsed) ?? '',
 }
 
-const generateDynamicHeaders = (transactionsPreview: PreviewCsv<CustomAccountTransactionRow>) => {
+const generateDynamicHeaders = (transactionsPreview: PreviewCsv<CustomAccountTransactionRow>): { [K in keyof CustomAccountTransactionRow]: string } => {
   const hasExternalId = transactionsPreview.some(transaction =>
     transaction.external_id?.parsed != null,
   )

--- a/src/components/UploadTransactions/template.ts
+++ b/src/components/UploadTransactions/template.ts
@@ -6,15 +6,26 @@ export const templateHeaders: { [K in keyof CustomAccountTransactionRow]: string
   amount: 'Amount',
 }
 
+export const allHeaders: { [K in keyof CustomAccountTransactionRow]: string } = {
+  external_id: 'External ID',
+  reference_number: 'Reference Number',
+  date: 'Date',
+  description: 'Description',
+  amount: 'Amount',
+}
+
 export const templateExampleTransactions: CustomAccountTransactionRow[] = [
   {
     date: '05/12/2025',
     description: 'Grocery Store Purchase',
     amount: -76.23,
+    external_id: null,
+    reference_number: '123',
   },
   {
     date: '05/18/2025',
     description: 'Monthly Interest',
     amount: 12.45,
+    external_id: 'txn-31415',
   },
 ]

--- a/src/components/UploadTransactions/template.ts
+++ b/src/components/UploadTransactions/template.ts
@@ -9,9 +9,7 @@ export const templateHeaders: { [K in keyof CustomAccountTransactionRow]: string
 export const allHeaders: { [K in keyof CustomAccountTransactionRow]: string } = {
   external_id: 'External ID',
   reference_number: 'Reference Number',
-  date: 'Date',
-  description: 'Description',
-  amount: 'Amount',
+  ...templateHeaders,
 }
 
 export const templateExampleTransactions: CustomAccountTransactionRow[] = [

--- a/src/contexts/ChartOfAccountsContext/ChartOfAccountsContext.tsx
+++ b/src/contexts/ChartOfAccountsContext/ChartOfAccountsContext.tsx
@@ -16,7 +16,7 @@ export const ChartOfAccountsContext = createContext<ChartOfAccountsContextType>(
     apiError: undefined,
     addAccount: () => {},
     editAccount: () => {},
-    deleteAccount: () => {},
+    deleteAccount: () => Promise.resolve(undefined),
     cancelForm: () => {},
     changeFormData: () => {},
     submitForm: () => {},


### PR DESCRIPTION
## Description
Fixes: LAY-1572
Include optional fields in example csv 

[upload_transactions (3).csv](https://github.com/user-attachments/files/21692714/upload_transactions.3.csv)


