### PR TITLE
fix: invoice sales taxes calculation

### DIFF
--- a/src/components/Invoices/InvoiceForm/formUtils.ts
+++ b/src/components/Invoices/InvoiceForm/formUtils.ts
@@ -160,8 +160,8 @@ export const convertInvoiceFormToParams = (form: InvoiceForm): unknown => ({
 
       if (!item.isTaxable || BD.equals(form.taxRate, BIG_DECIMAL_ZERO)) return baseLineItem
 
-      const itemAmountlLessDiscount = BD.multiply(item.amount, BD.subtract(BIG_DECIMAL_ONE, form.discountRate))
-      const itemTaxes = convertBigDecimalToCents(BD.multiply(itemAmountlLessDiscount, form.taxRate))
+      const itemAmountLessDiscount = BD.multiply(item.amount, BD.subtract(BIG_DECIMAL_ONE, form.discountRate))
+      const itemTaxes = convertBigDecimalToCents(BD.multiply(itemAmountLessDiscount, form.taxRate))
 
       return { ...baseLineItem, salesTaxes: [{ amount: itemTaxes }] }
     }),

--- a/src/components/Invoices/InvoiceForm/formUtils.ts
+++ b/src/components/Invoices/InvoiceForm/formUtils.ts
@@ -158,18 +158,12 @@ export const convertInvoiceFormToParams = (form: InvoiceForm): unknown => ({
         quantity: item.quantity,
       }
 
-      return !BD.equals(form.taxRate, BIG_DECIMAL_ZERO) && item.isTaxable
-        ? {
-          ...baseLineItem,
-          salesTaxes: [
-            {
-              amount: convertBigDecimalToCents(
-                BD.multiply(item.amount, form.taxRate),
-              ),
-            },
-          ],
-        }
-        : baseLineItem
+      if (!item.isTaxable || BD.equals(form.taxRate, BIG_DECIMAL_ZERO)) return baseLineItem
+
+      const itemAmountlLessDiscount = BD.multiply(item.amount, BD.subtract(BIG_DECIMAL_ONE, form.discountRate))
+      const itemTaxes = convertBigDecimalToCents(BD.multiply(itemAmountlLessDiscount, form.taxRate))
+
+      return { ...baseLineItem, salesTaxes: [{ amount: itemTaxes }] }
     }),
 
   ...(!BD.equals(form.discountRate, BIG_DECIMAL_ZERO) && {


### PR DESCRIPTION
## Description
Invoice line item sales taxes were being calculated incorrectly because I forgot to subtract out the discount rate before applying the sales tax percentage.