### PR TITLE
export entity name, fix parsing match details schema

### DIFF
--- a/src/components/BankTransactionMobileList/BankTransactionMobileListItem.tsx
+++ b/src/components/BankTransactionMobileList/BankTransactionMobileListItem.tsx
@@ -21,7 +21,7 @@ import { isCategorizationEnabledForStatus } from '../../utils/bookkeeping/isCate
 import { BankTransactionProcessingInfo } from '../BankTransactionList/BankTransactionProcessingInfo'
 import { useDelayedVisibility } from '../../hooks/visibility/useDelayedVisibility'
 import { LinkingMetadata, useInAppLinkContext } from '../../contexts/InAppLinkContext'
-import { convertMatchDetailsToLinkingMetadata } from '../../schemas/match'
+import { convertMatchDetailsToLinkingMetadata, decodeMatchDetails } from '../../schemas/match'
 
 export interface BankTransactionMobileListItemProps {
   index: number
@@ -54,7 +54,8 @@ const getAssignedValue = (
 
   if (bankTransaction.categorization_status === CategorizationStatus.MATCHED) {
     if (renderInAppLink && bankTransaction.match?.details) {
-      const inAppLink = renderInAppLink(convertMatchDetailsToLinkingMetadata(bankTransaction.match.details))
+      const matchDetails = bankTransaction.match.details ? decodeMatchDetails(bankTransaction.match.details) : undefined
+      const inAppLink = matchDetails ? renderInAppLink(convertMatchDetailsToLinkingMetadata(matchDetails)) : undefined
       if (inAppLink) return inAppLink
     }
     return bankTransaction.match?.details?.description

--- a/src/components/CategorySelect/CategorySelect.tsx
+++ b/src/components/CategorySelect/CategorySelect.tsx
@@ -23,7 +23,7 @@ import { parseISO, format as formatTime } from 'date-fns'
 import { useCategories } from '../../hooks/categories/useCategories'
 import { LinkingMetadata, useInAppLinkContext } from '../../contexts/InAppLinkContext'
 import { CategorySelectDrawer } from './CategorySelectDrawer'
-import { convertMatchDetailsToLinkingMetadata, MatchDetailsType } from '../../schemas/match'
+import { convertMatchDetailsToLinkingMetadata, decodeMatchDetails, MatchDetailsType } from '../../schemas/match'
 import { ReactNode } from 'react'
 import { useCallback, useState } from 'react'
 import type { Option } from '../BankTransactionMobileList/utils'
@@ -170,8 +170,9 @@ const Option = (
   }
 
   if (props.data.type === 'match') {
-    const inAppLink = props.renderInAppLink && props.data.payload.details
-      ? props.renderInAppLink(convertMatchDetailsToLinkingMetadata(props.data.payload.details))
+    const matchDetails = props.data.payload.details ? decodeMatchDetails(props.data.payload.details) : undefined
+    const inAppLink = props.renderInAppLink && matchDetails
+      ? props.renderInAppLink(convertMatchDetailsToLinkingMetadata(matchDetails))
       : null
 
     return (

--- a/src/components/MatchForm/MatchForm.tsx
+++ b/src/components/MatchForm/MatchForm.tsx
@@ -8,7 +8,7 @@ import { Text, TextUseTooltip, ErrorText } from '../Typography'
 import classNames from 'classnames'
 import { parseISO, format as formatTime } from 'date-fns'
 import { useInAppLinkContext } from '../../contexts/InAppLinkContext'
-import { convertMatchDetailsToLinkingMetadata } from '../../schemas/match'
+import { convertMatchDetailsToLinkingMetadata, decodeMatchDetails } from '../../schemas/match'
 
 export interface MatchFormProps {
   classNamePrefix: string
@@ -58,7 +58,8 @@ export const MatchForm = ({
         {match && <div className={`${classNamePrefix}__match-table__status`} />}
       </div>
       {effectiveSuggestedMatches.map((suggestedMatch) => {
-        const inAppLink = renderInAppLink ? renderInAppLink(convertMatchDetailsToLinkingMetadata(suggestedMatch.details)) : null
+        const matchDetails = suggestedMatch.details ? decodeMatchDetails(suggestedMatch.details) : undefined
+        const inAppLink = renderInAppLink && matchDetails ? renderInAppLink(convertMatchDetailsToLinkingMetadata(matchDetails)) : null
         return (
           <div
             key={suggestedMatch.id}

--- a/src/components/MatchForm/MatchFormMobile.tsx
+++ b/src/components/MatchForm/MatchFormMobile.tsx
@@ -6,7 +6,7 @@ import { MatchFormProps } from './MatchForm'
 import classNames from 'classnames'
 import { parseISO, format as formatTime } from 'date-fns'
 import { useInAppLinkContext } from '../../contexts/InAppLinkContext'
-import { convertMatchDetailsToLinkingMetadata } from '../../schemas/match'
+import { convertMatchDetailsToLinkingMetadata, decodeMatchDetails } from '../../schemas/match'
 import { HStack } from '../ui/Stack/Stack'
 
 export const MatchFormMobile = ({
@@ -21,7 +21,8 @@ export const MatchFormMobile = ({
   return (
     <div className={`${classNamePrefix}__match-list`}>
       {bankTransaction.suggested_matches?.map((match, idx) => {
-        const inAppLink = renderInAppLink ? renderInAppLink(convertMatchDetailsToLinkingMetadata(match.details)) : null
+        const matchDetails = match.details ? decodeMatchDetails(match.details) : undefined
+        const inAppLink = renderInAppLink && matchDetails ? renderInAppLink(convertMatchDetailsToLinkingMetadata(matchDetails)) : null
         return (
           <div
             key={idx}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,4 +64,4 @@ export { BankTransactionsProvider } from './providers/BankTransactionsProvider'
 export { useDataSync } from './hooks/useDataSync'
 
 export { DisplayState, Direction } from './types/bank_transactions'
-export { LinkingMetadata } from './contexts/InAppLinkContext'
+export { LinkingMetadata, EntityName } from './contexts/InAppLinkContext'

--- a/src/schemas/match.ts
+++ b/src/schemas/match.ts
@@ -32,7 +32,7 @@ const BaseMatchDetailsSchema = Schema.Struct({
   amount: Schema.Number,
   date: Schema.String,
   description: Schema.String,
-  adjustment: Schema.optional(Schema.NullOr(ApiMatchAdjustmentSchema)),
+  adjustment: Schema.NullOr(ApiMatchAdjustmentSchema),
   referenceNumber: pipe(
     Schema.optional(Schema.NullOr(Schema.String)),
     Schema.fromKey('reference_number'),


### PR DESCRIPTION
- Add export for EntityName enum. Useful for switch statements while linking so people can do stuff like have different logic for invoice payments vs bank transactions etc.

- Fix bug where we weren't decoding match details schema

<img width="493" height="231" alt="Screenshot 2025-09-16 at 7 26 55 PM" src="https://github.com/user-attachments/assets/9f6195e7-28c9-4cf2-bc31-703d2858d4f7" />

<img width="343" height="292" alt="Screenshot 2025-09-16 at 7 27 37 PM" src="https://github.com/user-attachments/assets/b217de10-7720-42fb-893d-15ffa34b3e1f" />
