### PR TITLE
api: align Tax Overview to new metrics response shape

### DIFF
--- a/src/components/TaxOverview/TaxOverview.tsx
+++ b/src/components/TaxOverview/TaxOverview.tsx
@@ -60,8 +60,7 @@ const TaxOverviewContent = ({ data }: { data: TaxOverviewApiData }) => {
   return (
     <VStack className='Layer__TaxOverview' gap='md'>
       <TaxableIncomeCard
-        totalIncome={data.totalIncome}
-        totalDeductions={data.totalDeductions}
+        metrics={data.metrics}
       />
     </VStack>
   )

--- a/src/components/TaxOverview/TaxableIncomeCard.tsx
+++ b/src/components/TaxOverview/TaxableIncomeCard.tsx
@@ -30,7 +30,7 @@ function useMetricRowProps({ metricType, amount, maxMeterValue, label }: {
 
   const slotProps = {
     Meter: {
-      className: meterClassByType[metricType],
+      className: `${meterClassByType[metricType]} Layer__TaxOverview__Meter`,
       label,
       minValue: 0,
       value: boundedMeterValue,

--- a/src/components/TaxOverview/TaxableIncomeCard.tsx
+++ b/src/components/TaxOverview/TaxableIncomeCard.tsx
@@ -25,6 +25,7 @@ function useMetricRowProps({ metricType, amount, maxMeterValue, label }: {
     TOTAL_INCOME: 'Layer__TaxOverview__IncomeMeter',
     TOTAL_PRE_AGI_DEDUCTIONS: 'Layer__TaxOverview__DeductionsMeter',
     TAXABLE_INCOME: 'Layer__TaxOverview__TaxableIncomeMeter',
+    UNKNOWN_TYPE: 'Layer__TaxOverview__UnknownMetricMeter',
   }
 
   const slotProps = {
@@ -65,12 +66,12 @@ export const TaxableIncomeCard = ({
       {isDesktop
         ? (
           <VStack gap='sm'>
-            {metrics.map(metric => <TotalMetricRow key={metric.metricType} metric={metric} />)}
+            {metrics.map((metric, index) => <TotalMetricRow key={`${metric.metricType}-${metric.label}-${index}`} metric={metric} />)}
           </VStack>
         )
         : (
           <Card className='Layer__TaxOverview__Card__MetricRow--mobile'>
-            {metrics.map(metric => <TotalMetricRow key={metric.metricType} metric={metric} />)}
+            {metrics.map((metric, index) => <TotalMetricRow key={`${metric.metricType}-${metric.label}-${index}`} metric={metric} />)}
           </Card>
         )}
     </VStack>

--- a/src/components/TaxOverview/TaxableIncomeCard.tsx
+++ b/src/components/TaxOverview/TaxableIncomeCard.tsx
@@ -17,7 +17,7 @@ function useMetricRowProps({ metricType, amount, maxMeterValue, label }: {
   label: string
 }) {
   const [viewportWidth] = useWindowSize()
-  const boundedMaxMeterValue = Math.max(maxMeterValue, 0)
+  const boundedMaxMeterValue = Math.max(maxMeterValue, 1)
   const boundedMeterValue = Math.min(Math.max(amount, 0), boundedMaxMeterValue)
   const showBorder = viewportWidth < METRIC_ROW_MOBILE_BREAKPOINT
 

--- a/src/components/TaxOverview/TaxableIncomeCard.tsx
+++ b/src/components/TaxOverview/TaxableIncomeCard.tsx
@@ -1,6 +1,4 @@
-import { useTranslation } from 'react-i18next'
-
-import { type TaxOverviewApiData } from '@schemas/taxEstimates/overview'
+import { type TaxOverviewMetric, type TaxOverviewMetricType } from '@schemas/taxEstimates/overview'
 import { useSizeClass, useWindowSize } from '@hooks/utils/size/useWindowSize'
 import { VStack } from '@ui/Stack/Stack'
 import { Card } from '@components/Card/Card'
@@ -8,33 +6,44 @@ import { MetricRow } from '@components/MetricRow/MetricRow'
 
 import './taxableIncomeCard.scss'
 const METRIC_ROW_MOBILE_BREAKPOINT = 600
-type TaxableIncomeCardProps = Pick<TaxOverviewApiData, 'totalDeductions' | 'totalIncome'>
+type TaxableIncomeCardProps = {
+  metrics: readonly TaxOverviewMetric[]
+}
 
-function useMetricRowProps({ type, amount, maxMeterValue }: { type: 'income' | 'deductions', amount: number, maxMeterValue: number }) {
-  const { t } = useTranslation()
+function useMetricRowProps({ metricType, amount, maxMeterValue, label }: { metricType: TaxOverviewMetricType, amount: number, maxMeterValue: number, label: string }) {
   const [viewportWidth] = useWindowSize()
   const boundedMaxMeterValue = Math.max(maxMeterValue, 0)
   const boundedMeterValue = Math.min(Math.max(amount, 0), boundedMaxMeterValue)
   const showBorder = viewportWidth < METRIC_ROW_MOBILE_BREAKPOINT
 
+  const meterClassByType: Record<TaxOverviewMetricType, string> = {
+    TOTAL_INCOME: 'Layer__TaxOverview__IncomeMeter',
+    TOTAL_PRE_AGI_DEDUCTIONS: 'Layer__TaxOverview__DeductionsMeter',
+    TAXABLE_INCOME: 'Layer__TaxOverview__TaxableIncomeMeter',
+  }
+
   const slotProps = {
     Meter: {
-      className: type === 'income' ? 'Layer__TaxOverview__IncomeMeter' : 'Layer__TaxOverview__DeductionsMeter',
-      label: type === 'income' ? t('taxEstimates:label.total_income', 'Total income') : t('taxEstimates:label.deductions', 'Deductions'),
+      className: meterClassByType[metricType],
+      label,
       minValue: 0,
       value: boundedMeterValue,
       maxValue: boundedMaxMeterValue,
-
     },
   }
   return { slotProps, showBorder }
 }
 
-function TotalMetricRow({ type, amount, maxMeterValue }: { type: 'income' | 'deductions', amount: number, maxMeterValue: number }) {
-  const { slotProps, showBorder } = useMetricRowProps({ type, amount, maxMeterValue })
+function TotalMetricRow({ metric }: { metric: TaxOverviewMetric }) {
+  const { slotProps, showBorder } = useMetricRowProps({
+    metricType: metric.metricType,
+    amount: metric.value,
+    maxMeterValue: metric.maxValue,
+    label: metric.label,
+  })
   return (
     <MetricRow
-      amount={amount}
+      amount={metric.value}
       showBorder={showBorder}
       slotProps={slotProps}
     />
@@ -42,25 +51,21 @@ function TotalMetricRow({ type, amount, maxMeterValue }: { type: 'income' | 'ded
 }
 
 export const TaxableIncomeCard = ({
-  totalDeductions,
-  totalIncome,
+  metrics,
 }: TaxableIncomeCardProps) => {
   const { isDesktop } = useSizeClass()
-  const maxMeterValue = Math.max(totalIncome, totalDeductions, 1)
 
   return (
     <VStack className='Layer__TaxOverview__Card' pi={!isDesktop ? undefined : 'md'}>
       {isDesktop
         ? (
           <VStack gap='sm'>
-            <TotalMetricRow type='income' amount={totalIncome} maxMeterValue={maxMeterValue} />
-            <TotalMetricRow type='deductions' amount={totalDeductions} maxMeterValue={maxMeterValue} />
+            {metrics.map(metric => <TotalMetricRow key={metric.metricType} metric={metric} />)}
           </VStack>
         )
         : (
           <Card className='Layer__TaxOverview__Card__MetricRow--mobile'>
-            <TotalMetricRow type='income' amount={totalIncome} maxMeterValue={maxMeterValue} />
-            <TotalMetricRow type='deductions' amount={totalDeductions} maxMeterValue={maxMeterValue} />
+            {metrics.map(metric => <TotalMetricRow key={metric.metricType} metric={metric} />)}
           </Card>
         )}
     </VStack>

--- a/src/components/TaxOverview/TaxableIncomeCard.tsx
+++ b/src/components/TaxOverview/TaxableIncomeCard.tsx
@@ -10,7 +10,12 @@ type TaxableIncomeCardProps = {
   metrics: readonly TaxOverviewMetric[]
 }
 
-function useMetricRowProps({ metricType, amount, maxMeterValue, label }: { metricType: TaxOverviewMetricType, amount: number, maxMeterValue: number, label: string }) {
+function useMetricRowProps({ metricType, amount, maxMeterValue, label }: {
+  metricType: TaxOverviewMetricType
+  amount: number
+  maxMeterValue: number
+  label: string
+}) {
   const [viewportWidth] = useWindowSize()
   const boundedMaxMeterValue = Math.max(maxMeterValue, 0)
   const boundedMeterValue = Math.min(Math.max(amount, 0), boundedMaxMeterValue)

--- a/src/components/TaxOverview/taxableIncomeCard.scss
+++ b/src/components/TaxOverview/taxableIncomeCard.scss
@@ -2,6 +2,7 @@
   --color-tax-overview-income-meter-fill: #6d3cc8;
   --color-tax-overview-deductions-meter-fill: #1c7e9a;
   --color-tax-overview-taxable-income-meter-fill: #3b9c63;
+  --color-tax-overview-unknown-meter-fill: var(--color-base-500);
 
   gap: var(--spacing-lg);
   padding: var(--spacing-lg);
@@ -14,14 +15,16 @@
 
 .Layer__TaxOverview__IncomeMeter,
 .Layer__TaxOverview__DeductionsMeter,
-.Layer__TaxOverview__TaxableIncomeMeter {
+.Layer__TaxOverview__TaxableIncomeMeter,
+.Layer__TaxOverview__UnknownMetricMeter {
   flex: 1;
   min-width: 9rem;
 }
 
 .Layer__TaxOverview__IncomeMeter__track,
 .Layer__TaxOverview__DeductionsMeter__track,
-.Layer__TaxOverview__TaxableIncomeMeter__track {
+.Layer__TaxOverview__TaxableIncomeMeter__track,
+.Layer__TaxOverview__UnknownMetricMeter__track {
   fill: var(--color-base-100);
 }
 
@@ -35,6 +38,10 @@
 
 .Layer__TaxOverview__TaxableIncomeMeter__fill {
   fill: var(--color-tax-overview-taxable-income-meter-fill);
+}
+
+.Layer__TaxOverview__UnknownMetricMeter__fill {
+  fill: var(--color-tax-overview-unknown-meter-fill);
 }
 
 @container (max-width: 720px) {
@@ -51,7 +58,8 @@
 
 .Layer__MetricCard .Layer__TaxOverview__IncomeMeter,
 .Layer__MetricCard .Layer__TaxOverview__DeductionsMeter,
-.Layer__MetricCard .Layer__TaxOverview__TaxableIncomeMeter {
+.Layer__MetricCard .Layer__TaxOverview__TaxableIncomeMeter,
+.Layer__MetricCard .Layer__TaxOverview__UnknownMetricMeter {
   width: 100%;
   min-width: 0;
 }

--- a/src/components/TaxOverview/taxableIncomeCard.scss
+++ b/src/components/TaxOverview/taxableIncomeCard.scss
@@ -1,6 +1,7 @@
 .Layer__TaxOverview__Card {
   --color-tax-overview-income-meter-fill: #6d3cc8;
   --color-tax-overview-deductions-meter-fill: #1c7e9a;
+  --color-tax-overview-taxable-income-meter-fill: #3b9c63;
 
   gap: var(--spacing-lg);
   padding: var(--spacing-lg);
@@ -12,13 +13,15 @@
 }
 
 .Layer__TaxOverview__IncomeMeter,
-.Layer__TaxOverview__DeductionsMeter {
+.Layer__TaxOverview__DeductionsMeter,
+.Layer__TaxOverview__TaxableIncomeMeter {
   flex: 1;
   min-width: 9rem;
 }
 
 .Layer__TaxOverview__IncomeMeter__track,
-.Layer__TaxOverview__DeductionsMeter__track {
+.Layer__TaxOverview__DeductionsMeter__track,
+.Layer__TaxOverview__TaxableIncomeMeter__track {
   fill: var(--color-base-100);
 }
 
@@ -28,6 +31,10 @@
 
 .Layer__TaxOverview__DeductionsMeter__fill {
   fill: var(--color-tax-overview-deductions-meter-fill);
+}
+
+.Layer__TaxOverview__TaxableIncomeMeter__fill {
+  fill: var(--color-tax-overview-taxable-income-meter-fill);
 }
 
 @container (max-width: 720px) {
@@ -43,7 +50,8 @@
 }
 
 .Layer__MetricCard .Layer__TaxOverview__IncomeMeter,
-.Layer__MetricCard .Layer__TaxOverview__DeductionsMeter {
+.Layer__MetricCard .Layer__TaxOverview__DeductionsMeter,
+.Layer__MetricCard .Layer__TaxOverview__TaxableIncomeMeter {
   width: 100%;
   min-width: 0;
 }

--- a/src/components/TaxOverview/taxableIncomeCard.scss
+++ b/src/components/TaxOverview/taxableIncomeCard.scss
@@ -13,18 +13,12 @@
   }
 }
 
-.Layer__TaxOverview__IncomeMeter,
-.Layer__TaxOverview__DeductionsMeter,
-.Layer__TaxOverview__TaxableIncomeMeter,
-.Layer__TaxOverview__UnknownMetricMeter {
+.Layer__TaxOverview__Meter {
   flex: 1;
   min-width: 9rem;
 }
 
-.Layer__TaxOverview__IncomeMeter__track,
-.Layer__TaxOverview__DeductionsMeter__track,
-.Layer__TaxOverview__TaxableIncomeMeter__track,
-.Layer__TaxOverview__UnknownMetricMeter__track {
+.Layer__TaxOverview__Meter__track {
   fill: var(--color-base-100);
 }
 
@@ -56,10 +50,7 @@
   padding: var(--spacing-sm);
 }
 
-.Layer__MetricCard .Layer__TaxOverview__IncomeMeter,
-.Layer__MetricCard .Layer__TaxOverview__DeductionsMeter,
-.Layer__MetricCard .Layer__TaxOverview__TaxableIncomeMeter,
-.Layer__MetricCard .Layer__TaxOverview__UnknownMetricMeter {
+.Layer__MetricCard .Layer__TaxOverview__Meter {
   width: 100%;
   min-width: 0;
 }

--- a/src/schemas/taxEstimates/overview.ts
+++ b/src/schemas/taxEstimates/overview.ts
@@ -1,31 +1,47 @@
 import { pipe, Schema } from 'effect'
 
+export enum TaxOverviewMetricType {
+  TotalIncome = 'TOTAL_INCOME',
+  TotalPreAgiDeductions = 'TOTAL_PRE_AGI_DEDUCTIONS',
+  TaxableIncome = 'TAXABLE_INCOME',
+}
+
+const TaxOverviewMetricTypeSchema = Schema.Enums(TaxOverviewMetricType)
+
+const TransformedTaxOverviewMetricTypeSchema = Schema.transform(
+  Schema.NonEmptyTrimmedString,
+  Schema.typeSchema(TaxOverviewMetricTypeSchema),
+  {
+    decode: (input) => {
+      if (Object.values(TaxOverviewMetricTypeSchema.enums).includes(input as TaxOverviewMetricType)) {
+        return input as TaxOverviewMetricType
+      }
+      return TaxOverviewMetricType.TotalIncome
+    },
+    encode: input => input,
+  },
+)
+
+export type TaxOverviewMetricTypeValue = typeof TransformedTaxOverviewMetricTypeSchema.Type
+
+const TaxOverviewMetricSchema = Schema.Struct({
+  value: Schema.Number,
+  maxValue: pipe(
+    Schema.propertySignature(Schema.Number),
+    Schema.fromKey('max_value'),
+  ),
+  label: Schema.String,
+  metricType: pipe(
+    Schema.propertySignature(TransformedTaxOverviewMetricTypeSchema),
+    Schema.fromKey('metric_type'),
+  ),
+})
+
+export type TaxOverviewMetric = typeof TaxOverviewMetricSchema.Type
+
 const TaxOverviewApiDataSchema = Schema.Struct({
   year: Schema.Number,
-  excludesPendingTransactions: pipe(
-    Schema.propertySignature(Schema.NullishOr(Schema.Boolean)),
-    Schema.fromKey('excludes_pending_transactions'),
-  ),
-  taxableIncomeEstimate: pipe(
-    Schema.propertySignature(Schema.Number),
-    Schema.fromKey('taxable_income_estimate'),
-  ),
-  totalIncome: pipe(
-    Schema.propertySignature(Schema.Number),
-    Schema.fromKey('total_income'),
-  ),
-  totalDeductions: pipe(
-    Schema.propertySignature(Schema.Number),
-    Schema.fromKey('total_deductions'),
-  ),
-  estimatedTaxesOwed: pipe(
-    Schema.propertySignature(Schema.Number),
-    Schema.fromKey('estimated_taxes_owed'),
-  ),
-  taxesDueDate: pipe(
-    Schema.propertySignature(Schema.NullishOr(Schema.Date)),
-    Schema.fromKey('taxes_due_date'),
-  ),
+  metrics: Schema.Array(TaxOverviewMetricSchema),
 })
 
 export type TaxOverviewApiData = typeof TaxOverviewApiDataSchema.Type

--- a/src/schemas/taxEstimates/overview.ts
+++ b/src/schemas/taxEstimates/overview.ts
@@ -1,28 +1,21 @@
 import { pipe, Schema } from 'effect'
 
+import { createTransformedEnumSchema } from '@schemas/utils'
+
 export enum TaxOverviewMetricType {
   TotalIncome = 'TOTAL_INCOME',
   TotalPreAgiDeductions = 'TOTAL_PRE_AGI_DEDUCTIONS',
   TaxableIncome = 'TAXABLE_INCOME',
+  UnknownType = 'UNKNOWN_TYPE',
 }
 
-const TaxOverviewMetricTypeSchema = Schema.Enums(TaxOverviewMetricType)
-
-const TransformedTaxOverviewMetricTypeSchema = Schema.transform(
-  Schema.NonEmptyTrimmedString,
-  Schema.typeSchema(TaxOverviewMetricTypeSchema),
-  {
-    decode: (input) => {
-      if (Object.values(TaxOverviewMetricTypeSchema.enums).includes(input as TaxOverviewMetricType)) {
-        return input as TaxOverviewMetricType
-      }
-      return TaxOverviewMetricType.TotalIncome
-    },
-    encode: input => input,
-  },
+const TaxOverviewMetricTypeSchema = createTransformedEnumSchema(
+  Schema.Enums(TaxOverviewMetricType),
+  TaxOverviewMetricType,
+  TaxOverviewMetricType.UnknownType,
 )
 
-export type TaxOverviewMetricTypeValue = typeof TransformedTaxOverviewMetricTypeSchema.Type
+export type TaxOverviewMetricTypeValue = typeof TaxOverviewMetricTypeSchema.Type
 
 const TaxOverviewMetricSchema = Schema.Struct({
   value: Schema.Number,
@@ -32,7 +25,7 @@ const TaxOverviewMetricSchema = Schema.Struct({
   ),
   label: Schema.String,
   metricType: pipe(
-    Schema.propertySignature(TransformedTaxOverviewMetricTypeSchema),
+    Schema.propertySignature(TaxOverviewMetricTypeSchema),
     Schema.fromKey('metric_type'),
   ),
 })


### PR DESCRIPTION
## Scope
- Update TaxOverview API schema to the new data.metrics array response shape
- Replace literal metric type parsing with enum + transformed schema fallback
- Refactor TaxOverview and TaxableIncomeCard to render metric rows directly from metrics
- Add meter styling support for TAXABLE_INCOME rows

## Verification
- npm run typecheck

<img width="1465" height="529" alt="image" src="https://github.com/user-attachments/assets/24255dbe-3a11-4f6b-b8be-2251feda8b85" />

<img width="496" height="451" alt="image" src="https://github.com/user-attachments/assets/6582a343-7706-4255-85c4-bec76ed0a603" />

## Notes
- No users are actively using this endpoint, so no concerns about breaking changes.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a breaking change to the Tax Overview API schema and the UI rendering path; risk is mainly mismatched backend/frontend response shape or unexpected metric types affecting display rather than security/data integrity.
> 
> **Overview**
> Tax Overview now consumes a new API shape where overview values are returned as a `metrics` array (each with `value`, `maxValue`, `label`, and `metricType`) instead of discrete fields like `totalIncome`/`totalDeductions`.
> 
> The UI is refactored so `TaxableIncomeCard` renders metric rows by iterating over `data.metrics`, applies meter styling based on a new `TaxOverviewMetricType` enum (with an unknown-type fallback), and adds meter styling for `TAXABLE_INCOME` plus shared `.Layer__TaxOverview__Meter` CSS selectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a24c3b09fb0ba2843ddd481f9887b64653ca4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->