### PR TITLE
fix: another batch of invoice form fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@floating-ui/react": "^0.27.8",
         "@internationalized/date": "^3.8.2",
-        "@tanstack/react-form": "^1.15.2",
+        "@tanstack/react-form": "^1.19.0",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.9",
         "classnames": "^2.5.1",
@@ -3595,9 +3595,9 @@
       }
     },
     "node_modules/@tanstack/form-core": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/form-core/-/form-core-1.15.1.tgz",
-      "integrity": "sha512-Z8+29KhaGko5VSmnt0iUpB7wlFqOsLCSL3EhC2F/xm/qMq6BzR0yJVpeunN8pwfnlVnkUAO7I8yxT9VS/7ncBA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/form-core/-/form-core-1.19.0.tgz",
+      "integrity": "sha512-LSV1XdQCS+0Xnwtqdcjxe3E9C6HeDdaqGm6krZeJ+OCLESsFqPp/jHyoVf5HLfTEGD16hETgYo+sPxC1cox8uQ==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/store": "^0.7.2"
@@ -3608,12 +3608,12 @@
       }
     },
     "node_modules/@tanstack/react-form": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-form/-/react-form-1.15.2.tgz",
-      "integrity": "sha512-mNW3xixPM99jIuU0moxatZ97B0J8YWlM9ROXLlyuEA4QabLjw7dtWpd1Rq3HVftNbAOneFxb/LwoNywb9pabXw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-form/-/react-form-1.19.0.tgz",
+      "integrity": "sha512-3w9gz5C5Egepx//KYvwh/Qndid2aF+x6E9H5hBSWj+xGKrZSIJz8d5RKMlqxxNJZpYRnplLVTV9bLtUFqI8wtA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/form-core": "1.15.1",
+        "@tanstack/form-core": "1.19.0",
         "@tanstack/react-store": "^0.7.3",
         "decode-formdata": "^0.9.0",
         "devalue": "^5.1.1"
@@ -3623,15 +3623,11 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-start": "^1.112.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "vinxi": "^0.5.0"
+        "@tanstack/react-start": "^1.130.10",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@tanstack/react-start": {
-          "optional": true
-        },
-        "vinxi": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.8",
     "@internationalized/date": "^3.8.2",
-    "@tanstack/react-form": "^1.15.2",
+    "@tanstack/react-form": "^1.19.0",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.9",
     "classnames": "^2.5.1",

--- a/src/components/Bills/useBillForm.ts
+++ b/src/components/Bills/useBillForm.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Bill, BillLineItem } from '../../types/bills'
-import { useForm, FormValidateOrFn, FormAsyncValidateOrFn, useStore } from '@tanstack/react-form'
+import { useStore } from '@tanstack/react-form'
 import { Vendor } from '../../types/vendors'
 import { convertFromCents, convertToCents } from '../../utils/format'
 import { Layer } from '../../api/layer'
@@ -9,6 +9,7 @@ import { useEnvironment } from '../../providers/Environment/EnvironmentInputProv
 import { useAuth } from '../../hooks/useAuth'
 import { useBillsContext } from '../../contexts/BillsContext'
 import { SaveBillPayload } from '../../api/layer/bills'
+import { useForm } from '../../features/forms/hooks/useForm'
 
 export type BillForm = {
   bill_number?: string
@@ -29,18 +30,7 @@ export const useBillForm = (bill?: EditableBill) => {
   const [submitError, setSubmitError] = useState<string | undefined>(undefined)
   const { openBillDetails, refetch } = useBillsContext()
 
-  const form = useForm<
-    BillForm,
-    FormValidateOrFn<BillForm>,
-    FormValidateOrFn<BillForm>,
-    FormAsyncValidateOrFn<BillForm>,
-    FormValidateOrFn<BillForm>,
-    FormAsyncValidateOrFn<BillForm>,
-    FormValidateOrFn<BillForm>,
-    FormAsyncValidateOrFn<BillForm>,
-    FormAsyncValidateOrFn<BillForm>,
-    FormAsyncValidateOrFn<BillForm>
-  >({
+  const form = useForm<BillForm>({
     defaultValues: {
       bill_number: bill?.bill_number,
       vendor: bill?.vendor,

--- a/src/components/BusinessForm/useBusinessForm.ts
+++ b/src/components/BusinessForm/useBusinessForm.ts
@@ -1,4 +1,6 @@
-import { useForm, FormValidateOrFn, FormAsyncValidateOrFn, useStore } from '@tanstack/react-form'
+import { useState } from 'react'
+import { useStore } from '@tanstack/react-form'
+import { useForm } from '../../features/forms/hooks/useForm'
 import { useLayerContext } from '../../contexts/LayerContext'
 import { USStateCode } from '../../types/location'
 import { EntityType } from '../../types/business'
@@ -7,7 +9,6 @@ import { useCreateBusinessPersonnel } from '../../hooks/businessPersonnel/useCre
 import { BusinessPersonnel } from '../../hooks/businessPersonnel/types'
 import { useUpdateBusinessPersonnel } from '../../hooks/businessPersonnel/useUpdateBusinessPersonnel'
 import { useUpdateBusiness } from '../../hooks/business/useUpdateBusiness'
-import { useState } from 'react'
 
 type BusinessFormData = {
   full_name?: string
@@ -46,17 +47,7 @@ export const useBusinessForm = ({ onSuccess }: UseBusinessFormProps) => {
   const { trigger: updateBusinessPersonnel } = useUpdateBusinessPersonnel({ businessPersonnelId: person?.id })
   const { trigger: updateBusiness } = useUpdateBusiness()
 
-  const form = useForm<
-    BusinessFormData,
-    FormValidateOrFn<BusinessFormData>,
-    FormValidateOrFn<BusinessFormData>,
-    FormAsyncValidateOrFn<BusinessFormData>,
-    FormValidateOrFn<BusinessFormData>,
-    FormAsyncValidateOrFn<BusinessFormData>,
-    FormValidateOrFn<BusinessFormData>,
-    FormAsyncValidateOrFn<BusinessFormData>,
-    FormAsyncValidateOrFn<BusinessFormData>,
-    FormAsyncValidateOrFn<BusinessFormData>> ({
+  const form = useForm<BusinessFormData>({
     defaultValues: {
       full_name: person?.fullName ?? undefined,
       preferred_name: person?.preferredName ?? undefined,

--- a/src/components/CustomAccountForm/useCustomAccountForm.ts
+++ b/src/components/CustomAccountForm/useCustomAccountForm.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { useForm, FormValidateOrFn, FormAsyncValidateOrFn, useStore } from '@tanstack/react-form'
+import { useStore } from '@tanstack/react-form'
+import { useForm } from '../../features/forms/hooks/useForm'
 import { useCreateCustomAccount } from '../../hooks/customAccounts/useCreateCustomAccount'
 import { CustomAccount, CustomAccountSubtype, CustomAccountType } from '../../hooks/customAccounts/types'
 import { unsafeAssertUnreachable } from '../../utils/switch/assertUnreachable'
@@ -33,17 +34,7 @@ export const useCustomAccountForm = ({ onSuccess }: UseCustomAccountFormProps) =
 
   const { trigger: createCustomAccount } = useCreateCustomAccount()
 
-  const form = useForm<
-    CustomAccountFormData,
-    FormValidateOrFn<CustomAccountFormData>,
-    FormValidateOrFn<CustomAccountFormData>,
-    FormValidateOrFn<CustomAccountFormData>,
-    FormValidateOrFn<CustomAccountFormData>,
-    FormAsyncValidateOrFn<CustomAccountFormData>,
-    FormValidateOrFn<CustomAccountFormData>,
-    FormAsyncValidateOrFn<CustomAccountFormData>,
-    FormAsyncValidateOrFn<CustomAccountFormData>,
-    FormAsyncValidateOrFn<CustomAccountFormData>>({
+  const form = useForm<CustomAccountFormData>({
     defaultValues: {
       account_name: undefined,
       institution_name: undefined,

--- a/src/components/Invoices/InvoiceDetail/InvoiceDetail.tsx
+++ b/src/components/Invoices/InvoiceDetail/InvoiceDetail.tsx
@@ -27,14 +27,13 @@ export const InvoiceDetail = (props: InvoiceDetailProps) => {
   const [isReadOnly, setIsReadOnly] = useState(props.mode === UpsertInvoiceMode.Update)
 
   const onSuccess = useCallback((invoice: Invoice) => {
-    setInvoiceState({ mode: UpsertInvoiceMode.Update, invoice })
-    setIsReadOnly(true)
-
     const toastContent = invoiceState.mode === UpsertInvoiceMode.Update
       ? 'Invoice updated successfully'
       : 'Invoice created successfully'
-
     addToast({ content: toastContent, type: 'success' })
+
+    setInvoiceState({ mode: UpsertInvoiceMode.Update, invoice })
+    setIsReadOnly(true)
   }, [invoiceState.mode, addToast])
 
   const onSubmit = useCallback(() => void formRef.current?.submit(), [])

--- a/src/components/Invoices/InvoiceDetail/InvoiceDetail.tsx
+++ b/src/components/Invoices/InvoiceDetail/InvoiceDetail.tsx
@@ -12,6 +12,7 @@ import { InvoiceStatusCell } from '../InvoiceStatusCell/InvoiceStatusCell'
 import { Button } from '../../ui/Button/Button'
 import { SquarePen } from 'lucide-react'
 import type { InvoiceFormState } from '../InvoiceForm/formUtils'
+import { useLayerContext } from '../../../contexts/LayerContext/LayerContext'
 
 export type InvoiceDetailProps = InvoiceFormMode & {
   onGoBack: () => void
@@ -19,6 +20,7 @@ export type InvoiceDetailProps = InvoiceFormMode & {
 
 export const InvoiceDetail = (props: InvoiceDetailProps) => {
   const { onGoBack, ...invoiceProps } = props
+  const { addToast } = useLayerContext()
   const formRef = useRef<{ submit: () => Promise<void> }>(null)
 
   const [invoiceState, setInvoiceState] = useState(invoiceProps)
@@ -27,7 +29,13 @@ export const InvoiceDetail = (props: InvoiceDetailProps) => {
   const onSuccess = useCallback((invoice: Invoice) => {
     setInvoiceState({ mode: UpsertInvoiceMode.Update, invoice })
     setIsReadOnly(true)
-  }, [])
+
+    const toastContent = invoiceState.mode === UpsertInvoiceMode.Update
+      ? 'Invoice updated successfully'
+      : 'Invoice created successfully'
+
+    addToast({ content: toastContent, type: 'success' })
+  }, [invoiceState.mode, addToast])
 
   const onSubmit = useCallback(() => void formRef.current?.submit(), [])
   const [formState, setFormState] = useState<InvoiceFormState>({

--- a/src/components/Invoices/InvoiceDetail/InvoiceDetail.tsx
+++ b/src/components/Invoices/InvoiceDetail/InvoiceDetail.tsx
@@ -14,15 +14,22 @@ import { SquarePen } from 'lucide-react'
 import type { InvoiceFormState } from '../InvoiceForm/formUtils'
 
 export type InvoiceDetailProps = InvoiceFormMode & {
-  onSuccess?: (invoice: Invoice) => void
   onGoBack: () => void
 }
 
 export const InvoiceDetail = (props: InvoiceDetailProps) => {
-  const { onSuccess, onGoBack, ...restProps } = props
+  const { onGoBack, ...invoiceProps } = props
+  const formRef = useRef<{ submit: () => Promise<void> }>(null)
+
+  const [invoiceState, setInvoiceState] = useState(invoiceProps)
   const [isReadOnly, setIsReadOnly] = useState(props.mode === UpsertInvoiceMode.Update)
-  const formRef = useRef<{ submit: () => void }>(null)
-  const onSubmit = useCallback(() => formRef.current?.submit(), [])
+
+  const onSuccess = useCallback((invoice: Invoice) => {
+    setInvoiceState({ mode: UpsertInvoiceMode.Update, invoice })
+    setIsReadOnly(true)
+  }, [])
+
+  const onSubmit = useCallback(() => void formRef.current?.submit(), [])
   const [formState, setFormState] = useState<InvoiceFormState>({
     isFormValid: true,
     isSubmitting: false,
@@ -40,19 +47,19 @@ export const InvoiceDetail = (props: InvoiceDetailProps) => {
         isReadOnly={isReadOnly}
         formState={formState}
         setIsReadOnly={setIsReadOnly}
-        {...restProps}
+        {...invoiceState}
       />
     )
-  }, [onSubmit, isReadOnly, formState, restProps])
+  }, [onSubmit, isReadOnly, formState, invoiceState])
 
   return (
     <BaseDetailView slots={{ Header }} name='Invoice Detail View' onGoBack={onGoBack}>
-      {restProps.mode === UpsertInvoiceMode.Update && <InvoiceDetailSubHeader invoice={restProps.invoice} />}
+      {invoiceState.mode === UpsertInvoiceMode.Update && <InvoiceDetailSubHeader invoice={invoiceState.invoice} />}
       <InvoiceForm
         isReadOnly={isReadOnly}
         onSuccess={onSuccess}
         onChangeFormState={onChangeFormState}
-        {...restProps}
+        {...invoiceState}
         ref={formRef}
       />
     </BaseDetailView>

--- a/src/components/Invoices/InvoiceForm/InvoiceForm.tsx
+++ b/src/components/Invoices/InvoiceForm/InvoiceForm.tsx
@@ -59,7 +59,7 @@ export type InvoiceFormProps = InvoiceFormMode & {
 
 export const InvoiceForm = forwardRef((props: InvoiceFormProps, ref) => {
   const { onSuccess, onChangeFormState, isReadOnly, mode } = props
-  const { form, formState, totals } = useInvoiceForm(
+  const { form, formState, totals, submitError } = useInvoiceForm(
     { onSuccess, ...(mode === UpsertInvoiceMode.Update ? { mode, invoice: props.invoice } : { mode }) },
   )
   const { subtotal, additionalDiscount, taxableSubtotal, taxes, grandTotal } = totals
@@ -103,14 +103,14 @@ export const InvoiceForm = forwardRef((props: InvoiceFormProps, ref) => {
       <form.Subscribe selector={state => state.errorMap}>
         {(errorMap) => {
           const validationErrors = flattenValidationErrors(errorMap)
-          if (validationErrors.length > 0) {
+          if (validationErrors.length > 0 || submitError) {
             return (
               <HStack className='Layer__InvoiceForm__FormError'>
                 <DataState
                   className='Layer__InvoiceForm__FormError__DataState'
                   icon={<AlertTriangle size={16} />}
                   status={DataStateStatus.failed}
-                  title={validationErrors[0]}
+                  title={validationErrors[0] || submitError}
                   titleSize={TextSize.md}
                   inline
                 />

--- a/src/components/Invoices/InvoiceForm/InvoiceForm.tsx
+++ b/src/components/Invoices/InvoiceForm/InvoiceForm.tsx
@@ -53,7 +53,7 @@ const InvoiceFormTotalRow = ({ label, value, children }: InvoiceFormTotalRowProp
 export type InvoiceFormMode = { mode: UpsertInvoiceMode.Update, invoice: Invoice } | { mode: UpsertInvoiceMode.Create }
 export type InvoiceFormProps = InvoiceFormMode & {
   isReadOnly: boolean
-  onSuccess?: (invoice: Invoice) => void
+  onSuccess: (invoice: Invoice) => void
   onChangeFormState?: (formState: InvoiceFormState) => void
 }
 

--- a/src/components/Invoices/InvoiceForm/InvoiceForm.tsx
+++ b/src/components/Invoices/InvoiceForm/InvoiceForm.tsx
@@ -15,7 +15,7 @@ import { convertCentsToCurrency } from '../../../utils/format'
 import { getDurationInDaysFromTerms, InvoiceTermsComboBox, InvoiceTermsValues } from '../InvoiceTermsComboBox/InvoiceTermsComboBox'
 import { type ZonedDateTime, toCalendarDate, fromDate } from '@internationalized/date'
 import { withForceUpdate } from '../../../features/forms/components/FormBigDecimalField'
-import { type InvoiceFormState, flattenValidationErrors, getEmptyLineItem } from './formUtils'
+import { type InvoiceFormState, flattenValidationErrors, EMPTY_LINE_ITEM } from './formUtils'
 import { DataState, DataStateStatus } from '../../DataState'
 import { AlertTriangle } from 'lucide-react'
 import { TextSize } from '../../Typography'
@@ -294,7 +294,7 @@ export const InvoiceForm = forwardRef((props: InvoiceFormProps, ref) => {
               ))}
               {!isReadOnly
                 && (
-                  <Button variant='outlined' onClick={() => field.pushValue(getEmptyLineItem())}>
+                  <Button variant='outlined' onClick={() => field.pushValue(EMPTY_LINE_ITEM)}>
                     Add line item
                     <Plus size={16} />
                   </Button>

--- a/src/components/Invoices/InvoiceForm/formUtils.ts
+++ b/src/components/Invoices/InvoiceForm/formUtils.ts
@@ -98,7 +98,7 @@ export const getInvoiceFormInitialValues = (invoice: Invoice): InvoiceForm => {
   }
 }
 
-export const validateOnSubmit = ({ value: invoice }: { value: InvoiceForm }) => {
+export const validateInvoiceForm = ({ value: invoice }: { value: InvoiceForm }) => {
   const { customer, invoiceNumber, sentAt, dueAt, lineItems } = invoice
 
   const errors = []

--- a/src/components/Invoices/InvoiceForm/formUtils.ts
+++ b/src/components/Invoices/InvoiceForm/formUtils.ts
@@ -8,7 +8,7 @@ import {
   getGrandTotalFromInvoice,
 } from './totalsUtils'
 import { startOfToday } from 'date-fns'
-import { getLocalTimeZone, fromDate } from '@internationalized/date'
+import { getLocalTimeZone, fromDate, toCalendarDate } from '@internationalized/date'
 import { getInvoiceTermsFromDates, InvoiceTermsValues } from '../InvoiceTermsComboBox/InvoiceTermsComboBox'
 import { ValidationErrorMap } from '@tanstack/react-form'
 
@@ -99,24 +99,30 @@ export const getInvoiceFormInitialValues = (invoice: Invoice): InvoiceForm => {
 }
 
 export const validateOnSubmit = ({ value: invoice }: { value: InvoiceForm }) => {
+  const { customer, invoiceNumber, sentAt, dueAt, lineItems } = invoice
+
   const errors = []
-  if (invoice.customer === null) {
+  if (customer === null) {
     errors.push({ customer: 'Customer is a required field.' })
   }
 
-  if (!invoice.invoiceNumber.trim()) {
+  if (!invoiceNumber.trim()) {
     errors.push({ invoiceNumber: 'Invoice number is a required field.' })
   }
 
-  if (invoice.sentAt === null) {
+  if (sentAt === null) {
     errors.push({ sentAt: 'Invoice date is a required field.' })
   }
 
-  if (invoice.dueAt === null) {
+  if (dueAt === null) {
     errors.push({ dueAt: 'Due date is a required field.' })
   }
 
-  const nonEmptyLineItems = invoice.lineItems.filter(item => !InvoiceFormLineItemEquivalence(EMPTY_LINE_ITEM, item))
+  if (sentAt !== null && dueAt !== null && toCalendarDate(dueAt).compare(toCalendarDate(sentAt)) < 0) {
+    errors.push({ dueAt: 'Due date must be after invoice date.' })
+  }
+
+  const nonEmptyLineItems = lineItems.filter(item => !InvoiceFormLineItemEquivalence(EMPTY_LINE_ITEM, item))
 
   if (nonEmptyLineItems.length === 0) {
     errors.push({ lineItems: 'Invoice requires at least one non-empty line item.' })

--- a/src/components/Invoices/InvoiceForm/useInvoiceForm.ts
+++ b/src/components/Invoices/InvoiceForm/useInvoiceForm.ts
@@ -105,6 +105,6 @@ export const useInvoiceForm = (props: UseInvoiceFormProps) => {
   }), [additionalDiscount, grandTotal, subtotal, taxableSubtotal, taxes])
 
   return useMemo(() => (
-    { form, formState, totals }),
-  [form, formState, totals])
+    { form, formState, totals, submitError }),
+  [form, formState, totals, submitError])
 }

--- a/src/components/Invoices/InvoiceForm/useInvoiceForm.ts
+++ b/src/components/Invoices/InvoiceForm/useInvoiceForm.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState, useRef } from 'react'
-import { useStore } from '@tanstack/react-form'
+import { useStore, revalidateLogic } from '@tanstack/react-form'
 import { useAppForm } from '../../../features/forms/hooks/useForm'
 import { UpsertInvoiceSchema, type Invoice, type InvoiceForm } from '../../../features/invoices/invoiceSchemas'
 import { useUpsertInvoice, UpsertInvoiceMode } from '../../../features/invoices/api/useUpsertInvoice'
@@ -12,7 +12,7 @@ import {
   computeTaxableSubtotal,
   computeTaxes,
 } from './totalsUtils'
-import { convertInvoiceFormToParams, getInvoiceFormDefaultValues, getInvoiceFormInitialValues, validateOnSubmit } from './formUtils'
+import { convertInvoiceFormToParams, getInvoiceFormDefaultValues, getInvoiceFormInitialValues, validateInvoiceForm } from './formUtils'
 
 type onSuccessFn = (invoice: Invoice) => void
 type UseInvoiceFormProps =
@@ -56,10 +56,19 @@ export const useInvoiceForm = (props: UseInvoiceFormProps) => {
   }, [onSuccess, upsertInvoice])
 
   const validators = useMemo(() => ({
-    onSubmit: validateOnSubmit,
+    onDynamic: validateInvoiceForm,
   }), [])
 
-  const form = useAppForm<InvoiceForm>({ defaultValues, onSubmit, validators })
+  const form = useAppForm<InvoiceForm>({
+    defaultValues,
+    onSubmit,
+    validators,
+    validationLogic: revalidateLogic({
+      mode: 'submit',
+      modeAfterSubmission: 'submit',
+    }),
+    canSubmitWhenInvalid: true,
+  })
   const isFormValid = useStore(form.store, state => state.isValid)
   const isSubmitting = useStore(form.store, state => state.isSubmitting)
 

--- a/src/components/Invoices/InvoiceForm/useInvoiceForm.ts
+++ b/src/components/Invoices/InvoiceForm/useInvoiceForm.ts
@@ -14,11 +14,12 @@ import {
 } from './totalsUtils'
 import { convertInvoiceFormToParams, getInvoiceFormDefaultValues, getInvoiceFormInitialValues, validateOnSubmit } from './formUtils'
 
+type onSuccessFn = (invoice: Invoice) => void
 type UseInvoiceFormProps =
-  | { onSuccess?: (invoice: Invoice) => void, mode: UpsertInvoiceMode.Create }
-  | { onSuccess?: (invoice: Invoice) => void, mode: UpsertInvoiceMode.Update, invoice: Invoice }
+  | { onSuccess: onSuccessFn, mode: UpsertInvoiceMode.Create }
+  | { onSuccess: onSuccessFn, mode: UpsertInvoiceMode.Update, invoice: Invoice }
 
-function isUpdateMode(props: UseInvoiceFormProps): props is { mode: UpsertInvoiceMode.Update, invoice: Invoice } {
+function isUpdateMode(props: UseInvoiceFormProps): props is { onSuccess: onSuccessFn, mode: UpsertInvoiceMode.Update, invoice: Invoice } {
   return props.mode === UpsertInvoiceMode.Update
 }
 
@@ -46,7 +47,7 @@ export const useInvoiceForm = (props: UseInvoiceFormProps) => {
       const { data: invoice } = await upsertInvoice(upsertInvoiceRequest)
 
       setSubmitError(undefined)
-      onSuccess?.(invoice)
+      onSuccess(invoice)
     }
     catch (e) {
       console.error(e)

--- a/src/features/forms/hooks/useForm.tsx
+++ b/src/features/forms/hooks/useForm.tsx
@@ -1,6 +1,7 @@
 import {
   createFormHookContexts,
   createFormHook,
+  useForm as internalUseForm,
   type FormOptions,
   type FormValidateOrFn,
   type FormAsyncValidateOrFn,
@@ -31,9 +32,11 @@ const { useAppForm: useInternalAppForm } = createFormHook({
   formContext,
 })
 
-export function useAppForm<T>(props: FormOptions<
+export function useAppForm<T extends Record<string, unknown>>(props: FormOptions<
   T,
   FormValidateOrFn<T>,
+  FormValidateOrFn<T>,
+  FormAsyncValidateOrFn<T>,
   FormValidateOrFn<T>,
   FormAsyncValidateOrFn<T>,
   FormValidateOrFn<T>,
@@ -44,4 +47,21 @@ export function useAppForm<T>(props: FormOptions<
   unknown
 >) {
   return useInternalAppForm(props)
+}
+
+export function useForm<T extends Record<string, unknown>>(props: FormOptions<
+  T,
+  FormValidateOrFn<T>,
+  FormValidateOrFn<T>,
+  FormAsyncValidateOrFn<T>,
+  FormValidateOrFn<T>,
+  FormAsyncValidateOrFn<T>,
+  FormValidateOrFn<T>,
+  FormAsyncValidateOrFn<T>,
+  FormValidateOrFn<T>,
+  FormAsyncValidateOrFn<T>,
+  FormAsyncValidateOrFn<T>,
+  unknown
+>) {
+  return internalUseForm(props)
 }


### PR DESCRIPTION
## Description
See commit messages for the incremental fixes. The main upshot:
1. Strip empty line items out of invoice creation request
2. Require that invoice due date is at/after creation date
3. Show API submission errors in addition to just form validation errors at top of form
4. Show toast on invoice creation/update success
5. Update validation logic ensure that we only revalidate on form submit (rather than field blur/change)
6. Upgrade TanStack Form to unlock new functionality needed for (5), and update types to match.