### PR TITLE
feat: reset invoices

### DIFF
--- a/src/components/Invoices/InvoiceDetail/InvoiceDetailHeaderMenu.tsx
+++ b/src/components/Invoices/InvoiceDetail/InvoiceDetailHeaderMenu.tsx
@@ -35,7 +35,7 @@ const availableActions: Record<InvoiceStatus, InvoiceDetailHeaderMenuActions[]> 
     InvoiceDetailHeaderMenuActions.Refund,
     InvoiceDetailHeaderMenuActions.Reset,
   ],
-  [InvoiceStatus.Voided]: [],
+  [InvoiceStatus.Voided]: [InvoiceDetailHeaderMenuActions.Reset],
   [InvoiceStatus.PartiallyWrittenOff]: [InvoiceDetailHeaderMenuActions.Reset],
   [InvoiceStatus.WrittenOff]: [InvoiceDetailHeaderMenuActions.Reset],
   [InvoiceStatus.Refunded]: [InvoiceDetailHeaderMenuActions.Reset],
@@ -139,7 +139,7 @@ export const InvoiceDetailHeaderMenu = ({ onEditInvoice }: InvoiceDetailHeaderMe
       <InvoiceResetModal
         isOpen={openModal === InvoiceDetailHeaderMenuActions.Reset}
         onOpenChange={onOpenChangeByMode(InvoiceDetailHeaderMenuActions.Reset)}
-        invoiceId={invoice.id}
+        invoice={invoice}
         onSuccess={onSuccessUpdateInvoice}
       />
     </>

--- a/src/components/Invoices/Modal/InvoiceResetModal.tsx
+++ b/src/components/Invoices/Modal/InvoiceResetModal.tsx
@@ -1,20 +1,33 @@
 import { ModalProps } from '../../ui/Modal/Modal'
 import { BaseConfirmationModal } from '../../BaseConfirmationModal/BaseConfirmationModal'
-import type { Invoice } from '../../../features/invoices/invoiceSchemas'
+import { InvoiceStatus, type Invoice } from '../../../features/invoices/invoiceSchemas'
+import { useResetInvoice } from '../../../features/invoices/api/useResetInvoice'
+import { useCallback } from 'react'
 
 type InvoiceResetModalProps = Pick<ModalProps, 'isOpen' | 'onOpenChange'> & {
-  invoiceId: string
+  invoice: Invoice
   onSuccess: (invoice: Invoice) => void
 }
 
-export function InvoiceResetModal({ isOpen, onOpenChange, invoiceId: _invoiceId }: InvoiceResetModalProps) {
+export function InvoiceResetModal({ isOpen, onOpenChange, invoice, onSuccess }: InvoiceResetModalProps) {
+  const { trigger: resetInvoice } = useResetInvoice({ invoiceId: invoice.id })
+
+  const onConfirm = useCallback(async () => {
+    const { data: invoice } = await resetInvoice()
+    onSuccess(invoice)
+  }, [onSuccess, resetInvoice])
+
+  const description = invoice.status === InvoiceStatus.Voided
+    ? 'Resetting this invoice will remove its current status as void and return it to a sent state.'
+    : 'Resetting this invoice will delete all payments, refunds, and write offs associated with it and return it to a sent state.'
+
   return (
     <BaseConfirmationModal
       isOpen={isOpen}
       onOpenChange={onOpenChange}
       title='Reset invoice to sent'
-      description='Resetting this invoice will delete all payments, refunds, and write offs associated with it. This action cannot be undone.'
-      onConfirm={() => {}}
+      description={description}
+      onConfirm={onConfirm}
       confirmLabel='Reset Invoice'
       errorText='There was an error resetting this invoice. Please check your connection and try again in a few seconds.'
     />

--- a/src/components/Invoices/Modal/InvoiceResetModal.tsx
+++ b/src/components/Invoices/Modal/InvoiceResetModal.tsx
@@ -15,7 +15,6 @@ export function InvoiceResetModal({ isOpen, onOpenChange, invoice, onSuccess }: 
   const onConfirm = useCallback(async () => {
     const { data: updatedInvoice } = await resetInvoice()
     onSuccess(updatedInvoice)
-    onSuccess(invoice)
   }, [onSuccess, resetInvoice])
 
   const description = invoice.status === InvoiceStatus.Voided

--- a/src/components/Invoices/Modal/InvoiceResetModal.tsx
+++ b/src/components/Invoices/Modal/InvoiceResetModal.tsx
@@ -13,7 +13,8 @@ export function InvoiceResetModal({ isOpen, onOpenChange, invoice, onSuccess }: 
   const { trigger: resetInvoice } = useResetInvoice({ invoiceId: invoice.id })
 
   const onConfirm = useCallback(async () => {
-    const { data: invoice } = await resetInvoice()
+    const { data: updatedInvoice } = await resetInvoice()
+    onSuccess(updatedInvoice)
     onSuccess(invoice)
   }, [onSuccess, resetInvoice])
 

--- a/src/features/invoices/api/useResetInvoice.tsx
+++ b/src/features/invoices/api/useResetInvoice.tsx
@@ -1,0 +1,132 @@
+import { useCallback } from 'react'
+import type { Key } from 'swr'
+import useSWRMutation, { type SWRMutationResponse } from 'swr/mutation'
+import { post } from '../../../api/layer/authenticated_http'
+import { useLayerContext } from '../../../contexts/LayerContext'
+import { useAuth } from '../../../hooks/useAuth'
+import { InvoiceSchema } from '../invoiceSchemas'
+import { Schema } from 'effect'
+import { useInvoicesGlobalCacheActions } from './useListInvoices'
+import { useInvoiceSummaryStatsCacheActions } from './useInvoiceSummaryStats'
+
+const RESET_INVOICE_TAG_KEY = '#reset-invoice'
+
+const ResetInvoiceReturnSchema = Schema.Struct({
+  data: InvoiceSchema,
+})
+
+type ResetInvoiceReturn = typeof ResetInvoiceReturnSchema.Type
+
+const resetInvoice = post<
+  ResetInvoiceReturn,
+  never,
+  { businessId: string, invoiceId: string }
+>(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/reset`)
+
+function buildKey({
+  access_token: accessToken,
+  apiUrl,
+  businessId,
+  invoiceId,
+}: {
+  access_token?: string
+  apiUrl?: string
+  businessId: string
+  invoiceId: string
+}) {
+  if (accessToken && apiUrl) {
+    return {
+      accessToken,
+      apiUrl,
+      businessId,
+      invoiceId,
+      tags: [RESET_INVOICE_TAG_KEY],
+    } as const
+  }
+}
+
+type ResetInvoiceSWRMutationResponse =
+    SWRMutationResponse<ResetInvoiceReturn, unknown, Key, never>
+
+class ResetInvoiceSWRResponse {
+  private swrResponse: ResetInvoiceSWRMutationResponse
+
+  constructor(swrResponse: ResetInvoiceSWRMutationResponse) {
+    this.swrResponse = swrResponse
+  }
+
+  get data() {
+    return this.swrResponse.data
+  }
+
+  get trigger() {
+    return this.swrResponse.trigger
+  }
+
+  get isMutating() {
+    return this.swrResponse.isMutating
+  }
+
+  get isError() {
+    return this.swrResponse.error !== undefined
+  }
+}
+
+type UseResetInvoiceProps = { invoiceId: string }
+
+export const useResetInvoice = ({ invoiceId }: UseResetInvoiceProps) => {
+  const { data } = useAuth()
+  const { businessId } = useLayerContext()
+
+  const rawMutationResponse = useSWRMutation(
+    () => buildKey({
+      ...data,
+      businessId,
+      invoiceId,
+    }),
+    (
+      { accessToken, apiUrl, businessId, invoiceId },
+    ) => {
+      return resetInvoice(
+        apiUrl,
+        accessToken,
+        { params: { businessId, invoiceId } },
+      ).then(Schema.decodeUnknownPromise(ResetInvoiceReturnSchema))
+    },
+    {
+      revalidate: false,
+      throwOnError: true,
+    },
+  )
+
+  const mutationResponse = new ResetInvoiceSWRResponse(rawMutationResponse)
+
+  const { patchInvoiceByKey } = useInvoicesGlobalCacheActions()
+  const { forceReloadInvoiceSummaryStats } = useInvoiceSummaryStatsCacheActions()
+
+  const originalTrigger = mutationResponse.trigger
+
+  const stableProxiedTrigger = useCallback(
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const triggerResult = await originalTrigger(...triggerParameters)
+
+      void patchInvoiceByKey(triggerResult.data)
+
+      void forceReloadInvoiceSummaryStats()
+
+      return triggerResult
+    },
+    [originalTrigger, patchInvoiceByKey, forceReloadInvoiceSummaryStats],
+  )
+
+  return new Proxy(mutationResponse, {
+    get(target, prop) {
+      if (prop === 'trigger') {
+        return stableProxiedTrigger
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return Reflect.get(target, prop)
+    },
+  })
+}


### PR DESCRIPTION
## Description
This PR wires up the new `/invoices/${invoiceId}/reset` endpoint to the frontend to allow end users to kick their invoices back to a "SENT" status by deleting payments, refunds, writeoffs, etc. and unvoiding.
