### PR TITLE
Change "match" tag to "transfer" in the bank transaction feed

### DIFF
--- a/src/components/CategorySelect/CategorySelect.tsx
+++ b/src/components/CategorySelect/CategorySelect.tsx
@@ -113,6 +113,7 @@ export const mapSuggestedMatchToOption = (
       display_name: record.details.description,
       amount: record.details.amount,
       subCategories: null,
+      details: record.details,
     },
   }
 }
@@ -137,7 +138,7 @@ const GroupHeading = (
     <components.GroupHeading
       className={classNames(
         props.className,
-        props.children === 'Match' || props.children === 'All categories'
+        props.children === 'Match' || props.children === 'Transfer' || props.children === 'All categories'
           ? 'Layer__select__group-heading--main'
           : '',
       )}
@@ -308,7 +309,7 @@ export const CategorySelect = ({
     !excludeMatches && bankTransaction?.suggested_matches
       ? [
           {
-            label: 'Match',
+            label: bankTransaction.suggested_matches.every(x => x.details.type === 'Transfer_Match') ? 'Transfer' : 'Match',
             options: bankTransaction.suggested_matches.map((x) => {
               return {
                 type: OptionActionType.MATCH,
@@ -421,7 +422,7 @@ export const CategorySelect = ({
         <div className='Layer__select__option-label'>
           {props.type === 'match' && (
             <Badge size={BadgeSize.SMALL} icon={<MinimizeTwo size={11} />}>
-              Match
+              {props.payload.details?.type === 'Transfer_Match' ? 'Transfer' : 'Match'}
             </Badge>
           )}
           <span>{props.payload.display_name}</span>


### PR DESCRIPTION
## Description
Change "match" tag to "transfer" in the bank transaction feed

[LAY-1763](https://linear.app/layerfi/issue/LAY-1763/change-match-tag-to-transfer-in-the-bank-transaction-feed)

## Changes
* 'Match' --> 'Transfer' when the match is identified as a transfer between accounts
* 'Match' --> 'Transfer' in the dropdown, when all matches are transfers between accounts


## How this has been tested?

<img width="547" height="318" alt="image" src="https://github.com/user-attachments/assets/76f0f59e-d946-4f5a-a8fb-7b6e32ac60af" />

<img width="671" height="461" alt="image" src="https://github.com/user-attachments/assets/4bcf4f07-3dd6-4702-9f3b-0c3db9d534fe" />


Note: There's a possible case with multiple matches, current implementation will only show "Transfer" as the dropdown category if they're all Transfer. If we're expecting multiple matches with some being Transfer and some being non-Transfer to be a frequent occurrence, will need to update.
