### PR TITLE
Taylor/time tracking/UI cleanup

### DIFF
--- a/src/assets/locales/en-US/common.json
+++ b/src/assets/locales/en-US/common.json
@@ -113,6 +113,7 @@
     "status": "Status",
     "tax_estimates": "Tax estimates",
     "taxes": "Taxes",
+    "this_period": "This Period",
     "today": "Today",
     "total": "Total",
     "transaction": "Transaction",

--- a/src/assets/locales/en-US/timeTracking.json
+++ b/src/assets/locales/en-US/timeTracking.json
@@ -53,7 +53,6 @@
     "select_customer": "Select a customer (optional)",
     "select_service": "Select a service",
     "service": "Service",
-    "this_period": "This Period",
     "time_entries": "Time Entries",
     "time_tracking": "Time Tracking"
   },

--- a/src/assets/locales/en-US/timeTracking.json
+++ b/src/assets/locales/en-US/timeTracking.json
@@ -45,6 +45,7 @@
     "entry_date": "Entry date",
     "entry_details": "Time entry details",
     "invoiced": "Invoiced",
+    "less_than_one_minute": "< 1 min",
     "memo": "Memo",
     "no_activity_breakdown": "No activity breakdown available for this period.",
     "no_services": "No services available",
@@ -52,6 +53,7 @@
     "select_customer": "Select a customer (optional)",
     "select_service": "Select a service",
     "service": "Service",
+    "this_period": "This Period",
     "time_entries": "Time Entries",
     "time_tracking": "Time Tracking"
   },
@@ -71,7 +73,6 @@
     "no_active": "No services yet",
     "no_archived": "No archived services",
     "rate_per_hour": "{{rate}}/hr",
-    "rate_per_hour_suffix": "/hr",
     "save": "Save",
     "service_name": "Service name",
     "tab_group_label": "Service list",

--- a/src/assets/locales/fr-CA/common.json
+++ b/src/assets/locales/fr-CA/common.json
@@ -113,6 +113,7 @@
     "status": "Statut",
     "tax_estimates": "Estimations fiscales",
     "taxes": "Taxes",
+    "this_period": "",
     "today": "Aujourd’hui",
     "total": "Total",
     "transaction": "Transaction",

--- a/src/assets/locales/fr-CA/timeTracking.json
+++ b/src/assets/locales/fr-CA/timeTracking.json
@@ -53,7 +53,6 @@
     "select_customer": "Sélectionner un client (facultatif)",
     "select_service": "Sélectionner un service",
     "service": "Service",
-    "this_period": "",
     "time_entries": "Entrées de temps",
     "time_tracking": ""
   },

--- a/src/assets/locales/fr-CA/timeTracking.json
+++ b/src/assets/locales/fr-CA/timeTracking.json
@@ -45,6 +45,7 @@
     "entry_date": "Date de l'entrée",
     "entry_details": "Détails de l'entrée de temps",
     "invoiced": "Facturé",
+    "less_than_one_minute": "",
     "memo": "Note",
     "no_activity_breakdown": "Aucune répartition des activités n'est disponible pour cette période.",
     "no_services": "Aucun service disponible",
@@ -52,6 +53,7 @@
     "select_customer": "Sélectionner un client (facultatif)",
     "select_service": "Sélectionner un service",
     "service": "Service",
+    "this_period": "",
     "time_entries": "Entrées de temps",
     "time_tracking": ""
   },
@@ -71,7 +73,6 @@
     "no_active": "Aucun service pour le moment",
     "no_archived": "Aucun service archivé",
     "rate_per_hour": "",
-    "rate_per_hour_suffix": "/h",
     "save": "Enregistrer",
     "service_name": "Nom du service",
     "tab_group_label": "Liste des services",

--- a/src/components/TimeEntries/ActiveTimeTracker/activeTimeTracker.scss
+++ b/src/components/TimeEntries/ActiveTimeTracker/activeTimeTracker.scss
@@ -137,7 +137,7 @@
   }
 
   .Layer__ActiveTimeTracker__Actions {
-    justify-content: flex-start;
+    justify-content: space-between;
     inline-size: 100%;
   }
 }

--- a/src/components/TimeEntries/ActiveTimeTracker/activeTimeTracker.scss
+++ b/src/components/TimeEntries/ActiveTimeTracker/activeTimeTracker.scss
@@ -116,7 +116,7 @@
   }
 
   .Layer__ActiveTimeTracker__TimerValue {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
   }
 
   .Layer__ActiveTimeTracker__Controls {

--- a/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
+++ b/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
@@ -84,20 +84,20 @@ const getColumnConfig = (t: TFunction): NestedColumnConfig<TimeEntry> => [
     cell: (row: TimeEntryRowType) => <TimeEntryDurationCell durationMinutes={row.original.durationMinutes} />,
   },
   {
+    id: TimeEntryColumns.Service,
+    header: t('timeTracking:label.service', 'Service'),
+    cell: (row: TimeEntryRowType) => (
+      <Span ellipsis withTooltip>{row.original.service?.name || '—'}</Span>
+    ),
+    isRowHeader: true,
+  },
+  {
     id: TimeEntryColumns.Customer,
     header: t('timeTracking:label.customer', 'Customer'),
     cell: (row: TimeEntryRowType) => (
       <Span ellipsis withTooltip>
         {row.original.customer?.individualName || row.original.customer?.companyName || '—'}
       </Span>
-    ),
-    isRowHeader: true,
-  },
-  {
-    id: TimeEntryColumns.Service,
-    header: t('timeTracking:label.service', 'Service'),
-    cell: (row: TimeEntryRowType) => (
-      <Span ellipsis withTooltip>{row.original.service?.name || '—'}</Span>
     ),
   },
   {

--- a/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
+++ b/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
@@ -36,7 +36,11 @@ const TimeEntryDateCell = memo(function TimeEntryDateCell({ date }: { date: Time
 })
 
 const TimeEntryDurationCell = memo(function TimeEntryDurationCell({ durationMinutes }: { durationMinutes: TimeEntry['durationMinutes'] }) {
+  const { t } = useTranslation()
   const { formatMinutesAsDuration } = useIntlFormatter()
+  if (durationMinutes < 1) {
+    return <Span>{t('timeTracking:label.less_than_one_minute', '< 1 min')}</Span>
+  }
   return <Span>{formatMinutesAsDuration(durationMinutes)}</Span>
 })
 

--- a/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
+++ b/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
@@ -38,7 +38,7 @@ const TimeEntryDateCell = memo(function TimeEntryDateCell({ date }: { date: Time
 const TimeEntryDurationCell = memo(function TimeEntryDurationCell({ durationMinutes }: { durationMinutes: TimeEntry['durationMinutes'] }) {
   const { t } = useTranslation()
   const { formatMinutesAsDuration } = useIntlFormatter()
-  if (durationMinutes < 1) {
+  if (durationMinutes === 0) {
     return <Span>{t('timeTracking:label.less_than_one_minute', '< 1 min')}</Span>
   }
   return <Span>{formatMinutesAsDuration(durationMinutes)}</Span>

--- a/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTableHeader.tsx
+++ b/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTableHeader.tsx
@@ -39,6 +39,14 @@ export const TimeEntriesTableHeader = () => {
 
   const HeaderFilters = useCallback(() => (
     <HStack gap='sm' align='end' className='Layer__TimeEntriesTable__Filters'>
+      <TimeEntryServiceSelector
+        selectedServiceId={selectedServiceId}
+        onSelectedServiceIdChange={setSelectedServiceId}
+        className='Layer__TimeEntriesTable__FilterService'
+        placeholder={t('timeTracking:label.all_services', 'All Services')}
+        showLabel={false}
+        inline
+      />
       <CustomerSelector
         selectedCustomer={selectedCustomer}
         onSelectedCustomerChange={setSelectedCustomer}
@@ -46,13 +54,7 @@ export const TimeEntriesTableHeader = () => {
         className='Layer__TimeEntriesTable__FilterCustomer'
         placeholder={t('timeTracking:label.all_customers', 'All Customers')}
         showLabel={false}
-      />
-      <TimeEntryServiceSelector
-        selectedServiceId={selectedServiceId}
-        onSelectedServiceIdChange={setSelectedServiceId}
-        className='Layer__TimeEntriesTable__FilterService'
-        placeholder={t('timeTracking:label.all_services', 'All Services')}
-        showLabel={false}
+        inline
       />
     </HStack>
   ), [selectedCustomer, setSelectedCustomer, selectedServiceId, setSelectedServiceId, t])

--- a/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTableHeader.tsx
+++ b/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTableHeader.tsx
@@ -37,27 +37,29 @@ export const TimeEntriesTableHeader = () => {
     </HStack>
   ), [t, onAddEntry, onStartTimer, isStartTimerDisabled])
 
-  const Filters = useCallback(() => (
-    <HStack fluid gap='lg' align='end' className='Layer__TimeEntriesTable__Filters'>
+  const HeaderFilters = useCallback(() => (
+    <HStack gap='sm' align='end' className='Layer__TimeEntriesTable__Filters'>
       <CustomerSelector
         selectedCustomer={selectedCustomer}
         onSelectedCustomerChange={setSelectedCustomer}
         isCreatable={false}
         className='Layer__TimeEntriesTable__FilterCustomer'
         placeholder={t('timeTracking:label.all_customers', 'All Customers')}
+        showLabel={false}
       />
       <TimeEntryServiceSelector
         selectedServiceId={selectedServiceId}
         onSelectedServiceIdChange={setSelectedServiceId}
         className='Layer__TimeEntriesTable__FilterService'
         placeholder={t('timeTracking:label.all_services', 'All Services')}
+        showLabel={false}
       />
     </HStack>
   ), [selectedCustomer, setSelectedCustomer, selectedServiceId, setSelectedServiceId, t])
 
   const headerSlots = useMemo(
-    () => ({ HeaderActions, Filters }),
-    [HeaderActions, Filters],
+    () => ({ HeaderActions, HeaderFilters }),
+    [HeaderActions, HeaderFilters],
   )
 
   return (

--- a/src/components/TimeEntries/TimeEntriesTable/timeEntriesTableHeader.scss
+++ b/src/components/TimeEntries/TimeEntriesTable/timeEntriesTableHeader.scss
@@ -1,55 +1,48 @@
+.Layer__CustomerSelector.Layer__TimeEntriesTable__FilterCustomer {
+  grid-template-areas: 'input';
+  gap: 0;
+}
+
 .Layer__TimeEntriesTable__FilterCustomer,
 .Layer__TimeEntriesTable__FilterService {
-  flex: 1 1 12rem;
-  max-width: 20rem;
+  flex: 0 0 13rem;
+  min-width: 13rem;
+  max-width: 13rem;
 }
 
 @container (max-width: 760px) {
   .Layer__TimeEntriesTable {
-    .Layer__DataTableHeader__Header,
-    .Layer__DataTableHeader__Filters {
+    .Layer__DataTableHeader__Header {
       height: auto;
+      padding-block: var(--spacing-sm);
     }
 
     .Layer__DataTableHeader__Header[data-direction='row'] {
       flex-direction: column;
+      gap: var(--spacing-sm);
       align-items: stretch;
-      padding-block: var(--spacing-sm);
     }
 
     .Layer__DataTableHeader__Header > .Layer__Stack:first-child,
-    .Layer__DataTableHeader__Header > .Layer__Stack:last-child,
-    .Layer__DataTableHeader__Filters > .Layer__Stack {
+    .Layer__DataTableHeader__Header > .Layer__Stack:last-child {
       box-sizing: border-box;
       inline-size: 100%;
-    }
-
-    .Layer__DataTableHeader__Header > .Layer__Stack:first-child,
-    .Layer__DataTableHeader__Header > .Layer__Stack:last-child,
-    .Layer__DataTableHeader__Filters {
       padding-inline: var(--spacing-md);
     }
 
     .Layer__DataTableHeader__Header > .Layer__Stack:first-child {
-      justify-content: space-between;
+      flex-direction: column;
+      gap: var(--spacing-sm);
+      align-items: stretch;
     }
 
     .Layer__DataTableHeader__Header > .Layer__Stack:last-child {
-      gap: var(--spacing-sm);
       justify-content: flex-start;
-      padding-top: var(--spacing-xs);
-      padding-bottom: var(--spacing-xs);
     }
 
     .Layer__DataTableHeader__Header > .Layer__Stack:last-child > .Layer__Stack {
       flex-wrap: wrap;
       inline-size: 100%;
-    }
-
-    .Layer__DataTableHeader__Filters {
-      padding-top: var(--spacing-sm);
-      padding-bottom: var(--spacing-sm);
-      border-bottom: 1px solid var(--border-color);
     }
 
     .Layer__TimeEntriesTable__Filters[data-direction='row'] {

--- a/src/components/TimeEntries/TimeEntriesTable/timeEntriesTableHeader.scss
+++ b/src/components/TimeEntries/TimeEntriesTable/timeEntriesTableHeader.scss
@@ -1,13 +1,7 @@
-.Layer__CustomerSelector.Layer__TimeEntriesTable__FilterCustomer {
-  grid-template-areas: 'input';
-  gap: 0;
-}
-
 .Layer__TimeEntriesTable__FilterCustomer,
 .Layer__TimeEntriesTable__FilterService {
-  flex: 0 0 13rem;
-  min-width: 13rem;
-  max-width: 13rem;
+  flex: 0 0 12rem;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 @container (max-width: 760px) {
@@ -54,7 +48,6 @@
     .Layer__TimeEntriesTable__FilterCustomer,
     .Layer__TimeEntriesTable__FilterService {
       flex: 1 1 auto;
-      max-width: none;
     }
   }
 }

--- a/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
+++ b/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
@@ -60,7 +60,6 @@ export function TimeEntryServiceSelector({
   const combinedClassName = classNames(
     'Layer__TimeEntryServiceSelector',
     inline && 'Layer__TimeEntryServiceSelector--inline',
-    !showLabel && 'Layer__TimeEntryServiceSelector--without-label',
     className,
   )
 

--- a/src/components/TimeEntries/TimeEntryServiceSelector/timeEntryServiceSelector.scss
+++ b/src/components/TimeEntries/TimeEntryServiceSelector/timeEntryServiceSelector.scss
@@ -12,8 +12,4 @@
 
     align-items: center;
   }
-
-  &--without-label {
-    grid-template-areas: 'input';
-  }
 }

--- a/src/components/TimeTrackingStats/TimeTrackingStats.tsx
+++ b/src/components/TimeTrackingStats/TimeTrackingStats.tsx
@@ -154,7 +154,7 @@ function TimeTrackingStatsContent({ summary }: { summary: TimeEntrySummary }) {
             <CombinedDateRangeSelection mode='full' showLabels={false} />
           </VStack>
           <VStack className='Layer__TimeTrackingStats__Summary' gap='3xs' pi='md'>
-            <Span size='sm' variant='subtle'>{t('timeTracking:label.this_period', 'This Period')}</Span>
+            <Span size='sm' variant='subtle'>{t('common:label.this_period', 'This Period')}</Span>
             <Span className='Layer__TimeTrackingStats__SummaryValue' weight='bold'>
               {formatMinutesAsDuration(summary.totalMinutes, { compact: true })}
             </Span>

--- a/src/components/TimeTrackingStats/TimeTrackingStats.tsx
+++ b/src/components/TimeTrackingStats/TimeTrackingStats.tsx
@@ -19,6 +19,7 @@ import './timeTrackingStats.scss'
 
 const CHART_HEIGHT = 24
 const CHART_MARGIN = { top: 0, right: 0, bottom: 0, left: 0 }
+const CHART_BORDER_RADIUS = 10
 
 type TimeTrackingServiceBreakdown = {
   color: string
@@ -78,11 +79,12 @@ const TimeTrackingStatsBreakdown = memo(function TimeTrackingStatsBreakdown({ en
     () => entries.reduce((total, entry) => total + entry.totalMinutes, 0),
     [entries],
   )
+  const chartKey = entries.map(entry => entry.key).join('|')
 
   return (
     <VStack className='Layer__TimeTrackingStats__Chart' gap='md' justify='center' pbs='lg'>
       <div className='Layer__TimeTrackingStats__ChartBar'>
-        <ResponsiveContainer width='100%' height={CHART_HEIGHT}>
+        <ResponsiveContainer key={chartKey} width='100%' height={CHART_HEIGHT}>
           <BarChart
             data={chartData}
             layout='vertical'
@@ -93,28 +95,38 @@ const TimeTrackingStatsBreakdown = memo(function TimeTrackingStatsBreakdown({ en
           >
             <XAxis type='number' hide domain={[0, Math.max(chartTotalMinutes, 1)]} allowDataOverflow />
             <YAxis type='category' dataKey='label' hide width={0} />
-            {entries.map(({ color, key }) => (
-              <Bar
-                key={key}
-                dataKey={key}
-                barSize={CHART_HEIGHT}
-                fill={color}
-                stackId='time-tracking-services'
-                isAnimationActive={false}
-              />
-            ))}
+            {entries.map(({ color, key }, index) => {
+              const isFirstSegment = index === 0
+              const isLastSegment = index === entries.length - 1
+              return (
+                <Bar
+                  key={key}
+                  dataKey={key}
+                  barSize={CHART_HEIGHT}
+                  fill={color}
+                  stackId='time-tracking-services'
+                  isAnimationActive={false}
+                  radius={[
+                    isFirstSegment ? CHART_BORDER_RADIUS : 0,
+                    isLastSegment ? CHART_BORDER_RADIUS : 0,
+                    isLastSegment ? CHART_BORDER_RADIUS : 0,
+                    isFirstSegment ? CHART_BORDER_RADIUS : 0,
+                  ]}
+                />
+              )
+            })}
           </BarChart>
         </ResponsiveContainer>
       </div>
       <HStack className='Layer__TimeTrackingStats__Legend' gap='lg' align='start'>
         {entries.map(({ color, key, percentage, serviceName, totalMinutes }) => (
           <VStack key={key} className='Layer__TimeTrackingStats__LegendItem' gap='2xs'>
-            <HStack gap='2xs' align='center'>
+            <HStack className='Layer__TimeTrackingStats__LegendLabel' gap='2xs' align='center'>
               <TimeTrackingStatsLegendSwatch color={color} />
               <Span size='md'>{serviceName}</Span>
             </HStack>
-            <Span size='xl' weight='bold'>{formatMinutesAsDuration(totalMinutes, { compact: true })}</Span>
-            <Span size='sm' variant='subtle'>
+            <Span className='Layer__TimeTrackingStats__LegendDuration' size='xl' weight='bold'>{formatMinutesAsDuration(totalMinutes, { compact: true })}</Span>
+            <Span className='Layer__TimeTrackingStats__LegendPercentage' size='sm' variant='subtle'>
               {formatPercent(percentage, { maximumFractionDigits: 0 })}
             </Span>
           </VStack>

--- a/src/components/TimeTrackingStats/TimeTrackingStats.tsx
+++ b/src/components/TimeTrackingStats/TimeTrackingStats.tsx
@@ -19,7 +19,7 @@ import './timeTrackingStats.scss'
 
 const CHART_HEIGHT = 24
 const CHART_MARGIN = { top: 0, right: 0, bottom: 0, left: 0 }
-const CHART_BORDER_RADIUS = 10
+const CHART_BORDER_RADIUS = 8
 
 type TimeTrackingServiceBreakdown = {
   color: string

--- a/src/components/TimeTrackingStats/TimeTrackingStats.tsx
+++ b/src/components/TimeTrackingStats/TimeTrackingStats.tsx
@@ -147,16 +147,19 @@ function TimeTrackingStatsContent({ summary }: { summary: TimeEntrySummary }) {
 
   return (
     <VStack className='Layer__TimeTrackingStats__Content' gap='lg' pb='md' pi='md'>
-      <HStack className='Layer__TimeTrackingStats__TopRow' justify='space-between' align='center' gap='lg'>
-        <VStack className='Layer__TimeTrackingStats__Summary' gap='2xs'>
-          <Span size='sm' variant='subtle'>{t('common:label.total', 'Total')}</Span>
-          <Heading className='Layer__TimeTrackingStats__SummaryValue' level={3} size='3xl' weight='bold'>
-            {formatMinutesAsDuration(summary.totalMinutes, { compact: true })}
-          </Heading>
-        </VStack>
-        <VStack className='Layer__TimeTrackingStats__DateSelection'>
-          <CombinedDateRangeSelection mode='full' showLabels={false} />
-        </VStack>
+      <HStack className='Layer__TimeTrackingStats__TopRow' justify='space-between' align='center' gap='md'>
+        <Heading size='md'>{t('common:label.overview', 'Overview')}</Heading>
+        <HStack className='Layer__TimeTrackingStats__Controls' gap='lg' align='center'>
+          <VStack className='Layer__TimeTrackingStats__DateSelection'>
+            <CombinedDateRangeSelection mode='full' showLabels={false} />
+          </VStack>
+          <VStack className='Layer__TimeTrackingStats__Summary' gap='3xs' pi='md'>
+            <Span size='sm' variant='subtle'>{t('timeTracking:label.this_period', 'This Period')}</Span>
+            <Span className='Layer__TimeTrackingStats__SummaryValue' weight='bold'>
+              {formatMinutesAsDuration(summary.totalMinutes, { compact: true })}
+            </Span>
+          </VStack>
+        </HStack>
       </HStack>
       {serviceBreakdown.length > 0
         ? (

--- a/src/components/TimeTrackingStats/timeTrackingStats.scss
+++ b/src/components/TimeTrackingStats/timeTrackingStats.scss
@@ -31,14 +31,15 @@
     padding: 0;
   }
 
-  overflow: hidden;
+  overflow: visible;
   block-size: 1.5rem;
-  border-radius: var(--border-radius-xs);
-  background-color: var(--color-base-100);
+  border-radius: 0.625rem;
+  background-color: transparent;
 }
 
 .Layer__TimeTrackingStats__ChartBar--empty {
   inline-size: 100%;
+  background-color: var(--color-base-100);
 }
 
 .Layer__TimeTrackingStats__Legend {
@@ -94,8 +95,44 @@
   }
 }
 
-@container time-tracking-stats (max-width: 640px) {
+@container time-tracking-stats (max-width: 1100px) {
+  .Layer__TimeTrackingStats__Legend {
+    flex-direction: column;
+    gap: var(--spacing-sm);
+    align-items: stretch;
+  }
+
   .Layer__TimeTrackingStats__LegendItem {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    row-gap: 0;
+    column-gap: var(--spacing-sm);
+    align-items: center;
     min-inline-size: 100%;
+  }
+
+  .Layer__TimeTrackingStats__LegendLabel {
+    min-inline-size: 0;
+  }
+
+  .Layer__TimeTrackingStats__LegendLabel .Layer__UI__Text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .Layer__TimeTrackingStats__LegendDuration,
+  .Layer__TimeTrackingStats__LegendPercentage {
+    white-space: nowrap;
+  }
+
+  .Layer__TimeTrackingStats__LegendDuration {
+    justify-self: end;
+  }
+
+  .Layer__TimeTrackingStats__LegendPercentage {
+    justify-self: end;
+    min-inline-size: 2.25rem;
+    text-align: right;
   }
 }

--- a/src/components/TimeTrackingStats/timeTrackingStats.scss
+++ b/src/components/TimeTrackingStats/timeTrackingStats.scss
@@ -6,10 +6,20 @@
   min-inline-size: 0;
 }
 
-.Layer__TimeTrackingStats__DateSelection {
+.Layer__TimeTrackingStats__Controls {
   flex: 1 1 auto;
+  justify-content: flex-end;
+  min-inline-size: 0;
+}
+
+.Layer__TimeTrackingStats__DateSelection {
+  flex: 0 1 30rem;
   min-inline-size: 0;
   container: time-tracking-stats-dates / inline-size;
+
+  .Layer__GlobalDateRangeSelection {
+    inline-size: 100%;
+  }
 }
 
 .Layer__TimeTrackingStats__Summary {
@@ -18,6 +28,7 @@
 }
 
 .Layer__TimeTrackingStats__SummaryValue {
+  font-size: var(--text-heading);
   font-variant-numeric: tabular-nums;
   line-height: 1;
 }
@@ -67,7 +78,14 @@
     justify-content: flex-start;
   }
 
+  .Layer__TimeTrackingStats__Controls[data-direction='row'] {
+    flex-direction: column;
+    align-items: stretch;
+    inline-size: 100%;
+  }
+
   .Layer__TimeTrackingStats__DateSelection {
+    flex-basis: auto;
     inline-size: 100%;
 
     .Layer__GlobalDateRangeSelection {

--- a/src/components/TimeTrackingStats/timeTrackingStats.scss
+++ b/src/components/TimeTrackingStats/timeTrackingStats.scss
@@ -31,14 +31,12 @@
     padding: 0;
   }
 
-  overflow: visible;
   block-size: 1.5rem;
-  border-radius: 0.625rem;
-  background-color: transparent;
 }
 
 .Layer__TimeTrackingStats__ChartBar--empty {
   inline-size: 100%;
+  border-radius: var(--border-radius-xs);
   background-color: var(--color-base-100);
 }
 

--- a/src/views/TimeTracking.tsx
+++ b/src/views/TimeTracking.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react'
-import { FileText, Wrench } from 'lucide-react'
+import { Briefcase, FileText } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { useActiveTimeTracker } from '@hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker'
@@ -54,7 +54,7 @@ export const TimeTracking = ({ showTitle = true, onReportsClick, stringOverrides
     {
       key: TimeTrackingHeaderMenuActions.Services,
       onClick: () => setIsServicesDrawerOpen(true),
-      icon: <Wrench size={20} strokeWidth={1.25} />,
+      icon: <Briefcase size={20} strokeWidth={1.25} />,
       label: t('timeTracking:services.title', 'Services'),
     },
   ], [t, onReportsClick])


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/i18n and styling changes with minimal behavioral impact; main risk is minor regressions in responsive layout or missing locale strings (notably fr-CA placeholders are still empty).
> 
> **Overview**
> Refines the Time Tracking UI for better readability and responsive layout: reorders `Service`/`Customer` columns in the time entries table, swaps filter order in the header, and adjusts mobile/tablet styling for the header and active timer controls.
> 
> Improves display details by showing a localized “< 1 min” label when a time entry duration is `0`, updating the stats header to an *Overview* layout with a “This Period” total, and rounding the stacked chart bar ends (plus forcing a chart remount when the service keys change).
> 
> Adds new i18n keys (`common:label.this_period`, `timeTracking:label.less_than_one_minute`) and removes the unused `rate_per_hour_suffix` key; also updates the Time Tracking menu icon from `Wrench` to `Briefcase`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18458880d41b0f011616e6739124832ddfe2379b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->