### PR TITLE
devx: Enforce !! over Boolean() in ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,6 +55,14 @@ export default tsEslint.config(
     rules: {
       'no-console': ['error', { allow: ['warn', 'error', 'debug'] }],
 
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'CallExpression[callee.name="Boolean"][arguments.length>0]',
+          message: 'Use `!!` instead of `Boolean()` for explicit coercion (keep `.filter(Boolean)` as-is).',
+        },
+      ],
+
       '@stylistic/quotes': ['error', 'single', { avoidEscape: false }],
       '@stylistic/jsx-quotes': ['error', 'prefer-single'],
       '@stylistic/semi': ['error', 'never'],

--- a/src/components/BalanceSheet/download/BalanceSheetDownloadButton.tsx
+++ b/src/components/BalanceSheet/download/BalanceSheetDownloadButton.tsx
@@ -24,7 +24,7 @@ export function BalanceSheetDownloadButton({
         iconOnly={iconOnly}
         onClick={() => { void trigger() }}
         isDownloading={isMutating}
-        requestFailed={!!(error)}
+        requestFailed={!!error}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />
     </>

--- a/src/components/BalanceSheet/download/BalanceSheetDownloadButton.tsx
+++ b/src/components/BalanceSheet/download/BalanceSheetDownloadButton.tsx
@@ -24,7 +24,7 @@ export function BalanceSheetDownloadButton({
         iconOnly={iconOnly}
         onClick={() => { void trigger() }}
         isDownloading={isMutating}
-        requestFailed={Boolean(error)}
+        requestFailed={!!(error)}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />
     </>

--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -75,7 +75,7 @@ export const BankTransactionRow = ({
 
   const categorized = isCategorized(bankTransaction)
 
-  const { isVisible } = useDelayedVisibility({ delay: index * 20, initialVisibility: Boolean(initialLoad) })
+  const { isVisible } = useDelayedVisibility({ delay: index * 20, initialVisibility: !!(initialLoad) })
 
   const { select, deselect } = useBulkSelectionActions()
   const isSelected = useIdIsSelected()

--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -75,7 +75,7 @@ export const BankTransactionRow = ({
 
   const categorized = isCategorized(bankTransaction)
 
-  const { isVisible } = useDelayedVisibility({ delay: index * 20, initialVisibility: !!(initialLoad) })
+  const { isVisible } = useDelayedVisibility({ delay: index * 20, initialVisibility: !!initialLoad })
 
   const { select, deselect } = useBulkSelectionActions()
   const isSelected = useIdIsSelected()

--- a/src/components/BankTransactions/BankTransactionsHeader.tsx
+++ b/src/components/BankTransactions/BankTransactionsHeader.tsx
@@ -107,7 +107,7 @@ const DownloadButton = ({
         iconOnly={iconOnly}
         onClick={handleDownloadTransactions}
         isDownloading={isMutating}
-        requestFailed={Boolean(error)}
+        requestFailed={!!(error)}
         text={downloadButtonTextOverride}
         disabled={disabled}
       />

--- a/src/components/BankTransactions/BankTransactionsHeader.tsx
+++ b/src/components/BankTransactions/BankTransactionsHeader.tsx
@@ -107,7 +107,7 @@ const DownloadButton = ({
         iconOnly={iconOnly}
         onClick={handleDownloadTransactions}
         isDownloading={isMutating}
-        requestFailed={!!(error)}
+        requestFailed={!!error}
         text={downloadButtonTextOverride}
         disabled={disabled}
       />

--- a/src/components/BankTransactions/BankTransactionsTableEmptyState.tsx
+++ b/src/components/BankTransactions/BankTransactionsTableEmptyState.tsx
@@ -28,7 +28,7 @@ export const BankTransactionsTableEmptyState = () => {
   const { filters } = useBankTransactionsFiltersContext()
 
   const isCategorizationMode = display !== DisplayState.categorized
-  const isFiltered = Boolean(filters?.query)
+  const isFiltered = !!(filters?.query)
 
   if (isFiltered) {
     return (

--- a/src/components/BankTransactions/BankTransactionsTableEmptyState.tsx
+++ b/src/components/BankTransactions/BankTransactionsTableEmptyState.tsx
@@ -28,7 +28,7 @@ export const BankTransactionsTableEmptyState = () => {
   const { filters } = useBankTransactionsFiltersContext()
 
   const isCategorizationMode = display !== DisplayState.categorized
-  const isFiltered = !!(filters?.query)
+  const isFiltered = !!filters?.query
 
   if (isFiltered) {
     return (

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListItem.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListItem.tsx
@@ -169,7 +169,7 @@ export const BankTransactionsMobileListItem = ({
     return getInAppLink(bankTransaction, renderInAppLink)
   }, [displayAsCategorized, bankTransaction, renderInAppLink])
 
-  const { isVisible } = useDelayedVisibility({ delay: index * 20, initialVisibility: !!(initialLoad) })
+  const { isVisible } = useDelayedVisibility({ delay: index * 20, initialVisibility: !!initialLoad })
 
   const className = 'Layer__bank-transaction-mobile-list-item'
   const openClassName = open ? `${className}--expanded` : ''

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListItem.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListItem.tsx
@@ -169,7 +169,7 @@ export const BankTransactionsMobileListItem = ({
     return getInAppLink(bankTransaction, renderInAppLink)
   }, [displayAsCategorized, bankTransaction, renderInAppLink])
 
-  const { isVisible } = useDelayedVisibility({ delay: index * 20, initialVisibility: Boolean(initialLoad) })
+  const { isVisible } = useDelayedVisibility({ delay: index * 20, initialVisibility: !!(initialLoad) })
 
   const className = 'Layer__bank-transaction-mobile-list-item'
   const openClassName = open ? `${className}--expanded` : ''

--- a/src/components/ChartOfAccounts/download/AccountBalancesDownloadButton.tsx
+++ b/src/components/ChartOfAccounts/download/AccountBalancesDownloadButton.tsx
@@ -30,7 +30,7 @@ export function AccountBalancesDownloadButton({
         iconOnly={iconOnly}
         onClick={() => { void trigger() }}
         isDownloading={isMutating}
-        requestFailed={Boolean(error)}
+        requestFailed={!!(error)}
         text={t('common:action.download_csv', 'Download CSV')}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />

--- a/src/components/ChartOfAccounts/download/AccountBalancesDownloadButton.tsx
+++ b/src/components/ChartOfAccounts/download/AccountBalancesDownloadButton.tsx
@@ -30,7 +30,7 @@ export function AccountBalancesDownloadButton({
         iconOnly={iconOnly}
         onClick={() => { void trigger() }}
         isDownloading={isMutating}
-        requestFailed={!!(error)}
+        requestFailed={!!error}
         text={t('common:action.download_csv', 'Download CSV')}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />

--- a/src/components/ChartOfAccountsForm/ChartOfAccountsForm.tsx
+++ b/src/components/ChartOfAccountsForm/ChartOfAccountsForm.tsx
@@ -149,7 +149,7 @@ export const ChartOfAccountsForm = ({
             value={form?.data.parent}
             onChange={sel => changeFormData('parent', sel)}
             disabled={sendingForm}
-            isInvalid={!!(form?.errors?.find(x => x.field === 'parent'))}
+            isInvalid={!!form?.errors?.find(x => x.field === 'parent')}
             errorMessage={form?.errors?.find(x => x.field === 'parent')?.message}
           />
         </InputGroup>
@@ -162,7 +162,7 @@ export const ChartOfAccountsForm = ({
             name='name'
             placeholder={t('chartOfAccounts:label.enter_name', 'Enter name...')}
             value={form?.data.name}
-            isInvalid={!!(form?.errors?.find(x => x.field === 'name'))}
+            isInvalid={!!form?.errors?.find(x => x.field === 'name')}
             errorMessage={form?.errors?.find(x => x.field === 'name')?.message}
             disabled={sendingForm}
             onChange={e =>
@@ -178,7 +178,7 @@ export const ChartOfAccountsForm = ({
             name='accountNumber'
             placeholder={t('chartOfAccounts:label.enter_account_number', 'Enter account number...')}
             value={form?.data.accountNumber}
-            isInvalid={!!(form?.errors?.find(x => x.field === 'accountNumber'))}
+            isInvalid={!!form?.errors?.find(x => x.field === 'accountNumber')}
             errorMessage={form?.errors?.find(x => x.field === 'accountNumber')?.message}
             disabled={sendingForm}
             onChange={e =>
@@ -194,7 +194,7 @@ export const ChartOfAccountsForm = ({
             options={ledgerAccountTypesOptions}
             value={form?.data.type}
             onChange={sel => changeFormData('type', sel)}
-            isInvalid={!!(form?.errors?.find(x => x.field === 'type'))}
+            isInvalid={!!form?.errors?.find(x => x.field === 'type')}
             errorMessage={form?.errors?.find(x => x.field === 'type')?.message}
             disabled={
               sendingForm
@@ -215,7 +215,7 @@ export const ChartOfAccountsForm = ({
                 : Object.values(ledgerAccountSubtypesForType).flat()
             }
             value={form?.data.subType}
-            isInvalid={!!(form?.errors?.find(x => x.field === 'subType'))}
+            isInvalid={!!form?.errors?.find(x => x.field === 'subType')}
             errorMessage={form?.errors?.find(x => x.field === 'subType')?.message}
             onChange={sel => changeFormData('subType', sel)}
             disabled={sendingForm}
@@ -229,9 +229,7 @@ export const ChartOfAccountsForm = ({
           <Select
             options={normalityOptions}
             value={form?.data.normality}
-            isInvalid={!!(
-              form?.errors?.find(x => x.field === 'normality')
-            )}
+            isInvalid={!!form?.errors?.find(x => x.field === 'normality')}
             errorMessage={
               form?.errors?.find(x => x.field === 'normality')?.message
             }

--- a/src/components/ChartOfAccountsForm/ChartOfAccountsForm.tsx
+++ b/src/components/ChartOfAccountsForm/ChartOfAccountsForm.tsx
@@ -149,7 +149,7 @@ export const ChartOfAccountsForm = ({
             value={form?.data.parent}
             onChange={sel => changeFormData('parent', sel)}
             disabled={sendingForm}
-            isInvalid={Boolean(form?.errors?.find(x => x.field === 'parent'))}
+            isInvalid={!!(form?.errors?.find(x => x.field === 'parent'))}
             errorMessage={form?.errors?.find(x => x.field === 'parent')?.message}
           />
         </InputGroup>
@@ -162,7 +162,7 @@ export const ChartOfAccountsForm = ({
             name='name'
             placeholder={t('chartOfAccounts:label.enter_name', 'Enter name...')}
             value={form?.data.name}
-            isInvalid={Boolean(form?.errors?.find(x => x.field === 'name'))}
+            isInvalid={!!(form?.errors?.find(x => x.field === 'name'))}
             errorMessage={form?.errors?.find(x => x.field === 'name')?.message}
             disabled={sendingForm}
             onChange={e =>
@@ -178,7 +178,7 @@ export const ChartOfAccountsForm = ({
             name='accountNumber'
             placeholder={t('chartOfAccounts:label.enter_account_number', 'Enter account number...')}
             value={form?.data.accountNumber}
-            isInvalid={Boolean(form?.errors?.find(x => x.field === 'accountNumber'))}
+            isInvalid={!!(form?.errors?.find(x => x.field === 'accountNumber'))}
             errorMessage={form?.errors?.find(x => x.field === 'accountNumber')?.message}
             disabled={sendingForm}
             onChange={e =>
@@ -194,7 +194,7 @@ export const ChartOfAccountsForm = ({
             options={ledgerAccountTypesOptions}
             value={form?.data.type}
             onChange={sel => changeFormData('type', sel)}
-            isInvalid={Boolean(form?.errors?.find(x => x.field === 'type'))}
+            isInvalid={!!(form?.errors?.find(x => x.field === 'type'))}
             errorMessage={form?.errors?.find(x => x.field === 'type')?.message}
             disabled={
               sendingForm
@@ -215,7 +215,7 @@ export const ChartOfAccountsForm = ({
                 : Object.values(ledgerAccountSubtypesForType).flat()
             }
             value={form?.data.subType}
-            isInvalid={Boolean(form?.errors?.find(x => x.field === 'subType'))}
+            isInvalid={!!(form?.errors?.find(x => x.field === 'subType'))}
             errorMessage={form?.errors?.find(x => x.field === 'subType')?.message}
             onChange={sel => changeFormData('subType', sel)}
             disabled={sendingForm}
@@ -229,8 +229,8 @@ export const ChartOfAccountsForm = ({
           <Select
             options={normalityOptions}
             value={form?.data.normality}
-            isInvalid={Boolean(
-              form?.errors?.find(x => x.field === 'normality'),
+            isInvalid={!!(
+              form?.errors?.find(x => x.field === 'normality')
             )}
             errorMessage={
               form?.errors?.find(x => x.field === 'normality')?.message

--- a/src/components/ChartOfAccountsTable/ChartOfAccountsTableWithPanel.tsx
+++ b/src/components/ChartOfAccountsTable/ChartOfAccountsTableWithPanel.tsx
@@ -71,7 +71,7 @@ export const ChartOfAccountsTableWithPanel = ({
           stringOverrides={stringOverrides?.chartOfAccountsForm}
         />
       )}
-      sidebarIsOpen={!!(form)}
+      sidebarIsOpen={!!form}
       parentRef={containerRef}
     >
       <Header className={`Layer__${COMPONENT_NAME}__header`} asHeader rounded>

--- a/src/components/ChartOfAccountsTable/ChartOfAccountsTableWithPanel.tsx
+++ b/src/components/ChartOfAccountsTable/ChartOfAccountsTableWithPanel.tsx
@@ -71,7 +71,7 @@ export const ChartOfAccountsTableWithPanel = ({
           stringOverrides={stringOverrides?.chartOfAccountsForm}
         />
       )}
-      sidebarIsOpen={Boolean(form)}
+      sidebarIsOpen={!!(form)}
       parentRef={containerRef}
     >
       <Header className={`Layer__${COMPONENT_NAME}__header`} asHeader rounded>

--- a/src/components/DueStatus/DueStatus.tsx
+++ b/src/components/DueStatus/DueStatus.tsx
@@ -122,7 +122,7 @@ export const DueStatus = ({ dueDate, paidAt, size = 'md' }: DueStatusProps) => {
         return null
       }
 
-      return dueStatusTitle(diff, Boolean(paidAt), t, formatNumber)
+      return dueStatusTitle(diff, !!(paidAt), t, formatNumber)
     }
     catch (_err) {
       return null

--- a/src/components/DueStatus/DueStatus.tsx
+++ b/src/components/DueStatus/DueStatus.tsx
@@ -122,7 +122,7 @@ export const DueStatus = ({ dueDate, paidAt, size = 'md' }: DueStatusProps) => {
         return null
       }
 
-      return dueStatusTitle(diff, !!(paidAt), t, formatNumber)
+      return dueStatusTitle(diff, !!paidAt, t, formatNumber)
     }
     catch (_err) {
       return null

--- a/src/components/Journal/JournalEntryForm/formUtils.ts
+++ b/src/components/Journal/JournalEntryForm/formUtils.ts
@@ -16,17 +16,17 @@ import type { ApiCustomJournalEntryWithEntry, CreateCustomJournalEntry, JournalE
  */
 export function isLineItemBlank(lineItem: JournalEntryFormLineItem): boolean {
   const hasAccount = lineItem.accountIdentifier.type === 'AccountId'
-    ? Boolean(lineItem.accountIdentifier.id)
+    ? !!(lineItem.accountIdentifier.id)
     : lineItem.accountIdentifier.type === 'StableName'
-      ? Boolean(lineItem.accountIdentifier.stableName)
+      ? !!(lineItem.accountIdentifier.stableName)
       : false
 
   const hasAmount = !BD.equals(lineItem.amount, BIG_DECIMAL_ZERO)
-  const hasMemo = Boolean(lineItem.memo?.trim())
-  const hasCustomer = Boolean(lineItem.customer)
-  const hasVendor = Boolean(lineItem.vendor)
+  const hasMemo = !!(lineItem.memo?.trim())
+  const hasCustomer = !!(lineItem.customer)
+  const hasVendor = !!(lineItem.vendor)
   const hasTags = lineItem.tags.length > 0
-  const hasExternalId = Boolean(lineItem.externalId)
+  const hasExternalId = !!(lineItem.externalId)
 
   return !hasAccount && !hasAmount && !hasMemo && !hasCustomer && !hasVendor && !hasTags && !hasExternalId
 }

--- a/src/components/Journal/JournalEntryForm/formUtils.ts
+++ b/src/components/Journal/JournalEntryForm/formUtils.ts
@@ -16,17 +16,17 @@ import type { ApiCustomJournalEntryWithEntry, CreateCustomJournalEntry, JournalE
  */
 export function isLineItemBlank(lineItem: JournalEntryFormLineItem): boolean {
   const hasAccount = lineItem.accountIdentifier.type === 'AccountId'
-    ? !!(lineItem.accountIdentifier.id)
+    ? !!lineItem.accountIdentifier.id
     : lineItem.accountIdentifier.type === 'StableName'
-      ? !!(lineItem.accountIdentifier.stableName)
+      ? !!lineItem.accountIdentifier.stableName
       : false
 
   const hasAmount = !BD.equals(lineItem.amount, BIG_DECIMAL_ZERO)
-  const hasMemo = !!(lineItem.memo?.trim())
-  const hasCustomer = !!(lineItem.customer)
-  const hasVendor = !!(lineItem.vendor)
+  const hasMemo = !!lineItem.memo?.trim()
+  const hasCustomer = !!lineItem.customer
+  const hasVendor = !!lineItem.vendor
   const hasTags = lineItem.tags.length > 0
-  const hasExternalId = !!(lineItem.externalId)
+  const hasExternalId = !!lineItem.externalId
 
   return !hasAccount && !hasAmount && !hasMemo && !hasCustomer && !hasVendor && !hasTags && !hasExternalId
 }

--- a/src/components/Journal/download/JournalEntriesDownloadButton.tsx
+++ b/src/components/Journal/download/JournalEntriesDownloadButton.tsx
@@ -29,7 +29,7 @@ export function JournalEntriesDownloadButton({
         iconOnly={iconOnly}
         onClick={() => { void trigger() }}
         isDownloading={isMutating}
-        requestFailed={Boolean(error)}
+        requestFailed={!!(error)}
         text={t('common:action.download_csv', 'Download CSV')}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />

--- a/src/components/Journal/download/JournalEntriesDownloadButton.tsx
+++ b/src/components/Journal/download/JournalEntriesDownloadButton.tsx
@@ -29,7 +29,7 @@ export function JournalEntriesDownloadButton({
         iconOnly={iconOnly}
         onClick={() => { void trigger() }}
         isDownloading={isMutating}
-        requestFailed={!!(error)}
+        requestFailed={!!error}
         text={t('common:action.download_csv', 'Download CSV')}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />

--- a/src/components/JournalEntryDetails/JournalEntryDetails.tsx
+++ b/src/components/JournalEntryDetails/JournalEntryDetails.tsx
@@ -265,7 +265,7 @@ export const JournalEntryDetails = () => {
                         ? t('generalLedger:error.operation_retry', 'Operation failed. Try again.')
                         : undefined
                   }
-                  disabled={!!(entry?.reversal_id)}
+                  disabled={!!entry?.reversal_id}
                 >
                   {t('generalLedger:action.reverse_entry', 'Reverse entry')}
                 </Button>

--- a/src/components/JournalEntryDetails/JournalEntryDetails.tsx
+++ b/src/components/JournalEntryDetails/JournalEntryDetails.tsx
@@ -265,7 +265,7 @@ export const JournalEntryDetails = () => {
                         ? t('generalLedger:error.operation_retry', 'Operation failed. Try again.')
                         : undefined
                   }
-                  disabled={Boolean(entry?.reversal_id)}
+                  disabled={!!(entry?.reversal_id)}
                 >
                   {t('generalLedger:action.reverse_entry', 'Reverse entry')}
                 </Button>

--- a/src/components/JournalTable/JournalTableWithPanel.tsx
+++ b/src/components/JournalTable/JournalTableWithPanel.tsx
@@ -85,7 +85,7 @@ export const JournalTableWithPanel = ({
     <Panel
       className={`Layer__${COMPONENT_NAME}`}
       sidebar={<JournalSidebar parentRef={containerRef} />}
-      sidebarIsOpen={Boolean(selectedEntryId && selectedEntryId !== 'new')}
+      sidebarIsOpen={!!(selectedEntryId && selectedEntryId !== 'new')}
       parentRef={containerRef}
     >
       <Header

--- a/src/components/LedgerAccount/LedgerAccountIndex.tsx
+++ b/src/components/LedgerAccount/LedgerAccountIndex.tsx
@@ -109,7 +109,7 @@ export const LedgerAccount = ({
           stringOverrides={stringOverrides?.ledgerEntryDetail}
         />
       )}
-      sidebarIsOpen={!!(selectedEntryId)}
+      sidebarIsOpen={!!selectedEntryId}
       parentRef={containerRef}
       className='Layer__ledger-account__panel'
     >

--- a/src/components/LedgerAccount/LedgerAccountIndex.tsx
+++ b/src/components/LedgerAccount/LedgerAccountIndex.tsx
@@ -109,7 +109,7 @@ export const LedgerAccount = ({
           stringOverrides={stringOverrides?.ledgerEntryDetail}
         />
       )}
-      sidebarIsOpen={Boolean(selectedEntryId)}
+      sidebarIsOpen={!!(selectedEntryId)}
       parentRef={containerRef}
       className='Layer__ledger-account__panel'
     >

--- a/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
+++ b/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
@@ -96,7 +96,7 @@ export function LinkAccountsLinkStep() {
             </VStack>
           </ElevatedLoadingSpinnerContainer>
         )}
-        isError={Boolean(error)}
+        isError={!!(error)}
         Error={(
           <DataState
             status={DataStateStatus.failed}

--- a/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
+++ b/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
@@ -96,7 +96,7 @@ export function LinkAccountsLinkStep() {
             </VStack>
           </ElevatedLoadingSpinnerContainer>
         )}
-        isError={!!(error)}
+        isError={!!error}
         Error={(
           <DataState
             status={DataStateStatus.failed}

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
@@ -93,7 +93,7 @@ function LinkedAccountsConfirmationModalContent({ onClose }: { onClose: () => vo
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const { trigger, isMutating, error } = useConfirmAndExcludeMultiple({ onSuccess: refetchAccounts })
-  const hasError = !!(error)
+  const hasError = !!error
 
   const handleFinish = async () => {
     const success = await trigger(formState)

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
@@ -93,7 +93,7 @@ function LinkedAccountsConfirmationModalContent({ onClose }: { onClose: () => vo
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const { trigger, isMutating, error } = useConfirmAndExcludeMultiple({ onSuccess: refetchAccounts })
-  const hasError = Boolean(error)
+  const hasError = !!(error)
 
   const handleFinish = async () => {
     const success = await trigger(formState)

--- a/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
+++ b/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
@@ -174,7 +174,7 @@ export function OpeningBalanceModal({
     setAccountsToAddOpeningBalanceInModal,
   } = useContext(LinkedAccountsContext)
 
-  const shouldShowModal = !!(accountsToAddOpeningBalanceInModal.length)
+  const shouldShowModal = !!accountsToAddOpeningBalanceInModal.length
 
   if (!shouldShowModal) {
     return null

--- a/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
+++ b/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
@@ -174,7 +174,7 @@ export function OpeningBalanceModal({
     setAccountsToAddOpeningBalanceInModal,
   } = useContext(LinkedAccountsContext)
 
-  const shouldShowModal = Boolean(accountsToAddOpeningBalanceInModal.length)
+  const shouldShowModal = !!(accountsToAddOpeningBalanceInModal.length)
 
   if (!shouldShowModal) {
     return null

--- a/src/components/ProfitAndLossDownloadButton/ProfitAndLossDetailLinesDownloadButton.tsx
+++ b/src/components/ProfitAndLossDownloadButton/ProfitAndLossDetailLinesDownloadButton.tsx
@@ -45,7 +45,7 @@ export function ProfitAndLossDetailLinesDownloadButton({
         iconOnly={iconOnly}
         onClick={() => { void trigger() }}
         isDownloading={isMutating}
-        requestFailed={Boolean(error)}
+        requestFailed={!!(error)}
         text={stringOverrides?.downloadButtonText || t('common:action.download_label', 'Download')}
         retryText={stringOverrides?.retryButtonText || t('common:action.retry_label', 'Retry')}
       />

--- a/src/components/ProfitAndLossDownloadButton/ProfitAndLossDetailLinesDownloadButton.tsx
+++ b/src/components/ProfitAndLossDownloadButton/ProfitAndLossDetailLinesDownloadButton.tsx
@@ -45,7 +45,7 @@ export function ProfitAndLossDetailLinesDownloadButton({
         iconOnly={iconOnly}
         onClick={() => { void trigger() }}
         isDownloading={isMutating}
-        requestFailed={!!(error)}
+        requestFailed={!!error}
         text={stringOverrides?.downloadButtonText || t('common:action.download_label', 'Download')}
         retryText={stringOverrides?.retryButtonText || t('common:action.retry_label', 'Retry')}
       />

--- a/src/components/ProfitAndLossView/ProfitAndLossView.tsx
+++ b/src/components/ProfitAndLossView/ProfitAndLossView.tsx
@@ -58,7 +58,7 @@ const ProfitAndLossPanel = ({
           stringOverrides={stringOverrides?.profitAndLossDetailedCharts}
         />
       )}
-      sidebarIsOpen={Boolean(sidebarScope)}
+      sidebarIsOpen={!!(sidebarScope)}
       parentRef={containerRef}
     >
       <ProfitAndLoss.Header

--- a/src/components/ProfitAndLossView/ProfitAndLossView.tsx
+++ b/src/components/ProfitAndLossView/ProfitAndLossView.tsx
@@ -58,7 +58,7 @@ const ProfitAndLossPanel = ({
           stringOverrides={stringOverrides?.profitAndLossDetailedCharts}
         />
       )}
-      sidebarIsOpen={!!(sidebarScope)}
+      sidebarIsOpen={!!sidebarScope}
       parentRef={containerRef}
     >
       <ProfitAndLoss.Header

--- a/src/components/StatementOfCashFlow/download/CashflowStatementDownloadButton.tsx
+++ b/src/components/StatementOfCashFlow/download/CashflowStatementDownloadButton.tsx
@@ -27,7 +27,7 @@ export function CashflowStatementDownloadButton({
         iconOnly={iconOnly}
         onClick={() => { void trigger() }}
         isDownloading={isMutating}
-        requestFailed={Boolean(error)}
+        requestFailed={!!(error)}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />
     </>

--- a/src/components/StatementOfCashFlow/download/CashflowStatementDownloadButton.tsx
+++ b/src/components/StatementOfCashFlow/download/CashflowStatementDownloadButton.tsx
@@ -27,7 +27,7 @@ export function CashflowStatementDownloadButton({
         iconOnly={iconOnly}
         onClick={() => { void trigger() }}
         isDownloading={isMutating}
-        requestFailed={!!(error)}
+        requestFailed={!!error}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />
     </>

--- a/src/hooks/features/profitAndLoss/useProfitAndLossComparison.tsx
+++ b/src/hooks/features/profitAndLoss/useProfitAndLossComparison.tsx
@@ -162,8 +162,8 @@ type Props = {
 }
 
 const isNotOnlyNoneTag = (compareOptions?: TagComparisonOption[]) => {
-  return Boolean(
-    compareOptions?.some(option => option.tagFilterConfig.tagFilters !== 'None'),
+  return !!(
+    compareOptions?.some(option => option.tagFilterConfig.tagFilters !== 'None')
   )
 }
 

--- a/src/hooks/features/profitAndLoss/useProfitAndLossComparison.tsx
+++ b/src/hooks/features/profitAndLoss/useProfitAndLossComparison.tsx
@@ -162,9 +162,7 @@ type Props = {
 }
 
 const isNotOnlyNoneTag = (compareOptions?: TagComparisonOption[]) => {
-  return !!(
-    compareOptions?.some(option => option.tagFilterConfig.tagFilters !== 'None')
-  )
+  return !!compareOptions?.some(option => option.tagFilterConfig.tagFilters !== 'None')
 }
 
 export function useProfitAndLossComparison({

--- a/src/hooks/legacy/useDataSync.tsx
+++ b/src/hooks/legacy/useDataSync.tsx
@@ -75,14 +75,14 @@ export const useDataSync: UseDataSync = () => {
       return false
     }
 
-    return Boolean(
+    return !!(
       DEPENDENCIES[lastRead.m]?.find((dep) => {
         return (
           dep in syncTimestamps
-          && Boolean(syncTimestamps[dep])
-          && (syncTimestamps[dep] as number) > (lastRead.t)
+          && !!(syncTimestamps[dep])
+          && (syncTimestamps[dep]) > (lastRead.t)
         )
-      }),
+      })
     )
   }
 

--- a/src/hooks/legacy/useJournal.tsx
+++ b/src/hooks/legacy/useJournal.tsx
@@ -152,9 +152,9 @@ export const useJournal: UseJournal = () => {
   const hasMore = useMemo(() => {
     if (paginatedData && paginatedData.length > 0) {
       const lastPage = paginatedData[paginatedData.length - 1]
-      return Boolean(
+      return !!(
         lastPage.meta?.pagination.cursor
-        && lastPage.meta?.pagination.has_more,
+        && lastPage.meta?.pagination.has_more
       )
     }
     return false

--- a/src/hooks/legacy/useJournal.tsx
+++ b/src/hooks/legacy/useJournal.tsx
@@ -152,10 +152,7 @@ export const useJournal: UseJournal = () => {
   const hasMore = useMemo(() => {
     if (paginatedData && paginatedData.length > 0) {
       const lastPage = paginatedData[paginatedData.length - 1]
-      return !!(
-        lastPage.meta?.pagination.cursor
-        && lastPage.meta?.pagination.has_more
-      )
+      return !!lastPage.meta?.pagination.cursor && lastPage.meta?.pagination.has_more
     }
     return false
   }, [paginatedData])

--- a/src/hooks/legacy/useJournal.tsx
+++ b/src/hooks/legacy/useJournal.tsx
@@ -152,7 +152,7 @@ export const useJournal: UseJournal = () => {
   const hasMore = useMemo(() => {
     if (paginatedData && paginatedData.length > 0) {
       const lastPage = paginatedData[paginatedData.length - 1]
-      return !!lastPage.meta?.pagination.cursor && lastPage.meta?.pagination.has_more
+      return !!(lastPage.meta?.pagination.cursor && lastPage.meta?.pagination.has_more)
     }
     return false
   }, [paginatedData])

--- a/src/hooks/legacy/useLedgerAccounts.tsx
+++ b/src/hooks/legacy/useLedgerAccounts.tsx
@@ -47,7 +47,7 @@ export const useLedgerAccounts: UseLedgerAccounts = () => {
   })
 
   // Only use the data when accountId is available
-  const shouldFetch = Boolean(selectedAccountId)
+  const shouldFetch = !!(selectedAccountId)
 
   const data = useMemo(() => {
     if (!paginatedData || !shouldFetch) return undefined
@@ -58,9 +58,9 @@ export const useLedgerAccounts: UseLedgerAccounts = () => {
     if (!shouldFetch || !paginatedData || paginatedData.length === 0) return false
 
     const lastPage = paginatedData[paginatedData.length - 1]
-    return Boolean(
+    return !!(
       lastPage.meta?.pagination.cursor
-      && lastPage.meta?.pagination.has_more,
+      && lastPage.meta?.pagination.has_more
     )
   }, [paginatedData, shouldFetch])
 

--- a/src/hooks/legacy/useLedgerAccounts.tsx
+++ b/src/hooks/legacy/useLedgerAccounts.tsx
@@ -47,7 +47,7 @@ export const useLedgerAccounts: UseLedgerAccounts = () => {
   })
 
   // Only use the data when accountId is available
-  const shouldFetch = !!(selectedAccountId)
+  const shouldFetch = !!selectedAccountId
 
   const data = useMemo(() => {
     if (!paginatedData || !shouldFetch) return undefined
@@ -58,10 +58,7 @@ export const useLedgerAccounts: UseLedgerAccounts = () => {
     if (!shouldFetch || !paginatedData || paginatedData.length === 0) return false
 
     const lastPage = paginatedData[paginatedData.length - 1]
-    return !!(
-      lastPage.meta?.pagination.cursor
-      && lastPage.meta?.pagination.has_more
-    )
+    return !!lastPage.meta?.pagination.cursor && lastPage.meta?.pagination.has_more
   }, [paginatedData, shouldFetch])
 
   const fetchMore = useCallback(() => {

--- a/src/hooks/legacy/useLedgerAccounts.tsx
+++ b/src/hooks/legacy/useLedgerAccounts.tsx
@@ -58,7 +58,7 @@ export const useLedgerAccounts: UseLedgerAccounts = () => {
     if (!shouldFetch || !paginatedData || paginatedData.length === 0) return false
 
     const lastPage = paginatedData[paginatedData.length - 1]
-    return !!lastPage.meta?.pagination.cursor && lastPage.meta?.pagination.has_more
+    return !!(lastPage.meta?.pagination.cursor && lastPage.meta?.pagination.has_more)
   }, [paginatedData, shouldFetch])
 
   const fetchMore = useCallback(() => {

--- a/src/hooks/legacy/useReceipts.ts
+++ b/src/hooks/legacy/useReceipts.ts
@@ -174,7 +174,7 @@ export const useReceipts: UseReceipts = ({
     const existingNames = [
       ...receiptUrls
         .map(r => r.name)
-        .filter((name): name is string => !!(name)),
+        .filter((name): name is string => !!name),
       ...pendingUploadNamesRef.current,
     ]
     const uniqueName = getUniqueFileName(file.name, existingNames)

--- a/src/hooks/legacy/useReceipts.ts
+++ b/src/hooks/legacy/useReceipts.ts
@@ -174,7 +174,7 @@ export const useReceipts: UseReceipts = ({
     const existingNames = [
       ...receiptUrls
         .map(r => r.name)
-        .filter((name): name is string => Boolean(name)),
+        .filter((name): name is string => !!(name)),
       ...pendingUploadNamesRef.current,
     ]
     const uniqueName = getUniqueFileName(file.name, existingNames)

--- a/src/utils/bankTransactions.ts
+++ b/src/utils/bankTransactions.ts
@@ -32,10 +32,10 @@ export interface NumericRangeFilter {
 }
 
 export const hasMatch = (bankTransaction?: BankTransaction) => {
-  return Boolean(
+  return !!(
     (bankTransaction?.suggested_matches
       && bankTransaction?.suggested_matches?.length > 0)
-    || bankTransaction?.match,
+    || bankTransaction?.match
   )
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds an ESLint rule so explicit boolean coercion uses `!!` instead of `Boolean(...)`, and updates existing call sites to match.

## Changes

- `no-restricted-syntax` targets `Boolean` **calls with arguments** only, so `.filter(Boolean)` and passing `Boolean` as a callback stay allowed.
- Replaced `Boolean(expr)` with `!!(expr)` (or equivalent) across the codebase; fixed invalid trailing commas that appeared when swapping multi-line `Boolean(...)` wrappers.

## Blockers

None.

## How this has been tested?

- `npm run lint:eslint`
- `npm run typecheck`

<img width="1124" height="355" alt="image" src="https://github.com/user-attachments/assets/cb7090bc-eb15-43f1-9faf-33e990770ab7" />

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-278586da-bed1-4d3d-b4b1-98a15b00d02d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-278586da-bed1-4d3d-b4b1-98a15b00d02d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

