### PR TITLE
fix: datepicker width to 24ch

### DIFF
--- a/src/styles/datepicker.scss
+++ b/src/styles/datepicker.scss
@@ -78,7 +78,7 @@
     button {
       box-sizing: border-box;
       position: relative;
-      width: 13rem;
+      width: 24ch;
       padding: 8px;
       border-radius: var(--input-border-radius);
       border: none;


### PR DESCRIPTION
## Description
Datepicker contents is no longer truncated by container at any zoom level.
<img width="478" height="149" alt="Screenshot 2025-08-15 at 2 13 05 PM" src="https://github.com/user-attachments/assets/bf5dc6dc-3935-4be2-b464-d610ac490b49" />