### PR TITLE
Time Tracking: Services drawer, stats & page view

### DIFF
--- a/src/components/TimeEntries/TimeTrackingServicesDrawer/TimeTrackingServicesDrawer.tsx
+++ b/src/components/TimeEntries/TimeTrackingServicesDrawer/TimeTrackingServicesDrawer.tsx
@@ -1,0 +1,582 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Archive, ArchiveRestore, Plus } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { useIntl } from 'react-intl'
+
+import { type CatalogService } from '@schemas/catalogService'
+import { convertCentsToDecimalString } from '@utils/format'
+import { toLocalizedCents } from '@utils/i18n/number/input'
+import { useArchiveCatalogService } from '@hooks/api/businesses/[business-id]/catalog/services/[service-id]/useArchiveCatalogService'
+import { useReactivateCatalogService } from '@hooks/api/businesses/[business-id]/catalog/services/[service-id]/useReactivateCatalogService'
+import { useUpdateCatalogService } from '@hooks/api/businesses/[business-id]/catalog/services/[service-id]/useUpdateCatalogService'
+import { useCreateCatalogService } from '@hooks/api/businesses/[business-id]/catalog/services/useCreateCatalogService'
+import { useListCatalogServices } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import Loader from '@icons/Loader'
+import { Button } from '@ui/Button/Button'
+import { FieldError, TextField } from '@ui/Form/Form'
+import { Input } from '@ui/Input/Input'
+import { InputGroup } from '@ui/Input/InputGroup'
+import { Drawer } from '@ui/Modal/Modal'
+import { ModalCloseButton, ModalHeading } from '@ui/Modal/ModalSlots'
+import { HStack, Spacer, VStack } from '@ui/Stack/Stack'
+import { Toggle, ToggleSize } from '@ui/Toggle/Toggle'
+import { Label, Span } from '@ui/Typography/Text'
+import { BaseConfirmationModal } from '@components/blocks/BaseConfirmationModal/BaseConfirmationModal'
+import { DataState, DataStateStatus } from '@components/DataState/DataState'
+import { ExpandableCard } from '@components/ExpandableCard/ExpandableCard'
+import { AmountInput } from '@components/Input/AmountInput'
+import { TextSize } from '@components/Typography/Text'
+
+import './timeTrackingServicesDrawer.scss'
+
+type ServicesTab = 'active' | 'archived'
+
+type HourlyRateFieldProps = {
+  inputId: string
+  name: string
+  value: string
+  onChange: (value: string) => void
+}
+
+function HourlyRateField({ inputId, name, value, onChange }: HourlyRateFieldProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className='Layer__TimeTrackingServicesDrawer__rateInputRow'>
+      <div className='Layer__TimeTrackingServicesDrawer__rateAmountWrap'>
+        <AmountInput
+          id={inputId}
+          name={name}
+          value={value}
+          onChange={next => onChange(next ?? '')}
+          className='Layer__TimeTrackingServicesDrawer__rateAmountInput'
+        />
+      </div>
+      <Span className='Layer__TimeTrackingServicesDrawer__rateSuffix'>
+        {t('timeTracking:services.rate_per_hour_suffix', '/hr')}
+      </Span>
+    </div>
+  )
+}
+
+type ServiceEditCardProps = {
+  service: CatalogService
+  onCollapse: () => void
+  onOpenArchive: () => void
+}
+
+const ServiceEditCard = ({ service, onCollapse, onOpenArchive }: ServiceEditCardProps) => {
+  const { t } = useTranslation()
+  const intl = useIntl()
+  const { trigger: updateService, isMutating } = useUpdateCatalogService({ serviceId: service.id })
+  const [name, setName] = useState(service.name)
+  const [hourlyRaw, setHourlyRaw] = useState(
+    () => service.billableRatePerHourAmount != null && !Number.isNaN(service.billableRatePerHourAmount)
+      ? convertCentsToDecimalString(service.billableRatePerHourAmount)
+      : '',
+  )
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setName(service.name)
+    setHourlyRaw(
+      service.billableRatePerHourAmount != null && !Number.isNaN(service.billableRatePerHourAmount)
+        ? convertCentsToDecimalString(service.billableRatePerHourAmount)
+        : '',
+    )
+    setSaveError(null)
+  }, [service])
+
+  const onSave = useCallback(async () => {
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setSaveError(t('timeTracking:validation.service_name_required', 'Service name is a required field.'))
+      return
+    }
+    setSaveError(null)
+    const trimmedRate = hourlyRaw.trim()
+    const billableRatePerHourAmount = trimmedRate === ''
+      ? null
+      : (toLocalizedCents(hourlyRaw, intl.locale) ?? null)
+    try {
+      await updateService({
+        name: trimmed,
+        billable_rate_per_hour_amount: billableRatePerHourAmount,
+      })
+      onCollapse()
+    }
+    catch {
+      setSaveError(t('timeTracking:error.update_service', 'Could not save this service. Please try again.'))
+    }
+  }, [hourlyRaw, intl.locale, name, onCollapse, t, updateService])
+
+  return (
+    <VStack className='Layer__TimeTrackingServicesDrawer__editForm' gap='md'>
+      <TextField
+        name={`service-name-${service.id}`}
+        className='Layer__TimeTrackingServicesDrawer__rateField'
+      >
+        <Label slot='label' size='sm' htmlFor={`service-name-${service.id}`} pbe='3xs'>
+          {t('timeTracking:services.service_name', 'Service name')}
+        </Label>
+        <InputGroup slot='input'>
+          <Input
+            id={`service-name-${service.id}`}
+            name={`service-name-${service.id}`}
+            value={name}
+            onChange={e => setName(e.target.value)}
+            inset
+          />
+        </InputGroup>
+      </TextField>
+      <div className='Layer__TimeTrackingServicesDrawer__rateField'>
+        <Label size='sm' htmlFor={`service-rate-${service.id}`} pbe='3xs'>
+          {t('timeTracking:services.hourly_rate_optional', 'Default hourly rate (optional)')}
+        </Label>
+        <HourlyRateField
+          inputId={`service-rate-${service.id}`}
+          name={`service-rate-${service.id}`}
+          value={hourlyRaw}
+          onChange={setHourlyRaw}
+        />
+      </div>
+      {saveError && <FieldError>{saveError}</FieldError>}
+      <HStack className='Layer__TimeTrackingServicesDrawer__cardActions' gap='sm' align='center'>
+        <Button variant='outlined' onPress={onOpenArchive}>
+          <Archive size={16} />
+          {t('timeTracking:services.archive', 'Archive')}
+        </Button>
+        <Button onPress={() => void onSave()} isDisabled={isMutating}>
+          {t('timeTracking:services.save', 'Save')}
+        </Button>
+      </HStack>
+    </VStack>
+  )
+}
+
+type AddServiceCardProps = {
+  onCancel: () => void
+  onCreated: () => void
+}
+
+const AddServiceCard = ({ onCancel, onCreated }: AddServiceCardProps) => {
+  const { t } = useTranslation()
+  const intl = useIntl()
+  const { trigger: createService, isMutating } = useCreateCatalogService()
+  const [name, setName] = useState('')
+  const [hourlyRaw, setHourlyRaw] = useState('')
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const onSave = useCallback(async () => {
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setSaveError(t('timeTracking:validation.service_name_required', 'Service name is a required field.'))
+      return
+    }
+    setSaveError(null)
+    const trimmedRate = hourlyRaw.trim()
+    const billableRatePerHourAmount = trimmedRate === ''
+      ? undefined
+      : toLocalizedCents(hourlyRaw, intl.locale)
+    try {
+      await createService({
+        name: trimmed,
+        billable_rate_per_hour_amount: billableRatePerHourAmount == null ? null : billableRatePerHourAmount,
+      })
+      onCreated()
+    }
+    catch {
+      setSaveError(t('timeTracking:error.create_service', 'Failed to create service. Please try again.'))
+    }
+  }, [createService, hourlyRaw, intl.locale, name, onCreated, t])
+
+  return (
+    <VStack className='Layer__TimeTrackingServicesDrawer__addCard' gap='md'>
+      <Span className='Layer__TimeTrackingServicesDrawer__addCardTitle' size='sm' weight='bold'>
+        {t('timeTracking:services.add_service', 'Add service')}
+      </Span>
+      <TextField
+        name='add-service-name'
+        className='Layer__TimeTrackingServicesDrawer__rateField'
+      >
+        <Label slot='label' size='sm' htmlFor='add-service-name' pbe='3xs'>
+          {t('timeTracking:services.service_name', 'Service name')}
+        </Label>
+        <InputGroup slot='input'>
+          <Input
+            id='add-service-name'
+            name='add-service-name'
+            value={name}
+            onChange={e => setName(e.target.value)}
+            inset
+          />
+        </InputGroup>
+      </TextField>
+      <div className='Layer__TimeTrackingServicesDrawer__rateField'>
+        <Label size='sm' htmlFor='add-service-rate' pbe='3xs'>
+          {t('timeTracking:services.hourly_rate_optional', 'Default hourly rate (optional)')}
+        </Label>
+        <HourlyRateField
+          inputId='add-service-rate'
+          name='add-service-rate'
+          value={hourlyRaw}
+          onChange={setHourlyRaw}
+        />
+      </div>
+      {saveError && <FieldError>{saveError}</FieldError>}
+      <HStack gap='sm' justify='end' align='center'>
+        <Button variant='outlined' onPress={onCancel}>
+          {t('timeTracking:services.cancel', 'Cancel')}
+        </Button>
+        <Button onPress={() => void onSave()} isDisabled={isMutating}>
+          {t('timeTracking:services.save', 'Save')}
+        </Button>
+      </HStack>
+    </VStack>
+  )
+}
+
+type ArchiveServiceModalProps = {
+  service: CatalogService
+  onOpenChange: (open: boolean) => void
+  onArchiveSuccess: () => void
+}
+
+const ArchiveServiceModal = ({
+  service,
+  onOpenChange,
+  onArchiveSuccess,
+}: ArchiveServiceModalProps) => {
+  const { t } = useTranslation()
+  const { isMobile } = useSizeClass()
+  const { trigger: archiveService } = useArchiveCatalogService({ serviceId: service.id })
+
+  const onConfirm = useCallback(async () => {
+    await archiveService()
+    onArchiveSuccess()
+  }, [archiveService, onArchiveSuccess])
+
+  return (
+    <BaseConfirmationModal
+      isOpen={true}
+      onOpenChange={onOpenChange}
+      title={t('timeTracking:services.archive_confirm_title', 'Archive this service?')}
+      description={t('timeTracking:services.archive_confirm_description', 'This service will be removed from your active list. Time entries that used it are unchanged.')}
+      onConfirm={onConfirm}
+      confirmLabel={t('timeTracking:services.archive', 'Archive')}
+      errorText={t('timeTracking:error.archive_service', 'Could not archive this service. Please try again.')}
+      useDrawer={isMobile}
+    />
+  )
+}
+
+type UnarchiveServiceModalProps = {
+  service: CatalogService
+  onOpenChange: (open: boolean) => void
+  onUnarchiveSuccess: () => void
+}
+
+const UnarchiveServiceModal = ({
+  service,
+  onOpenChange,
+  onUnarchiveSuccess,
+}: UnarchiveServiceModalProps) => {
+  const { t } = useTranslation()
+  const { isMobile } = useSizeClass()
+  const { trigger: reactivateService } = useReactivateCatalogService({ serviceId: service.id })
+
+  const onConfirm = useCallback(async () => {
+    await reactivateService()
+    onUnarchiveSuccess()
+  }, [onUnarchiveSuccess, reactivateService])
+
+  return (
+    <BaseConfirmationModal
+      isOpen={true}
+      onOpenChange={onOpenChange}
+      title={t('timeTracking:services.unarchive_confirm_title', 'Restore this service?')}
+      description={t('timeTracking:services.unarchive_confirm_description', 'This service will appear in your active list again.')}
+      onConfirm={onConfirm}
+      confirmLabel={t('timeTracking:services.unarchive', 'Restore')}
+      errorText={t('timeTracking:error.unarchive_service', 'Could not restore this service. Please try again.')}
+      useDrawer={isMobile}
+    />
+  )
+}
+
+export type TimeTrackingServicesDrawerProps = {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function TimeTrackingServicesDrawer({ isOpen, onOpenChange }: TimeTrackingServicesDrawerProps) {
+  const { t } = useTranslation()
+  const { formatCurrencyFromCents } = useIntlFormatter()
+  const { isMobile } = useSizeClass()
+  const { data, isLoading, isError } = useListCatalogServices()
+  const [tab, setTab] = useState<ServicesTab>('active')
+  const {
+    data: archivedData,
+    isLoading: isArchivedLoading,
+    isError: isArchivedError,
+  } = useListCatalogServices({
+    allowArchived: true,
+    isEnabled: isOpen && tab === 'archived',
+  })
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [isAdding, setIsAdding] = useState(false)
+  const [archiveTarget, setArchiveTarget] = useState<CatalogService | null>(null)
+  const [unarchiveTarget, setUnarchiveTarget] = useState<CatalogService | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setExpandedId(null)
+      setIsAdding(false)
+      setArchiveTarget(null)
+      setUnarchiveTarget(null)
+      setTab('active')
+    }
+  }, [isOpen])
+
+  const activeServices = useMemo(() => data?.data ?? [], [data])
+
+  const archivedServices = useMemo(() => {
+    const rows = archivedData?.data ?? []
+    const withArchived = rows.filter(s => s.archivedAt != null)
+    return withArchived.length > 0 ? withArchived : rows
+  }, [archivedData])
+
+  const formatHourly = useCallback(
+    (service: CatalogService) => {
+      const cents = service.billableRatePerHourAmount
+      if (cents == null) {
+        return null
+      }
+      return `${formatCurrencyFromCents(cents)}${t('timeTracking:services.rate_per_hour_suffix', '/hr')}`
+    },
+    [formatCurrencyFromCents, t],
+  )
+
+  const tabOptions = useMemo(
+    () => [
+      { value: 'active' as const, label: t('timeTracking:label.active', 'Active') },
+      { value: 'archived' as const, label: t('timeTracking:services.archived', 'Archived') },
+    ],
+    [t],
+  )
+
+  const startAdd = useCallback(() => {
+    setIsAdding(true)
+    setExpandedId(null)
+  }, [])
+
+  const listForTab = tab === 'active' ? activeServices : archivedServices
+  const isArchivedInitialLoading = tab === 'archived' && isArchivedLoading && archivedData === undefined
+  const showEmptyList = listForTab.length === 0
+    && !(tab === 'active' && isAdding)
+    && !isArchivedInitialLoading
+    && !(tab === 'archived' && isArchivedError)
+
+  const Header = useCallback(
+    ({ close }: { close: () => void }) => (
+      <VStack gap='md'>
+        <HStack className='Layer__TimeTrackingServicesDrawer__headerTop' gap='sm' align='center'>
+          <ModalHeading>{t('timeTracking:services.title', 'Services')}</ModalHeading>
+          <HStack gap='xs' align='center'>
+            <Button onPress={startAdd} isDisabled={isAdding}>
+              <Plus size={16} />
+              {t('timeTracking:services.add', 'Add')}
+            </Button>
+            <ModalCloseButton onClose={close} />
+          </HStack>
+        </HStack>
+        <div className='Layer__TimeTrackingServicesDrawer__tabs'>
+          <Toggle
+            ariaLabel={t('timeTracking:services.tab_group_label', 'Service list')}
+            options={tabOptions}
+            selectedKey={tab}
+            onSelectionChange={key => setTab(key as ServicesTab)}
+            size={ToggleSize.xsmall}
+          />
+        </div>
+      </VStack>
+    ),
+    [isAdding, startAdd, t, tab, tabOptions],
+  )
+
+  const toggleExpanded = useCallback((serviceId: string) => {
+    setIsAdding(false)
+    setExpandedId(prev => (prev === serviceId ? null : serviceId))
+  }, [])
+
+  return (
+    <>
+      <Drawer
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        isDismissable
+        variant={isMobile ? 'mobile-drawer' : 'drawer'}
+        flexBlock={isMobile}
+        aria-label={t('timeTracking:services.title', 'Services')}
+        slots={{ Header }}
+      >
+        {() => (
+          <div className='Layer__TimeTrackingServicesDrawer'>
+            {isError && (
+              <DataState
+                status={DataStateStatus.failed}
+                title={t('timeTracking:error.load_services', 'Failed to load services.')}
+                titleSize={TextSize.md}
+                spacing
+              />
+            )}
+            {!isError && isLoading && !data && (
+              <DataState
+                status={DataStateStatus.info}
+                title={t('common:label.loading', 'Loading...')}
+                icon={<Loader className='Layer__anim--rotating' />}
+                titleSize={TextSize.md}
+                spacing
+              />
+            )}
+            {!isError && data && (
+              <VStack className='Layer__TimeTrackingServicesDrawer__list' gap='sm'>
+                {tab === 'archived' && isArchivedError && (
+                  <DataState
+                    status={DataStateStatus.failed}
+                    title={t('timeTracking:error.load_services', 'Failed to load services.')}
+                    titleSize={TextSize.md}
+                    spacing
+                  />
+                )}
+                {tab === 'archived' && !isArchivedError && isArchivedInitialLoading && (
+                  <DataState
+                    status={DataStateStatus.info}
+                    title={t('common:label.loading', 'Loading...')}
+                    icon={<Loader className='Layer__anim--rotating' />}
+                    titleSize={TextSize.md}
+                    spacing
+                  />
+                )}
+                {tab === 'active' && isAdding && (
+                  <div className='Layer__TimeTrackingServicesDrawer__addWrap'>
+                    <AddServiceCard
+                      onCancel={() => setIsAdding(false)}
+                      onCreated={() => {
+                        setIsAdding(false)
+                      }}
+                    />
+                  </div>
+                )}
+                {showEmptyList && (
+                  <DataState
+                    status={DataStateStatus.allDone}
+                    title={tab === 'active'
+                      ? t('timeTracking:services.no_active', 'No services yet')
+                      : t('timeTracking:services.no_archived', 'No archived services')}
+                    titleSize={TextSize.md}
+                    spacing
+                  />
+                )}
+                {tab === 'active' && activeServices.length > 0 && (
+                  <div className='Layer__TimeTrackingServicesDrawer__accordion'>
+                    {activeServices.map((service) => {
+                      const rateLabel = formatHourly(service)
+                      return (
+                        <ExpandableCard
+                          key={service.id}
+                          isExpanded={expandedId === service.id}
+                          onToggleExpanded={() => toggleExpanded(service.id)}
+                          slots={{
+                            Heading: (
+                              <HStack align='center' gap='sm' fluid>
+                                <Span className='Layer__TimeTrackingServicesDrawer__rowName' size='sm'>
+                                  {service.name}
+                                </Span>
+                                <Spacer />
+                                {rateLabel && (
+                                  <Span className='Layer__TimeTrackingServicesDrawer__rowRate' size='sm'>
+                                    {rateLabel}
+                                  </Span>
+                                )}
+                              </HStack>
+                            ),
+                          }}
+                        >
+                          <ServiceEditCard
+                            service={service}
+                            onCollapse={() => setExpandedId(null)}
+                            onOpenArchive={() => setArchiveTarget(service)}
+                          />
+                        </ExpandableCard>
+                      )
+                    })}
+                  </div>
+                )}
+                {tab === 'archived' && !isArchivedError && !isArchivedInitialLoading && archivedServices.length > 0 && (
+                  <div className='Layer__TimeTrackingServicesDrawer__archivedList'>
+                    {archivedServices.map((service) => {
+                      const archivedRate = formatHourly(service)
+                      return (
+                        <HStack
+                          key={service.id}
+                          className='Layer__TimeTrackingServicesDrawer__archivedRow'
+                          gap='sm'
+                          align='center'
+                        >
+                          <Span className='Layer__TimeTrackingServicesDrawer__rowName' size='sm'>
+                            {service.name}
+                          </Span>
+                          <Spacer />
+                          {archivedRate && (
+                            <Span className='Layer__TimeTrackingServicesDrawer__rowRate' size='sm'>
+                              {archivedRate}
+                            </Span>
+                          )}
+                          <Button variant='outlined' inset onPress={() => setUnarchiveTarget(service)}>
+                            <ArchiveRestore size={14} />
+                            {t('timeTracking:services.unarchive', 'Restore')}
+                          </Button>
+                        </HStack>
+                      )
+                    })}
+                  </div>
+                )}
+              </VStack>
+            )}
+          </div>
+        )}
+      </Drawer>
+      {archiveTarget !== null && (
+        <ArchiveServiceModal
+          key={archiveTarget.id}
+          service={archiveTarget}
+          onOpenChange={(open) => {
+            if (!open) {
+              setArchiveTarget(null)
+            }
+          }}
+          onArchiveSuccess={() => {
+            setExpandedId(null)
+          }}
+        />
+      )}
+      {unarchiveTarget !== null && (
+        <UnarchiveServiceModal
+          key={unarchiveTarget.id}
+          service={unarchiveTarget}
+          onOpenChange={(open) => {
+            if (!open) {
+              setUnarchiveTarget(null)
+            }
+          }}
+          onUnarchiveSuccess={() => {
+            setUnarchiveTarget(null)
+          }}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/TimeEntries/TimeTrackingServicesDrawer/timeTrackingServicesDrawer.scss
+++ b/src/components/TimeEntries/TimeTrackingServicesDrawer/timeTrackingServicesDrawer.scss
@@ -1,0 +1,172 @@
+.Layer__TimeTrackingServicesDrawer {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding-block-start: var(--spacing-md);
+  padding-block-end: var(--spacing-lg);
+  padding-inline: var(--spacing-md);
+}
+
+.Layer__TimeTrackingServicesDrawer__headerTop {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.Layer__TimeTrackingServicesDrawer__tabs {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+
+  .Layer__UI__Toggle[data-size='xsmall'] {
+    height: auto;
+    padding: 2px;
+    border-radius: var(--border-radius-2xs);
+  }
+
+  .Layer__UI__Toggle[data-size='xsmall'] .Layer__UI__ToggleOption {
+    height: 26px;
+    padding: 4px 12px;
+    border-radius: var(--border-radius-2xs);
+  }
+
+  .Layer__UI__Toggle[data-size='xsmall'] .Layer__UI__ToggleOption-SelectionIndicator {
+    border-radius: var(--border-radius-2xs);
+  }
+}
+
+.Layer__TimeTrackingServicesDrawer__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.Layer__TimeTrackingServicesDrawer__addWrap {
+  overflow: hidden;
+  border-radius: var(--border-radius-2xs);
+
+  border: 1px solid var(--border-color);
+}
+
+.Layer__TimeTrackingServicesDrawer__accordion {
+  overflow: hidden;
+  border-radius: var(--border-radius-2xs);
+
+  border: 1px solid var(--border-color);
+
+  .Layer__ExpandableCard:first-child {
+    border-top: none;
+  }
+}
+
+.Layer__TimeTrackingServicesDrawer__archivedList {
+  overflow: hidden;
+  border-radius: var(--border-radius-2xs);
+
+  border: 1px solid var(--border-color);
+}
+
+.Layer__TimeTrackingServicesDrawer__archivedRow {
+  box-sizing: border-box;
+
+  padding: var(--spacing-sm) var(--spacing-md);
+
+  border-block-start: 1px solid var(--border-color);
+
+  background-color: white;
+
+  &:first-child {
+    border-block-start: none;
+  }
+
+  .Layer__UI__Button {
+    gap: var(--spacing-2xs);
+    padding-inline: var(--spacing-sm);
+    font-size: var(--text-sm);
+  }
+}
+
+.Layer__TimeTrackingServicesDrawer__rowName {
+  flex: 1;
+  min-width: 0;
+}
+
+.Layer__TimeTrackingServicesDrawer__rowRate {
+  flex-shrink: 0;
+}
+
+.Layer__TimeTrackingServicesDrawer__addCard {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+
+  padding: var(--spacing-md);
+
+  background-color: var(--bg-subtle);
+}
+
+.Layer__TimeTrackingServicesDrawer__addCardTitle {
+  font-weight: var(--font-weight-semibold);
+}
+
+.Layer__TimeTrackingServicesDrawer__editForm {
+  box-sizing: border-box;
+
+  padding: var(--spacing-md);
+
+  margin-inline: calc(-1 * var(--spacing-md));
+
+  background-color: var(--bg-subtle);
+
+  border-block-start: 1px solid var(--color-base-300);
+}
+
+.Layer__TimeTrackingServicesDrawer__rateField {
+  display: grid;
+  gap: var(--spacing-3xs);
+}
+
+.Layer__TimeTrackingServicesDrawer__rateInputRow {
+  display: flex;
+  align-items: stretch;
+  border-radius: var(--border-radius-2xs);
+
+  border: 1px solid var(--border-color);
+
+  background-color: white;
+}
+
+.Layer__TimeTrackingServicesDrawer__rateAmountWrap {
+  flex: 1;
+  min-width: 0;
+
+  .Layer__input-tooltip {
+    display: block;
+    height: 100%;
+  }
+
+  .Layer__TimeTrackingServicesDrawer__rateAmountInput {
+    width: 100%;
+    border-radius: 0;
+
+    border: none;
+
+    background: transparent;
+  }
+}
+
+.Layer__TimeTrackingServicesDrawer__rateSuffix {
+  display: flex;
+  align-items: center;
+
+  padding-inline: var(--spacing-sm);
+
+  font-size: var(--text-sm);
+
+  color: var(--color-base-600);
+}
+
+.Layer__TimeTrackingServicesDrawer__cardActions {
+  justify-content: space-between;
+}

--- a/src/components/TimeTrackingStats/TimeTrackingStats.tsx
+++ b/src/components/TimeTrackingStats/TimeTrackingStats.tsx
@@ -1,0 +1,248 @@
+import { memo, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis } from 'recharts'
+
+import { formatMinutesAsDuration } from '@utils/time/timeUtils'
+import { type TimeTrackingSummaryFilterParams, useTimeTrackingSummary } from '@hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary'
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+import { Container } from '@components/Container/Container'
+import { DataState, DataStateStatus } from '@components/DataState/DataState'
+import { CombinedDateRangeSelection } from '@components/DateSelection/CombinedDateRangeSelection'
+import { Loader } from '@components/Loader/Loader'
+
+import './timeTrackingStats.scss'
+
+const SERVICE_COLORS = [
+  '#1F4F4C',
+  '#DCA900',
+  '#B79BD0',
+  '#4D9CA3',
+  '#D4845A',
+  '#8B6BAE',
+  '#5C8A4D',
+  '#7CB9E0',
+]
+
+const CHART_HEIGHT = 24
+const CHART_MARGIN = { top: 0, right: 0, bottom: 0, left: 0 }
+const SERVICE_BREAKDOWN_TOP_N = 5
+const OTHER_BUCKET_KEY = '__other__'
+
+type ByServiceEntry = {
+  serviceId?: string | null
+  serviceName?: string | null
+  totalMinutes: number
+}
+
+type TimeTrackingServiceBreakdown = ByServiceEntry & {
+  color: string
+  key: string
+  percentage: number
+  serviceName: string
+}
+
+type TimeTrackingStatsProps = {
+  selectedFilterParams: TimeTrackingSummaryFilterParams
+}
+
+const normalizeByServiceEntry = (entry: unknown): ByServiceEntry | null => {
+  if (!entry || typeof entry !== 'object') {
+    return null
+  }
+
+  const encodedEntry = entry as Record<string, unknown>
+  const totalMinutes = typeof encodedEntry.totalMinutes === 'number'
+    ? encodedEntry.totalMinutes
+    : typeof encodedEntry.total_minutes === 'number'
+      ? encodedEntry.total_minutes
+      : 0
+
+  if (totalMinutes <= 0) {
+    return null
+  }
+
+  const serviceId = typeof encodedEntry.serviceId === 'string'
+    ? encodedEntry.serviceId
+    : typeof encodedEntry.id === 'string'
+      ? encodedEntry.id
+      : null
+
+  const serviceName = typeof encodedEntry.serviceName === 'string'
+    ? encodedEntry.serviceName
+    : typeof encodedEntry.name === 'string'
+      ? encodedEntry.name
+      : null
+
+  return {
+    serviceId,
+    serviceName,
+    totalMinutes,
+  }
+}
+
+const TimeTrackingStatsLegendSwatch = ({ color }: { color: string }) => (
+  <svg
+    aria-hidden
+    className='Layer__TimeTrackingStats__LegendSwatch'
+    viewBox='0 0 10 10'
+  >
+    <circle cx='5' cy='5' r='5' fill={color} />
+  </svg>
+)
+
+const TimeTrackingStatsBreakdown = memo(function TimeTrackingStatsBreakdown({ entries }: { entries: TimeTrackingServiceBreakdown[] }) {
+  const chartData = useMemo(() => {
+    const stackedEntry = entries.reduce<Record<string, number | string>>((acc, entry) => {
+      acc[entry.key] = entry.totalMinutes
+      return acc
+    }, { label: 'services' })
+
+    return [stackedEntry]
+  }, [entries])
+  const chartTotalMinutes = useMemo(
+    () => entries.reduce((total, entry) => total + entry.totalMinutes, 0),
+    [entries],
+  )
+
+  return (
+    <VStack className='Layer__TimeTrackingStats__Chart' gap='md' justify='center'>
+      <div className='Layer__TimeTrackingStats__ChartBar'>
+        <ResponsiveContainer width='100%' height={CHART_HEIGHT} style={{ padding: 0 }}>
+          <BarChart
+            data={chartData}
+            layout='vertical'
+            margin={CHART_MARGIN}
+            barCategoryGap='0%'
+            barGap={0}
+            barSize={CHART_HEIGHT}
+          >
+            <XAxis type='number' hide domain={[0, Math.max(chartTotalMinutes, 1)]} allowDataOverflow />
+            <YAxis type='category' dataKey='label' hide width={0} />
+            {entries.map(({ color, key }) => (
+              <Bar
+                key={key}
+                dataKey={key}
+                barSize={CHART_HEIGHT}
+                fill={color}
+                stackId='time-tracking-services'
+                isAnimationActive={false}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <HStack className='Layer__TimeTrackingStats__Legend' gap='lg' align='start'>
+        {entries.map(({ color, key, percentage, serviceName, totalMinutes }) => (
+          <VStack key={key} className='Layer__TimeTrackingStats__LegendItem' gap='2xs'>
+            <HStack gap='2xs' align='center'>
+              <TimeTrackingStatsLegendSwatch color={color} />
+              <Span size='md'>{serviceName}</Span>
+            </HStack>
+            <Span size='xl' weight='bold'>{formatMinutesAsDuration(totalMinutes, { compact: true })}</Span>
+            <Span size='sm' variant='subtle'>
+              {percentage}
+              %
+            </Span>
+          </VStack>
+        ))}
+      </HStack>
+    </VStack>
+  )
+})
+
+export const TimeTrackingStats = ({ selectedFilterParams }: TimeTrackingStatsProps) => {
+  const { t } = useTranslation()
+  const { data: selectedSummary, isLoading: selectedLoading, isError: selectedError } = useTimeTrackingSummary(selectedFilterParams)
+
+  const serviceBreakdown = useMemo<TimeTrackingServiceBreakdown[]>(() => {
+    if (!selectedSummary?.byService) {
+      return []
+    }
+
+    const byService = selectedSummary.byService
+      .map(normalizeByServiceEntry)
+      .filter((entry): entry is ByServiceEntry => entry !== null)
+
+    const totalMinutes = byService.reduce((total, entry) => total + entry.totalMinutes, 0)
+
+    const sorted = [...byService].sort((a, b) => b.totalMinutes - a.totalMinutes)
+    const topEntries = sorted.slice(0, SERVICE_BREAKDOWN_TOP_N)
+    const remainder = sorted.slice(SERVICE_BREAKDOWN_TOP_N)
+
+    const rows: TimeTrackingServiceBreakdown[] = topEntries.map((entry, index) => ({
+      ...entry,
+      color: SERVICE_COLORS[index % SERVICE_COLORS.length],
+      key: entry.serviceId ?? `service-${index}`,
+      percentage: totalMinutes > 0
+        ? Math.round((entry.totalMinutes / totalMinutes) * 100)
+        : 0,
+      serviceName: entry.serviceName || t('timeTracking:label.other', 'Other'),
+    }))
+
+    if (remainder.length > 0) {
+      const otherMinutes = remainder.reduce((sum, entry) => sum + entry.totalMinutes, 0)
+      const otherIndex = topEntries.length
+      rows.push({
+        serviceId: null,
+        serviceName: t('timeTracking:label.other', 'Other'),
+        totalMinutes: otherMinutes,
+        color: SERVICE_COLORS[otherIndex % SERVICE_COLORS.length],
+        key: OTHER_BUCKET_KEY,
+        percentage: totalMinutes > 0
+          ? Math.round((otherMinutes / totalMinutes) * 100)
+          : 0,
+      })
+    }
+
+    return rows
+  }, [selectedSummary, t])
+
+  if (selectedError) {
+    return (
+      <Container name='time-tracking-stats'>
+        <DataState status={DataStateStatus.failed} title={t('timeTracking:error.load_summary', 'Failed to load time tracking summary')} spacing />
+      </Container>
+    )
+  }
+
+  if (selectedLoading || !selectedSummary) {
+    return (
+      <Container name='time-tracking-stats'>
+        <HStack className='Layer__TimeTrackingStats__Content' gap='lg' justify='center' align='center'>
+          <Loader />
+        </HStack>
+      </Container>
+    )
+  }
+
+  return (
+    <Container name='time-tracking-stats'>
+      <VStack className='Layer__TimeTrackingStats__Content' gap='lg'>
+        <HStack className='Layer__TimeTrackingStats__TopRow' justify='space-between' align='center' gap='lg'>
+          <VStack className='Layer__TimeTrackingStats__Summary' gap='2xs'>
+            <Span size='sm' variant='subtle'>{t('common:label.total', 'Total')}</Span>
+            <Span className='Layer__TimeTrackingStats__SummaryValue' size='xl' weight='bold'>
+              {formatMinutesAsDuration(selectedSummary.totalMinutes, { compact: true })}
+            </Span>
+          </VStack>
+          <VStack className='Layer__TimeTrackingStats__DateSelection'>
+            <CombinedDateRangeSelection mode='full' showLabels={false} />
+          </VStack>
+        </HStack>
+        {serviceBreakdown.length > 0
+          ? (
+            <TimeTrackingStatsBreakdown entries={serviceBreakdown} />
+          )
+          : (
+            <VStack className='Layer__TimeTrackingStats__Chart' gap='md' justify='center'>
+              <HStack className='Layer__TimeTrackingStats__ChartBar Layer__TimeTrackingStats__ChartBar--empty' />
+              <Span size='sm' variant='subtle'>
+                {t('timeTracking:label.no_activity_breakdown', 'No activity breakdown available for this period.')}
+              </Span>
+            </VStack>
+          )}
+      </VStack>
+    </Container>
+  )
+}

--- a/src/components/TimeTrackingStats/timeTrackingStats.scss
+++ b/src/components/TimeTrackingStats/timeTrackingStats.scss
@@ -1,0 +1,106 @@
+.Layer__TimeTrackingStats__Content {
+  container: time-tracking-stats / inline-size;
+  gap: var(--spacing-lg);
+  padding: var(--spacing-md);
+}
+
+.Layer__TimeTrackingStats__TopRow {
+  gap: var(--spacing-lg);
+  min-inline-size: 0;
+}
+
+.Layer__TimeTrackingStats__DateSelection {
+  flex: 1 1 auto;
+  min-inline-size: 0;
+  container: time-tracking-stats-dates / inline-size;
+}
+
+.Layer__TimeTrackingStats__Summary {
+  flex: 0 0 auto;
+  min-inline-size: 0;
+}
+
+.Layer__TimeTrackingStats__SummaryValue {
+  font-size: var(--text-heading-3xl);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.Layer__TimeTrackingStats__Chart {
+  padding-block-start: var(--spacing-lg);
+  border-top: 1px solid var(--color-base-300);
+}
+
+.Layer__TimeTrackingStats__ChartBar {
+  .recharts-responsive-container {
+    padding: 0;
+  }
+
+  overflow: hidden;
+  block-size: 1.5rem;
+  border-radius: var(--border-radius-xs);
+  background-color: var(--color-base-100);
+}
+
+.Layer__TimeTrackingStats__ChartBar--empty {
+  inline-size: 100%;
+}
+
+.Layer__TimeTrackingStats__Legend {
+  flex-wrap: wrap;
+}
+
+.Layer__TimeTrackingStats__LegendItem {
+  min-inline-size: 10rem;
+}
+
+.Layer__TimeTrackingStats__LegendSwatch {
+  flex-shrink: 0;
+  block-size: 0.625rem;
+  inline-size: 0.625rem;
+}
+
+@container time-tracking-stats (max-width: 760px) {
+  .Layer__TimeTrackingStats__TopRow[data-direction='row'] {
+    flex-direction: column;
+  }
+
+  .Layer__TimeTrackingStats__TopRow[data-align='center'] {
+    align-items: stretch;
+  }
+
+  .Layer__TimeTrackingStats__TopRow[data-justify='space-between'] {
+    justify-content: flex-start;
+  }
+
+  .Layer__TimeTrackingStats__DateSelection {
+    inline-size: 100%;
+
+    .Layer__GlobalDateRangeSelection {
+      grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
+      inline-size: 100%;
+      min-inline-size: 0;
+
+      &.Layer__GlobalDateRangeSelection--mobile {
+        grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
+      }
+
+      & > * {
+        min-inline-size: 0;
+      }
+    }
+  }
+}
+
+@container time-tracking-stats (max-width: 430px) {
+  .Layer__TimeTrackingStats__DateSelection .Layer__GlobalDateRangeSelection,
+  .Layer__TimeTrackingStats__DateSelection .Layer__GlobalDateRangeSelection.Layer__GlobalDateRangeSelection--mobile {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@container time-tracking-stats (max-width: 640px) {
+  .Layer__TimeTrackingStats__LegendItem {
+    min-inline-size: 100%;
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -59,6 +59,7 @@ export { unstable_MileageTracking } from './views/MileageTracking'
 export { ProjectProfitabilityView } from './views/ProjectProfitability/ProjectProfitability'
 export { Reports } from './views/Reports/Reports'
 export { TaxEstimatesView } from './views/TaxEstimates/TaxEstimates'
+export { unstable_TimeTracking, type UnstableTimeTrackingProps } from './views/TimeTracking'
 
 /*
 ======================= Layer Provider & Context =======================

--- a/src/views/TimeTracking.tsx
+++ b/src/views/TimeTracking.tsx
@@ -1,0 +1,72 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { getTimeTrackingDateFilterParams } from '@utils/time/timeUtils'
+import { useActiveTimeTracker } from '@hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker'
+import { useGlobalDateRange } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
+import { Button } from '@ui/Button/Button'
+import { HStack } from '@ui/Stack/Stack'
+import { ActiveTimeTrackerBanner } from '@components/TimeEntries/ActiveTimeTrackerBanner/ActiveTimeTrackerBanner'
+import { TimeEntries } from '@components/TimeEntries/TimeEntries'
+import { TimeTrackingServicesDrawer } from '@components/TimeEntries/TimeTrackingServicesDrawer/TimeTrackingServicesDrawer'
+import { TimeTrackingStats } from '@components/TimeTrackingStats/TimeTrackingStats'
+import { View } from '@components/View/View'
+
+export type UnstableTimeTrackingProps = {
+  showTitle?: boolean
+  onReportsClick?: () => void
+}
+
+export const unstable_TimeTracking = ({ showTitle = true, onReportsClick }: UnstableTimeTrackingProps) => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { t } = useTranslation()
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { startDate, endDate } = useGlobalDateRange({ dateSelectionMode: 'full' })
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { data: activeTimeEntry, isLoading: isActiveTimeEntryLoading } = useActiveTimeTracker()
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const [isActiveTimerDrawerOpen, setIsActiveTimerDrawerOpen] = useState(false)
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const [isServicesDrawerOpen, setIsServicesDrawerOpen] = useState(false)
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const summaryFilterParams = useMemo(
+    () => getTimeTrackingDateFilterParams({ startDate, endDate }),
+    [endDate, startDate],
+  )
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const onStartTimer = useCallback(() => {
+    setIsActiveTimerDrawerOpen(true)
+  }, [])
+
+  return (
+    <View
+      title={t('timeTracking:label.time_tracking', 'Time Tracking')}
+      showHeader={showTitle}
+      header={(
+        <HStack gap='sm' align='center' justify='end'>
+          {onReportsClick !== undefined && (
+            <Button variant='outlined' onPress={onReportsClick}>
+              {t('reports:label.reports', 'Reports')}
+            </Button>
+          )}
+          <Button variant='outlined' onPress={() => setIsServicesDrawerOpen(true)}>
+            {t('timeTracking:services.title', 'Services')}
+          </Button>
+        </HStack>
+      )}
+    >
+      <ActiveTimeTrackerBanner
+        isDrawerOpen={isActiveTimerDrawerOpen}
+        onDrawerOpenChange={setIsActiveTimerDrawerOpen}
+      />
+      <TimeTrackingStats selectedFilterParams={summaryFilterParams} />
+      <TimeEntries
+        onStartTimer={onStartTimer}
+        isStartTimerDisabled={isActiveTimeEntryLoading || activeTimeEntry !== null}
+      />
+      <TimeTrackingServicesDrawer isOpen={isServicesDrawerOpen} onOpenChange={setIsServicesDrawerOpen} />
+    </View>
+  )
+}


### PR DESCRIPTION
## Summary
- Add TimeTrackingServicesDrawer for CRUD on catalog services
- Add TimeTrackingStats summary component with activity breakdown
- Add TimeTracking page view composing all time tracking components
- Register /time-tracking route in app index

## Merge Order
> **This is PR 4 of 4** — merge last, after PRs 1, 2, and 3 are all merged.
>
> ```
> hooks-and-schemas
>       ↓
>    PR 1           (first)
>     /       \
>   PR 2      PR 3  (parallel)
>     \       /
>  ➡️ PR 4 (this)   (last)
> ```
>
> **Depends on:** #1271, #1272, #1273

## Test plan
- [ ] Verify TimeTrackingServicesDrawer supports create, edit, archive, and restore
- [ ] Verify TimeTrackingStats renders summary with activity breakdown
- [ ] Verify TimeTracking page view composes all components correctly
- [ ] Verify /time-tracking route is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new time tracking UI flows that call service CRUD and summary APIs; risk is mainly around new client-side state/formatting and ensuring the new drawers/charts handle loading/error/archived edge cases correctly.
> 
> **Overview**
> Introduces a new `unstable_TimeTracking` view that composes the existing time-entry experience with an activity summary panel and a services management drawer, and exports it from `src/index.tsx`.
> 
> Adds a `TimeTrackingServicesDrawer` UI to **create/edit services**, set an optional default hourly rate with localized currency parsing, and **archive/restore** services (including confirmation modals and active/archived tabs with distinct loading/error/empty states).
> 
> Adds `TimeTrackingStats`, which fetches the time tracking summary for the selected date range and renders **total time plus a by-service breakdown** (top N services + “Other”) as a stacked bar chart with a legend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba642e52f4a55721383a618092d4258041c113ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->