### PR TITLE
fix: dropdown issue for BrightGo

### DIFF
--- a/src/components/ui/ListBox/ListBox.tsx
+++ b/src/components/ui/ListBox/ListBox.tsx
@@ -52,7 +52,7 @@ function InternalListBoxSection<
    * a section.
   */
   const stopClickEventsRef = useStopClickEventsRefCallback()
-  const mergedRef = mergeRefs(stopClickEventsRef, ref)
+  const mergedRef = mergeRefs<HTMLElement>(stopClickEventsRef, ref)
 
   return (
     <ReactAriaListBoxSection

--- a/src/schemas/bankTransactions/bankTransaction.ts
+++ b/src/schemas/bankTransactions/bankTransaction.ts
@@ -5,12 +5,7 @@ import { CustomerSchema } from '../customer'
 import { VendorSchema } from '../vendor'
 import { TransactionTagSchema } from '../../features/tags/tagSchemas'
 import { UpdateCategorizationRulesSuggestionSchema } from './categorizationRules/categorizationRule'
-
-export enum BankTransactionDirection {
-  Credit = 'CREDIT',
-  Debit = 'DEBIT',
-}
-export const BankTransactionDirectionSchema = Schema.Enums(BankTransactionDirection)
+import { BankTransactionDirectionSchema } from './base'
 
 export enum CategorizationStatus {
   PENDING = 'PENDING',
@@ -91,28 +86,4 @@ export const BankTransactionSchema = Schema.Struct({
     Schema.optional(Schema.NullOr(UpdateCategorizationRulesSuggestionSchema)),
     Schema.fromKey('update_categorization_rules_suggestion'),
   ),
-})
-
-// Maps onto the same object as BankTransactionSchema but minimal fields (for avoiding recursion for suggested rule updates)
-export const MinimalBankTransactionSchema = Schema.Struct({
-  id: Schema.String,
-  date: Schema.Date,
-  direction: BankTransactionDirectionSchema,
-  amount: Schema.Number,
-  counterpartyName: pipe(
-    Schema.optional(Schema.NullOr(Schema.String)),
-    Schema.fromKey('counterparty_name'),
-  ),
-  description: Schema.optional(Schema.NullOr(Schema.String)),
-})
-
-export const BankTransactionCounterpartySchema = Schema.Struct({
-  id: Schema.String,
-  externalId: Schema.optional(Schema.String).pipe(
-    Schema.fromKey('external_id'),
-  ),
-  name: Schema.optional(Schema.NullOr(Schema.String)),
-  website: Schema.optional(Schema.NullOr(Schema.String)),
-  logo: Schema.optional(Schema.NullOr(Schema.String)),
-  mccs: Schema.Array(Schema.String),
 })

--- a/src/schemas/bankTransactions/base.ts
+++ b/src/schemas/bankTransactions/base.ts
@@ -1,0 +1,30 @@
+import { Schema, pipe } from 'effect'
+
+export enum BankTransactionDirection {
+  Credit = 'CREDIT',
+  Debit = 'DEBIT',
+}
+export const BankTransactionDirectionSchema = Schema.Enums(BankTransactionDirection)
+
+export const MinimalBankTransactionSchema = Schema.Struct({
+  id: Schema.String,
+  date: Schema.Date,
+  direction: BankTransactionDirectionSchema,
+  amount: Schema.Number,
+  counterpartyName: pipe(
+    Schema.optional(Schema.NullOr(Schema.String)),
+    Schema.fromKey('counterparty_name'),
+  ),
+  description: Schema.optional(Schema.NullOr(Schema.String)),
+})
+
+export const BankTransactionCounterpartySchema = Schema.Struct({
+  id: Schema.String,
+  externalId: Schema.optional(Schema.String).pipe(
+    Schema.fromKey('external_id'),
+  ),
+  name: Schema.optional(Schema.NullOr(Schema.String)),
+  website: Schema.optional(Schema.NullOr(Schema.String)),
+  logo: Schema.optional(Schema.NullOr(Schema.String)),
+  mccs: Schema.Array(Schema.String),
+})

--- a/src/schemas/bankTransactions/categorizationRules/categorizationRule.ts
+++ b/src/schemas/bankTransactions/categorizationRules/categorizationRule.ts
@@ -1,5 +1,5 @@
 import { pipe, Schema } from 'effect/index'
-import { BankTransactionCounterpartySchema, MinimalBankTransactionSchema } from '../bankTransaction'
+import { BankTransactionCounterpartySchema, MinimalBankTransactionSchema } from '../base'
 import { CategorizationSchema } from '../../categorization'
 
 export enum BankTransactionType {


### PR DESCRIPTION
## Description
This PR fixes a bug with `react-aria-components` and our combobox where when the React Aria modal is shown, the combobox is no longer interactive because it is "inert." This new property tells React Aria to chill out.

Also fixed a circular dependency issue with new schemas.
