### PR TITLE
[old][reference]: Tax Estimates Overview revamp + dark banner variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .idea/
 .vscode/
 .DS_Store
+.codex/

--- a/src/assets/locales/en-US/taxEstimates.json
+++ b/src/assets/locales/en-US/taxEstimates.json
@@ -13,6 +13,7 @@
     "load_tax_information": "Unable to load tax information",
     "load_tax_payments": "We couldnʼt load your tax payments",
     "retrieve_tax_profile": "We couldn’t retrieve your tax profile. Please check your connection and try again.",
+    "while_loading_tax_estimates": "An error occurred while loading your tax estimates. Please check your connection and try again.",
     "while_loading_tax_payments": "An error occurred while loading your tax payments. Please check your connection and try again.",
     "while_loading_tax_summary": "An error occurred while loading your tax summary. Please check your connection and try again."
   },

--- a/src/assets/locales/fr-CA/taxEstimates.json
+++ b/src/assets/locales/fr-CA/taxEstimates.json
@@ -13,6 +13,7 @@
     "load_tax_information": "Impossible de charger les renseignements fiscaux",
     "load_tax_payments": "Nous n’avons pas pu charger vos paiements d’impôt",
     "retrieve_tax_profile": "Nous n’avons pas pu récupérer votre profil fiscal. Veuillez vérifier votre connexion et réessayer.",
+    "while_loading_tax_estimates": "Une erreur s’est produite lors du chargement de vos estimations fiscales. Veuillez vérifier votre connexion et réessayer.",
     "while_loading_tax_payments": "Une erreur s’est produite lors du chargement de vos paiements d’impôt. Veuillez vérifier votre connexion et réessayer.",
     "while_loading_tax_summary": "Une erreur s’est produite lors du chargement de votre sommaire fiscal. Veuillez vérifier votre connexion et réessayer."
   },

--- a/src/components/MetricRow/MetricRow.tsx
+++ b/src/components/MetricRow/MetricRow.tsx
@@ -1,0 +1,42 @@
+import { Meter } from '@ui/Meter/Meter'
+import { HStack } from '@ui/Stack/Stack'
+import { MoneySpan } from '@ui/Typography/MoneySpan'
+import { Span } from '@ui/Typography/Text'
+
+type MetricRowProps = {
+  amount: number
+  isMobile: boolean
+  label: string
+  maxMeterValue: number
+  meterClassName: string
+}
+
+export const MetricRow = ({
+  amount,
+  isMobile,
+  label,
+  maxMeterValue,
+  meterClassName,
+}: MetricRowProps) => {
+  if (isMobile) {
+    return (
+      <HStack className='Layer__MetricCard' align='center' gap='md'>
+        <Span size='md' className='Layer__MetricCardLabel'>{label}</Span>
+        <HStack className='Layer__MetricCardMeter' align='center'>
+          <Meter className={meterClassName} label={label} minValue={0} maxValue={maxMeterValue} value={amount} meterOnly />
+        </HStack>
+        <MoneySpan size='md' weight='bold' amount={amount} />
+      </HStack>
+    )
+  }
+
+  return (
+    <HStack className='Layer__MetricRow' justify='space-between' align='center' gap='md'>
+      <Span size='md'>{label}</Span>
+      <HStack className='Layer__MetricValue' align='center' gap='md'>
+        <MoneySpan size='md' weight='bold' amount={amount} />
+        <Meter className={meterClassName} label={label} minValue={0} maxValue={maxMeterValue} value={amount} meterOnly />
+      </HStack>
+    </HStack>
+  )
+}

--- a/src/components/MetricRow/MetricRow.tsx
+++ b/src/components/MetricRow/MetricRow.tsx
@@ -1,3 +1,5 @@
+import classNames from 'classnames'
+
 import { Meter } from '@ui/Meter/Meter'
 import { HStack } from '@ui/Stack/Stack'
 import { MoneySpan } from '@ui/Typography/MoneySpan'
@@ -9,10 +11,12 @@ type MetricRowProps = {
   label: string
   maxMeterValue: number
   meterClassName: string
+  classNamePrefix?: string
 }
 
 export const MetricRow = ({
   amount,
+  classNamePrefix,
   isMobile,
   label,
   maxMeterValue,
@@ -20,9 +24,9 @@ export const MetricRow = ({
 }: MetricRowProps) => {
   if (isMobile) {
     return (
-      <HStack className='Layer__MetricCard' align='center' gap='md'>
-        <Span size='md' className='Layer__MetricCardLabel'>{label}</Span>
-        <HStack className='Layer__MetricCardMeter' align='center'>
+      <HStack className={classNames('Layer__MetricCard', classNamePrefix && `${classNamePrefix}__MetricCard`)} align='center' gap='md'>
+        <Span size='md' className={classNames('Layer__MetricCardLabel', classNamePrefix && `${classNamePrefix}__MetricCardLabel`)}>{label}</Span>
+        <HStack className={classNames('Layer__MetricCardMeter', classNamePrefix && `${classNamePrefix}__MetricCardMeter`)} align='center'>
           <Meter className={meterClassName} label={label} minValue={0} maxValue={maxMeterValue} value={amount} meterOnly />
         </HStack>
         <MoneySpan size='md' weight='bold' amount={amount} />
@@ -31,9 +35,9 @@ export const MetricRow = ({
   }
 
   return (
-    <HStack className='Layer__MetricRow' justify='space-between' align='center' gap='md'>
+    <HStack className={classNames('Layer__MetricRow', classNamePrefix && `${classNamePrefix}__MetricRow`)} justify='space-between' align='center' gap='md'>
       <Span size='md'>{label}</Span>
-      <HStack className='Layer__MetricValue' align='center' gap='md'>
+      <HStack className={classNames('Layer__MetricValue', classNamePrefix && `${classNamePrefix}__MetricValue`)} align='center' gap='md'>
         <MoneySpan size='md' weight='bold' amount={amount} />
         <Meter className={meterClassName} label={label} minValue={0} maxValue={maxMeterValue} value={amount} meterOnly />
       </HStack>

--- a/src/components/TaxDetails/TaxBanner.tsx
+++ b/src/components/TaxDetails/TaxBanner.tsx
@@ -1,0 +1,53 @@
+import { FileText } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+import type { TaxOverviewBannerReview } from '@schemas/taxEstimates/overview'
+import { Banner } from '@ui/Banner/Banner'
+import { Button } from '@ui/Button/Button'
+
+export type TaxBannerReviewPayload = TaxOverviewBannerReview
+
+type TaxBannerAction = {
+  label: ReactNode
+  onPress: (payload: TaxBannerReviewPayload) => void
+  payload: TaxBannerReviewPayload
+  isDisabled?: boolean
+  isPending?: boolean
+}
+
+export type TaxBannerProps = {
+  title: string
+  description?: string
+  action?: TaxBannerAction
+  icon?: ReactNode
+}
+
+export const TaxBanner = ({
+  title,
+  description,
+  action,
+  icon = <FileText size={16} />,
+}: TaxBannerProps) => {
+  return (
+    <Banner
+      variant='dark'
+      title={title}
+      description={description}
+      slots={{
+        Icon: icon,
+        Button: action
+          ? (
+            <Button
+              variant='solid'
+              onPress={() => action.onPress(action.payload)}
+              isDisabled={action.isDisabled}
+              isPending={action.isPending}
+            >
+              {action.label}
+            </Button>
+          )
+          : undefined,
+      }}
+    />
+  )
+}

--- a/src/components/TaxDetails/TaxBanner.tsx
+++ b/src/components/TaxDetails/TaxBanner.tsx
@@ -2,6 +2,7 @@ import { FileText } from 'lucide-react'
 import type { ReactNode } from 'react'
 
 import type { TaxOverviewBannerReview } from '@schemas/taxEstimates/overview'
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { Banner } from '@ui/Banner/Banner'
 import { Button } from '@ui/Button/Button'
 
@@ -28,13 +29,14 @@ export const TaxBanner = ({
   action,
   icon = <FileText size={16} />,
 }: TaxBannerProps) => {
+  const { isMobile } = useSizeClass()
   return (
     <Banner
       variant='dark'
       title={title}
       description={description}
       slots={{
-        Icon: icon,
+        Icon: isMobile ? null : icon,
         Button: action
           ? (
             <Button

--- a/src/components/TaxDetails/TaxDetails.tsx
+++ b/src/components/TaxDetails/TaxDetails.tsx
@@ -113,7 +113,7 @@ export const TaxDetails = () => {
           <DataState
             status={DataStateStatus.failed}
             title={t('taxEstimates:error.load_tax_estimates', 'We couldn\'t load your tax estimates')}
-            description={t('taxEstimates:error.load_tax_estimates', 'An error occurred while loading your tax estimates. Please check your connection and try again.')}
+            description={t('taxEstimates:error.while_loading_tax_estimates', 'An error occurred while loading your tax estimates. Please check your connection and try again.')}
             spacing
           />
         )}

--- a/src/components/TaxEstimatesSummaryCard/DonutChart.tsx
+++ b/src/components/TaxEstimatesSummaryCard/DonutChart.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from 'react-i18next'
+
+import { VStack } from '@ui/Stack/Stack'
+import { MoneySpan } from '@ui/Typography/MoneySpan'
+import { Span } from '@ui/Typography/Text'
+
+import {
+  DONUT_CIRCUMFERENCE,
+  DONUT_RADIUS,
+  DONUT_SEGMENT_GAP,
+  DONUT_STROKE_WIDTH,
+  getCategoryStroke,
+} from './constants'
+import type { SummaryCardProps } from './types'
+
+type DonutChartProps = Pick<SummaryCardProps, 'categories' | 'total'>
+
+export const DonutChart = ({
+  categories,
+  total,
+}: DonutChartProps) => {
+  const { t } = useTranslation()
+  let offset = 0
+
+  return (
+    <VStack className='Layer__TaxEstimatesSummaryCard__DonutChart' align='center' justify='center'>
+      <svg className='Layer__TaxEstimatesSummaryCard__DonutChartSvg' viewBox='0 0 140 140' aria-hidden='true' focusable='false'>
+        <circle
+          className='Layer__TaxEstimatesSummaryCard__DonutChartTrack'
+          cx='70'
+          cy='70'
+          r={DONUT_RADIUS}
+          strokeWidth={DONUT_STROKE_WIDTH}
+          fill='none'
+        />
+        {total > 0 && categories.map((category) => {
+          const rawSegmentLength = (category.amount / total) * DONUT_CIRCUMFERENCE
+          const segmentLength = Math.max(rawSegmentLength - DONUT_SEGMENT_GAP, 0)
+          const circle = (
+            <circle
+              key={category.key}
+              cx='70'
+              cy='70'
+              r={DONUT_RADIUS}
+              strokeWidth={DONUT_STROKE_WIDTH}
+              fill='none'
+              stroke={getCategoryStroke(category.key)}
+              strokeDasharray={`${segmentLength} ${DONUT_CIRCUMFERENCE}`}
+              strokeDashoffset={-offset}
+              strokeLinecap='round'
+            />
+          )
+
+          offset += rawSegmentLength
+          return circle
+        })}
+      </svg>
+      <VStack className='Layer__TaxEstimatesSummaryCard__DonutChartCenter' align='center' justify='center' gap='3xs'>
+        <Span size='sm' variant='subtle'>{t('common:label.total', 'Total')}</Span>
+        <MoneySpan size='lg' weight='bold' amount={total} />
+      </VStack>
+    </VStack>
+  )
+}

--- a/src/components/TaxEstimatesSummaryCard/Legend.tsx
+++ b/src/components/TaxEstimatesSummaryCard/Legend.tsx
@@ -1,0 +1,50 @@
+import { ArrowUpDown } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { MoneySpan } from '@ui/Typography/MoneySpan'
+import { Span } from '@ui/Typography/Text'
+
+import { getCategoryClassName } from './constants'
+import type { SummaryCardProps } from './types'
+
+type LegendProps = Pick<SummaryCardProps, 'categories' | 'total'> & {
+  isMobile: boolean
+}
+
+export const Legend = ({
+  categories,
+  isMobile,
+  total,
+}: LegendProps) => {
+  const { t } = useTranslation()
+  const { formatPercent } = useIntlFormatter()
+  const className = isMobile
+    ? 'Layer__TaxEstimatesSummaryCard__LegendCard'
+    : 'Layer__TaxEstimatesSummaryCard__Legend'
+
+  return (
+    <VStack className={className} gap='sm' fluid>
+      <HStack justify='space-between' className='Layer__TaxEstimatesSummaryCard__LegendHeader'>
+        <Span size='sm' variant='subtle'>{t('common:label.category', 'Category')}</Span>
+        <HStack className='Layer__TaxEstimatesSummaryCard__LegendHeaderValue' align='center' gap='2xs'>
+          <Span size='sm' variant='subtle'>{t('common:label.value', 'Value')}</Span>
+          <ArrowUpDown size={12} />
+        </HStack>
+      </HStack>
+      {categories.map(category => (
+        <HStack key={category.key} className='Layer__TaxEstimatesSummaryCard__LegendRow' justify='space-between' align='center' gap='md'>
+          <Span size='sm'>{category.label}</Span>
+          <HStack className='Layer__TaxEstimatesSummaryCard__LegendValueGroup' align='center' gap='sm'>
+            <MoneySpan size='sm' weight='bold' amount={category.amount} />
+            <Span size='sm' variant='subtle'>
+              {formatPercent(total === 0 ? 0 : category.amount / total)}
+            </Span>
+            <Span nonAria className={`Layer__TaxEstimatesSummaryCard__LegendSwatch ${getCategoryClassName(category.key)}`} />
+          </HStack>
+        </HStack>
+      ))}
+    </VStack>
+  )
+}

--- a/src/components/TaxEstimatesSummaryCard/NextPaymentBanner.tsx
+++ b/src/components/TaxEstimatesSummaryCard/NextPaymentBanner.tsx
@@ -1,0 +1,67 @@
+import classNames from 'classnames'
+import { BellRing } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { HStack } from '@ui/Stack/Stack'
+import { MoneySpan } from '@ui/Typography/MoneySpan'
+import { Span } from '@ui/Typography/Text'
+
+import type { SummaryCardProps } from './types'
+
+type NextPaymentBannerProps = Pick<SummaryCardProps, 'nextTax'> & {
+  isMobile: boolean
+  isSummaryCardLayout: boolean
+}
+
+export const NextPaymentBanner = ({
+  isMobile,
+  isSummaryCardLayout,
+  nextTax,
+}: NextPaymentBannerProps) => {
+  const { t } = useTranslation()
+  const { formatDate } = useIntlFormatter()
+  const nextPaymentLabel = isMobile
+    ? t(
+      'taxEstimates:label.next_quarter_due_on_short',
+      'Q{{quarter}} due {{date}}',
+      {
+        quarter: nextTax.quarter,
+        date: formatDate(nextTax.dueAt),
+      },
+    )
+    : t(
+      'taxEstimates:label.next_quarter_payment_due_on',
+      'Q{{quarter}} payment due: {{date}}',
+      {
+        quarter: nextTax.quarter,
+        date: formatDate(nextTax.dueAt),
+      },
+    )
+
+  return (
+    <HStack className={classNames('Layer__TaxEstimatesSummaryCard__NextPaymentBanner', isSummaryCardLayout && 'Layer__TaxEstimatesSummaryCard__NextPaymentBanner--summaryCard')} justify='space-between' align='center' gap='md'>
+      <HStack className='Layer__TaxEstimatesSummaryCard__NextPaymentCopy' align='center' gap='md'>
+        {!isMobile && (
+          <Span nonAria className='Layer__TaxEstimatesSummaryCard__NextPaymentIcon'>
+            <BellRing size={14} />
+          </Span>
+        )}
+        <Span
+          className='Layer__TaxEstimatesSummaryCard__NextPaymentText'
+          size='sm'
+          weight='bold'
+          variant='inherit'
+        >
+          {nextPaymentLabel}
+        </Span>
+      </HStack>
+      <MoneySpan
+        size={isMobile ? 'sm' : 'md'}
+        weight='bold'
+        amount={nextTax.amount}
+        variant='inherit'
+      />
+    </HStack>
+  )
+}

--- a/src/components/TaxEstimatesSummaryCard/NextPaymentBanner.tsx
+++ b/src/components/TaxEstimatesSummaryCard/NextPaymentBanner.tsx
@@ -21,6 +21,11 @@ export const NextPaymentBanner = ({
 }: NextPaymentBannerProps) => {
   const { t } = useTranslation()
   const { formatDate } = useIntlFormatter()
+
+  if (!nextTax) {
+    return null
+  }
+
   const nextPaymentLabel = isMobile
     ? t(
       'taxEstimates:label.next_quarter_due_on_short',

--- a/src/components/TaxEstimatesSummaryCard/NextPaymentBanner.tsx
+++ b/src/components/TaxEstimatesSummaryCard/NextPaymentBanner.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import { BellRing } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { DateFormat } from '@utils/i18n/date/patterns'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { HStack } from '@ui/Stack/Stack'
 import { MoneySpan } from '@ui/Typography/MoneySpan'
@@ -32,7 +33,7 @@ export const NextPaymentBanner = ({
       'Q{{quarter}} due {{date}}',
       {
         quarter: nextTax.quarter,
-        date: formatDate(nextTax.dueAt),
+        date: formatDate(nextTax.dueAt, DateFormat.DateShort),
       },
     )
     : t(
@@ -40,7 +41,7 @@ export const NextPaymentBanner = ({
       'Q{{quarter}} payment due: {{date}}',
       {
         quarter: nextTax.quarter,
-        date: formatDate(nextTax.dueAt),
+        date: formatDate(nextTax.dueAt, DateFormat.DateShort),
       },
     )
 

--- a/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
+++ b/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
@@ -25,36 +25,38 @@ export const TaxEstimatesSummaryCard = ({
   const isSummaryCardLayout = layout === 'summaryCard'
 
   return (
-    <Card className={classNames('Layer__TaxEstimatesSummaryCard', isSummaryCardLayout && 'Layer__TaxEstimatesSummaryCard--summaryCard', className)}>
-      <VStack gap='md' className='Layer__TaxEstimatesSummaryCard__Body'>
-        <HStack
-          className={classNames('Layer__TaxEstimatesSummaryCard__Header', isSummaryCardLayout && 'Layer__SummaryCard__ContainerHeader')}
-          justify='space-between'
-          align={isSummaryCardLayout ? 'center' : 'start'}
-          gap='md'
-        >
-          <Span size='lg' weight='bold'>{title}</Span>
-          {headerAction}
-        </HStack>
-        {(isMobile || isSummaryCardLayout)
-          ? (
-            <VStack className='Layer__TaxEstimatesSummaryCard__Content Layer__TaxEstimatesSummaryCard__Content--mobile' gap='lg'>
-              <DonutChart categories={categories} total={total} />
-              <Legend categories={categories} total={total} isMobile={isMobile} />
-            </VStack>
-          )
-          : (
-            <HStack className='Layer__TaxEstimatesSummaryCard__Content' align='center' gap='lg'>
-              <DonutChart categories={categories} total={total} />
-              <Legend categories={categories} total={total} isMobile={false} />
-            </HStack>
-          )}
-        <NextPaymentBanner
-          isSummaryCardLayout={isSummaryCardLayout}
-          isMobile={isMobile}
-          nextTax={nextTax}
-        />
-      </VStack>
-    </Card>
+    <VStack className='Layer__TaxEstimatesSummaryCard__Container'>
+      <Card className={classNames('Layer__TaxEstimatesSummaryCard', isSummaryCardLayout && 'Layer__TaxEstimatesSummaryCard--summaryCard', className)}>
+        <VStack gap='md' className='Layer__TaxEstimatesSummaryCard__Body'>
+          <HStack
+            className={classNames('Layer__TaxEstimatesSummaryCard__Header', isSummaryCardLayout && 'Layer__SummaryCard__ContainerHeader')}
+            justify='space-between'
+            align={isSummaryCardLayout ? 'center' : 'start'}
+            gap='md'
+          >
+            <Span size='lg' weight='bold'>{title}</Span>
+            {headerAction}
+          </HStack>
+          {(isMobile || isSummaryCardLayout)
+            ? (
+              <VStack className='Layer__TaxEstimatesSummaryCard__Content Layer__TaxEstimatesSummaryCard__Content--mobile' gap='lg'>
+                <DonutChart categories={categories} total={total} />
+                <Legend categories={categories} total={total} isMobile={isMobile} />
+              </VStack>
+            )
+            : (
+              <HStack className='Layer__TaxEstimatesSummaryCard__Content' align='center' gap='lg'>
+                <DonutChart categories={categories} total={total} />
+                <Legend categories={categories} total={total} isMobile={false} />
+              </HStack>
+            )}
+          <NextPaymentBanner
+            isSummaryCardLayout={isSummaryCardLayout}
+            isMobile={isMobile}
+            nextTax={nextTax}
+          />
+        </VStack>
+      </Card>
+    </VStack>
   )
 }

--- a/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
+++ b/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
@@ -1,0 +1,60 @@
+import classNames from 'classnames'
+
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+import { Card } from '@components/Card/Card'
+
+import './taxEstimatesSummaryCard.scss'
+
+import { DonutChart } from './DonutChart'
+import { Legend } from './Legend'
+import { NextPaymentBanner } from './NextPaymentBanner'
+import type { SummaryCardProps } from './types'
+
+export const TaxEstimatesSummaryCard = ({
+  categories,
+  className,
+  headerAction,
+  layout = 'taxOverview',
+  nextTax,
+  title,
+  total,
+}: SummaryCardProps) => {
+  const { isMobile } = useSizeClass()
+  const isSummaryCardLayout = layout === 'summaryCard'
+
+  return (
+    <Card className={classNames('Layer__TaxEstimatesSummaryCard', isSummaryCardLayout && 'Layer__TaxEstimatesSummaryCard--summaryCard', className)}>
+      <VStack gap='md' className='Layer__TaxEstimatesSummaryCard__Body'>
+        <HStack
+          className={classNames('Layer__TaxEstimatesSummaryCard__Header', isSummaryCardLayout && 'Layer__SummaryCard__ContainerHeader')}
+          justify='space-between'
+          align={isSummaryCardLayout ? 'center' : 'start'}
+          gap='md'
+        >
+          <Span size='lg' weight='bold'>{title}</Span>
+          {headerAction}
+        </HStack>
+        {(isMobile || isSummaryCardLayout)
+          ? (
+            <VStack className='Layer__TaxEstimatesSummaryCard__Content Layer__TaxEstimatesSummaryCard__Content--mobile' gap='lg'>
+              <DonutChart categories={categories} total={total} />
+              <Legend categories={categories} total={total} isMobile={isMobile} />
+            </VStack>
+          )
+          : (
+            <HStack className='Layer__TaxEstimatesSummaryCard__Content' align='center' gap='lg'>
+              <DonutChart categories={categories} total={total} />
+              <Legend categories={categories} total={total} isMobile={false} />
+            </HStack>
+          )}
+        <NextPaymentBanner
+          isSummaryCardLayout={isSummaryCardLayout}
+          isMobile={isMobile}
+          nextTax={nextTax}
+        />
+      </VStack>
+    </Card>
+  )
+}

--- a/src/components/TaxEstimatesSummaryCard/constants.ts
+++ b/src/components/TaxEstimatesSummaryCard/constants.ts
@@ -11,6 +11,5 @@ export const getCategoryStroke = (key: TaxOverviewCategory['key']) => {
   switch (key) {
     case 'federal': return '#6D3CC8'
     case 'state': return '#D8B8F4'
-    case 'selfEmployment': return '#1E4D57'
   }
 }

--- a/src/components/TaxEstimatesSummaryCard/constants.ts
+++ b/src/components/TaxEstimatesSummaryCard/constants.ts
@@ -1,0 +1,16 @@
+import { type TaxOverviewCategory } from '@schemas/taxEstimates/overview'
+
+export const DONUT_RADIUS = 52
+export const DONUT_STROKE_WIDTH = 12
+export const DONUT_CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS
+export const DONUT_SEGMENT_GAP = 4
+
+export const getCategoryClassName = (key: TaxOverviewCategory['key']) => `Layer__TaxEstimatesSummaryCard__LegendSwatch--${key}`
+
+export const getCategoryStroke = (key: TaxOverviewCategory['key']) => {
+  switch (key) {
+    case 'federal': return '#6D3CC8'
+    case 'state': return '#D8B8F4'
+    case 'selfEmployment': return '#1E4D57'
+  }
+}

--- a/src/components/TaxEstimatesSummaryCard/taxEstimatesSummaryCard.scss
+++ b/src/components/TaxEstimatesSummaryCard/taxEstimatesSummaryCard.scss
@@ -4,6 +4,11 @@
   border-bottom: 1px solid var(--color-base-300);
 }
 
+.Layer__TaxEstimatesSummaryCard__Container {
+  container-type: inline-size;
+  min-width: 0;
+}
+
 .Layer__TaxEstimatesSummaryCard {
   min-width: 0;
 
@@ -166,7 +171,7 @@
   }
 }
 
-@media (width <= 720px) {
+@container (max-width: 760px) {
   .Layer__TaxEstimatesSummaryCard.Layer__card:not(.Layer__TaxEstimatesSummaryCard--summaryCard) {
     gap: var(--spacing-md);
     padding: var(--spacing-md);
@@ -198,9 +203,7 @@
     white-space: normal;
   }
 
-  .Layer__TaxEstimatesSummaryCard--summaryCard {
-    .Layer__TaxEstimatesSummaryCard__Header {
-      padding: var(--spacing-md);
-    }
+  .Layer__TaxEstimatesSummaryCard--summaryCard .Layer__TaxEstimatesSummaryCard__Header {
+    padding: var(--spacing-md);
   }
 }

--- a/src/components/TaxEstimatesSummaryCard/taxEstimatesSummaryCard.scss
+++ b/src/components/TaxEstimatesSummaryCard/taxEstimatesSummaryCard.scss
@@ -78,10 +78,6 @@
     &--state {
       background-color: #d8b8f4;
     }
-
-    &--selfEmployment {
-      background-color: #1e4d57;
-    }
   }
 
   &__DonutChart {

--- a/src/components/TaxEstimatesSummaryCard/taxEstimatesSummaryCard.scss
+++ b/src/components/TaxEstimatesSummaryCard/taxEstimatesSummaryCard.scss
@@ -1,0 +1,206 @@
+.Layer__SummaryCard__ContainerHeader {
+  box-sizing: border-box;
+  min-height: 85px;
+  border-bottom: 1px solid var(--color-base-300);
+}
+
+.Layer__TaxEstimatesSummaryCard {
+  min-width: 0;
+
+  &.Layer__card {
+    gap: var(--spacing-lg);
+    padding: var(--spacing-lg);
+    border: 1px solid var(--color-base-200);
+    box-shadow: none;
+  }
+
+  &__Content {
+    justify-content: space-between;
+    min-width: 0;
+  }
+
+  &__Content--mobile {
+    align-items: center;
+  }
+
+  &__Header,
+  &__Body {
+    min-width: 0;
+  }
+
+  &__Legend {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__LegendCard {
+    box-sizing: border-box;
+    width: 100%;
+    padding: var(--spacing-md);
+    border-radius: var(--border-radius-xs);
+    border: 1px solid var(--color-base-200);
+    background-color: var(--color-base-0);
+  }
+
+  &__LegendHeader {
+    padding-block-end: var(--spacing-xs);
+    border-block-end: 1px solid var(--color-base-100);
+  }
+
+  &__LegendHeaderValue {
+    color: var(--color-base-500);
+  }
+
+  &__LegendRow {
+    min-block-size: 2rem;
+  }
+
+  &__LegendValueGroup {
+    justify-content: flex-end;
+    min-inline-size: 12rem;
+  }
+
+  &__LegendSwatch {
+    display: inline-flex;
+    height: 0.75rem;
+    width: 0.75rem;
+    border-radius: var(--border-radius-2xs);
+
+    &--federal {
+      background-color: #6d3cc8;
+    }
+
+    &--state {
+      background-color: #d8b8f4;
+    }
+
+    &--selfEmployment {
+      background-color: #1e4d57;
+    }
+  }
+
+  &__DonutChart {
+    position: relative;
+    flex-shrink: 0;
+    aspect-ratio: 1;
+    width: 9.5rem;
+  }
+
+  &__DonutChartSvg {
+    height: 100%;
+    width: 100%;
+    transform: rotate(-90deg);
+  }
+
+  &__DonutChartTrack {
+    stroke: var(--color-base-100);
+  }
+
+  &__DonutChartCenter {
+    position: absolute;
+    inset: 0;
+  }
+
+  &__NextPaymentBanner {
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--border-radius-xs);
+    border: 1px solid var(--color-info-warning-bg);
+    background-color: var(--color-info-warning-bg);
+    color: var(--color-info-warning-fg);
+  }
+
+  &__NextPaymentBanner .Layer__MoneySpan {
+    color: var(--color-info-warning-fg);
+  }
+
+  &__NextPaymentCopy {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__NextPaymentText {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__NextPaymentIcon {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    height: 1.5rem;
+    width: 1.5rem;
+    border-radius: 999px;
+    background-color: color-mix(in srgb, var(--color-base-0), white 20%);
+    color: var(--color-info-warning-fg);
+    opacity: 0.75;
+  }
+
+  &--summaryCard {
+    &.Layer__card {
+      gap: 0;
+      width: auto;
+      max-width: 100%;
+      padding: 0;
+    }
+
+    .Layer__TaxEstimatesSummaryCard__Header {
+      padding: var(--spacing-lg);
+    }
+
+    .Layer__TaxEstimatesSummaryCard__Content {
+      align-items: center;
+      padding-block: var(--spacing-md);
+      padding-inline: var(--spacing-lg);
+      border-bottom: 1px solid var(--color-base-300);
+    }
+
+    .Layer__TaxEstimatesSummaryCard__Legend {
+      width: 100%;
+    }
+
+    .Layer__TaxEstimatesSummaryCard__NextPaymentBanner {
+      margin: var(--spacing-sm);
+    }
+  }
+}
+
+@media (width <= 720px) {
+  .Layer__TaxEstimatesSummaryCard.Layer__card:not(.Layer__TaxEstimatesSummaryCard--summaryCard) {
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+  }
+
+  .Layer__TaxEstimatesSummaryCard__Content {
+    align-items: center;
+  }
+
+  .Layer__TaxEstimatesSummaryCard__LegendCard {
+    min-inline-size: 0;
+  }
+
+  .Layer__TaxEstimatesSummaryCard__LegendValueGroup {
+    min-inline-size: 0;
+  }
+
+  .Layer__TaxEstimatesSummaryCard__DonutChart {
+    width: 11rem;
+  }
+
+  .Layer__TaxEstimatesSummaryCard__NextPaymentBanner {
+    gap: var(--spacing-sm);
+  }
+
+  .Layer__TaxEstimatesSummaryCard__NextPaymentText {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
+
+  .Layer__TaxEstimatesSummaryCard--summaryCard {
+    .Layer__TaxEstimatesSummaryCard__Header {
+      padding: var(--spacing-md);
+    }
+  }
+}

--- a/src/components/TaxEstimatesSummaryCard/types.ts
+++ b/src/components/TaxEstimatesSummaryCard/types.ts
@@ -7,7 +7,7 @@ export type SummaryCardProps = {
   className?: string
   headerAction?: ReactNode
   layout?: 'taxOverview' | 'summaryCard'
-  nextTax: TaxOverviewNextTax
+  nextTax?: TaxOverviewNextTax
   title: string
   total: number
 }

--- a/src/components/TaxEstimatesSummaryCard/types.ts
+++ b/src/components/TaxEstimatesSummaryCard/types.ts
@@ -1,0 +1,13 @@
+import { type ReactNode } from 'react'
+
+import { type TaxOverviewCategory, type TaxOverviewNextTax } from '@schemas/taxEstimates/overview'
+
+export type SummaryCardProps = {
+  categories: readonly TaxOverviewCategory[]
+  className?: string
+  headerAction?: ReactNode
+  layout?: 'taxOverview' | 'summaryCard'
+  nextTax: TaxOverviewNextTax
+  title: string
+  total: number
+}

--- a/src/components/TaxOverview/TaxDeadlinesCard.tsx
+++ b/src/components/TaxOverview/TaxDeadlinesCard.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next'
+
+import type { TaxOverviewData } from '@schemas/taxEstimates/overview'
+import { VStack } from '@ui/Stack/Stack'
+import { Heading } from '@ui/Typography/Heading'
+import { Card } from '@components/Card/Card'
+import type { TaxBannerReviewPayload } from '@components/TaxDetails/TaxBanner'
+import { TaxOverviewDeadlineCard } from '@components/TaxOverview/TaxOverviewDeadlineCard'
+
+type TaxDeadlinesCardProps = Pick<TaxOverviewData, 'annualDeadline' | 'paymentDeadlines'> & {
+  onTaxBannerReviewClick?: (payload: TaxBannerReviewPayload) => void
+}
+
+export const TaxDeadlinesCard = ({
+  annualDeadline,
+  onTaxBannerReviewClick,
+  paymentDeadlines,
+}: TaxDeadlinesCardProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <Card className='Layer__TaxOverview__Card'>
+      <VStack gap='lg'>
+        <Heading level={2} size='md'>{t('taxEstimates:label.your_tax_deadlines', 'Your tax deadlines')}</Heading>
+        <VStack gap='sm'>
+          {paymentDeadlines.map(deadline => (
+            <TaxOverviewDeadlineCard
+              key={deadline.id}
+              deadline={deadline}
+              onTaxBannerReviewClick={onTaxBannerReviewClick}
+            />
+          ))}
+          <TaxOverviewDeadlineCard
+            key={annualDeadline.id}
+            deadline={annualDeadline}
+            onTaxBannerReviewClick={onTaxBannerReviewClick}
+          />
+        </VStack>
+      </VStack>
+    </Card>
+  )
+}

--- a/src/components/TaxOverview/TaxOverview.tsx
+++ b/src/components/TaxOverview/TaxOverview.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from 'react-i18next'
 
 import {
   type TaxOverviewData,
-  type TaxOverviewNextTax,
 } from '@schemas/taxEstimates/overview'
 import { useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
 import { VStack } from '@ui/Stack/Stack'
@@ -14,15 +13,14 @@ import { TaxDeadlinesCard } from '@components/TaxOverview/TaxDeadlinesCard'
 import './taxOverview.scss'
 
 type TaxOverviewProps = {
-  nextTax: TaxOverviewNextTax
+  data: TaxOverviewData
   onTaxBannerReviewClick?: (payload: TaxBannerReviewPayload) => void
 }
 
 export const TaxOverview = ({
   data,
-  nextTax,
   onTaxBannerReviewClick,
-}: TaxOverviewProps & { data: TaxOverviewData }) => {
+}: TaxOverviewProps) => {
   const { t } = useTranslation()
   const { year } = useTaxEstimatesYear()
 
@@ -39,7 +37,7 @@ export const TaxOverview = ({
             title={t('taxEstimates:label.estimated_taxes_for_year', 'Estimated taxes for {{year}}', { year })}
             categories={data.estimatedTaxCategories}
             total={data.estimatedTaxesTotal}
-            nextTax={nextTax}
+            nextTax={data.nextTax}
           />
         </VStack>
         <TaxDeadlinesCard

--- a/src/components/TaxOverview/TaxOverview.tsx
+++ b/src/components/TaxOverview/TaxOverview.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from 'react-i18next'
+
+import {
+  type TaxOverviewData,
+  type TaxOverviewNextTax,
+} from '@schemas/taxEstimates/overview'
+import { useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
+import { VStack } from '@ui/Stack/Stack'
+import type { TaxBannerReviewPayload } from '@components/TaxDetails/TaxBanner'
+import { TaxEstimatesSummaryCard } from '@components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard'
+import { TaxableIncomeCard } from '@components/TaxOverview/TaxableIncomeCard'
+import { TaxDeadlinesCard } from '@components/TaxOverview/TaxDeadlinesCard'
+
+import './taxOverview.scss'
+
+type TaxOverviewProps = {
+  nextTax: TaxOverviewNextTax
+  onTaxBannerReviewClick?: (payload: TaxBannerReviewPayload) => void
+}
+
+export const TaxOverview = ({
+  data,
+  nextTax,
+  onTaxBannerReviewClick,
+}: TaxOverviewProps & { data: TaxOverviewData }) => {
+  const { t } = useTranslation()
+  const { year } = useTaxEstimatesYear()
+
+  return (
+    <VStack className='Layer__TaxOverview' gap='md'>
+      <VStack className='Layer__TaxOverview__Grid' gap='md'>
+        <VStack className='Layer__TaxOverview__PrimaryColumn' gap='md'>
+          <TaxableIncomeCard
+            incomeTotal={data.incomeTotal}
+            deductionsTotal={data.deductionsTotal}
+          />
+          <TaxEstimatesSummaryCard
+            className='Layer__TaxOverview__Card'
+            title={t('taxEstimates:label.estimated_taxes_for_year', 'Estimated taxes for {{year}}', { year })}
+            categories={data.estimatedTaxCategories}
+            total={data.estimatedTaxesTotal}
+            nextTax={nextTax}
+          />
+        </VStack>
+        <TaxDeadlinesCard
+          paymentDeadlines={data.paymentDeadlines}
+          annualDeadline={data.annualDeadline}
+          onTaxBannerReviewClick={onTaxBannerReviewClick}
+        />
+      </VStack>
+    </VStack>
+  )
+}

--- a/src/components/TaxOverview/TaxOverview.tsx
+++ b/src/components/TaxOverview/TaxOverview.tsx
@@ -26,26 +26,24 @@ export const TaxOverview = ({
 
   return (
     <VStack className='Layer__TaxOverview' gap='md'>
-      <VStack className='Layer__TaxOverview__Grid' gap='md'>
-        <VStack className='Layer__TaxOverview__PrimaryColumn' gap='md'>
-          <TaxableIncomeCard
-            incomeTotal={data.incomeTotal}
-            deductionsTotal={data.deductionsTotal}
-          />
-          <TaxEstimatesSummaryCard
-            className='Layer__TaxOverview__Card'
-            title={t('taxEstimates:label.estimated_taxes_for_year', 'Estimated taxes for {{year}}', { year })}
-            categories={data.estimatedTaxCategories}
-            total={data.estimatedTaxesTotal}
-            nextTax={data.nextTax}
-          />
-        </VStack>
-        <TaxDeadlinesCard
-          paymentDeadlines={data.paymentDeadlines}
-          annualDeadline={data.annualDeadline}
-          onTaxBannerReviewClick={onTaxBannerReviewClick}
+      <VStack className='Layer__TaxOverview__PrimaryColumn' gap='md'>
+        <TaxableIncomeCard
+          incomeTotal={data.incomeTotal}
+          deductionsTotal={data.deductionsTotal}
+        />
+        <TaxEstimatesSummaryCard
+          className='Layer__TaxOverview__Card'
+          title={t('taxEstimates:label.estimated_taxes_for_year', 'Estimated taxes for {{year}}', { year })}
+          categories={data.estimatedTaxCategories}
+          total={data.estimatedTaxesTotal}
+          nextTax={data.nextTax}
         />
       </VStack>
+      <TaxDeadlinesCard
+        paymentDeadlines={data.paymentDeadlines}
+        annualDeadline={data.annualDeadline}
+        onTaxBannerReviewClick={onTaxBannerReviewClick}
+      />
     </VStack>
   )
 }

--- a/src/components/TaxOverview/TaxOverview.tsx
+++ b/src/components/TaxOverview/TaxOverview.tsx
@@ -3,9 +3,13 @@ import { useTranslation } from 'react-i18next'
 import {
   type TaxOverviewData,
 } from '@schemas/taxEstimates/overview'
-import { useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
+import { tConditional } from '@utils/i18n/conditional'
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import { useFullYearProjection, useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
 import { VStack } from '@ui/Stack/Stack'
 import type { TaxBannerReviewPayload } from '@components/TaxDetails/TaxBanner'
+import { FullYearProjectionComboBox } from '@components/TaxEstimates/FullYearProjectionComboBox/FullYearProjectionComboBox'
+import { TaxEstimatesHeader } from '@components/TaxEstimates/TaxEstimatesHeader'
 import { TaxEstimatesSummaryCard } from '@components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard'
 import { TaxableIncomeCard } from '@components/TaxOverview/TaxableIncomeCard'
 import { TaxDeadlinesCard } from '@components/TaxOverview/TaxDeadlinesCard'
@@ -23,13 +27,50 @@ export const TaxOverview = ({
 }: TaxOverviewProps) => {
   const { t } = useTranslation()
   const { year } = useTaxEstimatesYear()
+  const { fullYearProjection } = useFullYearProjection()
+  const { isMobile } = useSizeClass()
+  const projectedCondition: 'default' | 'projected' = fullYearProjection ? 'projected' : 'default'
+
+  const taxableIncomeTitle = tConditional(t, 'taxEstimates:label.taxable_income_for_year', {
+    condition: projectedCondition,
+    cases: {
+      default: 'Taxable income for {{year}}',
+      projected: 'Projected taxable income for {{year}}',
+    },
+    contexts: {
+      projected: 'projected',
+    },
+    year,
+  })
+  const taxableIncomeDescription = tConditional(t, 'taxEstimates:label.taxable_income_estimate_to_date_for_year', {
+    condition: projectedCondition,
+    cases: {
+      default: 'Taxable income estimate to date for year {{year}}',
+      projected: 'Taxable income projection for year {{year}}',
+    },
+    contexts: {
+      projected: 'projected',
+    },
+    year,
+  })
 
   return (
     <VStack className='Layer__TaxOverview' gap='md'>
+      {isMobile && (
+        <TaxEstimatesHeader
+          title={taxableIncomeTitle}
+          description={taxableIncomeDescription}
+          isMobile
+        />
+      )}
       <VStack className='Layer__TaxOverview__PrimaryColumn' gap='md'>
         <TaxableIncomeCard
+          description={taxableIncomeDescription}
           incomeTotal={data.incomeTotal}
           deductionsTotal={data.deductionsTotal}
+          title={taxableIncomeTitle}
+          showHeader={!isMobile}
+          headerAction={!isMobile ? <FullYearProjectionComboBox /> : undefined}
         />
         <TaxEstimatesSummaryCard
           className='Layer__TaxOverview__Card'

--- a/src/components/TaxOverview/TaxOverviewDeadlineCard.tsx
+++ b/src/components/TaxOverview/TaxOverviewDeadlineCard.tsx
@@ -1,0 +1,115 @@
+import { Check, CircleAlert, Clock3, FileText } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { type TaxOverviewDeadline, type TaxOverviewDeadlineStatus } from '@schemas/taxEstimates/overview'
+import { DateFormat } from '@utils/i18n/date/patterns'
+import { tPlural } from '@utils/i18n/plural'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { Button } from '@ui/Button/Button'
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { Heading } from '@ui/Typography/Heading'
+import { MoneySpan } from '@ui/Typography/MoneySpan'
+import { Span } from '@ui/Typography/Text'
+import type { TaxBannerReviewPayload } from '@components/TaxDetails/TaxBanner'
+
+const getDeadlineAmountTone = (status?: TaxOverviewDeadlineStatus) => {
+  switch (status?.kind) {
+    case 'pastDue':
+      return 'pastDue'
+    case 'paid':
+      return 'paid'
+    case 'due':
+      return 'due'
+    case 'categorizationIncomplete':
+      return 'warning'
+    default:
+      return 'neutral'
+  }
+}
+
+const TaxOverviewDeadlineStatusIcon = ({ status }: { status?: TaxOverviewDeadlineStatus }) => {
+  const tone = getDeadlineAmountTone(status)
+  const Icon = (() => {
+    switch (status?.kind) {
+      case 'paid':
+        return Check
+      case 'due':
+        return Clock3
+      case 'pastDue':
+      case 'categorizationIncomplete':
+      default:
+        return CircleAlert
+    }
+  })()
+
+  return (
+    <Span
+      nonAria
+      className={`Layer__TaxOverview__AmountIcon Layer__TaxOverview__AmountIcon--${tone}`}
+    >
+      <Icon size={12} strokeWidth={2.25} />
+    </Span>
+  )
+}
+
+type TaxOverviewDeadlineCardProps = {
+  deadline: TaxOverviewDeadline
+  onTaxBannerReviewClick?: (payload: TaxBannerReviewPayload) => void
+}
+
+export const TaxOverviewDeadlineCard = ({
+  deadline,
+  onTaxBannerReviewClick,
+}: TaxOverviewDeadlineCardProps) => {
+  const { t } = useTranslation()
+  const { formatDate } = useIntlFormatter()
+  const reviewAction = deadline.reviewAction
+
+  return (
+    <VStack className='Layer__TaxOverview__DeadlineCard' gap='md'>
+      <HStack className='Layer__TaxOverview__DeadlineRow' justify='space-between' align='start' gap='md'>
+        <VStack className='Layer__TaxOverview__DeadlineContent' gap='3xs'>
+          <Heading level={3} size='sm'>{deadline.title}</Heading>
+          <Span size='sm' variant='subtle'>
+            {t('taxEstimates:label.due_with_date', 'Due: {{date}}', { date: formatDate(deadline.dueAt, DateFormat.DateShort) })}
+          </Span>
+        </VStack>
+        <VStack className='Layer__TaxOverview__DeadlineAmountColumn' align='end' gap='xs'>
+          <VStack align='end' gap='3xs'>
+            <HStack className='Layer__TaxOverview__DeadlineValueRow' align='center' gap='xs'>
+              <TaxOverviewDeadlineStatusIcon status={deadline.status} />
+              <MoneySpan size='lg' weight='bold' amount={deadline.amount} />
+            </HStack>
+            <VStack className='Layer__TaxOverview__DeadlineAmountCopy' align='end' gap='3xs'>
+              <Span size='xs' variant='subtle'>{deadline.description}</Span>
+            </VStack>
+          </VStack>
+        </VStack>
+      </HStack>
+      {reviewAction && (
+        <HStack className='Layer__TaxOverview__DeadlineReviewRow' justify='space-between' align='center' gap='md'>
+          <HStack className='Layer__TaxOverview__DeadlineReviewContent' align='center' gap='xs'>
+            <Span nonAria className='Layer__TaxOverview__DeadlineReviewIcon'>
+              <FileText size={12} />
+            </Span>
+            <Span className='Layer__TaxOverview__DeadlineReviewLabel' size='sm' weight='bold'>
+              {tPlural(t, 'taxEstimates:label.uncategorized_transactions', {
+                count: reviewAction.payload.count,
+                one: '{{count}} uncategorized transaction',
+                other: '{{count}} uncategorized transactions',
+              })}
+            </Span>
+          </HStack>
+          {onTaxBannerReviewClick && (
+            <Button
+              variant='outlined'
+              onPress={() => onTaxBannerReviewClick(reviewAction.payload)}
+            >
+              {t('taxEstimates:action.review_banner', 'Review')}
+            </Button>
+          )}
+        </HStack>
+      )}
+    </VStack>
+  )
+}

--- a/src/components/TaxOverview/TaxOverviewDeadlineCard.tsx
+++ b/src/components/TaxOverview/TaxOverviewDeadlineCard.tsx
@@ -47,7 +47,7 @@ const TaxOverviewDeadlineStatusIcon = ({ status }: { status?: TaxOverviewDeadlin
       nonAria
       className={`Layer__TaxOverview__AmountIcon Layer__TaxOverview__AmountIcon--${tone}`}
     >
-      <Icon size={12} strokeWidth={2.25} />
+      <Icon size={14} strokeWidth={2.25} />
     </Span>
   )
 }

--- a/src/components/TaxOverview/TaxableIncomeCard.tsx
+++ b/src/components/TaxOverview/TaxableIncomeCard.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next'
+
+import type { TaxOverviewData } from '@schemas/taxEstimates/overview'
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import { useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
+import { VStack } from '@ui/Stack/Stack'
+import { Heading } from '@ui/Typography/Heading'
+import { Span } from '@ui/Typography/Text'
+import { Card } from '@components/Card/Card'
+import { MetricRow } from '@components/MetricRow/MetricRow'
+
+type TaxableIncomeCardProps = Pick<TaxOverviewData, 'deductionsTotal' | 'incomeTotal'>
+
+export const TaxableIncomeCard = ({
+  deductionsTotal,
+  incomeTotal,
+}: TaxableIncomeCardProps) => {
+  const { t } = useTranslation()
+  const { year } = useTaxEstimatesYear()
+  const { isMobile } = useSizeClass()
+  const maxMeterValue = Math.max(incomeTotal, deductionsTotal, 1)
+
+  return (
+    <Card className='Layer__TaxOverview__Card'>
+      <VStack gap='xs'>
+        <Heading level={2} size='md'>
+          {t('taxEstimates:label.taxable_income_for_year', 'Taxable income for {{year}}', { year })}
+        </Heading>
+        <Span size='sm' variant='subtle'>
+          {t(
+            'taxEstimates:label.taxable_income_estimate_to_date_for_year',
+            'Taxable income estimate to date for year {{year}}',
+            { year },
+          )}
+        </Span>
+      </VStack>
+      <VStack gap={isMobile ? 'sm' : 'md'}>
+        <MetricRow
+          label={t('taxEstimates:label.total_income', 'Total income')}
+          amount={incomeTotal}
+          maxMeterValue={maxMeterValue}
+          meterClassName='Layer__TaxOverview__IncomeMeter'
+          isMobile={isMobile}
+        />
+        <MetricRow
+          label={t('taxEstimates:label.deductions', 'Deductions')}
+          amount={deductionsTotal}
+          maxMeterValue={maxMeterValue}
+          meterClassName='Layer__TaxOverview__DeductionsMeter'
+          isMobile={isMobile}
+        />
+      </VStack>
+    </Card>
+  )
+}

--- a/src/components/TaxOverview/TaxableIncomeCard.tsx
+++ b/src/components/TaxOverview/TaxableIncomeCard.tsx
@@ -38,6 +38,7 @@ export const TaxableIncomeCard = ({
         <MetricRow
           label={t('taxEstimates:label.total_income', 'Total income')}
           amount={incomeTotal}
+          classNamePrefix='Layer__TaxOverview'
           maxMeterValue={maxMeterValue}
           meterClassName='Layer__TaxOverview__IncomeMeter'
           isMobile={isMobile}
@@ -45,6 +46,7 @@ export const TaxableIncomeCard = ({
         <MetricRow
           label={t('taxEstimates:label.deductions', 'Deductions')}
           amount={deductionsTotal}
+          classNamePrefix='Layer__TaxOverview'
           maxMeterValue={maxMeterValue}
           meterClassName='Layer__TaxOverview__DeductionsMeter'
           isMobile={isMobile}

--- a/src/components/TaxOverview/TaxableIncomeCard.tsx
+++ b/src/components/TaxOverview/TaxableIncomeCard.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 
 import type { TaxOverviewData } from '@schemas/taxEstimates/overview'
-import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import { useWindowSize } from '@hooks/utils/size/useWindowSize'
 import { useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
 import { VStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
@@ -10,6 +10,7 @@ import { Card } from '@components/Card/Card'
 import { MetricRow } from '@components/MetricRow/MetricRow'
 
 type TaxableIncomeCardProps = Pick<TaxOverviewData, 'deductionsTotal' | 'incomeTotal'>
+const METRIC_ROW_MOBILE_BREAKPOINT = 600
 
 export const TaxableIncomeCard = ({
   deductionsTotal,
@@ -17,7 +18,8 @@ export const TaxableIncomeCard = ({
 }: TaxableIncomeCardProps) => {
   const { t } = useTranslation()
   const { year } = useTaxEstimatesYear()
-  const { isMobile } = useSizeClass()
+  const [viewportWidth] = useWindowSize()
+  const isMetricRowMobile = viewportWidth < METRIC_ROW_MOBILE_BREAKPOINT
   const maxMeterValue = Math.max(incomeTotal, deductionsTotal, 1)
 
   return (
@@ -34,14 +36,14 @@ export const TaxableIncomeCard = ({
           )}
         </Span>
       </VStack>
-      <VStack gap={isMobile ? 'sm' : 'md'}>
+      <VStack gap={isMetricRowMobile ? 'sm' : 'md'}>
         <MetricRow
           label={t('taxEstimates:label.total_income', 'Total income')}
           amount={incomeTotal}
           classNamePrefix='Layer__TaxOverview'
           maxMeterValue={maxMeterValue}
           meterClassName='Layer__TaxOverview__IncomeMeter'
-          isMobile={isMobile}
+          isMobile={isMetricRowMobile}
         />
         <MetricRow
           label={t('taxEstimates:label.deductions', 'Deductions')}
@@ -49,7 +51,7 @@ export const TaxableIncomeCard = ({
           classNamePrefix='Layer__TaxOverview'
           maxMeterValue={maxMeterValue}
           meterClassName='Layer__TaxOverview__DeductionsMeter'
-          isMobile={isMobile}
+          isMobile={isMetricRowMobile}
         />
       </VStack>
     </Card>

--- a/src/components/TaxOverview/TaxableIncomeCard.tsx
+++ b/src/components/TaxOverview/TaxableIncomeCard.tsx
@@ -1,41 +1,46 @@
+import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { TaxOverviewData } from '@schemas/taxEstimates/overview'
 import { useWindowSize } from '@hooks/utils/size/useWindowSize'
-import { useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
-import { VStack } from '@ui/Stack/Stack'
+import { HStack, VStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
 import { Span } from '@ui/Typography/Text'
 import { Card } from '@components/Card/Card'
 import { MetricRow } from '@components/MetricRow/MetricRow'
 
-type TaxableIncomeCardProps = Pick<TaxOverviewData, 'deductionsTotal' | 'incomeTotal'>
+type TaxableIncomeCardProps = Pick<TaxOverviewData, 'deductionsTotal' | 'incomeTotal'> & {
+  title: string
+  description: string
+  showHeader?: boolean
+  headerAction?: ReactNode
+}
 const METRIC_ROW_MOBILE_BREAKPOINT = 600
 
 export const TaxableIncomeCard = ({
+  description,
   deductionsTotal,
+  headerAction,
   incomeTotal,
+  showHeader = true,
+  title,
 }: TaxableIncomeCardProps) => {
   const { t } = useTranslation()
-  const { year } = useTaxEstimatesYear()
   const [viewportWidth] = useWindowSize()
   const isMetricRowMobile = viewportWidth < METRIC_ROW_MOBILE_BREAKPOINT
   const maxMeterValue = Math.max(incomeTotal, deductionsTotal, 1)
 
   return (
     <Card className='Layer__TaxOverview__Card'>
-      <VStack gap='xs'>
-        <Heading level={2} size='md'>
-          {t('taxEstimates:label.taxable_income_for_year', 'Taxable income for {{year}}', { year })}
-        </Heading>
-        <Span size='sm' variant='subtle'>
-          {t(
-            'taxEstimates:label.taxable_income_estimate_to_date_for_year',
-            'Taxable income estimate to date for year {{year}}',
-            { year },
-          )}
-        </Span>
-      </VStack>
+      {showHeader && (
+        <VStack gap='xs'>
+          <HStack justify='space-between' align='start' gap='md'>
+            <Heading level={2} size='md'>{title}</Heading>
+            {headerAction}
+          </HStack>
+          <Span size='sm' variant='subtle'>{description}</Span>
+        </VStack>
+      )}
       <VStack gap={isMetricRowMobile ? 'sm' : 'md'}>
         <MetricRow
           label={t('taxEstimates:label.total_income', 'Total income')}

--- a/src/components/TaxOverview/taxOverview.scss
+++ b/src/components/TaxOverview/taxOverview.scss
@@ -1,13 +1,13 @@
 .Layer__TaxOverview {
+  /* &__Grid { */
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(23rem, 0.92fr);
+  gap: var(--spacing-md);
+  align-items: start;
   inline-size: min(100%, 1406px);
   container-type: inline-size;
 
-  &__Grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(23rem, 0.92fr);
-    gap: var(--spacing-md);
-    align-items: start;
-  }
+  /* } */
 
   &__PrimaryColumn {
     min-width: 0;
@@ -157,7 +157,7 @@
 }
 
 @container (max-width: 920px) {
-  .Layer__TaxOverview__Grid {
+  .Layer__TaxOverview {
     grid-template-columns: 1fr;
   }
 }

--- a/src/components/TaxOverview/taxOverview.scss
+++ b/src/components/TaxOverview/taxOverview.scss
@@ -1,13 +1,10 @@
 .Layer__TaxOverview {
-  /* &__Grid { */
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(23rem, 0.92fr);
   gap: var(--spacing-md);
   align-items: start;
   inline-size: min(100%, 1406px);
   container-type: inline-size;
-
-  /* } */
 
   &__PrimaryColumn {
     min-width: 0;

--- a/src/components/TaxOverview/taxOverview.scss
+++ b/src/components/TaxOverview/taxOverview.scss
@@ -1,0 +1,185 @@
+.Layer__TaxOverview {
+  inline-size: min(100%, 1406px);
+  container-type: inline-size;
+
+  &__Grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(23rem, 0.92fr);
+    gap: var(--spacing-md);
+    align-items: start;
+  }
+
+  &__PrimaryColumn {
+    min-width: 0;
+  }
+
+  &__Card.Layer__card {
+    gap: var(--spacing-lg);
+    padding: var(--spacing-lg);
+    border: 1px solid var(--color-base-200);
+    box-shadow: none;
+  }
+
+  &__MetricRow {
+    min-block-size: 2.5rem;
+  }
+
+  &__MetricCard {
+    min-width: 0;
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--border-radius-xs);
+    background-color: var(--color-base-50);
+  }
+
+  &__MetricCardLabel {
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
+  &__MetricCardMeter {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__MetricValue {
+    flex: 0 0 56%;
+    justify-content: flex-end;
+    min-width: 0;
+  }
+
+  &__IncomeMeter,
+  &__DeductionsMeter {
+    flex: 1;
+    min-width: 9rem;
+  }
+
+  &__MetricCard .Layer__TaxOverview__IncomeMeter,
+  &__MetricCard .Layer__TaxOverview__DeductionsMeter {
+    width: 100%;
+    min-width: 0;
+  }
+
+  &__MetricCard .Layer__MoneySpan {
+    flex-shrink: 0;
+  }
+
+  &__IncomeMeter__track,
+  &__DeductionsMeter__track {
+    fill: var(--color-base-100);
+  }
+
+  &__IncomeMeter__fill {
+    fill: #6d3cc8;
+  }
+
+  &__DeductionsMeter__fill {
+    fill: #1c7e9a;
+  }
+
+  &__DeadlineCard {
+    box-sizing: border-box;
+    min-width: 0;
+    padding: var(--spacing-md);
+    border-radius: var(--border-radius-xs);
+    border: 1px solid var(--color-base-200);
+    background-color: var(--color-base-0);
+  }
+
+  &__DeadlineContent {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__DeadlineAmountColumn {
+    flex-shrink: 0;
+    min-width: 10rem;
+  }
+
+  &__DeadlineValueRow {
+    justify-content: flex-end;
+  }
+
+  &__AmountIcon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 1.25rem;
+    width: 1.25rem;
+    border-radius: 999px;
+    background-color: var(--color-info-neutral-bg);
+    color: var(--color-info-neutral-fg);
+
+    &--neutral {
+      background-color: var(--color-info-neutral-bg);
+      color: var(--color-info-neutral-fg);
+    }
+
+    &--warning {
+      background-color: var(--color-info-warning-bg);
+      color: var(--color-info-warning-fg);
+    }
+
+    &--pastDue {
+      background-color: var(--color-info-error-bg);
+      color: var(--color-info-error);
+    }
+
+    &--paid {
+      background-color: var(--color-info-success-bg);
+      color: var(--color-info-success);
+    }
+
+    &--due {
+      background-color: var(--color-info-bg);
+      color: var(--color-info);
+    }
+  }
+
+  &__DeadlineReviewRow {
+    padding-block-start: var(--spacing-xs);
+    border-block-start: 1px solid var(--color-base-100);
+  }
+
+  &__DeadlineReviewContent {
+    min-width: 0;
+  }
+
+  &__DeadlineReviewIcon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-info-warning);
+  }
+
+  &__DeadlineReviewLabel {
+    color: var(--color-info-warning-fg);
+  }
+}
+
+@container (max-width: 920px) {
+  .Layer__TaxOverview__Grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@container (max-width: 720px) {
+  .Layer__TaxOverview__MetricRow,
+  .Layer__TaxOverview__MetricValue,
+  .Layer__TaxOverview__DeadlineReviewRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .Layer__TaxOverview__Card.Layer__card {
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+  }
+
+  .Layer__TaxOverview__MetricValue {
+    flex-basis: auto;
+  }
+
+  .Layer__TaxOverview__DeadlineReviewRow .Layer__button {
+    width: 100%;
+  }
+}

--- a/src/components/ui/Banner/Banner.tsx
+++ b/src/components/ui/Banner/Banner.tsx
@@ -126,9 +126,11 @@ const Banner = forwardRef<HTMLDivElement, BannerProps>((
       {...dataProperties}
       {...ariaProperties}
     >
-      <HStack align='center' justify='center' className={BANNER_CLASS_NAMES.ICON_CONTAINER}>
-        {renderedIcon}
-      </HStack>
+      {slots?.Icon !== null && (
+        <HStack align='center' justify='center' className={BANNER_CLASS_NAMES.ICON_CONTAINER}>
+          {renderedIcon}
+        </HStack>
+      )}
       <BannerContent title={title} description={description}>
         {children}
       </BannerContent>

--- a/src/components/ui/Banner/Banner.tsx
+++ b/src/components/ui/Banner/Banner.tsx
@@ -17,7 +17,7 @@ export const BANNER_CLASS_NAMES = {
   ACTIONS: 'Layer__UI__Banner__actions',
 }
 
-export type BannerVariant = 'default' | 'info' | 'warning' | 'error' | 'success'
+export type BannerVariant = 'default' | 'info' | 'warning' | 'error' | 'success' | 'dark'
 
 export type BannerProps = PropsWithChildren<{
   variant?: BannerVariant
@@ -44,6 +44,7 @@ function getAriaProperties(
     case 'success':
     case 'info':
       return { 'role': 'status', 'aria-atomic': true }
+    case 'dark':
     case 'default':
     default:
       return { 'role': 'region', 'aria-label': ariaLabel ?? 'Notification' }

--- a/src/components/ui/Banner/banner.scss
+++ b/src/components/ui/Banner/banner.scss
@@ -45,6 +45,14 @@
     --banner-fg-muted: var(--color-base-600);
     --banner-icon-color: var(--color-base-800);
   }
+
+  &[data-variant='dark'] {
+    --banner-bg: var(--color-base-900);
+    --banner-border-color: var(--color-base-800);
+    --banner-fg: var(--color-base-0);
+    --banner-fg-muted: var(--color-base-300);
+    --banner-icon-color: var(--color-base-900);
+  }
 }
 
 .Layer__UI__Banner__iconContainer {
@@ -67,6 +75,31 @@
 
 .Layer__UI__Banner__actions {
   flex-shrink: 0;
+}
+
+.Layer__UI__Banner[data-variant='dark'] .Layer__UI__Banner__iconContainer {
+  flex-shrink: 0;
+  min-block-size: 2rem;
+  min-inline-size: 2rem;
+  border-radius: var(--border-radius-2xs);
+  border: 1px solid var(--color-base-200);
+  background-color: var(--color-base-0);
+}
+
+.Layer__UI__Banner[data-variant='dark'] .Layer__UI__Button {
+  --button-bg-default: var(--color-base-0);
+  --button-fg-default: var(--color-base-900);
+  --button-bg-active: var(--color-base-200);
+  --button-bg-disabled: var(--color-base-200);
+  --button-fg-disabled: var(--color-base-600);
+
+  --button-fg-ghost: var(--color-base-0);
+  --button-border-color-ghost: var(--color-base-500);
+  --button-border-color-ghost-active: var(--color-base-0);
+  --button-bg-ghost-hovered: hsl(var(--color-light-h) var(--color-light-s) var(--color-light-l) / 10%);
+  --button-bg-ghost-pressed: hsl(var(--color-light-h) var(--color-light-s) var(--color-light-l) / 16%);
+
+  --outline-default: var(--color-base-400);
 }
 
 @container (max-width: 560px) {

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
@@ -47,7 +47,7 @@ function buildKey({
   apiUrl?: string
   businessId: string
   year: number
-  reportingBasis?: ReportingBasis
+  reportingBasis?: TaxReportingBasis
   fullYearProjection?: boolean
   enabled?: boolean
 }) {

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
@@ -15,9 +15,10 @@ type UseTaxOverviewOptions = {
   year: number
   reportingBasis?: ReportingBasis
   fullYearProjection?: boolean
+  enabled?: boolean
 }
 
-type GetTaxOverviewParams = UseTaxOverviewOptions & {
+type GetTaxOverviewParams = Omit<UseTaxOverviewOptions, 'enabled'> & {
   businessId: string
 }
 
@@ -39,6 +40,7 @@ function buildKey({
   year,
   reportingBasis,
   fullYearProjection,
+  enabled = true,
 }: {
   access_token?: string
   apiUrl?: string
@@ -46,7 +48,12 @@ function buildKey({
   year: number
   reportingBasis?: ReportingBasis
   fullYearProjection?: boolean
+  enabled?: boolean
 }) {
+  if (!enabled) {
+    return
+  }
+
   if (accessToken && apiUrl) {
     return {
       accessToken,
@@ -60,7 +67,7 @@ function buildKey({
   }
 }
 
-export function useTaxOverview({ year, reportingBasis, fullYearProjection }: UseTaxOverviewOptions) {
+export function useTaxOverview({ year, reportingBasis, fullYearProjection, enabled = true }: UseTaxOverviewOptions) {
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
 
@@ -71,6 +78,7 @@ export function useTaxOverview({ year, reportingBasis, fullYearProjection }: Use
       year,
       reportingBasis,
       fullYearProjection,
+      enabled,
     }),
     async ({ accessToken, apiUrl, businessId, year, reportingBasis, fullYearProjection }) => {
       return getTaxOverview(

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
@@ -1,0 +1,94 @@
+import { Schema } from 'effect'
+import useSWR from 'swr'
+
+import type { ReportingBasis } from '@internal-types/general'
+import { type TaxOverviewApiResponse, TaxOverviewApiResponseSchema } from '@schemas/taxEstimates/overview'
+import { get } from '@utils/api/authenticatedHttp'
+import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
+import { useAuth } from '@hooks/utils/auth/useAuth'
+import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+
+const TAX_OVERVIEW_TAG_KEY = '#tax-overview'
+
+type UseTaxOverviewOptions = {
+  year: number
+  reportingBasis?: ReportingBasis
+  fullYearProjection?: boolean
+}
+
+type GetTaxOverviewParams = UseTaxOverviewOptions & {
+  businessId: string
+}
+
+const getTaxOverview = get<TaxOverviewApiResponse, GetTaxOverviewParams>(
+  ({ businessId, year, reportingBasis, fullYearProjection }) => {
+    const parameters = toDefinedSearchParameters({
+      year,
+      reporting_basis: reportingBasis,
+      full_year_projection: fullYearProjection,
+    })
+    return `/v1/businesses/${businessId}/tax-estimates/overview?${parameters}`
+  },
+)
+
+function buildKey({
+  access_token: accessToken,
+  apiUrl,
+  businessId,
+  year,
+  reportingBasis,
+  fullYearProjection,
+}: {
+  access_token?: string
+  apiUrl?: string
+  businessId: string
+  year: number
+  reportingBasis?: ReportingBasis
+  fullYearProjection?: boolean
+}) {
+  if (accessToken && apiUrl) {
+    return {
+      accessToken,
+      apiUrl,
+      businessId,
+      year,
+      reportingBasis,
+      fullYearProjection,
+      tags: [TAX_OVERVIEW_TAG_KEY],
+    } as const
+  }
+}
+
+export function useTaxOverview({ year, reportingBasis, fullYearProjection }: UseTaxOverviewOptions) {
+  const { data: auth } = useAuth()
+  const { businessId } = useLayerContext()
+
+  const swrResponse = useSWR(
+    () => buildKey({
+      ...auth,
+      businessId,
+      year,
+      reportingBasis,
+      fullYearProjection,
+    }),
+    async ({ accessToken, apiUrl, businessId, year, reportingBasis, fullYearProjection }) => {
+      return getTaxOverview(
+        apiUrl,
+        accessToken,
+        {
+          params: {
+            businessId,
+            year,
+            reportingBasis,
+            fullYearProjection,
+          },
+        },
+      )()
+        .then(Schema.decodeUnknownPromise(TaxOverviewApiResponseSchema))
+        .then(({ data }) => data)
+    },
+  )
+
+  return new SWRQueryResult(swrResponse)
+}

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
@@ -18,9 +18,10 @@ type UseTaxSummaryOptions = {
   year: number
   reportingBasis?: TaxReportingBasis
   fullYearProjection?: boolean
+  enabled?: boolean
 }
 
-type GetTaxSummaryParams = UseTaxSummaryOptions & {
+type GetTaxSummaryParams = Omit<UseTaxSummaryOptions, 'enabled'> & {
   businessId: string
 }
 
@@ -38,6 +39,7 @@ function buildKey({
   year,
   reportingBasis,
   fullYearProjection,
+  enabled = true,
 }: {
   access_token?: string
   apiUrl?: string
@@ -45,7 +47,12 @@ function buildKey({
   year: number
   reportingBasis?: TaxReportingBasis
   fullYearProjection?: boolean
+  enabled?: boolean
 }) {
+  if (!enabled) {
+    return
+  }
+
   if (accessToken && apiUrl) {
     return {
       accessToken,
@@ -59,7 +66,7 @@ function buildKey({
   }
 }
 
-export function useTaxSummary({ year, reportingBasis, fullYearProjection }: UseTaxSummaryOptions) {
+export function useTaxSummary({ year, reportingBasis, fullYearProjection, enabled = true }: UseTaxSummaryOptions) {
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
 
@@ -70,6 +77,7 @@ export function useTaxSummary({ year, reportingBasis, fullYearProjection }: UseT
       year,
       reportingBasis,
       fullYearProjection,
+      enabled,
     }),
     async ({ accessToken, apiUrl, businessId, year, reportingBasis, fullYearProjection }) => {
       return getTaxSummary(

--- a/src/providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider.tsx
+++ b/src/providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider.tsx
@@ -5,6 +5,7 @@ import { createStore, useStore } from 'zustand'
 import { useTaxProfile } from '@hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile'
 
 export enum TaxEstimatesRoute {
+  Overview = 'Overview',
   Estimates = 'Estimates',
   Payments = 'Payments',
   Profile = 'Profile',
@@ -35,7 +36,7 @@ type TaxEstimatesRouteStoreShape = {
 
 const TaxEstimatesRouteStoreContext = createContext(
   createStore<TaxEstimatesRouteStoreShape>(() => ({
-    routeState: { route: TaxEstimatesRoute.Estimates },
+    routeState: { route: TaxEstimatesRoute.Overview },
     onboardingStatus: OnboardingStatus.Loading,
     navigate: () => {},
     year: getYear(new Date()),
@@ -86,7 +87,7 @@ export function TaxEstimatesRouteStoreProvider(props: PropsWithChildren) {
   const { data: taxProfile, isLoading, isError } = useTaxProfile()
   const [store] = useState(() =>
     createStore<TaxEstimatesRouteStoreShape>(set => ({
-      routeState: { route: TaxEstimatesRoute.Estimates },
+      routeState: { route: TaxEstimatesRoute.Overview },
       onboardingStatus: OnboardingStatus.Loading,
       navigate: (route: TaxEstimatesRoute) => {
         set({ routeState: { route } })

--- a/src/schemas/taxEstimates/banner.ts
+++ b/src/schemas/taxEstimates/banner.ts
@@ -51,16 +51,16 @@ export type TaxEstimatesBanner = typeof TaxEstimatesBannerSchema.Type
 export const getTaxEstimatesBannerQuarterStatus = (
   quarter: TaxEstimatesBannerQuarter,
 ): TaxOverviewDeadlineStatus => {
-  if (quarter.uncategorizedCount > 0) {
-    return { kind: 'categorizationIncomplete' }
-  }
-
   if (quarter.amountOwed > 0 && quarter.balance <= 0) {
     return { kind: 'paid' }
   }
 
   if (quarter.isPastDue) {
     return { kind: 'pastDue' }
+  }
+
+  if (quarter.uncategorizedCount > 0) {
+    return { kind: 'categorizationIncomplete' }
   }
 
   return { kind: 'due' }

--- a/src/schemas/taxEstimates/banner.ts
+++ b/src/schemas/taxEstimates/banner.ts
@@ -1,5 +1,7 @@
 import { pipe, Schema } from 'effect'
 
+import type { TaxOverviewDeadlineStatus, TaxOverviewNextTax } from '@schemas/taxEstimates/overview'
+
 const TaxEstimatesBannerQuarterSchema = Schema.Struct({
   quarter: Schema.Number,
   dueDate: pipe(
@@ -45,6 +47,46 @@ const TaxEstimatesBannerSchema = Schema.Struct({
 })
 
 export type TaxEstimatesBanner = typeof TaxEstimatesBannerSchema.Type
+
+export const getTaxEstimatesBannerQuarterStatus = (
+  quarter: TaxEstimatesBannerQuarter,
+): TaxOverviewDeadlineStatus => {
+  if (quarter.uncategorizedCount > 0) {
+    return { kind: 'categorizationIncomplete' }
+  }
+
+  if (quarter.amountOwed > 0 && quarter.balance <= 0) {
+    return { kind: 'paid' }
+  }
+
+  if (quarter.isPastDue) {
+    return { kind: 'pastDue' }
+  }
+
+  return { kind: 'due' }
+}
+
+export const getNextTaxFromTaxEstimatesBanner = (
+  taxBanner?: TaxEstimatesBanner,
+): TaxOverviewNextTax | undefined => {
+  if (!taxBanner) {
+    return
+  }
+
+  const nextQuarter = taxBanner.quarters.find(quarter => !quarter.isPastDue && quarter.amountOwed > 0)
+    ?? taxBanner.quarters.find(quarter => quarter.amountOwed > 0)
+
+  if (!nextQuarter) {
+    return
+  }
+
+  return {
+    quarter: nextQuarter.quarter,
+    amount: nextQuarter.amountOwed,
+    dueAt: nextQuarter.dueDate,
+    status: getTaxEstimatesBannerQuarterStatus(nextQuarter),
+  }
+}
 
 export const TaxEstimatesBannerResponseSchema = Schema.Struct({
   data: TaxEstimatesBannerSchema,

--- a/src/schemas/taxEstimates/banner.ts
+++ b/src/schemas/taxEstimates/banner.ts
@@ -73,8 +73,8 @@ export const getNextTaxFromTaxEstimatesBanner = (
     return
   }
 
-  const nextQuarter = taxBanner.quarters.find(quarter => !quarter.isPastDue && quarter.amountOwed > 0)
-    ?? taxBanner.quarters.find(quarter => quarter.amountOwed > 0)
+  const nextQuarter = taxBanner.quarters.find(quarter => !quarter.isPastDue && quarter.balance > 0)
+    ?? taxBanner.quarters.find(quarter => quarter.balance > 0)
 
   if (!nextQuarter) {
     return
@@ -82,7 +82,7 @@ export const getNextTaxFromTaxEstimatesBanner = (
 
   return {
     quarter: nextQuarter.quarter,
-    amount: nextQuarter.amountOwed,
+    amount: nextQuarter.balance,
     dueAt: nextQuarter.dueDate,
     status: getTaxEstimatesBannerQuarterStatus(nextQuarter),
   }

--- a/src/schemas/taxEstimates/overview.ts
+++ b/src/schemas/taxEstimates/overview.ts
@@ -101,7 +101,7 @@ const TaxOverviewNextTaxSchema = Schema.Struct({
 
 export type TaxOverviewNextTax = typeof TaxOverviewNextTaxSchema.Type
 
-const TaxOverviewDataSchema = Schema.Struct({
+const _TaxOverviewDataSchema = Schema.Struct({
   annualDeadline: TaxOverviewDeadlineSchema,
   bannerReview: Schema.optional(TaxOverviewBannerReviewSchema),
   deductionsTotal: Schema.Number,
@@ -112,10 +112,4 @@ const TaxOverviewDataSchema = Schema.Struct({
   paymentDeadlines: Schema.Array(TaxOverviewDeadlineSchema),
 })
 
-export type TaxOverviewData = typeof TaxOverviewDataSchema.Type
-
-export const TaxOverviewResponseSchema = Schema.Struct({
-  data: TaxOverviewDataSchema,
-})
-
-export type TaxOverviewResponse = typeof TaxOverviewResponseSchema.Type
+export type TaxOverviewData = typeof _TaxOverviewDataSchema.Type

--- a/src/schemas/taxEstimates/overview.ts
+++ b/src/schemas/taxEstimates/overview.ts
@@ -42,7 +42,7 @@ export type TaxOverviewBannerReview = {
   type: 'UNCATEGORIZED_TRANSACTIONS'
 }
 
-export type TaxOverviewCategoryKey = 'federal' | 'selfEmployment' | 'state'
+export type TaxOverviewCategoryKey = 'federal' | 'state'
 
 export type TaxOverviewCategory = {
   amount: number

--- a/src/schemas/taxEstimates/overview.ts
+++ b/src/schemas/taxEstimates/overview.ts
@@ -108,7 +108,7 @@ const TaxOverviewDataSchema = Schema.Struct({
   estimatedTaxCategories: Schema.Array(TaxOverviewCategorySchema),
   estimatedTaxesTotal: Schema.Number,
   incomeTotal: Schema.Number,
-  nextTax: TaxOverviewNextTaxSchema,
+  nextTax: Schema.optional(TaxOverviewNextTaxSchema),
   paymentDeadlines: Schema.Array(TaxOverviewDeadlineSchema),
 })
 

--- a/src/schemas/taxEstimates/overview.ts
+++ b/src/schemas/taxEstimates/overview.ts
@@ -1,0 +1,121 @@
+import { pipe, Schema } from 'effect'
+
+// ============================================================
+// API Response Schema - matches actual /tax-estimates/overview endpoint
+// ============================================================
+
+const TaxOverviewApiDataSchema = Schema.Struct({
+  year: Schema.Number,
+  excludesPendingTransactions: pipe(
+    Schema.optionalWith(Schema.Boolean, { default: () => true }),
+    Schema.fromKey('excludes_pending_transactions'),
+  ),
+  taxableIncomeEstimate: pipe(
+    Schema.propertySignature(Schema.Number),
+    Schema.fromKey('taxable_income_estimate'),
+  ),
+  totalIncome: pipe(
+    Schema.propertySignature(Schema.Number),
+    Schema.fromKey('total_income'),
+  ),
+  totalDeductions: pipe(
+    Schema.propertySignature(Schema.Number),
+    Schema.fromKey('total_deductions'),
+  ),
+  estimatedTaxesOwed: pipe(
+    Schema.propertySignature(Schema.Number),
+    Schema.fromKey('estimated_taxes_owed'),
+  ),
+  taxesDueDate: pipe(
+    Schema.optionalWith(Schema.Date, { nullable: true }),
+    Schema.fromKey('taxes_due_date'),
+  ),
+})
+
+export type TaxOverviewApiData = typeof TaxOverviewApiDataSchema.Type
+
+export const TaxOverviewApiResponseSchema = Schema.Struct({
+  data: TaxOverviewApiDataSchema,
+})
+
+export type TaxOverviewApiResponse = typeof TaxOverviewApiResponseSchema.Type
+
+// ============================================================
+// Legacy Types - used by UI components (will be derived from multiple endpoints)
+// ============================================================
+
+const TaxOverviewBannerReviewSchema = Schema.Struct({
+  type: Schema.Literal('UNCATEGORIZED_TRANSACTIONS'),
+  count: Schema.Number,
+  amount: Schema.Number,
+})
+
+export type TaxOverviewBannerReview = typeof TaxOverviewBannerReviewSchema.Type
+
+const TaxOverviewCategoryKeySchema = Schema.Literal('federal', 'selfEmployment', 'state')
+
+export type TaxOverviewCategoryKey = typeof TaxOverviewCategoryKeySchema.Type
+
+const TaxOverviewCategorySchema = Schema.Struct({
+  amount: Schema.Number,
+  key: TaxOverviewCategoryKeySchema,
+  label: Schema.String,
+})
+
+export type TaxOverviewCategory = typeof TaxOverviewCategorySchema.Type
+
+const TaxOverviewDeadlineStatusKindSchema = Schema.Literal('pastDue', 'paid', 'due', 'categorizationIncomplete')
+
+export type TaxOverviewDeadlineStatusKind = typeof TaxOverviewDeadlineStatusKindSchema.Type
+
+const TaxOverviewDeadlineStatusSchema = Schema.Struct({
+  kind: TaxOverviewDeadlineStatusKindSchema,
+})
+
+export type TaxOverviewDeadlineStatus = typeof TaxOverviewDeadlineStatusSchema.Type
+
+const TaxOverviewDeadlineReviewActionSchema = Schema.Struct({
+  payload: TaxOverviewBannerReviewSchema,
+})
+
+export type TaxOverviewDeadlineReviewAction = typeof TaxOverviewDeadlineReviewActionSchema.Type
+
+const TaxOverviewDeadlineSchema = Schema.Struct({
+  amount: Schema.Number,
+  description: Schema.String,
+  dueAt: Schema.Date,
+  id: Schema.String,
+  reviewAction: Schema.optional(TaxOverviewDeadlineReviewActionSchema),
+  status: Schema.optional(TaxOverviewDeadlineStatusSchema),
+  title: Schema.String,
+})
+
+export type TaxOverviewDeadline = typeof TaxOverviewDeadlineSchema.Type
+
+const TaxOverviewNextTaxSchema = Schema.Struct({
+  amount: Schema.Number,
+  dueAt: Schema.Date,
+  quarter: Schema.Number,
+  status: TaxOverviewDeadlineStatusSchema,
+})
+
+export type TaxOverviewNextTax = typeof TaxOverviewNextTaxSchema.Type
+
+const TaxOverviewDataSchema = Schema.Struct({
+  annualDeadline: TaxOverviewDeadlineSchema,
+  bannerReview: Schema.optional(TaxOverviewBannerReviewSchema),
+  deductionsTotal: Schema.Number,
+  estimatedTaxCategories: Schema.Array(TaxOverviewCategorySchema),
+  estimatedTaxesTotal: Schema.Number,
+  incomeTotal: Schema.Number,
+  nextTax: TaxOverviewNextTaxSchema,
+  paymentDeadlines: Schema.Array(TaxOverviewDeadlineSchema),
+})
+
+export type TaxOverviewData = typeof TaxOverviewDataSchema.Type
+
+export const TaxOverviewResponseSchema = Schema.Struct({
+  data: TaxOverviewDataSchema,
+})
+
+export type TaxOverviewResponse = typeof TaxOverviewResponseSchema.Type

--- a/src/schemas/taxEstimates/overview.ts
+++ b/src/schemas/taxEstimates/overview.ts
@@ -10,10 +10,6 @@ const TaxOverviewApiDataSchema = Schema.Struct({
     Schema.optionalWith(Schema.Boolean, { default: () => true }),
     Schema.fromKey('excludes_pending_transactions'),
   ),
-  taxableIncomeEstimate: pipe(
-    Schema.propertySignature(Schema.Number),
-    Schema.fromKey('taxable_income_estimate'),
-  ),
   totalIncome: pipe(
     Schema.propertySignature(Schema.Number),
     Schema.fromKey('total_income'),
@@ -21,10 +17,6 @@ const TaxOverviewApiDataSchema = Schema.Struct({
   totalDeductions: pipe(
     Schema.propertySignature(Schema.Number),
     Schema.fromKey('total_deductions'),
-  ),
-  estimatedTaxesOwed: pipe(
-    Schema.propertySignature(Schema.Number),
-    Schema.fromKey('estimated_taxes_owed'),
   ),
   taxesDueDate: pipe(
     Schema.optionalWith(Schema.Date, { nullable: true }),

--- a/src/schemas/taxEstimates/summary.ts
+++ b/src/schemas/taxEstimates/summary.ts
@@ -1,6 +1,11 @@
 import { pipe, Schema } from 'effect'
 
+const TaxSummarySectionTypeSchema = Schema.Literal('federal', 'state')
+
+export type TaxSummarySectionType = typeof TaxSummarySectionTypeSchema.Type
+
 const TaxSummarySectionSchema = Schema.Struct({
+  type: TaxSummarySectionTypeSchema,
   label: Schema.String,
   total: Schema.Number,
   taxesPaid: pipe(

--- a/src/styles/view.scss
+++ b/src/styles/view.scss
@@ -19,7 +19,7 @@
     width: 100%;
     max-width: 100%;
 
-    padding: 0 var(--spacing-md);
+    padding: 0 var(--spacing-lg);
     border-bottom: 1px solid var(--border-color);
     container-type: inline-size;
 
@@ -37,7 +37,7 @@
     align-items: center;
     min-height: 44px;
     width: 100%;
-    padding: var(--spacing-md) var(--spacing-sm);
+    padding: var(--spacing-md) 0;
   }
 
   .Layer__view-header__content {
@@ -45,7 +45,7 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    max-width: 1460px;
+    max-width: 1406px;
   }
 
   .Layer__view-header--paddings {

--- a/src/views/TaxEstimates/TaxEstimates.tsx
+++ b/src/views/TaxEstimates/TaxEstimates.tsx
@@ -1,172 +1,41 @@
-import { useCallback, useMemo } from 'react'
-import { getYear } from 'date-fns'
-import { Menu as MenuIcon, UserRoundPen } from 'lucide-react'
-import type { Key } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
 
-import { translationKey } from '@utils/i18n/translationKey'
-import { convertDateToZonedDateTime } from '@utils/time/timeUtils'
-import { useBusinessActivationDate } from '@hooks/features/business/useBusinessActivationDate'
-import {
-  OnboardingStatus,
-  TaxEstimatesRoute,
-  TaxEstimatesRouteStoreProvider,
-  useTaxEstimatesNavigation,
-  useTaxEstimatesOnboardingStatus,
-  useTaxEstimatesRouteState,
-  useTaxEstimatesYear,
-} from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
-import { Button } from '@ui/Button/Button'
-import { DropdownMenu, MenuItem, MenuList } from '@ui/DropdownMenu/DropdownMenu'
-import { HStack } from '@ui/Stack/Stack'
-import { Toggle } from '@ui/Toggle/Toggle'
-import { Span } from '@ui/Typography/Text'
+import { TaxEstimatesRouteStoreProvider } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
+import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { Container } from '@components/Container/Container'
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
-import { Loader } from '@components/Loader/Loader'
-import { TaxDetails } from '@components/TaxDetails/TaxDetails'
-import { TaxPayments } from '@components/TaxPayments/TaxPayments'
 import { View } from '@components/View/View'
-import { YearPicker } from '@components/YearPicker/YearPicker'
-import { TaxProfile } from '@views/TaxEstimates/TaxProfile'
+import type { TaxEstimatesViewProps } from '@views/TaxEstimates/taxEstimatesTypes'
+import { TaxEstimatesViewContent } from '@views/TaxEstimates/TaxEstimatesViewContent'
 
-const TAX_ESTIMATES_MIN_YEAR = 2024
+export type { TaxEstimatesViewProps } from '@views/TaxEstimates/taxEstimatesTypes'
 
-export const TaxEstimatesView = () => {
-  return (
-    <TaxEstimatesRouteStoreProvider>
-      <TaxEstimatesViewContent />
-    </TaxEstimatesRouteStoreProvider>
-  )
-}
-
-const TaxEstimatesViewContent = () => {
+export const TaxEstimatesView = ({ onTaxBannerReviewClick }: TaxEstimatesViewProps) => {
   const { t } = useTranslation()
-  const onboardingStatus = useTaxEstimatesOnboardingStatus()
-  const header = useMemo(
-    () => onboardingStatus === OnboardingStatus.Onboarded && <TaxEstimatesViewHeader />,
-    [onboardingStatus],
-  )
+  const { accountingConfiguration } = useLayerContext()
 
-  const viewContent = useMemo(() => {
-    switch (onboardingStatus) {
-      case OnboardingStatus.Loading:
-        return (
-          <Container name='tax-estimates'>
-            <Loader />
-          </Container>
-        )
-
-      case OnboardingStatus.Error:
-        return (
-          <Container name='tax-estimates'>
-            <DataState
-              status={DataStateStatus.failed}
-              title={t('taxEstimates:error.load_tax_information', 'Unable to load tax information')}
-              description={t('taxEstimates:error.retrieve_tax_profile', 'We couldn’t retrieve your tax profile. Please check your connection and try again.')}
-              spacing
-            />
-          </Container>
-        )
-
-      case OnboardingStatus.Onboarded:
-        return <TaxEstimatesOnboardedViewContent />
-
-      case OnboardingStatus.NotOnboarded:
-      default:
-        return <TaxProfile />
-    }
-  }, [onboardingStatus, t])
-
-  return (
-    <View title={t('common:label.taxes', 'Taxes')} header={header}>
-      {viewContent}
-    </View>
-  )
-}
-
-const TaxEstimatesViewHeader = () => {
-  const { t } = useTranslation()
-  const navigate = useTaxEstimatesNavigation()
-  const { year, setYear } = useTaxEstimatesYear()
-  const activationDate = useBusinessActivationDate()
-
-  const minDateZdt = useMemo(() => {
-    const activationYear = activationDate ? getYear(activationDate) : TAX_ESTIMATES_MIN_YEAR
-    const effectiveMinYear = Math.max(activationYear, TAX_ESTIMATES_MIN_YEAR)
-    return convertDateToZonedDateTime(new Date(effectiveMinYear, 0, 1))
-  }, [activationDate])
-
-  const maxDateZdt = useMemo(() => convertDateToZonedDateTime(new Date()), [])
-
-  const Trigger = useCallback(() => {
+  if (accountingConfiguration?.enableTaxEstimates === false) {
     return (
-      <Button icon variant='outlined'>
-        <MenuIcon size={14} />
-      </Button>
+      <View title={t('common:label.taxes', 'Taxes')}>
+        <Container name='tax-estimates'>
+          <DataState
+            status={DataStateStatus.failed}
+            title={t('common:state.feature_not_enabled', 'Feature not enabled')}
+            description={t(
+              'common:label.feature_not_enabled_for_business',
+              '{{featureName}} is not enabled.',
+              { featureName: t('taxEstimates:label.tax_estimates', 'Tax estimates') },
+            )}
+            spacing
+          />
+        </Container>
+      </View>
     )
-  }, [])
-
-  return (
-    <HStack gap='xs'>
-      <YearPicker
-        year={year}
-        onChange={setYear}
-        minDate={minDateZdt}
-        maxDate={maxDateZdt}
-      />
-      <DropdownMenu
-        ariaLabel={t('taxEstimates:label.additional_actions', 'Additional actions')}
-        slots={{ Trigger }}
-        slotProps={{ Dialog: { width: 160 } }}
-      >
-        <MenuList>
-          <MenuItem key={TaxEstimatesRoute.Profile} onClick={() => navigate(TaxEstimatesRoute.Profile)}>
-            <UserRoundPen size={20} strokeWidth={1.25} />
-            <Span size='sm'>{t('taxEstimates:action.update_tax_profile', 'Update tax profile')}</Span>
-          </MenuItem>
-        </MenuList>
-      </DropdownMenu>
-    </HStack>
-  )
-}
-
-const TAX_ESTIMATES_TAB_CONFIG = [
-  { value: TaxEstimatesRoute.Estimates, ...translationKey('taxEstimates:label.estimates', 'Estimates') },
-  { value: TaxEstimatesRoute.Payments, ...translationKey('taxEstimates:label.payments', 'Payments') },
-]
-
-const TaxEstimatesOnboardedViewContent = () => {
-  const { t } = useTranslation()
-  const { route } = useTaxEstimatesRouteState()
-  const navigate = useTaxEstimatesNavigation()
-
-  const tabOptions = useMemo(
-    () => TAX_ESTIMATES_TAB_CONFIG.map(opt => ({
-      value: opt.value,
-      label: t(opt.i18nKey, opt.defaultValue),
-    })),
-    [t],
-  )
-
-  const handleTabChange = useCallback((key: Key) => {
-    navigate(key as TaxEstimatesRoute)
-  }, [navigate])
-
-  if (route === TaxEstimatesRoute.Profile) {
-    return <TaxProfile />
   }
 
   return (
-    <>
-      <Toggle
-        ariaLabel={t('taxEstimates:label.tax_estimate_view', 'Tax estimate view')}
-        options={tabOptions}
-        selectedKey={route}
-        onSelectionChange={handleTabChange}
-      />
-      {route === TaxEstimatesRoute.Estimates && <TaxDetails />}
-      {route === TaxEstimatesRoute.Payments && <TaxPayments />}
-    </>
+    <TaxEstimatesRouteStoreProvider>
+      <TaxEstimatesViewContent onTaxBannerReviewClick={onTaxBannerReviewClick} />
+    </TaxEstimatesRouteStoreProvider>
   )
 }

--- a/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useMemo } from 'react'
+import type { Key } from 'react-aria-components'
+import { useTranslation } from 'react-i18next'
+
+import { getNextTaxFromTaxEstimatesBanner, getTaxEstimatesBannerQuarterStatus, type TaxEstimatesBanner } from '@schemas/taxEstimates/banner'
+import type { TaxOverviewCategory, TaxOverviewCategoryKey, TaxOverviewData, TaxOverviewDeadline } from '@schemas/taxEstimates/overview'
+import { convertCentsToDecimalString } from '@utils/format'
+import { tPlural } from '@utils/i18n/plural'
+import { translationKey } from '@utils/i18n/translationKey'
+import { useTaxEstimatesBanner } from '@hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner'
+import { useTaxOverview } from '@hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview'
+import { useTaxSummary } from '@hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary'
+import { TaxEstimatesRoute, useTaxEstimatesNavigation, useTaxEstimatesRouteState, useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
+import { VStack } from '@ui/Stack/Stack'
+import { Toggle } from '@ui/Toggle/Toggle'
+import { TaxBanner, type TaxBannerReviewPayload } from '@components/TaxDetails/TaxBanner'
+import { TaxDetails } from '@components/TaxDetails/TaxDetails'
+import { TaxOverview } from '@components/TaxOverview/TaxOverview'
+import { TaxPayments } from '@components/TaxPayments/TaxPayments'
+import { TaxProfile } from '@views/TaxEstimates/TaxProfile'
+
+import type { TaxEstimatesViewProps } from './taxEstimatesTypes'
+
+const TAX_ESTIMATES_TAB_CONFIG = [
+  { value: TaxEstimatesRoute.Overview, ...translationKey('common:label.overview', 'Overview') },
+  { value: TaxEstimatesRoute.Estimates, ...translationKey('taxEstimates:label.estimates', 'Estimates') },
+  { value: TaxEstimatesRoute.Payments, ...translationKey('taxEstimates:label.payments', 'Payments') },
+]
+
+const SECTION_TO_CATEGORY_KEY: Record<string, TaxOverviewCategoryKey> = {
+  'Federal Income & Self-Employment Tax': 'federal',
+  'State Income Tax': 'state',
+}
+
+const getTaxBannerReviewPayload = (taxBanner?: TaxEstimatesBanner): TaxBannerReviewPayload | undefined => {
+  if (!taxBanner || taxBanner.totalUncategorizedCount <= 0) {
+    return
+  }
+
+  return {
+    type: 'UNCATEGORIZED_TRANSACTIONS',
+    count: taxBanner.totalUncategorizedCount,
+    amount: taxBanner.totalUncategorizedSum,
+  }
+}
+
+const transformSummaryToCategories = (
+  sections: ReadonlyArray<{ label: string, taxesOwed: number }>,
+): TaxOverviewCategory[] => {
+  return sections
+    .map((section): TaxOverviewCategory | undefined => {
+      const key = SECTION_TO_CATEGORY_KEY[section.label]
+
+      if (!key) {
+        return
+      }
+
+      return {
+        key,
+        label: key === 'federal' ? 'Federal + SE' : 'State',
+        amount: section.taxesOwed,
+      }
+    })
+    .filter((category): category is TaxOverviewCategory => category !== undefined)
+}
+
+const transformBannerToDeadlines = (
+  banner: TaxEstimatesBanner,
+): TaxOverviewDeadline[] => {
+  return banner.quarters.map(quarter => ({
+    id: `quarter-${quarter.quarter}`,
+    title: `Q${quarter.quarter} taxes`,
+    dueAt: quarter.dueDate,
+    amount: quarter.balance,
+    description: 'Estimated tax',
+    status: getTaxEstimatesBannerQuarterStatus(quarter),
+    reviewAction: quarter.uncategorizedCount > 0
+      ? {
+        payload: {
+          type: 'UNCATEGORIZED_TRANSACTIONS',
+          count: quarter.uncategorizedCount,
+          amount: quarter.uncategorizedSum,
+        },
+      }
+      : undefined,
+  }))
+}
+
+export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: TaxEstimatesViewProps) => {
+  const { t } = useTranslation()
+  const { route } = useTaxEstimatesRouteState()
+  const navigate = useTaxEstimatesNavigation()
+  const { year } = useTaxEstimatesYear()
+  const { data: taxBannerData } = useTaxEstimatesBanner({ year })
+  const { data: taxOverviewApi } = useTaxOverview({ year })
+  const { data: taxSummary } = useTaxSummary({ year })
+
+  const handleTaxBannerReview = useCallback((payload: TaxBannerReviewPayload) => {
+    onTaxBannerReviewClick?.(payload)
+  }, [onTaxBannerReviewClick])
+
+  const tabOptions = useMemo(
+    () => TAX_ESTIMATES_TAB_CONFIG.map(opt => ({
+      value: opt.value,
+      label: t(opt.i18nKey, opt.defaultValue),
+    })),
+    [t],
+  )
+
+  const handleTabChange = useCallback((key: Key) => {
+    navigate(key as TaxEstimatesRoute)
+  }, [navigate])
+
+  const uncategorizedReviewPayload = useMemo(
+    () => getTaxBannerReviewPayload(taxBannerData),
+    [taxBannerData],
+  )
+  const nextTax = useMemo(
+    () => getNextTaxFromTaxEstimatesBanner(taxBannerData),
+    [taxBannerData],
+  )
+
+  const taxOverviewData = useMemo((): TaxOverviewData | undefined => {
+    if (!taxOverviewApi || !taxSummary || !taxBannerData || !nextTax) {
+      return undefined
+    }
+
+    const estimatedTaxCategories = transformSummaryToCategories(taxSummary.sections)
+    const paymentDeadlines = transformBannerToDeadlines(taxBannerData)
+
+    return {
+      incomeTotal: taxOverviewApi.totalIncome,
+      deductionsTotal: taxOverviewApi.totalDeductions,
+      estimatedTaxCategories,
+      estimatedTaxesTotal: taxSummary.projectedTaxesOwed,
+      nextTax,
+      paymentDeadlines,
+      annualDeadline: {
+        id: 'annual-income-taxes',
+        title: 'Annual income taxes',
+        dueAt: new Date(year + 1, 3, 15),
+        amount: taxSummary.projectedTaxesOwed,
+        description: 'Estimated tax',
+      },
+    }
+  }, [taxOverviewApi, taxSummary, taxBannerData, nextTax, year])
+
+  const taxBanner = uncategorizedReviewPayload && (
+    <VStack className='Layer__TaxEstimates__TaxBannerWrapper'>
+      <TaxBanner
+        title={t('taxEstimates:banner.categorization_incomplete.title', 'Your tax estimates are incomplete')}
+        description={tPlural(
+          t,
+          'taxEstimates:banner.categorization_incomplete.description',
+          {
+            count: uncategorizedReviewPayload.count,
+            amount: convertCentsToDecimalString(uncategorizedReviewPayload.amount),
+            one: 'You have {{count}} uncategorized transaction with ${{amount}} in potential deductions to review.',
+            other: 'You have {{count}} uncategorized transactions with ${{amount}} in potential deductions to review.',
+          },
+        )}
+        action={{
+          label: t('taxEstimates:action.review_banner', 'Review'),
+          onPress: handleTaxBannerReview,
+          payload: uncategorizedReviewPayload,
+        }}
+      />
+    </VStack>
+  )
+
+  if (route === TaxEstimatesRoute.Profile) {
+    return <TaxProfile />
+  }
+
+  return (
+    <VStack gap='md'>
+      <Toggle
+        ariaLabel={t('taxEstimates:label.tax_estimate_view', 'Tax estimate view')}
+        options={tabOptions}
+        selectedKey={route}
+        onSelectionChange={handleTabChange}
+      />
+      {taxBanner}
+      {route === TaxEstimatesRoute.Overview && taxOverviewData && nextTax && (
+        <TaxOverview
+          data={taxOverviewData}
+          nextTax={nextTax}
+          onTaxBannerReviewClick={onTaxBannerReviewClick}
+        />
+      )}
+      {route === TaxEstimatesRoute.Estimates && <TaxDetails />}
+      {route === TaxEstimatesRoute.Payments && <TaxPayments />}
+    </VStack>
+  )
+}

--- a/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
@@ -27,10 +27,7 @@ const TAX_ESTIMATES_TAB_CONFIG = [
   { value: TaxEstimatesRoute.Payments, ...translationKey('taxEstimates:label.payments', 'Payments') },
 ]
 
-const SECTION_TO_CATEGORY_KEY: Record<string, TaxOverviewCategoryKey> = {
-  'Federal Income & Self-Employment Tax': 'federal',
-  'State Income Tax': 'state',
-}
+const TAX_OVERVIEW_CATEGORY_KEYS: readonly TaxOverviewCategoryKey[] = ['federal', 'state', 'selfEmployment']
 
 const getTaxBannerReviewPayload = (taxBanner?: TaxEstimatesBanner): TaxBannerReviewPayload | undefined => {
   if (!taxBanner || taxBanner.totalUncategorizedCount <= 0) {
@@ -48,8 +45,8 @@ const transformSummaryToCategories = (
   sections: ReadonlyArray<{ label: string, taxesOwed: number }>,
 ): TaxOverviewCategory[] => {
   return sections
-    .map((section): TaxOverviewCategory | undefined => {
-      const key = SECTION_TO_CATEGORY_KEY[section.label]
+    .map((section, index): TaxOverviewCategory | undefined => {
+      const key = TAX_OVERVIEW_CATEGORY_KEYS[index]
 
       if (!key) {
         return
@@ -57,7 +54,7 @@ const transformSummaryToCategories = (
 
       return {
         key,
-        label: key === 'federal' ? 'Federal + SE' : 'State',
+        label: section.label,
         amount: section.taxesOwed,
       }
     })
@@ -121,7 +118,7 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
   )
 
   const taxOverviewData = useMemo((): TaxOverviewData | undefined => {
-    if (!taxOverviewApi || !taxSummary || !taxBannerData || !nextTax) {
+    if (!taxOverviewApi || !taxSummary || !taxBannerData) {
       return undefined
     }
 
@@ -133,7 +130,7 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
       deductionsTotal: taxOverviewApi.totalDeductions,
       estimatedTaxCategories,
       estimatedTaxesTotal: taxSummary.projectedTaxesOwed,
-      nextTax,
+      ...(nextTax ? { nextTax } : {}),
       paymentDeadlines,
       annualDeadline: {
         id: 'annual-income-taxes',
@@ -146,7 +143,7 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
   }, [taxOverviewApi, taxSummary, taxBannerData, nextTax, year])
 
   const taxBanner = uncategorizedReviewPayload && (
-    <VStack className='Layer__TaxEstimates__TaxBannerWrapper'>
+    <VStack>
       <TaxBanner
         title={t('taxEstimates:banner.categorization_incomplete.title', 'Your tax estimates are incomplete')}
         description={tPlural(
@@ -181,10 +178,9 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
         onSelectionChange={handleTabChange}
       />
       {taxBanner}
-      {route === TaxEstimatesRoute.Overview && taxOverviewData && nextTax && (
+      {route === TaxEstimatesRoute.Overview && taxOverviewData && (
         <TaxOverview
           data={taxOverviewData}
-          nextTax={nextTax}
           onTaxBannerReviewClick={onTaxBannerReviewClick}
         />
       )}

--- a/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
@@ -24,6 +24,8 @@ import { TaxPayments } from '@components/TaxPayments/TaxPayments'
 import { ConditionalBlock } from '@components/utility/ConditionalBlock'
 import { TaxProfile } from '@views/TaxEstimates/TaxProfile'
 
+import './taxEstimatesOnboardedViewContent.scss'
+
 import type { TaxEstimatesViewProps } from './taxEstimatesTypes'
 
 const TAX_ESTIMATES_TAB_CONFIG = [
@@ -143,7 +145,7 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
   }, [taxOverviewApi, taxSummary, taxBannerData, nextTax, t, year])
 
   const taxBanner = uncategorizedReviewPayload && (
-    <VStack>
+    <VStack className='Layer__TaxEstimates__TaxBannerWrapper'>
       <TaxBanner
         title={t('taxEstimates:banner.categorization_incomplete.title', 'Your tax estimates are incomplete')}
         description={tPlural(

--- a/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
@@ -80,12 +80,17 @@ const transformBannerToDeadlines = (
 export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: TaxEstimatesViewProps) => {
   const { t } = useTranslation()
   const { route } = useTaxEstimatesRouteState()
+  const isOverviewRoute = route === TaxEstimatesRoute.Overview
   const navigate = useTaxEstimatesNavigation()
   const { year } = useTaxEstimatesYear()
   const { fullYearProjection } = useFullYearProjection()
   const { data: taxBannerData, isLoading: isTaxBannerLoading, isError: isTaxBannerError } = useTaxEstimatesBanner({ year })
-  const { data: taxOverviewApi, isLoading: isTaxOverviewLoading, isError: isTaxOverviewError } = useTaxOverview({ year, fullYearProjection })
-  const { data: taxSummary, isLoading: isTaxSummaryLoading, isError: isTaxSummaryError } = useTaxSummary({ year, fullYearProjection })
+  const { data: taxOverviewApi, isLoading: isTaxOverviewLoading, isError: isTaxOverviewError } = useTaxOverview({
+    year,
+    fullYearProjection,
+    enabled: isOverviewRoute,
+  })
+  const { data: taxSummary, isLoading: isTaxSummaryLoading, isError: isTaxSummaryError } = useTaxSummary({ year, fullYearProjection, enabled: isOverviewRoute })
 
   const handleTaxBannerReview = useCallback((payload: TaxBannerReviewPayload) => {
     onTaxBannerReviewClick?.(payload)
@@ -176,7 +181,7 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
         onSelectionChange={handleTabChange}
       />
       {taxBanner}
-      {route === TaxEstimatesRoute.Overview && (
+      {isOverviewRoute && (
         <ConditionalBlock
           isLoading={isOverviewLoading}
           isError={isOverviewError}

--- a/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useMemo } from 'react'
+import type { TFunction } from 'i18next'
 import type { Key } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
 
 import { getNextTaxFromTaxEstimatesBanner, getTaxEstimatesBannerQuarterStatus, type TaxEstimatesBanner } from '@schemas/taxEstimates/banner'
-import type { TaxOverviewCategory, TaxOverviewCategoryKey, TaxOverviewData, TaxOverviewDeadline } from '@schemas/taxEstimates/overview'
+import type { TaxSummarySection } from '@schemas/taxEstimates/summary'
+import type { TaxOverviewCategory, TaxOverviewData, TaxOverviewDeadline } from '@schemas/taxEstimates/overview'
 import { convertCentsToDecimalString } from '@utils/format'
 import { tPlural } from '@utils/i18n/plural'
 import { translationKey } from '@utils/i18n/translationKey'
@@ -27,8 +29,6 @@ const TAX_ESTIMATES_TAB_CONFIG = [
   { value: TaxEstimatesRoute.Payments, ...translationKey('taxEstimates:label.payments', 'Payments') },
 ]
 
-const TAX_OVERVIEW_CATEGORY_KEYS: readonly TaxOverviewCategoryKey[] = ['federal', 'state', 'selfEmployment']
-
 const getTaxBannerReviewPayload = (taxBanner?: TaxEstimatesBanner): TaxBannerReviewPayload | undefined => {
   if (!taxBanner || taxBanner.totalUncategorizedCount <= 0) {
     return
@@ -42,34 +42,25 @@ const getTaxBannerReviewPayload = (taxBanner?: TaxEstimatesBanner): TaxBannerRev
 }
 
 const transformSummaryToCategories = (
-  sections: ReadonlyArray<{ label: string, taxesOwed: number }>,
+  sections: ReadonlyArray<Pick<TaxSummarySection, 'label' | 'taxesOwed' | 'type'>>,
 ): TaxOverviewCategory[] => {
-  return sections
-    .map((section, index): TaxOverviewCategory | undefined => {
-      const key = TAX_OVERVIEW_CATEGORY_KEYS[index]
-
-      if (!key) {
-        return
-      }
-
-      return {
-        key,
-        label: section.label,
-        amount: section.taxesOwed,
-      }
-    })
-    .filter((category): category is TaxOverviewCategory => category !== undefined)
+  return sections.map(section => ({
+    key: section.type,
+    label: section.label,
+    amount: section.taxesOwed,
+  }))
 }
 
 const transformBannerToDeadlines = (
   banner: TaxEstimatesBanner,
+  t: TFunction,
 ): TaxOverviewDeadline[] => {
   return banner.quarters.map(quarter => ({
     id: `quarter-${quarter.quarter}`,
-    title: `Q${quarter.quarter} taxes`,
+    title: t('taxEstimates:label.quarter_taxes', 'Q{{quarter}} taxes', { quarter: quarter.quarter }),
     dueAt: quarter.dueDate,
     amount: quarter.balance,
-    description: 'Estimated tax',
+    description: t('taxEstimates:label.estimated_tax', 'Estimated tax'),
     status: getTaxEstimatesBannerQuarterStatus(quarter),
     reviewAction: quarter.uncategorizedCount > 0
       ? {
@@ -123,7 +114,7 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
     }
 
     const estimatedTaxCategories = transformSummaryToCategories(taxSummary.sections)
-    const paymentDeadlines = transformBannerToDeadlines(taxBannerData)
+    const paymentDeadlines = transformBannerToDeadlines(taxBannerData, t)
 
     return {
       incomeTotal: taxOverviewApi.totalIncome,
@@ -134,13 +125,13 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
       paymentDeadlines,
       annualDeadline: {
         id: 'annual-income-taxes',
-        title: 'Annual income taxes',
+        title: t('taxEstimates:label.annual_income_taxes', 'Annual income taxes'),
         dueAt: new Date(year + 1, 3, 15),
         amount: taxSummary.projectedTaxesOwed,
-        description: 'Estimated tax',
+        description: t('taxEstimates:label.estimated_tax', 'Estimated tax'),
       },
     }
-  }, [taxOverviewApi, taxSummary, taxBannerData, nextTax, year])
+  }, [taxOverviewApi, taxSummary, taxBannerData, nextTax, t, year])
 
   const taxBanner = uncategorizedReviewPayload && (
     <VStack>

--- a/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
@@ -86,7 +86,7 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
   const navigate = useTaxEstimatesNavigation()
   const { year } = useTaxEstimatesYear()
   const { fullYearProjection } = useFullYearProjection()
-  const { data: taxBannerData, isLoading: isTaxBannerLoading, isError: isTaxBannerError } = useTaxEstimatesBanner({ year })
+  const { data: taxBannerData, isLoading: isTaxBannerLoading, isError: isTaxBannerError } = useTaxEstimatesBanner({ year, fullYearProjection })
   const { data: taxOverviewApi, isLoading: isTaxOverviewLoading, isError: isTaxOverviewError } = useTaxOverview({
     year,
     fullYearProjection,

--- a/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
@@ -187,7 +187,7 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
             <DataState
               status={DataStateStatus.failed}
               title={t('taxEstimates:error.load_tax_estimates', 'We couldn\'t load your tax estimates')}
-              description={t('taxEstimates:error.load_tax_estimates', 'An error occurred while loading your tax estimates. Please check your connection and try again.')}
+              description={t('taxEstimates:error.while_loading_tax_estimates', 'An error occurred while loading your tax estimates. Please check your connection and try again.')}
               spacing
             />
           )}

--- a/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
@@ -135,7 +135,7 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
       annualDeadline: {
         id: 'annual-income-taxes',
         title: t('taxEstimates:label.annual_income_taxes', 'Annual income taxes'),
-        dueAt: new Date(year + 1, 3, 15),
+        dueAt: taxOverviewApi.taxesDueDate ?? new Date(year + 1, 3, 15),
         amount: taxSummary.projectedTaxesOwed,
         description: t('taxEstimates:label.estimated_tax', 'Estimated tax'),
       },

--- a/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
@@ -4,15 +4,15 @@ import type { Key } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
 
 import { getNextTaxFromTaxEstimatesBanner, getTaxEstimatesBannerQuarterStatus, type TaxEstimatesBanner } from '@schemas/taxEstimates/banner'
-import type { TaxSummarySection } from '@schemas/taxEstimates/summary'
 import type { TaxOverviewCategory, TaxOverviewData, TaxOverviewDeadline } from '@schemas/taxEstimates/overview'
+import type { TaxSummarySection } from '@schemas/taxEstimates/summary'
 import { convertCentsToDecimalString } from '@utils/format'
 import { tPlural } from '@utils/i18n/plural'
 import { translationKey } from '@utils/i18n/translationKey'
 import { useTaxEstimatesBanner } from '@hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner'
 import { useTaxOverview } from '@hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview'
 import { useTaxSummary } from '@hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary'
-import { TaxEstimatesRoute, useTaxEstimatesNavigation, useTaxEstimatesRouteState, useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
+import { TaxEstimatesRoute, useFullYearProjection, useTaxEstimatesNavigation, useTaxEstimatesRouteState, useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
 import { VStack } from '@ui/Stack/Stack'
 import { Toggle } from '@ui/Toggle/Toggle'
 import { TaxBanner, type TaxBannerReviewPayload } from '@components/TaxDetails/TaxBanner'
@@ -79,9 +79,10 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
   const { route } = useTaxEstimatesRouteState()
   const navigate = useTaxEstimatesNavigation()
   const { year } = useTaxEstimatesYear()
+  const { fullYearProjection } = useFullYearProjection()
   const { data: taxBannerData } = useTaxEstimatesBanner({ year })
-  const { data: taxOverviewApi } = useTaxOverview({ year })
-  const { data: taxSummary } = useTaxSummary({ year })
+  const { data: taxOverviewApi } = useTaxOverview({ year, fullYearProjection })
+  const { data: taxSummary } = useTaxSummary({ year, fullYearProjection })
 
   const handleTaxBannerReview = useCallback((payload: TaxBannerReviewPayload) => {
     onTaxBannerReviewClick?.(payload)

--- a/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesOnboardedViewContent.tsx
@@ -15,10 +15,13 @@ import { useTaxSummary } from '@hooks/api/businesses/[business-id]/tax-estimates
 import { TaxEstimatesRoute, useFullYearProjection, useTaxEstimatesNavigation, useTaxEstimatesRouteState, useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
 import { VStack } from '@ui/Stack/Stack'
 import { Toggle } from '@ui/Toggle/Toggle'
+import { DataState, DataStateStatus } from '@components/DataState/DataState'
+import { Loader } from '@components/Loader/Loader'
 import { TaxBanner, type TaxBannerReviewPayload } from '@components/TaxDetails/TaxBanner'
 import { TaxDetails } from '@components/TaxDetails/TaxDetails'
 import { TaxOverview } from '@components/TaxOverview/TaxOverview'
 import { TaxPayments } from '@components/TaxPayments/TaxPayments'
+import { ConditionalBlock } from '@components/utility/ConditionalBlock'
 import { TaxProfile } from '@views/TaxEstimates/TaxProfile'
 
 import type { TaxEstimatesViewProps } from './taxEstimatesTypes'
@@ -80,9 +83,9 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
   const navigate = useTaxEstimatesNavigation()
   const { year } = useTaxEstimatesYear()
   const { fullYearProjection } = useFullYearProjection()
-  const { data: taxBannerData } = useTaxEstimatesBanner({ year })
-  const { data: taxOverviewApi } = useTaxOverview({ year, fullYearProjection })
-  const { data: taxSummary } = useTaxSummary({ year, fullYearProjection })
+  const { data: taxBannerData, isLoading: isTaxBannerLoading, isError: isTaxBannerError } = useTaxEstimatesBanner({ year })
+  const { data: taxOverviewApi, isLoading: isTaxOverviewLoading, isError: isTaxOverviewError } = useTaxOverview({ year, fullYearProjection })
+  const { data: taxSummary, isLoading: isTaxSummaryLoading, isError: isTaxSummaryError } = useTaxSummary({ year, fullYearProjection })
 
   const handleTaxBannerReview = useCallback((payload: TaxBannerReviewPayload) => {
     onTaxBannerReviewClick?.(payload)
@@ -161,6 +164,9 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
     return <TaxProfile />
   }
 
+  const isOverviewLoading = isTaxBannerLoading || isTaxOverviewLoading || isTaxSummaryLoading
+  const isOverviewError = isTaxBannerError || isTaxOverviewError || isTaxSummaryError
+
   return (
     <VStack gap='md'>
       <Toggle
@@ -170,11 +176,29 @@ export const TaxEstimatesOnboardedViewContent = ({ onTaxBannerReviewClick }: Tax
         onSelectionChange={handleTabChange}
       />
       {taxBanner}
-      {route === TaxEstimatesRoute.Overview && taxOverviewData && (
-        <TaxOverview
+      {route === TaxEstimatesRoute.Overview && (
+        <ConditionalBlock
+          isLoading={isOverviewLoading}
+          isError={isOverviewError}
           data={taxOverviewData}
-          onTaxBannerReviewClick={onTaxBannerReviewClick}
-        />
+          Loading={<Loader />}
+          Inactive={null}
+          Error={(
+            <DataState
+              status={DataStateStatus.failed}
+              title={t('taxEstimates:error.load_tax_estimates', 'We couldn\'t load your tax estimates')}
+              description={t('taxEstimates:error.load_tax_estimates', 'An error occurred while loading your tax estimates. Please check your connection and try again.')}
+              spacing
+            />
+          )}
+        >
+          {({ data: overviewData }) => (
+            <TaxOverview
+              data={overviewData}
+              onTaxBannerReviewClick={onTaxBannerReviewClick}
+            />
+          )}
+        </ConditionalBlock>
       )}
       {route === TaxEstimatesRoute.Estimates && <TaxDetails />}
       {route === TaxEstimatesRoute.Payments && <TaxPayments />}

--- a/src/views/TaxEstimates/TaxEstimatesViewContent.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesViewContent.tsx
@@ -52,7 +52,7 @@ export const TaxEstimatesViewContent = ({ onTaxBannerReviewClick }: TaxEstimates
   }, [onTaxBannerReviewClick, onboardingStatus, t])
 
   return (
-    <View title='Taxes' header={header}>
+    <View title={t('common:label.taxes', 'Taxes')} header={header}>
       {viewContent}
     </View>
   )

--- a/src/views/TaxEstimates/TaxEstimatesViewContent.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesViewContent.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { OnboardingStatus, useTaxEstimatesOnboardingStatus } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
+import { Container } from '@components/Container/Container'
+import { DataState, DataStateStatus } from '@components/DataState/DataState'
+import { Loader } from '@components/Loader/Loader'
+import { View } from '@components/View/View'
+import { TaxProfile } from '@views/TaxEstimates/TaxProfile'
+
+import { TaxEstimatesOnboardedViewContent } from './TaxEstimatesOnboardedViewContent'
+import type { TaxEstimatesViewProps } from './taxEstimatesTypes'
+import { TaxEstimatesViewHeader } from './TaxEstimatesViewHeader'
+
+export const TaxEstimatesViewContent = ({ onTaxBannerReviewClick }: TaxEstimatesViewProps) => {
+  const { t } = useTranslation()
+  const onboardingStatus = useTaxEstimatesOnboardingStatus()
+
+  const header = useMemo(
+    () => onboardingStatus === OnboardingStatus.Onboarded && <TaxEstimatesViewHeader />,
+    [onboardingStatus],
+  )
+
+  const viewContent = useMemo(() => {
+    switch (onboardingStatus) {
+      case OnboardingStatus.Loading:
+        return (
+          <Container name='tax-estimates'>
+            <Loader />
+          </Container>
+        )
+
+      case OnboardingStatus.Error:
+        return (
+          <Container name='tax-estimates'>
+            <DataState
+              status={DataStateStatus.failed}
+              title={t('taxEstimates:error.load_tax_information', 'Unable to load tax information')}
+              description={t('taxEstimates:error.retrieve_tax_profile', 'We couldn’t retrieve your tax profile. Please check your connection and try again.')}
+              spacing
+            />
+          </Container>
+        )
+
+      case OnboardingStatus.Onboarded:
+        return <TaxEstimatesOnboardedViewContent onTaxBannerReviewClick={onTaxBannerReviewClick} />
+
+      case OnboardingStatus.NotOnboarded:
+      default:
+        return <TaxProfile />
+    }
+  }, [onTaxBannerReviewClick, onboardingStatus, t])
+
+  return (
+    <View title='Taxes' header={header}>
+      {viewContent}
+    </View>
+  )
+}

--- a/src/views/TaxEstimates/TaxEstimatesViewHeader.tsx
+++ b/src/views/TaxEstimates/TaxEstimatesViewHeader.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useMemo } from 'react'
+import { getYear } from 'date-fns'
+import { Menu as MenuIcon, UserRoundPen } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { convertDateToZonedDateTime } from '@utils/time/timeUtils'
+import { useBusinessActivationDate } from '@hooks/features/business/useBusinessActivationDate'
+import { TaxEstimatesRoute, useTaxEstimatesNavigation, useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
+import { Button } from '@ui/Button/Button'
+import { DropdownMenu, MenuItem, MenuList } from '@ui/DropdownMenu/DropdownMenu'
+import { HStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+import { YearPicker } from '@components/YearPicker/YearPicker'
+
+const TAX_ESTIMATES_MIN_YEAR = 2024
+
+export const TaxEstimatesViewHeader = () => {
+  const { t } = useTranslation()
+  const navigate = useTaxEstimatesNavigation()
+  const { year, setYear } = useTaxEstimatesYear()
+  const activationDate = useBusinessActivationDate()
+
+  const minDateZdt = useMemo(() => {
+    const activationYear = activationDate ? getYear(activationDate) : TAX_ESTIMATES_MIN_YEAR
+    const effectiveMinYear = Math.max(activationYear, TAX_ESTIMATES_MIN_YEAR)
+    return convertDateToZonedDateTime(new Date(effectiveMinYear, 0, 1))
+  }, [activationDate])
+
+  const maxDateZdt = useMemo(() => convertDateToZonedDateTime(new Date()), [])
+
+  const Trigger = useCallback(() => {
+    return (
+      <Button icon variant='outlined'>
+        <MenuIcon size={14} />
+      </Button>
+    )
+  }, [])
+
+  return (
+    <HStack gap='xs'>
+      <YearPicker
+        year={year}
+        onChange={setYear}
+        minDate={minDateZdt}
+        maxDate={maxDateZdt}
+      />
+      <DropdownMenu
+        ariaLabel={t('taxEstimates:label.additional_actions', 'Additional actions')}
+        slots={{ Trigger }}
+        slotProps={{ Dialog: { width: 160 } }}
+      >
+        <MenuList>
+          <MenuItem key={TaxEstimatesRoute.Profile} onClick={() => navigate(TaxEstimatesRoute.Profile)}>
+            <UserRoundPen size={20} strokeWidth={1.25} />
+            <Span size='sm'>{t('taxEstimates:action.update_tax_profile', 'Update tax profile')}</Span>
+          </MenuItem>
+        </MenuList>
+      </DropdownMenu>
+    </HStack>
+  )
+}

--- a/src/views/TaxEstimates/taxEstimates.scss
+++ b/src/views/TaxEstimates/taxEstimates.scss
@@ -1,3 +1,0 @@
-.Layer__TaxEstimates__TaxBannerWrapper {
-  inline-size: min(100%, 1406px);
-}

--- a/src/views/TaxEstimates/taxEstimates.scss
+++ b/src/views/TaxEstimates/taxEstimates.scss
@@ -1,0 +1,3 @@
+.Layer__TaxEstimates__TaxBannerWrapper {
+  inline-size: min(100%, 1406px);
+}

--- a/src/views/TaxEstimates/taxEstimatesOnboardedViewContent.scss
+++ b/src/views/TaxEstimates/taxEstimatesOnboardedViewContent.scss
@@ -1,0 +1,3 @@
+.Layer__TaxEstimates__TaxBannerWrapper {
+  inline-size: min(100%, 1406px);
+}

--- a/src/views/TaxEstimates/taxEstimatesTypes.ts
+++ b/src/views/TaxEstimates/taxEstimatesTypes.ts
@@ -1,0 +1,5 @@
+import type { TaxBannerReviewPayload } from '@components/TaxDetails/TaxBanner'
+
+export type TaxEstimatesViewProps = {
+  onTaxBannerReviewClick?: (payload: TaxBannerReviewPayload) => void
+}


### PR DESCRIPTION
## Summary

Adds a new 'Overview' tab under Tax Estimates. This is a completely new page with new components.

## Inclusions
- New `TaxOverview` react component represents the whole tab
- Banner changes extended to support black and white design as Banner `variant=dark`; hooked into all tabs of tax estimates

## Exclusions
- No UI updates on payments tab or estimates tab yet
- UI fixes for banner width extending beyond usual length
- No changes yet to AccountingOverview or BookkeepingOverview; No additions for new layout `TaxOverview` which is a sibling of the other two overviews (not the tab in tax-estimates page).

## Changes
- implement overview foundation flow for Tax Estimates using dedicated overview components and route store support
- add tax overview data hook and schema for /tax-estimates/overview
- add TaxableIncomeCard, TaxDeadlinesCard, deadline card UI, and shared MetricRow
- add TaxEstimatesSummaryCard with extracted subcomponents (DonutChart, Legend, NextPaymentBanner)
- keep overview tab scoped changes only (no estimates/payments UI rewrites)
- introduce shared Banner dark variant and update TaxBanner to use it
- split TaxEstimates view into focused view/header/content files

## Validation
- npx lint-staged
- npm run typecheck
- visual check

Loom Recording

<div>
    <a href="https://www.loom.com/share/a44bee70cfad4299b2e2aa4b841f4872">
      <p>Tax Estimates - Overview Tab - Mobile Responsiveness + YTD vs. Projected - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/a44bee70cfad4299b2e2aa4b841f4872">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/a44bee70cfad4299b2e2aa4b841f4872-82bbca0245bedabb-full-play.gif#t=0.1">
    </a>
  </div>

📸  Screenshots below.

<img width="1870" height="970" alt="Screenshot 2026-03-31 at 6 01 19 PM" src="https://github.com/user-attachments/assets/8014de04-1763-464b-bc5a-f320949d926a" />

Mobile

<img width="383" height="838" alt="Screenshot 2026-04-02 at 3 18 16 PM" src="https://github.com/user-attachments/assets/548a3877-f90d-4816-9a41-b841cdf55209" />
<img width="410" height="866" alt="image" src="https://github.com/user-attachments/assets/2181a516-0652-4393-a5fa-01334d152885" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Tax Estimates Overview route that composes data from multiple endpoints and introduces new UI components/layouts, so regressions are most likely in routing/state and data-loading behavior rather than core security concerns.
> 
> **Overview**
> Adds a new **`Overview`** tab to Tax Estimates, including new `TaxOverview` UI (taxable income, estimated tax breakdown donut/legend, next payment banner, and deadline cards) and shared building blocks like `MetricRow`.
> 
> Updates data flow to support the overview by introducing `/tax-estimates/overview` types and `useTaxOverview`, deriving overview-ready categories/deadlines/“next tax” from the existing banner/summary responses, and adding `enabled` flags to `useTaxOverview`/`useTaxSummary` to avoid fetching when the tab isn’t active.
> 
> Extends the shared `Banner` with a new **`dark`** variant and icon suppression (`slots.Icon = null`), switches `TaxBanner` to use it, refactors the Tax Estimates view into header/content modules, and tweaks header/layout sizing plus adds new i18n key `taxEstimates:error.while_loading_tax_estimates` and `.codex/` to `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8e01cf3f7cd845d2120400aeaf2863be017e0b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->