### PR TITLE
feat: filter bank txns on global date range

### DIFF
--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -6,7 +6,7 @@ import {
   useBankTransactionsContext,
 } from '../../contexts/BankTransactionsContext'
 import { useAugmentedBankTransactions } from '../../hooks/useBankTransactions/useAugmentedBankTransactions'
-import { BankTransactionFilters } from '../../hooks/useBankTransactions/types'
+import { BankTransactionFilters, BankTransactionsDateFilterMode } from '../../hooks/useBankTransactions/types'
 import { useElementSize } from '../../hooks/useElementSize'
 import { useIsVisible } from '../../hooks/useIsVisible'
 import { useLinkedAccounts } from '../../hooks/useLinkedAccounts'
@@ -27,7 +27,6 @@ import {
 } from './BankTransactionsHeader'
 import { BankTransactionsTableEmptyStates } from './BankTransactionsTableEmptyState'
 import { MobileComponentType } from './constants'
-import { endOfMonth, startOfMonth } from 'date-fns'
 import type { LayerError } from '../../models/ErrorHandler'
 import { BookkeepingStatus, useEffectiveBookkeepingStatus } from '../../hooks/bookkeeping/useBookkeepingStatus'
 import { isCategorizationEnabledForStatus } from '../../utils/bookkeeping/isCategorizationEnabled'
@@ -38,6 +37,7 @@ import { usePreloadTagDimensions } from '../../features/tags/api/useTagDimension
 import { BankTransactionCustomerVendorVisibilityProvider } from '../../features/bankTransactions/[bankTransactionId]/customerVendor/components/BankTransactionCustomerVendorVisibilityProvider'
 import { usePreloadVendors } from '../../features/vendors/api/useListVendors'
 import { usePreloadCustomers } from '../../features/customers/api/useListCustomers'
+import { HStack } from '../ui/Stack/Stack'
 
 const COMPONENT_NAME = 'bank-transactions'
 
@@ -65,6 +65,7 @@ export interface BankTransactionsProps {
   showReceiptUploads?: boolean
   showTooltips?: boolean
   showUploadOptions?: boolean
+  applyGlobalDateRange?: boolean
 
   monthlyView?: boolean
   categorizeView?: boolean
@@ -83,6 +84,8 @@ export const BankTransactions = ({
   onError,
   showTags = false,
   showCustomerVendor = false,
+  monthlyView = false,
+  applyGlobalDateRange = false,
   mode,
   ...props
 }: BankTransactionsWithErrorProps) => {
@@ -90,7 +93,7 @@ export const BankTransactions = ({
   usePreloadCustomers({ isEnabled: showCustomerVendor })
   usePreloadVendors({ isEnabled: showCustomerVendor })
 
-  const contextData = useAugmentedBankTransactions({ monthlyView: props.monthlyView })
+  const contextData = useAugmentedBankTransactions({ monthlyView, applyGlobalDateRange })
 
   return (
     <ErrorBoundary onError={onError}>
@@ -116,18 +119,12 @@ const BankTransactionsContent = ({
   showTooltips = false,
   showUploadOptions = false,
 
-  monthlyView = false,
   categorizeView: categorizeViewProp,
   mobileComponent,
   filters: inputFilters,
   hideHeader = false,
   stringOverrides,
 }: BankTransactionsProps) => {
-  const [defaultDateRange] = useState(() => ({
-    startDate: startOfMonth(new Date()),
-    endDate: endOfMonth(new Date()),
-  }))
-
   const scrollPaginationRef = useRef<HTMLDivElement>(null)
   const isVisible = useIsVisible(scrollPaginationRef)
 
@@ -149,6 +146,7 @@ const BankTransactionsContent = ({
     hasMore,
     fetchMore,
     removeAfterCategorize,
+    dateFilterMode,
   } = useBankTransactionsContext()
 
   const { data: linkedAccounts } = useLinkedAccounts()
@@ -157,20 +155,21 @@ const BankTransactionsContent = ({
     () => Boolean(linkedAccounts?.some(item => item.is_syncing)),
     [linkedAccounts],
   )
+  const isMonthlyViewMode = dateFilterMode === BankTransactionsDateFilterMode.MonthlyView
 
   useEffect(() => {
     // Reset date range when switching from monthly view to non-monthly view
-    if (!monthlyView && filters?.dateRange) {
+    if (!isMonthlyViewMode && filters?.dateRange) {
       setFilters({ ...filters, dateRange: undefined })
     }
-  }, [monthlyView])
+  }, [isMonthlyViewMode])
 
   useEffect(() => {
     // Fetch more when the user scrolls to the bottom of the page
-    if (monthlyView && isVisible && !isLoading && hasMore) {
+    if (isMonthlyViewMode && isVisible && !isLoading && hasMore) {
       fetchMore()
     }
-  }, [monthlyView, isVisible, isLoading, hasMore])
+  }, [isMonthlyViewMode, isVisible, isLoading, hasMore, fetchMore])
 
   useEffect(() => {
     if (JSON.stringify(inputFilters) !== JSON.stringify(filters)) {
@@ -222,14 +221,12 @@ const BankTransactionsContent = ({
   }, [filters])
 
   const bankTransactions = useMemo(() => {
-    if (monthlyView) {
-      return data
-    }
+    if (isMonthlyViewMode) return data
 
     const firstPageIndex = (currentPage - 1) * pageSize
     const lastPageIndex = firstPageIndex + pageSize
     return data?.slice(firstPageIndex, lastPageIndex)
-  }, [currentPage, data, monthlyView, pageSize])
+  }, [currentPage, data, isMonthlyViewMode, pageSize])
 
   const onCategorizationDisplayChange = (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -306,17 +303,9 @@ const BankTransactionsContent = ({
           asWidget={asWidget}
           categorizedOnly={!categorizationEnabled}
           categorizeView={categorizeView}
-          display={display}
           onCategorizationDisplayChange={onCategorizationDisplayChange}
           mobileComponent={mobileComponent}
-          withDatePicker={monthlyView}
           listView={listView}
-          dateRange={{ ...defaultDateRange, ...filters?.dateRange }}
-          setDateRange={(v) => {
-            if (monthlyView) {
-              setFilters({ ...filters, dateRange: v })
-            }
-          }}
           stringOverrides={stringOverrides?.bankTransactionsHeader}
           isDataLoading={isLoadingWithoutData}
           isSyncing={isSyncing}
@@ -396,18 +385,20 @@ const BankTransactionsContent = ({
         )
         : null}
 
-      {!monthlyView && (
-        <Pagination
-          currentPage={currentPage}
-          totalCount={data?.length || 0}
-          pageSize={pageSize}
-          onPageChange={page => setCurrentPage(page)}
-          fetchMore={fetchMore}
-          hasMore={hasMore}
-        />
+      {!isMonthlyViewMode && (
+        <HStack justify='end'>
+          <Pagination
+            currentPage={currentPage}
+            totalCount={data?.length || 0}
+            pageSize={pageSize}
+            onPageChange={page => setCurrentPage(page)}
+            fetchMore={fetchMore}
+            hasMore={hasMore}
+          />
+        </HStack>
       )}
 
-      {monthlyView ? <div ref={scrollPaginationRef} /> : null}
+      {isMonthlyViewMode ? <div ref={scrollPaginationRef} /> : null}
     </Container>
   )
 }

--- a/src/components/BankTransactions/BankTransactionsHeader.tsx
+++ b/src/components/BankTransactions/BankTransactionsHeader.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useCallback, useState } from 'react'
 import { useLayerContext } from '../../contexts/LayerContext'
-import { DateRange, DisplayState } from '../../types'
+import { DisplayState, type DateRange } from '../../types'
 import { getEarliestDateToBrowse } from '../../utils/business'
 import { ButtonVariant, DownloadButton as DownloadButtonComponent } from '../Button'
 import { Header } from '../Container'
@@ -21,21 +21,18 @@ import { useBankTransactionsDownload } from '../../hooks/useBankTransactions/use
 import InvisibleDownload, { useInvisibleDownload } from '../utility/InvisibleDownload'
 import { bankTransactionFiltersToHookOptions } from '../../hooks/useBankTransactions/useAugmentedBankTransactions'
 import { BankTransactionsUploadMenu } from './BankTransactionsUploadMenu'
+import { BankTransactionsDateFilterMode } from '../../hooks/useBankTransactions/types'
 
 export interface BankTransactionsHeaderProps {
   shiftStickyHeader: number
   asWidget?: boolean
   categorizedOnly?: boolean
   categorizeView?: boolean
-  display?: DisplayState
   onCategorizationDisplayChange: (event: ChangeEvent<HTMLInputElement>) => void
   mobileComponent?: MobileComponentType
-  withDatePicker?: boolean
   listView?: boolean
-  dateRange?: DateRange
   isDataLoading?: boolean
   isSyncing?: boolean
-  setDateRange?: (value: DateRange) => void
   stringOverrides?: BankTransactionsHeaderStringOverrides
   withUploadMenu?: boolean
 }
@@ -115,18 +112,26 @@ export const BankTransactionsHeader = ({
   asWidget,
   categorizedOnly,
   categorizeView = true,
-  display,
   onCategorizationDisplayChange,
   mobileComponent,
-  withDatePicker,
   listView,
-  dateRange,
-  setDateRange,
   stringOverrides,
   isSyncing,
   withUploadMenu,
 }: BankTransactionsHeaderProps) => {
   const { business } = useLayerContext()
+  const {
+    setFilters,
+    filters,
+    dateFilterMode,
+    display,
+  } = useBankTransactionsContext()
+
+  const withDatePicker = dateFilterMode === BankTransactionsDateFilterMode.MonthlyView
+  const dateRange = filters?.dateRange
+  const setDateRange = useCallback((newRange: DateRange) => {
+    setFilters({ dateRange: newRange })
+  }, [setFilters])
 
   return (
     <Header
@@ -155,7 +160,7 @@ export const BankTransactionsHeader = ({
             />
           )}
         </div>
-        {withDatePicker && dateRange && setDateRange
+        {withDatePicker && dateRange
           ? (
             <DatePicker
               displayMode='monthPicker'

--- a/src/contexts/BankTransactionsContext/BankTransactionsContext.tsx
+++ b/src/contexts/BankTransactionsContext/BankTransactionsContext.tsx
@@ -14,6 +14,7 @@ export const BankTransactionsContext =
     match: () => Promise.resolve(undefined),
     filters: undefined,
     setFilters: () => {},
+    dateFilterMode: undefined,
     metadata: {
       pagination: {
         cursor: undefined,

--- a/src/contexts/BankTransactionsContext/BankTransactionsContext.tsx
+++ b/src/contexts/BankTransactionsContext/BankTransactionsContext.tsx
@@ -12,7 +12,7 @@ export const BankTransactionsContext =
     refetch: () => {},
     categorize: () => Promise.resolve(undefined),
     match: () => Promise.resolve(undefined),
-    filters: undefined,
+    filters: {},
     setFilters: () => {},
     dateFilterMode: undefined,
     metadata: {

--- a/src/hooks/useBankTransactions/types.ts
+++ b/src/hooks/useBankTransactions/types.ts
@@ -20,12 +20,18 @@ export type BankTransactionFilters = {
   account?: string[]
   direction?: Direction[]
   categorizationStatus?: DisplayState
-  dateRange?: Partial<DateRange>
+  dateRange?: DateRange
   query?: string
   tagFilter?: TagFilterInput
 }
 
-export type UseBankTransactionsParams = {
+export enum BankTransactionsDateFilterMode {
+  MonthlyView = 'MonthlyView',
+  GlobalDateRange = 'GlobalDateRange',
+}
+
+export type UseAugmentedBankTransactionsParams = {
   scope?: DisplayState
   monthlyView?: boolean
+  applyGlobalDateRange?: boolean
 }

--- a/src/hooks/useBankTransactions/useAugmentedBankTransactions.tsx
+++ b/src/hooks/useBankTransactions/useAugmentedBankTransactions.tsx
@@ -196,11 +196,11 @@ export const useAugmentedBankTransactions = (
   )
 
   const setFilters = useCallback((newFilters: BankTransactionFilters) => {
-    setBaseFilters({
-      ...baseFilters,
+    setBaseFilters((prevFilters: BankTransactionFilters) => ({
+      ...prevFilters,
       ...newFilters,
-    })
-  }, [baseFilters])
+    }))
+  }, [])
 
   const filteredData = useMemo(() => {
     let filtered = data

--- a/src/hooks/useBankTransactions/useAugmentedBankTransactions.tsx
+++ b/src/hooks/useBankTransactions/useAugmentedBankTransactions.tsx
@@ -138,7 +138,7 @@ export const useAugmentedBankTransactions = (
     ...(dateFilterMode === BankTransactionsDateFilterMode.MonthlyView && { dateRange: defaultDateRange }),
   }
 
-  const [baseFilters, setBaseFilters] = useState<BankTransactionFilters | undefined>(initialFilters)
+  const [baseFilters, setBaseFilters] = useState<BankTransactionFilters>(initialFilters)
 
   const filters = useMemo(() => ({
     ...baseFilters,
@@ -195,7 +195,7 @@ export const useAugmentedBankTransactions = (
     [data],
   )
 
-  const setFilters = useCallback((newFilters: Partial<BankTransactionFilters>) => {
+  const setFilters = useCallback((newFilters: BankTransactionFilters) => {
     setBaseFilters({
       ...baseFilters,
       ...newFilters,

--- a/src/hooks/useBankTransactions/useAugmentedBankTransactions.tsx
+++ b/src/hooks/useBankTransactions/useAugmentedBankTransactions.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { TagFilterInput } from '../../types/tags'
 import { useLayerContext } from '../../contexts/LayerContext'
 import {
@@ -15,7 +15,8 @@ import { DataModel } from '../../types/general'
 import { useLinkedAccounts } from '../useLinkedAccounts'
 import {
   BankTransactionFilters,
-  UseBankTransactionsParams,
+  BankTransactionsDateFilterMode,
+  UseAugmentedBankTransactionsParams,
 } from './types'
 import {
   applyAccountFilter,
@@ -27,6 +28,7 @@ import { endOfMonth, startOfMonth } from 'date-fns'
 import { useBankTransactions, type UseBankTransactionsOptions } from './useBankTransactions'
 import { useCategorizeBankTransaction } from './useCategorizeBankTransaction'
 import { useMatchBankTransaction } from './useMatchBankTransaction'
+import { useGlobalDateRange } from '../../providers/GlobalDateStore/GlobalDateStoreProvider'
 
 const INITIAL_POLL_INTERVAL_MS = 1000
 const POLL_INTERVAL_AFTER_TXNS_RECEIVED_MS = 5000
@@ -81,30 +83,6 @@ const filtersSettingString = (filters?: BankTransactionFilters): string => {
   }`
 }
 
-const buildInitialFilters = ({
-  scope = undefined,
-  monthlyView = false,
-}: UseBankTransactionsParams) => {
-  let initialFilters = {}
-  if (monthlyView) {
-    initialFilters = {
-      dateRange: {
-        startDate: startOfMonth(new Date()),
-        endDate: endOfMonth(new Date()),
-      },
-    }
-  }
-
-  if (scope) {
-    initialFilters = {
-      ...initialFilters,
-      categorizationStatus: scope,
-    }
-  }
-
-  return initialFilters
-}
-
 export function bankTransactionFiltersToHookOptions(
   filters?: BankTransactionFilters,
 ): UseBankTransactionsOptions {
@@ -127,7 +105,7 @@ export function bankTransactionFiltersToHookOptions(
 }
 
 export const useAugmentedBankTransactions = (
-  params?: UseBankTransactionsParams,
+  params?: UseAugmentedBankTransactionsParams,
 ) => {
   const {
     addToast,
@@ -138,19 +116,36 @@ export const useAugmentedBankTransactions = (
     eventCallbacks,
   } = useLayerContext()
 
-  const [filters, setTheFilters] = useState<BankTransactionFilters | undefined>(
-    buildInitialFilters(params ?? {}),
-  )
-  const display = useMemo(() => {
-    if (filters?.categorizationStatus === DisplayState.review) {
-      return DisplayState.review
-    }
-    else if (filters?.categorizationStatus === DisplayState.all) {
-      return DisplayState.all
-    }
+  const dateFilterMode = params?.applyGlobalDateRange
+    ? BankTransactionsDateFilterMode.GlobalDateRange
+    : params?.monthlyView
+      ? BankTransactionsDateFilterMode.MonthlyView
+      : undefined
 
-    return DisplayState.categorized
-  }, [filters?.categorizationStatus])
+  const { start, end } = useGlobalDateRange({ displayMode: 'monthPicker' })
+  const globalDateRange = useMemo(() => ({
+    startDate: start,
+    endDate: end,
+  }), [start, end])
+
+  const defaultDateRange = {
+    startDate: startOfMonth(new Date()),
+    endDate: endOfMonth(new Date()),
+  }
+
+  const initialFilters: BankTransactionFilters = {
+    ...(params?.scope && { categorizationStatus: params?.scope }),
+    ...(dateFilterMode === BankTransactionsDateFilterMode.MonthlyView && { dateRange: defaultDateRange }),
+  }
+
+  const [baseFilters, setBaseFilters] = useState<BankTransactionFilters | undefined>(initialFilters)
+
+  const filters = useMemo(() => ({
+    ...baseFilters,
+    ...(dateFilterMode === BankTransactionsDateFilterMode.GlobalDateRange && { dateRange: globalDateRange }),
+  }), [dateFilterMode, baseFilters, globalDateRange])
+
+  const display = filters?.categorizationStatus ?? DisplayState.categorized
 
   const {
     data: rawResponseData,
@@ -200,12 +195,12 @@ export const useAugmentedBankTransactions = (
     [data],
   )
 
-  const setFilters = (value?: Partial<BankTransactionFilters>) => {
-    setTheFilters({
-      ...filters,
-      ...(value ?? {}),
+  const setFilters = useCallback((newFilters: Partial<BankTransactionFilters>) => {
+    setBaseFilters({
+      ...baseFilters,
+      ...newFilters,
     })
-  }
+  }, [baseFilters])
 
   const filteredData = useMemo(() => {
     let filtered = data
@@ -390,19 +385,19 @@ export const useAugmentedBankTransactions = (
           data: page.data?.filter(bt => bt.id !== bankTransaction.id),
         }
       })
-      mutate(updatedData, { revalidate: false })
+      void mutate(updatedData, { revalidate: false })
     }
   }
 
   const refetch = () => {
-    mutate()
+    void mutate()
   }
 
-  const fetchMore = () => {
+  const fetchMore = useCallback(() => {
     if (hasMore) {
-      setSize(size + 1)
+      void setSize(size + 1)
     }
-  }
+  }, [hasMore, setSize, size])
 
   const getCacheKey = (txnFilters?: BankTransactionFilters) => {
     return filtersSettingString(txnFilters)
@@ -447,7 +442,7 @@ export const useAugmentedBankTransactions = (
   useEffect(() => {
     if (refreshTrigger !== -1) {
       refetch()
-      refetchAccounts()
+      void refetchAccounts()
     }
   }, [refreshTrigger])
 
@@ -491,6 +486,7 @@ export const useAugmentedBankTransactions = (
     removeAfterCategorize,
     filters,
     setFilters,
+    dateFilterMode,
     accountsList,
     display,
     fetchMore,


### PR DESCRIPTION
## Description
This PR adds a new `applyGlobalDateRange` prop to the `BankTransactions` component that applies the current global month (e.g., selected in the overview component) to the list of bank txns.