### PR TITLE
Added new hook for reports config

### DIFF
--- a/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
@@ -8,7 +8,7 @@ import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
-const REPORT_CONFIG_TAG_KEY = '#report-config'
+export const REPORT_CONFIG_TAG_KEY = '#report-config'
 
 type GetReportConfigParams = {
   businessId: string

--- a/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
@@ -1,0 +1,66 @@
+import { Schema } from 'effect'
+import useSWR from 'swr'
+
+import { type ReportConfigResponse, ReportConfigResponseSchema } from '@schemas/reports/reportConfig'
+import { get } from '@utils/api/authenticatedHttp'
+import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
+import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
+import { useAuth } from '@hooks/utils/auth/useAuth'
+import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+
+const REPORT_CONFIG_TAG_KEY = '#report-config'
+
+type GetReportConfigParams = {
+  businessId: string
+}
+
+const getReportConfig = get<ReportConfigResponse, GetReportConfigParams>(
+  ({ businessId }) => `/v1/businesses/${businessId}/reports/config`,
+)
+
+function buildKey({
+  access_token: accessToken,
+  apiUrl,
+  businessId,
+}: {
+  access_token?: string
+  apiUrl?: string
+  businessId: string
+}) {
+  if (accessToken && apiUrl) {
+    return {
+      accessToken,
+      apiUrl,
+      businessId,
+      tags: [REPORT_CONFIG_TAG_KEY],
+    } as const
+  }
+}
+
+export function useReportConfig() {
+  const withLocale = useLocalizedKey()
+  const { data: auth } = useAuth()
+  const { businessId } = useLayerContext()
+
+  const swrResponse = useSWR(
+    () => withLocale(buildKey({
+      ...auth,
+      businessId,
+    })),
+    async ({ accessToken, apiUrl, businessId }) => {
+      return getReportConfig(
+        apiUrl,
+        accessToken,
+        {
+          params: {
+            businessId,
+          },
+        },
+      )()
+        .then(Schema.decodeUnknownPromise(ReportConfigResponseSchema))
+        .then(({ data }) => data)
+    },
+  )
+
+  return new SWRQueryResult(swrResponse)
+}

--- a/src/schemas/reports/reportConfig.ts
+++ b/src/schemas/reports/reportConfig.ts
@@ -1,0 +1,91 @@
+import { pipe, Schema } from 'effect'
+
+export const ReportControlSchema = Schema.Literal('date_range', 'group_by', 'unknown')
+export type ReportControl = typeof ReportControlSchema.Type
+
+const TransformedReportControlSchema = Schema.transform(
+  Schema.NonEmptyTrimmedString,
+  Schema.typeSchema(ReportControlSchema),
+  {
+    decode: (input) => {
+      if (ReportControlSchema.literals.includes(input as ReportControl)) {
+        return input as ReportControl
+      }
+
+      return 'unknown'
+    },
+    encode: input => input,
+  },
+)
+
+export const ReportTypeSchema = Schema.Literal('profit-and-loss', 'cashflow-statement', 'unknown')
+export type ReportType = typeof ReportTypeSchema.Type
+
+const TransformedReportTypeSchema = Schema.transform(
+  Schema.NonEmptyTrimmedString,
+  Schema.typeSchema(ReportTypeSchema),
+  {
+    decode: (input) => {
+      if (ReportTypeSchema.literals.includes(input as ReportType)) {
+        return input as ReportType
+      }
+
+      return 'unknown'
+    },
+    encode: input => input,
+  },
+)
+
+export const ReportGroupTypeSchema = Schema.Literal('accounting', 'unknown')
+export type ReportGroupType = typeof ReportGroupTypeSchema.Type
+
+const TransformedReportGroupTypeSchema = Schema.transform(
+  Schema.NonEmptyTrimmedString,
+  Schema.typeSchema(ReportGroupTypeSchema),
+  {
+    decode: (input) => {
+      if (ReportGroupTypeSchema.literals.includes(input as ReportGroupType)) {
+        return input as ReportGroupType
+      }
+
+      return 'unknown'
+    },
+    encode: input => input,
+  },
+)
+
+export const ReportConfigSchema = Schema.Struct({
+  key: Schema.String,
+  reportType: pipe(
+    Schema.propertySignature(TransformedReportTypeSchema),
+    Schema.fromKey('report_type'),
+  ),
+  displayName: pipe(
+    Schema.propertySignature(Schema.String),
+    Schema.fromKey('display_name'),
+  ),
+  controls: Schema.Array(TransformedReportControlSchema),
+  baseQueryParameters: pipe(
+    Schema.propertySignature(Schema.Record({ key: Schema.String, value: Schema.String })),
+    Schema.fromKey('base_query_parameters'),
+  ),
+})
+export type ReportConfig = typeof ReportConfigSchema.Type
+
+export const ReportGroupSchema = Schema.Struct({
+  groupType: pipe(
+    Schema.propertySignature(TransformedReportGroupTypeSchema),
+    Schema.fromKey('group_type'),
+  ),
+  displayName: pipe(
+    Schema.propertySignature(Schema.String),
+    Schema.fromKey('display_name'),
+  ),
+  reports: Schema.Array(ReportConfigSchema),
+})
+export type ReportGroup = typeof ReportGroupSchema.Type
+
+export const ReportConfigResponseSchema = Schema.Struct({
+  data: Schema.Array(ReportGroupSchema),
+})
+export type ReportConfigResponse = typeof ReportConfigResponseSchema.Type

--- a/src/schemas/reports/reportConfig.ts
+++ b/src/schemas/reports/reportConfig.ts
@@ -1,57 +1,44 @@
 import { pipe, Schema } from 'effect'
 
-export const ReportControlSchema = Schema.Literal('date_range', 'group_by', 'unknown')
-export type ReportControl = typeof ReportControlSchema.Type
+import { createTransformedEnumSchema } from '@schemas/utils'
 
-const TransformedReportControlSchema = Schema.transform(
-  Schema.NonEmptyTrimmedString,
-  Schema.typeSchema(ReportControlSchema),
-  {
-    decode: (input) => {
-      if (ReportControlSchema.literals.includes(input as ReportControl)) {
-        return input as ReportControl
-      }
+export enum ReportControl {
+  DATE_RANGE = 'date_range',
+  GROUP_BY = 'group_by',
+  UNKNOWN = 'unknown',
+}
 
-      return 'unknown'
-    },
-    encode: input => input,
-  },
+export enum ReportType {
+  PROFIT_AND_LOSS = 'profit-and-loss',
+  CASHFLOW_STATEMENT = 'cashflow-statement',
+  UNKNOWN = 'unknown',
+}
+
+export enum ReportGroupType {
+  ACCOUNTING = 'accounting',
+  UNKNOWN = 'unknown',
+}
+
+const ReportControlSchema = Schema.Enums(ReportControl)
+const ReportTypeSchema = Schema.Enums(ReportType)
+const ReportGroupTypeSchema = Schema.Enums(ReportGroupType)
+
+const TransformedReportControlSchema = createTransformedEnumSchema(
+  ReportControlSchema,
+  ReportControl,
+  ReportControl.UNKNOWN,
 )
 
-export const ReportTypeSchema = Schema.Literal('profit-and-loss', 'cashflow-statement', 'unknown')
-export type ReportType = typeof ReportTypeSchema.Type
-
-const TransformedReportTypeSchema = Schema.transform(
-  Schema.NonEmptyTrimmedString,
-  Schema.typeSchema(ReportTypeSchema),
-  {
-    decode: (input) => {
-      if (ReportTypeSchema.literals.includes(input as ReportType)) {
-        return input as ReportType
-      }
-
-      return 'unknown'
-    },
-    encode: input => input,
-  },
+const TransformedReportTypeSchema = createTransformedEnumSchema(
+  ReportTypeSchema,
+  ReportType,
+  ReportType.UNKNOWN,
 )
 
-export const ReportGroupTypeSchema = Schema.Literal('accounting', 'unknown')
-export type ReportGroupType = typeof ReportGroupTypeSchema.Type
-
-const TransformedReportGroupTypeSchema = Schema.transform(
-  Schema.NonEmptyTrimmedString,
-  Schema.typeSchema(ReportGroupTypeSchema),
-  {
-    decode: (input) => {
-      if (ReportGroupTypeSchema.literals.includes(input as ReportGroupType)) {
-        return input as ReportGroupType
-      }
-
-      return 'unknown'
-    },
-    encode: input => input,
-  },
+const TransformedReportGroupTypeSchema = createTransformedEnumSchema(
+  ReportGroupTypeSchema,
+  ReportGroupType,
+  ReportGroupType.UNKNOWN,
 )
 
 export const ReportConfigSchema = Schema.Struct({


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new report-config fetching hook and response schemas without modifying existing flows; main risk is incorrect schema mapping/enum defaults causing runtime decode failures.
> 
> **Overview**
> Adds a new `useReportConfig` SWR hook to fetch `/v1/businesses/{businessId}/reports/config`, using auth + locale-aware cache keys and tagging (`#report-config`).
> 
> Introduces `reportConfig` schemas and enums (`ReportControl`, `ReportType`, `ReportGroupType`) with unknown-safe enum transforms, plus typed decoding for the grouped report config response shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7df0ca33b12c6f5984ba6a0d452572fa647e385f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->