### PR TITLE
Encoding team preferences on modules and index.ts

### DIFF
--- a/docs/modules-and-indexes.md
+++ b/docs/modules-and-indexes.md
@@ -1,0 +1,14 @@
+# Team's best practices
+
+## Avoid having multiple index.ts files or one per component
+
+Better to maintain a single index.ts file used for exporting components.
+
+### Cons we're avoiding
+
+Maintenance overhead - Every time we add/remove/rename something, we need to update the index file. This is the concern @sarahraines is raising.
+Ambiguity in editors - When we have many tabs open, they all say "index.ts" making it harder to identify which file we're in.
+Import cycles risk - Index files can make it easier to accidentally create circular dependencies.
+Not always necessary - For simple components with a single file, an index.ts adds extra ceremony without much benefit.
+Debugging confusion - Stack traces and errors pointing to "index.ts" are less informative than ones pointing to the actual component file.
+


### PR DESCRIPTION
Sarah mentioned that we should avoid having multiple index.ts as it introduces extra maintenance overhead, and multiple levels of indirection that may not be necessary.

We should:
- Have a single `src/index.ts` referring to what components we export to our customers.
- Avoid `index.ts` for components or hooks.


## Rationale - Why I'm writing these team preferences

So that agents (e.g. `.cursorrules` or `CLAUDE.md`) can be pointed to these `docs/` and thus write code following our tribal knowledge/team preferences.

## Clarification

There are some `index.ts` within the useHooks initiated by Tom 18-20 months ago, or by Sarah under `useChartOfAccounts` 5 months ago. Just want to confirm that this is no longer something we want to do even in hooks.