### PR TITLE
feat: nav for unified reports and schema fixes

### DIFF
--- a/src/assets/locales/en-US/common.json
+++ b/src/assets/locales/en-US/common.json
@@ -32,6 +32,7 @@
     "show_archived": "Show archived",
     "submit_label": "Submit",
     "toggle_bulk_actions": "Toggle bulk actions",
+    "toggle_section": "Toggle {{name}}",
     "uncategorize": "Uncategorize",
     "update_label": "Update",
     "upload_label": "Upload",

--- a/src/assets/locales/en-US/reports.json
+++ b/src/assets/locales/en-US/reports.json
@@ -1,6 +1,8 @@
 {
   "action": {
+    "collapse_all": "Collapse All",
     "collapse_rows": "Collapse all rows",
+    "expand_all": "Expand All",
     "expand_rows": "Expand all rows"
   },
   "empty": {
@@ -11,15 +13,16 @@
   },
   "error": {
     "couldnt_load_report": "We couldn’t load your report",
+    "couldnt_load_reports": "Failed to load reports",
     "load_detail_lines": "Error loading detail lines",
     "load_pnl_detail_lines": "There was an error loading the profit and loss detail lines",
-    "load_report": "An error occurred while loading your report. Please check your connection and try again."
+    "load_report": "An error occurred while loading your report. Please check your connection and try again.",
+    "load_reports_navigation": "Something went wrong while loading this navigation. Please try again."
   },
   "label": {
     "adjustments_net_income": "Adjustments to Net Income",
     "assets": "Assets",
     "balance_sheet": "Balance Sheet",
-    "balance_sheet_report": "Balance Sheet Report",
     "cash_beginning_of_period": "Cash at Beginning of Period",
     "cash_end_of_period": "Cash at End of Period",
     "compare": "Compare by",
@@ -36,12 +39,11 @@
     "other_outflows": "Other Outflows",
     "profit_before_taxes": "Profit Before Taxes",
     "profit_loss_detail_report": "Profit and Loss Detail Report",
-    "profit_loss_report": "Profit & Loss Report",
     "report_period": "Report period",
     "report_type": "Report type",
     "reports": "Reports",
+    "reports_navigation": "Reports navigation",
     "statement_cash_flow": "Statement of Cash Flow",
-    "statement_cash_flow_report": "Statement of Cash Flow Report",
     "total_display_name": "Total of {{displayName}}"
   }
 }

--- a/src/assets/locales/fr-CA/common.json
+++ b/src/assets/locales/fr-CA/common.json
@@ -32,6 +32,7 @@
     "show_archived": "Afficher les éléments archivés",
     "submit_label": "Soumettre",
     "toggle_bulk_actions": "Afficher/masquer les actions groupées",
+    "toggle_section": "",
     "uncategorize": "Retirer la catégorie",
     "update_label": "Mettre à jour",
     "upload_label": "Téléverser",

--- a/src/assets/locales/fr-CA/reports.json
+++ b/src/assets/locales/fr-CA/reports.json
@@ -1,6 +1,8 @@
 {
   "action": {
+    "collapse_all": "",
     "collapse_rows": "Réduire toutes les lignes",
+    "expand_all": "",
     "expand_rows": "Afficher toutes les lignes"
   },
   "empty": {
@@ -11,15 +13,16 @@
   },
   "error": {
     "couldnt_load_report": "Nous n’avons pas pu charger votre rapport",
+    "couldnt_load_reports": "",
     "load_detail_lines": "Erreur lors du chargement des lignes de détail",
     "load_pnl_detail_lines": "Une erreur s’est produite lors du chargement des lignes de détail de l’état des résultats",
-    "load_report": "Une erreur s’est produite lors du chargement de votre rapport. Veuillez vérifier votre connexion et réessayer."
+    "load_report": "Une erreur s’est produite lors du chargement de votre rapport. Veuillez vérifier votre connexion et réessayer.",
+    "load_reports_navigation": ""
   },
   "label": {
     "adjustments_net_income": "Ajustements au bénéfice net",
     "assets": "Actifs",
     "balance_sheet": "Bilan",
-    "balance_sheet_report": "Rapport du bilan",
     "cash_beginning_of_period": "Trésorerie au début de la période",
     "cash_end_of_period": "Trésorerie à la fin de la période",
     "compare": "Comparer par",
@@ -36,12 +39,11 @@
     "other_outflows": "Autres sorties de fonds",
     "profit_before_taxes": "Bénéfice avant impôts",
     "profit_loss_detail_report": "Rapport détaillé de l’état des résultats",
-    "profit_loss_report": "Rapport de l’état des résultats",
     "report_period": "Période du rapport",
     "report_type": "Type de rapport",
     "reports": "Rapports",
+    "reports_navigation": "",
     "statement_cash_flow": "État des flux de trésorerie",
-    "statement_cash_flow_report": "Rapport de l’état des flux de trésorerie",
     "total_display_name": "Total de {{displayName}}"
   }
 }

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -109,6 +109,7 @@ export const DataTable = <TData extends object>({
                 <Cell
                   key={`${row.id}-${cell.id}`}
                   className={`Layer__UI__Table-Cell__${componentName}--${cell.column.id}`}
+                  alignment={cell.column.columnDef.meta?.alignment}
                   nonAria={nonAria}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -131,6 +132,7 @@ export const DataTable = <TData extends object>({
                 key={header.id}
                 isRowHeader={header.column.columnDef.meta?.isRowHeader}
                 className={`Layer__UI__Table-Column__${componentName}--${header.id}`}
+                alignment={header.column.columnDef.meta?.alignment}
                 nonAria={nonAria}
                 colSpan={header.colSpan}
               >

--- a/src/components/DataTable/columnUtils.ts
+++ b/src/components/DataTable/columnUtils.ts
@@ -1,15 +1,19 @@
 import { type ColumnDef, createColumnHelper, type Row } from '@tanstack/react-table'
 
-export type LeafColumn<TData> = {
+import { type Alignment } from '@schemas/reports/unifiedReport'
+
+type BaseColumn = {
   id: string
   header?: React.ReactNode
-  cell: (row: Row<TData>) => React.ReactNode
-  isRowHeader?: true
+  alignment?: Alignment
+  isRowHeader?: boolean
 }
 
-export type GroupColumn<TData> = {
-  id: string
-  header?: React.ReactNode
+export type LeafColumn<TData> = BaseColumn & {
+  cell: (row: Row<TData>) => React.ReactNode
+}
+
+export type GroupColumn<TData> = BaseColumn & {
   columns: ColumnNode<TData>[]
 }
 
@@ -25,6 +29,11 @@ export const isGroupColumn = <TData>(col: ColumnNode<TData>): col is GroupColumn
 
 export type NestedColumnConfig<TData> = ColumnNode<TData>[]
 
+const getColumnMeta = (col: BaseColumn) => ({
+  alignment: col.alignment,
+  isRowHeader: col.isRowHeader ?? false,
+})
+
 export const getColumnDefs = <TData>(
   columnConfig: NestedColumnConfig<TData>,
 ): ColumnDef<TData>[] => {
@@ -36,9 +45,7 @@ export const getColumnDefs = <TData>(
         id: col.id,
         header: () => col.header,
         cell: ({ row }) => col.cell(row),
-        meta: {
-          isRowHeader: col.isRowHeader || false,
-        },
+        meta: getColumnMeta(col),
       })
     }
 
@@ -46,6 +53,7 @@ export const getColumnDefs = <TData>(
       id: col.id,
       header: () => col.header,
       columns: getColumnDefs(col.columns),
+      meta: getColumnMeta(col),
     })
   })
 }

--- a/src/components/ReportsNavigation/ReportsNavigation.tsx
+++ b/src/components/ReportsNavigation/ReportsNavigation.tsx
@@ -1,5 +1,6 @@
 import { Landmark } from 'lucide-react'
 import type { ComponentType } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import type { ReportConfig, ReportGroup } from '@schemas/reports/reportConfig'
 import { ReportGroupType } from '@schemas/reports/reportConfig'
@@ -20,14 +21,17 @@ import { ConditionalBlock } from '@components/utility/ConditionalBlock'
 
 import './reportsNavigation.scss'
 
-const ReportsNavigationError = () => (
-  <DataState
-    status={DataStateStatus.failed}
-    title='Failed to load reports'
-    description='Something went wrong while loading this navigation. Please try again.'
-    spacing
-  />
-)
+const ReportsNavigationError = () => {
+  const { t } = useTranslation()
+  return (
+    <DataState
+      status={DataStateStatus.failed}
+      title={t('reports:error.couldnt_load_reports', 'Failed to load reports')}
+      description={t('reports:error.load_reports_navigation', 'Something went wrong while loading this navigation. Please try again.')}
+      spacing
+    />
+  )
+}
 
 const REPORT_GROUP_ICON: Record<ReportGroupType, ComponentType<IconSvgProps>> = {
   [ReportGroupType.Accounting]: Landmark,
@@ -38,6 +42,7 @@ const isReportGroup = (item: ReportGroup | ReportConfig): item is ReportGroup =>
   'reports' in item
 
 export function ReportsNavigation() {
+  const { t } = useTranslation()
   const { data, isLoading, isError } = useReportConfig()
   const { report, setReport } = useActiveUnifiedReport()
 
@@ -74,7 +79,7 @@ export function ReportsNavigation() {
     >
       {({ data }) => (
         <TreeNavigation
-          ariaLabel='Reports navigation'
+          ariaLabel={t('reports:label.reports_navigation', 'Reports navigation')}
           items={data}
           selectedItem={report?.key ?? null}
           isGroup={isReportGroup}

--- a/src/components/ReportsNavigation/ReportsNavigation.tsx
+++ b/src/components/ReportsNavigation/ReportsNavigation.tsx
@@ -1,0 +1,87 @@
+import { Landmark } from 'lucide-react'
+import type { ComponentType } from 'react'
+
+import type { ReportConfig, ReportGroup } from '@schemas/reports/reportConfig'
+import { ReportGroupType } from '@schemas/reports/reportConfig'
+import { useReportConfig } from '@hooks/api/businesses/[business-id]/reports/config/useReportConfig'
+import { useActiveUnifiedReport } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
+import Folder from '@icons/Folder'
+import type { IconSvgProps } from '@icons/types'
+import { HStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+import { DataState, DataStateStatus } from '@components/DataState/DataState'
+import {
+  TreeNavigation,
+  type TreeNavigationGroupConfig,
+  type TreeNavigationLeafConfig,
+} from '@components/TreeNavigation/TreeNavigation'
+import { TreeNavigationSkeleton } from '@components/TreeNavigation/TreeNavigationSkeleton'
+import { ConditionalBlock } from '@components/utility/ConditionalBlock'
+
+import './reportsNavigation.scss'
+
+const ReportsNavigationError = () => (
+  <DataState
+    status={DataStateStatus.failed}
+    title='Failed to load reports'
+    description='Something went wrong while loading this navigation. Please try again.'
+    spacing
+  />
+)
+
+const REPORT_GROUP_ICON: Record<ReportGroupType, ComponentType<IconSvgProps>> = {
+  [ReportGroupType.Accounting]: Landmark,
+  [ReportGroupType.Unknown]: Folder,
+}
+
+const isReportGroup = (item: ReportGroup | ReportConfig): item is ReportGroup =>
+  'reports' in item
+
+export function ReportsNavigation() {
+  const { data, isLoading, isError } = useReportConfig()
+  const { report, setReport } = useActiveUnifiedReport()
+
+  const groupConfig: TreeNavigationGroupConfig<ReportGroup, ReportConfig> = {
+    getId: group => group.groupType,
+    getTextValue: group => group.displayName,
+    getChildren: group => group.reports,
+    renderLabel: (group) => {
+      const Icon = REPORT_GROUP_ICON[group.groupType]
+      return (
+        <HStack className='Layer__ReportsNavigation-GroupLabel' gap='sm' align='center'>
+          <Icon className='Layer__ReportsNavigation-GroupIcon' strokeWidth={1.5} size={16} />
+          <Span ellipsis variant='subtle' weight='bold'>{group.displayName}</Span>
+        </HStack>
+      )
+    },
+  }
+
+  const leafConfig: TreeNavigationLeafConfig<ReportConfig> = {
+    getId: leaf => leaf.key,
+    getTextValue: leaf => leaf.displayName,
+    renderLabel: leaf => <Span ellipsis>{leaf.displayName}</Span>,
+    onAction: setReport,
+  }
+
+  return (
+    <ConditionalBlock
+      data={data}
+      isLoading={isLoading}
+      Loading={<TreeNavigationSkeleton />}
+      Inactive={null}
+      isError={isError}
+      Error={<ReportsNavigationError />}
+    >
+      {({ data }) => (
+        <TreeNavigation
+          ariaLabel='Reports navigation'
+          items={data}
+          selectedItem={report?.key ?? null}
+          isGroup={isReportGroup}
+          groupConfig={groupConfig}
+          leafConfig={leafConfig}
+        />
+      )}
+    </ConditionalBlock>
+  )
+}

--- a/src/components/ReportsNavigation/ReportsNavigation.tsx
+++ b/src/components/ReportsNavigation/ReportsNavigation.tsx
@@ -41,32 +41,34 @@ const REPORT_GROUP_ICON: Record<ReportGroupType, ComponentType<IconSvgProps>> = 
 const isReportGroup = (item: ReportGroup | ReportConfig): item is ReportGroup =>
   'reports' in item
 
+const groupConfig: TreeNavigationGroupConfig<ReportGroup, ReportConfig> = {
+  getId: group => group.groupType,
+  getTextValue: group => group.displayName,
+  getChildren: group => group.reports,
+  renderLabel: (group) => {
+    const Icon = REPORT_GROUP_ICON[group.groupType]
+    return (
+      <HStack className='Layer__ReportsNavigation__GroupLabel' gap='sm' align='center'>
+        <Icon className='Layer__ReportsNavigation__GroupIcon' strokeWidth={1.5} size={16} />
+        <Span ellipsis variant='subtle' weight='bold'>{group.displayName}</Span>
+      </HStack>
+    )
+  },
+}
+
+const buildLeafConfig = (onSelectLeaf: (report: ReportConfig) => void): TreeNavigationLeafConfig<ReportConfig> => ({
+  getId: leaf => leaf.key,
+  getTextValue: leaf => leaf.displayName,
+  renderLabel: leaf => <Span ellipsis>{leaf.displayName}</Span>,
+  onSelectLeaf,
+})
+
 export function ReportsNavigation() {
   const { t } = useTranslation()
   const { data, isLoading, isError } = useReportConfig()
   const { report, setReport } = useActiveUnifiedReport()
 
-  const groupConfig = useMemo<TreeNavigationGroupConfig<ReportGroup, ReportConfig>>(() => ({
-    getId: group => group.groupType,
-    getTextValue: group => group.displayName,
-    getChildren: group => group.reports,
-    renderLabel: (group) => {
-      const Icon = REPORT_GROUP_ICON[group.groupType]
-      return (
-        <HStack className='Layer__ReportsNavigation-GroupLabel' gap='sm' align='center'>
-          <Icon className='Layer__ReportsNavigation-GroupIcon' strokeWidth={1.5} size={16} />
-          <Span ellipsis variant='subtle' weight='bold'>{group.displayName}</Span>
-        </HStack>
-      )
-    },
-  }), [])
-
-  const leafConfig = useMemo<TreeNavigationLeafConfig<ReportConfig>>(() => ({
-    getId: leaf => leaf.key,
-    getTextValue: leaf => leaf.displayName,
-    renderLabel: leaf => <Span ellipsis>{leaf.displayName}</Span>,
-    onAction: setReport,
-  }), [setReport])
+  const leafConfig = useMemo(() => buildLeafConfig(setReport), [setReport])
 
   return (
     <ConditionalBlock

--- a/src/components/ReportsNavigation/ReportsNavigation.tsx
+++ b/src/components/ReportsNavigation/ReportsNavigation.tsx
@@ -1,5 +1,5 @@
+import { type ComponentType, useMemo } from 'react'
 import { Landmark } from 'lucide-react'
-import type { ComponentType } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { ReportConfig, ReportGroup } from '@schemas/reports/reportConfig'
@@ -46,7 +46,7 @@ export function ReportsNavigation() {
   const { data, isLoading, isError } = useReportConfig()
   const { report, setReport } = useActiveUnifiedReport()
 
-  const groupConfig: TreeNavigationGroupConfig<ReportGroup, ReportConfig> = {
+  const groupConfig = useMemo<TreeNavigationGroupConfig<ReportGroup, ReportConfig>>(() => ({
     getId: group => group.groupType,
     getTextValue: group => group.displayName,
     getChildren: group => group.reports,
@@ -59,14 +59,14 @@ export function ReportsNavigation() {
         </HStack>
       )
     },
-  }
+  }), [])
 
-  const leafConfig: TreeNavigationLeafConfig<ReportConfig> = {
+  const leafConfig = useMemo<TreeNavigationLeafConfig<ReportConfig>>(() => ({
     getId: leaf => leaf.key,
     getTextValue: leaf => leaf.displayName,
     renderLabel: leaf => <Span ellipsis>{leaf.displayName}</Span>,
     onAction: setReport,
-  }
+  }), [setReport])
 
   return (
     <ConditionalBlock

--- a/src/components/ReportsNavigation/reportsNavigation.scss
+++ b/src/components/ReportsNavigation/reportsNavigation.scss
@@ -1,0 +1,7 @@
+.Layer__ReportsNavigation-GroupLabel {
+  min-width: 0;
+}
+
+.Layer__ReportsNavigation-GroupIcon {
+  color: var(--color-base-500);
+}

--- a/src/components/ReportsNavigation/reportsNavigation.scss
+++ b/src/components/ReportsNavigation/reportsNavigation.scss
@@ -1,7 +1,7 @@
-.Layer__ReportsNavigation-GroupLabel {
+.Layer__ReportsNavigation__GroupLabel {
   min-width: 0;
 }
 
-.Layer__ReportsNavigation-GroupIcon {
+.Layer__ReportsNavigation__GroupIcon {
   color: var(--color-base-500);
 }

--- a/src/components/TreeNavigation/TreeNavigation.tsx
+++ b/src/components/TreeNavigation/TreeNavigation.tsx
@@ -1,4 +1,5 @@
 import { type ReactElement, type ReactNode, useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   Button as ReactAriaButton,
   Collection as ReactAriaCollection,
@@ -43,6 +44,7 @@ type RenderTreeGroupArgs<TGroup extends object, TLeaf extends object> = {
   groupConfig: TreeNavigationGroupConfig<TGroup, TLeaf>
   onToggle: (groupId: Key) => void
   renderItem: (item: TGroup | TLeaf) => ReactElement
+  chevronLabel: (groupName: string) => string
 }
 
 const renderTreeGroup = <TGroup extends object, TLeaf extends object>({
@@ -50,18 +52,24 @@ const renderTreeGroup = <TGroup extends object, TLeaf extends object>({
   groupConfig,
   onToggle,
   renderItem,
+  chevronLabel,
 }: RenderTreeGroupArgs<TGroup, TLeaf>): ReactElement => {
   const groupId = groupConfig.getId(group)
+  const textValue = groupConfig.getTextValue(group)
   return (
     <TreeItem
       id={groupId}
-      textValue={groupConfig.getTextValue(group)}
+      textValue={textValue}
       onAction={() => onToggle(groupId)}
     >
       <TreeItemContent>
         <HStack className='Layer__TreeNavigation-Row' align='center' justify='space-between'>
           {groupConfig.renderLabel(group)}
-          <ReactAriaButton className='Layer__TreeNavigation-Chevron' slot='chevron'>
+          <ReactAriaButton
+            className='Layer__TreeNavigation-Chevron'
+            slot='chevron'
+            aria-label={chevronLabel(textValue)}
+          >
             <ChevronRight width={16} height={16} />
           </ReactAriaButton>
         </HStack>
@@ -103,6 +111,11 @@ export function TreeNavigation<TGroup extends object, TLeaf extends object>({
   leafConfig,
   ariaLabel,
 }: TreeNavigationProps<TGroup, TLeaf>) {
+  const { t } = useTranslation()
+  const chevronLabel = useCallback(
+    (groupName: string) => t('common:action.toggle_section', 'Toggle {{name}}', { name: groupName }),
+    [t],
+  )
   const itemArray = useMemo(() => Array.from(items), [items])
 
   const { groupIds, leafMap } = useMemo(
@@ -150,6 +163,7 @@ export function TreeNavigation<TGroup extends object, TLeaf extends object>({
         groupConfig,
         onToggle: toggleGroup,
         renderItem,
+        chevronLabel,
       })
     }
     return renderTreeLeaf({ leaf: item, leafConfig })

--- a/src/components/TreeNavigation/TreeNavigation.tsx
+++ b/src/components/TreeNavigation/TreeNavigation.tsx
@@ -1,0 +1,173 @@
+import { type ReactElement, type ReactNode, useCallback, useMemo, useState } from 'react'
+import {
+  Button as ReactAriaButton,
+  Collection as ReactAriaCollection,
+  type Selection,
+} from 'react-aria-components'
+
+import Check from '@icons/Check'
+import ChevronRight from '@icons/ChevronRight'
+import { HStack } from '@ui/Stack/Stack'
+import { Tree, TreeItem, TreeItemContent } from '@ui/Tree/Tree'
+import { indexTree, type Key } from '@components/TreeNavigation/utils'
+
+import './treeNavigation.scss'
+
+type TreeNavigationItemConfig<T> = {
+  getId: (item: T) => Key
+  getTextValue: (item: T) => string
+  renderLabel: (item: T) => ReactNode
+}
+
+export type TreeNavigationGroupConfig<TGroup, TLeaf> = TreeNavigationItemConfig<TGroup> & {
+  getChildren: (group: TGroup) => Iterable<TGroup | TLeaf>
+}
+
+export type TreeNavigationLeafConfig<TLeaf> = TreeNavigationItemConfig<TLeaf> & {
+  onAction: (leaf: TLeaf) => void
+}
+
+type TreeNavigationProps<TGroup extends object, TLeaf extends object> = {
+  items: Iterable<TGroup | TLeaf>
+  selectedItem?: Key | null
+
+  isGroup: (item: TGroup | TLeaf) => item is TGroup
+  groupConfig: TreeNavigationGroupConfig<TGroup, TLeaf>
+  leafConfig: TreeNavigationLeafConfig<TLeaf>
+
+  ariaLabel: string
+}
+
+type RenderTreeGroupArgs<TGroup extends object, TLeaf extends object> = {
+  group: TGroup
+  groupConfig: TreeNavigationGroupConfig<TGroup, TLeaf>
+  onToggle: (groupId: Key) => void
+  renderItem: (item: TGroup | TLeaf) => ReactElement
+}
+
+const renderTreeGroup = <TGroup extends object, TLeaf extends object>({
+  group,
+  groupConfig,
+  onToggle,
+  renderItem,
+}: RenderTreeGroupArgs<TGroup, TLeaf>): ReactElement => {
+  const groupId = groupConfig.getId(group)
+  return (
+    <TreeItem
+      id={groupId}
+      textValue={groupConfig.getTextValue(group)}
+      onAction={() => onToggle(groupId)}
+    >
+      <TreeItemContent>
+        <HStack className='Layer__TreeNavigation-Row' align='center' justify='space-between'>
+          {groupConfig.renderLabel(group)}
+          <ReactAriaButton className='Layer__TreeNavigation-Chevron' slot='chevron'>
+            <ChevronRight width={16} height={16} />
+          </ReactAriaButton>
+        </HStack>
+      </TreeItemContent>
+      <ReactAriaCollection items={Array.from(groupConfig.getChildren(group))}>
+        {renderItem}
+      </ReactAriaCollection>
+    </TreeItem>
+  )
+}
+
+type RenderTreeLeafArgs<TLeaf extends object> = {
+  leaf: TLeaf
+  leafConfig: TreeNavigationLeafConfig<TLeaf>
+}
+
+const renderTreeLeaf = <TLeaf extends object>({
+  leaf,
+  leafConfig,
+}: RenderTreeLeafArgs<TLeaf>): ReactElement => (
+  <TreeItem
+    id={leafConfig.getId(leaf)}
+    textValue={leafConfig.getTextValue(leaf)}
+  >
+    <TreeItemContent>
+      <HStack className='Layer__TreeNavigation-Row' align='center' justify='space-between'>
+        {leafConfig.renderLabel(leaf)}
+        <Check className='Layer__TreeNavigation-Check' width={14} height={14} />
+      </HStack>
+    </TreeItemContent>
+  </TreeItem>
+)
+
+export function TreeNavigation<TGroup extends object, TLeaf extends object>({
+  items,
+  selectedItem,
+  isGroup,
+  groupConfig,
+  leafConfig,
+  ariaLabel,
+}: TreeNavigationProps<TGroup, TLeaf>) {
+  const itemArray = useMemo(() => Array.from(items), [items])
+
+  const { groupIds, leafMap } = useMemo(
+    () => indexTree({
+      items: itemArray,
+      isGroup,
+      getChildren: groupConfig.getChildren,
+      getGroupId: groupConfig.getId,
+      getLeafId: leafConfig.getId,
+    }),
+    [itemArray, isGroup, groupConfig, leafConfig],
+  )
+
+  const [expandedKeys, setExpandedKeys] = useState<Set<Key>>(new Set(groupIds))
+
+  const toggleGroup = useCallback((groupId: Key) => {
+    setExpandedKeys((prev) => {
+      const next = new Set(prev)
+      if (next.has(groupId)) {
+        next.delete(groupId)
+      }
+      else {
+        next.add(groupId)
+      }
+      return next
+    })
+  }, [])
+
+  const handleSelectionChange = useCallback((selection: Selection) => {
+    if (selection === 'all') return
+
+    const nextKey = selection.values().next().value
+    if (nextKey == null) return
+
+    const leaf = leafMap.get(nextKey)
+    if (leaf) leafConfig.onAction(leaf)
+  }, [leafMap, leafConfig])
+
+  const selectedItems = selectedItem != null ? [selectedItem] : []
+
+  const renderItem = (item: TGroup | TLeaf): ReactElement => {
+    if (isGroup(item)) {
+      return renderTreeGroup({
+        group: item,
+        groupConfig,
+        onToggle: toggleGroup,
+        renderItem,
+      })
+    }
+    return renderTreeLeaf({ leaf: item, leafConfig })
+  }
+
+  return (
+    <Tree
+      aria-label={ariaLabel}
+      selectionMode='single'
+      selectedKeys={selectedItems}
+      onSelectionChange={handleSelectionChange}
+      disabledKeys={groupIds}
+      disabledBehavior='selection'
+      expandedKeys={expandedKeys}
+      onExpandedChange={setExpandedKeys}
+      items={itemArray}
+    >
+      {renderItem}
+    </Tree>
+  )
+}

--- a/src/components/TreeNavigation/TreeNavigation.tsx
+++ b/src/components/TreeNavigation/TreeNavigation.tsx
@@ -25,7 +25,7 @@ export type TreeNavigationGroupConfig<TGroup, TLeaf> = TreeNavigationItemConfig<
 }
 
 export type TreeNavigationLeafConfig<TLeaf> = TreeNavigationItemConfig<TLeaf> & {
-  onAction: (leaf: TLeaf) => void
+  onSelectLeaf: (leaf: TLeaf) => void
 }
 
 type TreeNavigationProps<TGroup extends object, TLeaf extends object> = {
@@ -57,16 +57,12 @@ const renderTreeGroup = <TGroup extends object, TLeaf extends object>({
   const groupId = groupConfig.getId(group)
   const textValue = groupConfig.getTextValue(group)
   return (
-    <TreeItem
-      id={groupId}
-      textValue={textValue}
-      onAction={() => onToggle(groupId)}
-    >
+    <TreeItem id={groupId} textValue={textValue} onAction={() => onToggle(groupId)}>
       <TreeItemContent>
-        <HStack className='Layer__TreeNavigation-Row' align='center' justify='space-between'>
+        <HStack className='Layer__TreeNavigation__Row' align='center' justify='space-between'>
           {groupConfig.renderLabel(group)}
           <ReactAriaButton
-            className='Layer__TreeNavigation-Chevron'
+            className='Layer__TreeNavigation__Chevron'
             slot='chevron'
             aria-label={chevronLabel(textValue)}
           >
@@ -86,18 +82,12 @@ type RenderTreeLeafArgs<TLeaf extends object> = {
   leafConfig: TreeNavigationLeafConfig<TLeaf>
 }
 
-const renderTreeLeaf = <TLeaf extends object>({
-  leaf,
-  leafConfig,
-}: RenderTreeLeafArgs<TLeaf>): ReactElement => (
-  <TreeItem
-    id={leafConfig.getId(leaf)}
-    textValue={leafConfig.getTextValue(leaf)}
-  >
+const renderTreeLeaf = <TLeaf extends object>({ leaf, leafConfig }: RenderTreeLeafArgs<TLeaf>): ReactElement => (
+  <TreeItem id={leafConfig.getId(leaf)} textValue={leafConfig.getTextValue(leaf)}>
     <TreeItemContent>
       <HStack align='center' justify='space-between'>
         {leafConfig.renderLabel(leaf)}
-        <Check className='Layer__TreeNavigation-Check' width={14} height={14} />
+        <Check className='Layer__TreeNavigation__Check' width={14} height={14} />
       </HStack>
     </TreeItemContent>
   </TreeItem>
@@ -151,7 +141,7 @@ export function TreeNavigation<TGroup extends object, TLeaf extends object>({
     if (nextKey == null) return
 
     const leaf = leafMap.get(nextKey)
-    if (leaf) leafConfig.onAction(leaf)
+    if (leaf) leafConfig.onSelectLeaf(leaf)
   }, [leafMap, leafConfig])
 
   const selectedItems = selectedItem != null ? [selectedItem] : []

--- a/src/components/TreeNavigation/TreeNavigation.tsx
+++ b/src/components/TreeNavigation/TreeNavigation.tsx
@@ -95,7 +95,7 @@ const renderTreeLeaf = <TLeaf extends object>({
     textValue={leafConfig.getTextValue(leaf)}
   >
     <TreeItemContent>
-      <HStack className='Layer__TreeNavigation-Row' align='center' justify='space-between'>
+      <HStack align='center' justify='space-between'>
         {leafConfig.renderLabel(leaf)}
         <Check className='Layer__TreeNavigation-Check' width={14} height={14} />
       </HStack>
@@ -180,6 +180,7 @@ export function TreeNavigation<TGroup extends object, TLeaf extends object>({
       expandedKeys={expandedKeys}
       onExpandedChange={setExpandedKeys}
       items={itemArray}
+      className='Layer__TreeNavigation'
     >
       {renderItem}
     </Tree>

--- a/src/components/TreeNavigation/TreeNavigation.tsx
+++ b/src/components/TreeNavigation/TreeNavigation.tsx
@@ -1,10 +1,10 @@
 import { type ReactElement, type ReactNode, useCallback, useMemo, useState } from 'react'
-import { useTranslation } from 'react-i18next'
 import {
   Button as ReactAriaButton,
   Collection as ReactAriaCollection,
   type Selection,
 } from 'react-aria-components'
+import { useTranslation } from 'react-i18next'
 
 import Check from '@icons/Check'
 import ChevronRight from '@icons/ChevronRight'

--- a/src/components/TreeNavigation/TreeNavigationSkeleton.tsx
+++ b/src/components/TreeNavigation/TreeNavigationSkeleton.tsx
@@ -1,0 +1,30 @@
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { SkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
+
+import './treeNavigationSkeleton.scss'
+
+type TreeNavigationSkeletonProps = {
+  groups?: number
+  leavesPerGroup?: number
+}
+
+export const TreeNavigationSkeleton = ({
+  groups = 2,
+  leavesPerGroup = 3,
+}: TreeNavigationSkeletonProps) => (
+  <VStack className='Layer__TreeNavigationSkeleton' aria-hidden='true'>
+    {Array.from({ length: groups }).map((_, groupIndex) => (
+      <VStack key={groupIndex}>
+        <HStack className='Layer__TreeNavigationSkeleton-Group' align='center' gap='sm'>
+          <SkeletonLoader width='16px' height='16px' />
+          <SkeletonLoader width='60%' height='12px' />
+        </HStack>
+        {Array.from({ length: leavesPerGroup }).map((_, leafIndex) => (
+          <HStack key={leafIndex} className='Layer__TreeNavigationSkeleton-Leaf' align='center'>
+            <SkeletonLoader width='70%' height='12px' />
+          </HStack>
+        ))}
+      </VStack>
+    ))}
+  </VStack>
+)

--- a/src/components/TreeNavigation/TreeNavigationSkeleton.tsx
+++ b/src/components/TreeNavigation/TreeNavigationSkeleton.tsx
@@ -15,12 +15,12 @@ export const TreeNavigationSkeleton = ({
   <VStack className='Layer__TreeNavigationSkeleton' aria-hidden='true'>
     {Array.from({ length: groups }).map((_, groupIndex) => (
       <VStack key={groupIndex}>
-        <HStack className='Layer__TreeNavigationSkeleton-Group' align='center' gap='sm'>
+        <HStack className='Layer__TreeNavigationSkeleton__Group' align='center' gap='sm'>
           <SkeletonLoader width='16px' height='16px' />
           <SkeletonLoader width='60%' height='12px' />
         </HStack>
         {Array.from({ length: leavesPerGroup }).map((_, leafIndex) => (
-          <HStack key={leafIndex} className='Layer__TreeNavigationSkeleton-Leaf' align='center'>
+          <HStack key={leafIndex} className='Layer__TreeNavigationSkeleton__Leaf' align='center'>
             <SkeletonLoader width='70%' height='12px' />
           </HStack>
         ))}

--- a/src/components/TreeNavigation/treeNavigation.scss
+++ b/src/components/TreeNavigation/treeNavigation.scss
@@ -9,7 +9,7 @@
   border-bottom: 1px solid var(--color-base-300);
   cursor: pointer;
 
-  .Layer__TreeNavigation-Check {
+  .Layer__TreeNavigation__Check {
     visibility: hidden;
   }
 
@@ -38,19 +38,19 @@
       background: black;
     }
 
-    .Layer__TreeNavigation-Check {
+    .Layer__TreeNavigation__Check {
       visibility: visible;
     }
   }
 }
 
-.Layer__TreeNavigation-Chevron {
+.Layer__TreeNavigation__Chevron {
   padding: 0;
   border: none;
   background: transparent;
   transition: transform var(--transition-speed) ease;
 }
 
-.Layer__UI__TreeItem[data-expanded] .Layer__TreeNavigation-Chevron {
+.Layer__UI__TreeItem[data-expanded] .Layer__TreeNavigation__Chevron {
   transform: rotate(90deg);
 }

--- a/src/components/TreeNavigation/treeNavigation.scss
+++ b/src/components/TreeNavigation/treeNavigation.scss
@@ -1,0 +1,55 @@
+.Layer__TreeNavigation-Row {
+  cursor: pointer;
+}
+
+.Layer__UI__TreeItem {
+  position: relative;
+  align-content: center;
+  height: var(--spacing-5xl);
+
+  padding-inline-start: calc(var(--spacing-sm) * calc(var(--tree-item-level) - 1) + var(--spacing-md) * var(--tree-item-level));
+  padding-inline-end: var(--spacing-md);
+
+  border-bottom: 1px solid var(--color-base-300);
+
+  .Layer__TreeNavigation-Check {
+    visibility: hidden;
+  }
+
+  &[aria-level='1'] {
+    background-color: var(--color-base-0);
+  }
+
+  &[aria-level='2'] {
+    background-color: var(--color-base-50);
+  }
+
+  &[data-selected] {
+    font-weight: var(--font-weight-bold);
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: 2px;
+      background: black;
+    }
+
+    .Layer__TreeNavigation-Check {
+      visibility: visible;
+    }
+  }
+}
+
+.Layer__TreeNavigation-Chevron {
+  padding: 0;
+  border: none;
+  background: transparent;
+  transition: transform var(--transition-speed) ease;
+}
+
+.Layer__UI__TreeItem[data-expanded] .Layer__TreeNavigation-Chevron {
+  transform: rotate(90deg);
+}

--- a/src/components/TreeNavigation/treeNavigation.scss
+++ b/src/components/TreeNavigation/treeNavigation.scss
@@ -1,8 +1,4 @@
-.Layer__TreeNavigation-Row {
-  cursor: pointer;
-}
-
-.Layer__UI__TreeItem {
+.Layer__TreeNavigation .Layer__UI__TreeItem {
   position: relative;
   align-content: center;
   height: var(--spacing-5xl);
@@ -11,6 +7,7 @@
   padding-inline-end: var(--spacing-md);
 
   border-bottom: 1px solid var(--color-base-300);
+  cursor: pointer;
 
   .Layer__TreeNavigation-Check {
     visibility: hidden;
@@ -22,6 +19,10 @@
 
   &[aria-level='2'] {
     background-color: var(--color-base-50);
+  }
+
+  &[data-hovered] {
+    background-color: var(--color-base-100);
   }
 
   &[data-selected] {

--- a/src/components/TreeNavigation/treeNavigationSkeleton.scss
+++ b/src/components/TreeNavigation/treeNavigationSkeleton.scss
@@ -1,0 +1,15 @@
+.Layer__TreeNavigationSkeleton {
+  width: 100%;
+
+  &-Group,
+  &-Leaf {
+    height: var(--spacing-5xl);
+    padding-inline: var(--spacing-md);
+    border-bottom: 1px solid var(--color-base-300);
+  }
+
+  &-Leaf {
+    padding-inline-start: calc(var(--spacing-lg) + var(--spacing-md));
+    background-color: var(--color-base-50);
+  }
+}

--- a/src/components/TreeNavigation/treeNavigationSkeleton.scss
+++ b/src/components/TreeNavigation/treeNavigationSkeleton.scss
@@ -1,14 +1,14 @@
 .Layer__TreeNavigationSkeleton {
   width: 100%;
 
-  &-Group,
-  &-Leaf {
+  &__Group,
+  &__Leaf {
     height: var(--spacing-5xl);
     padding-inline: var(--spacing-md);
     border-bottom: 1px solid var(--color-base-300);
   }
 
-  &-Leaf {
+  &__Leaf {
     padding-inline-start: calc(var(--spacing-lg) + var(--spacing-md));
     background-color: var(--color-base-50);
   }

--- a/src/components/TreeNavigation/utils.ts
+++ b/src/components/TreeNavigation/utils.ts
@@ -1,6 +1,6 @@
 export type Key = string | number
 
-export const visitTree = <TGroup extends object, TLeaf extends object>(
+const visitTree = <TGroup extends object, TLeaf extends object>(
   items: Iterable<TGroup | TLeaf>,
   isGroup: (item: TGroup | TLeaf) => item is TGroup,
   getChildren: (group: TGroup) => Iterable<TGroup | TLeaf>,

--- a/src/components/TreeNavigation/utils.ts
+++ b/src/components/TreeNavigation/utils.ts
@@ -1,0 +1,48 @@
+export type Key = string | number
+
+export const visitTree = <TGroup extends object, TLeaf extends object>(
+  items: Iterable<TGroup | TLeaf>,
+  isGroup: (item: TGroup | TLeaf) => item is TGroup,
+  getChildren: (group: TGroup) => Iterable<TGroup | TLeaf>,
+  onGroup: (group: TGroup) => void,
+  onLeaf: (leaf: TLeaf) => void,
+): void => {
+  for (const node of items) {
+    if (isGroup(node)) {
+      onGroup(node)
+      visitTree(getChildren(node), isGroup, getChildren, onGroup, onLeaf)
+    }
+    else {
+      onLeaf(node)
+    }
+  }
+}
+
+type IndexTreeOptions<TGroup extends object, TLeaf extends object> = {
+  items: Iterable<TGroup | TLeaf>
+  isGroup: (item: TGroup | TLeaf) => item is TGroup
+  getChildren: (group: TGroup) => Iterable<TGroup | TLeaf>
+  getGroupId: (group: TGroup) => Key
+  getLeafId: (leaf: TLeaf) => Key
+}
+
+export const indexTree = <TGroup extends object, TLeaf extends object>({
+  items,
+  isGroup,
+  getChildren,
+  getGroupId,
+  getLeafId,
+}: IndexTreeOptions<TGroup, TLeaf>): { groupIds: Key[], leafMap: Map<Key, TLeaf> } => {
+  const groupIds: Key[] = []
+  const leafMap = new Map<Key, TLeaf>()
+
+  visitTree<TGroup, TLeaf>(
+    items,
+    isGroup,
+    getChildren,
+    group => groupIds.push(getGroupId(group)),
+    leaf => leafMap.set(getLeafId(leaf), leaf),
+  )
+
+  return { groupIds, leafMap }
+}

--- a/src/components/UnifiedReport/UnifiedReport.tsx
+++ b/src/components/UnifiedReport/UnifiedReport.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 import { UnifiedReportStoreProvider } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { HStack, VStack } from '@ui/Stack/Stack'
@@ -14,8 +16,9 @@ type UnifiedReportProps = {
 }
 
 export const UnifiedReport = ({ dateSelectionMode = 'full' }: UnifiedReportProps) => {
+  const { t } = useTranslation()
   return (
-    <View title='Reports' viewClassName='Layer__UnifiedReport'>
+    <View title={t('reports:label.reports', 'Reports')} viewClassName='Layer__UnifiedReport'>
       <UnifiedReportStoreProvider>
         <ExpandableDataTableProvider>
           <HStack className='Layer__UnifiedReport__Layout'>

--- a/src/components/UnifiedReport/UnifiedReport.tsx
+++ b/src/components/UnifiedReport/UnifiedReport.tsx
@@ -1,9 +1,11 @@
 import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 import { UnifiedReportStoreProvider } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
-import { Container } from '@components/Container/Container'
+import { HStack, VStack } from '@ui/Stack/Stack'
 import { ExpandableDataTableProvider } from '@components/ExpandableDataTable/ExpandableDataTableProvider'
+import { ReportsNavigation } from '@components/ReportsNavigation/ReportsNavigation'
 import { UnifiedReportTable } from '@components/UnifiedReport/UnifiedReportTable'
 import { UnifiedReportTableHeader } from '@components/UnifiedReport/UnifiedReportTableHeader'
+import { View } from '@components/View/View'
 
 import './unifiedReport.scss'
 
@@ -13,13 +15,20 @@ type UnifiedReportProps = {
 
 export const UnifiedReport = ({ dateSelectionMode = 'full' }: UnifiedReportProps) => {
   return (
-    <Container name='UnifiedReport'>
+    <View title='Reports' viewClassName='Layer__UnifiedReport'>
       <UnifiedReportStoreProvider>
         <ExpandableDataTableProvider>
-          <UnifiedReportTableHeader dateSelectionMode={dateSelectionMode} />
-          <UnifiedReportTable dateSelectionMode={dateSelectionMode} />
+          <HStack className='Layer__UnifiedReport__Layout'>
+            <VStack className='Layer__UnifiedReport__Sidebar'>
+              <ReportsNavigation />
+            </VStack>
+            <VStack fluid className='Layer__UnifiedReport__Content'>
+              <UnifiedReportTableHeader dateSelectionMode={dateSelectionMode} />
+              <UnifiedReportTable dateSelectionMode={dateSelectionMode} />
+            </VStack>
+          </HStack>
         </ExpandableDataTableProvider>
       </UnifiedReportStoreProvider>
-    </Container>
+    </View>
   )
 }

--- a/src/components/UnifiedReport/UnifiedReport.tsx
+++ b/src/components/UnifiedReport/UnifiedReport.tsx
@@ -21,7 +21,7 @@ export const UnifiedReport = ({ dateSelectionMode = 'full' }: UnifiedReportProps
     <View title={t('reports:label.reports', 'Reports')} viewClassName='Layer__UnifiedReport'>
       <UnifiedReportStoreProvider>
         <ExpandableDataTableProvider>
-          <HStack className='Layer__UnifiedReport__Layout'>
+          <HStack>
             <VStack className='Layer__UnifiedReport__Sidebar'>
               <ReportsNavigation />
             </VStack>

--- a/src/components/UnifiedReport/UnifiedReportTable.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTable.tsx
@@ -110,7 +110,7 @@ export const UnifiedReportTable = ({ dateSelectionMode }: UnifiedReportTableProp
 
   return (
     <ExpandableDataTable
-      ariaLabel={report?.displayName ?? ''}
+      ariaLabel={report?.displayName ?? t('reports:label.reports', 'Reports')}
       data={mutableRows}
       isLoading={data === undefined || isLoading}
       isError={isError}

--- a/src/components/UnifiedReport/UnifiedReportTable.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTable.tsx
@@ -18,11 +18,15 @@ import './unifiedReportTable.scss'
 
 const COMPONENT_NAME = 'UnifiedReport'
 
-const makeLeafColumn = (col: UnifiedReportColumn): LeafColumn<UnifiedReportRow> => ({
+const makeBaseColumn = (col: UnifiedReportColumn) => ({
   id: col.columnKey,
   header: col.displayName,
   isRowHeader: col.isRowHeader,
   alignment: col.alignment,
+})
+
+const makeLeafColumn = (col: UnifiedReportColumn): LeafColumn<UnifiedReportRow> => ({
+  ...makeBaseColumn(col),
   cell: (row: RowType) => {
     const cellValue = row.original.cells[col.columnKey]?.value
 
@@ -34,19 +38,13 @@ const makeLeafColumn = (col: UnifiedReportColumn): LeafColumn<UnifiedReportRow> 
       return <MoneySpan ellipsis amount={cellValue.value} />
     }
 
-    if (isEmptyCellValue(cellValue)) {
-      return null
-    }
-
     return <Span ellipsis>{String(cellValue.value)}</Span>
   },
 })
 
 type UnifiedReportColumnWithRequiredColumns = UnifiedReportColumn & Required<Pick<UnifiedReportColumn, 'columns'>>
 const makeGroupColumn = (col: UnifiedReportColumnWithRequiredColumns): GroupColumn<UnifiedReportRow> => ({
-  id: col.columnKey,
-  header: col.displayName,
-  alignment: col.alignment,
+  ...makeBaseColumn(col),
   columns: buildNestedColumnConfig(col.columns),
 })
 

--- a/src/components/UnifiedReport/UnifiedReportTable.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTable.tsx
@@ -6,11 +6,11 @@ import { isAmountCellValue, isEmptyCellValue, type UnifiedReportColumn, type Uni
 import { asMutable } from '@utils/asMutable'
 import { useUnifiedReport } from '@hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport'
 import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
-import { useUnifiedReportName, useUnifiedReportState } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
+import { useActiveUnifiedReport, useUnifiedReportParams } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { MoneySpan } from '@ui/Typography/MoneySpan'
 import { Span } from '@ui/Typography/Text'
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
-import { type ColumnNode, type GroupColumn, type LeafColumn, type NestedColumnConfig } from '@components/DataTable/columnUtils'
+import { type ColumnNode, type GroupColumn, type LeafColumn } from '@components/DataTable/columnUtils'
 import { ExpandableDataTable } from '@components/ExpandableDataTable/ExpandableDataTable'
 import { ExpandableDataTableContext } from '@components/ExpandableDataTable/ExpandableDataTableProvider'
 
@@ -21,6 +21,8 @@ const COMPONENT_NAME = 'UnifiedReport'
 const makeLeafColumn = (col: UnifiedReportColumn): LeafColumn<UnifiedReportRow> => ({
   id: col.columnKey,
   header: col.displayName,
+  isRowHeader: col.isRowHeader,
+  alignment: col.alignment,
   cell: (row: RowType) => {
     const cellValue = row.original.cells[col.columnKey]?.value
 
@@ -44,6 +46,7 @@ type UnifiedReportColumnWithRequiredColumns = UnifiedReportColumn & Required<Pic
 const makeGroupColumn = (col: UnifiedReportColumnWithRequiredColumns): GroupColumn<UnifiedReportRow> => ({
   id: col.columnKey,
   header: col.displayName,
+  alignment: col.alignment,
   columns: buildNestedColumnConfig(col.columns),
 })
 
@@ -61,19 +64,6 @@ const buildNestedColumnConfig = (columns: ReadonlyArray<UnifiedReportColumn>): C
   })
 }
 
-export const buildColumnConfig = (columns: ReadonlyArray<UnifiedReportColumn>): NestedColumnConfig<UnifiedReportRow> => {
-  const displayNameColumn: LeafColumn<UnifiedReportRow> = {
-    id: 'displayName',
-    header: '',
-    cell: (row: RowType) => (
-      <Span weight={row.depth === 0 ? 'bold' : 'normal'} ellipsis>{row.original.displayName}</Span>
-    ),
-    isRowHeader: true,
-  }
-
-  return [displayNameColumn, ...buildNestedColumnConfig(columns)]
-}
-
 const getSubRows = (row: UnifiedReportRow) => row.rows ? asMutable(row.rows) : undefined
 
 type UnifiedReportTableProps = {
@@ -82,13 +72,13 @@ type UnifiedReportTableProps = {
 
 export const UnifiedReportTable = ({ dateSelectionMode }: UnifiedReportTableProps) => {
   const { t } = useTranslation()
-  const reportName = useUnifiedReportName()
-  const { report, groupBy, ...dateParams } = useUnifiedReportState({ dateSelectionMode })
-  const { data, isLoading, isError, refetch } = useUnifiedReport({ report, groupBy, ...dateParams })
+  const { report } = useActiveUnifiedReport()
+  const reportState = useUnifiedReportParams({ dateSelectionMode })
+  const { data, isLoading, isError, refetch } = useUnifiedReport(reportState)
   const { setExpanded } = useContext(ExpandableDataTableContext)
   const mutableRows = data?.rows ? asMutable(data.rows) : undefined
 
-  const columnConfig = useMemo(() => data ? buildColumnConfig(data.columns) : [], [data])
+  const columnConfig = useMemo(() => data ? buildNestedColumnConfig(data.columns) : [], [data])
 
   useEffect(() => {
     // Expand the top-level rows on initial data load
@@ -120,7 +110,7 @@ export const UnifiedReportTable = ({ dateSelectionMode }: UnifiedReportTableProp
 
   return (
     <ExpandableDataTable
-      ariaLabel={reportName}
+      ariaLabel={report?.displayName ?? ''}
       data={mutableRows}
       isLoading={data === undefined || isLoading}
       isError={isError}

--- a/src/components/UnifiedReport/UnifiedReportTableHeader.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTableHeader.tsx
@@ -1,13 +1,15 @@
 import { useCallback, useContext } from 'react'
 
 import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
-import { UnifiedReportDateVariant, useUnifiedReportDateVariant, useUnifiedReportGroupBy } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
+import { UnifiedReportDateVariant, useActiveUnifiedReport, useUnifiedReportDateVariant, useUnifiedReportGroupByParam } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { Button } from '@ui/Button/Button'
-import { HStack } from '@ui/Stack/Stack'
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { Header } from '@ui/Typography/Text'
 import { CombinedDateRangeSelection } from '@components/DateSelection/CombinedDateRangeSelection'
 import { CombinedDateSelection } from '@components/DateSelection/CombinedDateSelection'
 import { DateGroupByComboBox } from '@components/DateSelection/DateGroupByComboBox'
 import { ExpandableDataTableContext } from '@components/ExpandableDataTable/ExpandableDataTableProvider'
+import { SkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
 import { UnifiedReportDownloadButton } from '@components/UnifiedReport/UnifiedReportDownloadButton'
 
 import './unifiedReportTableHeader.scss'
@@ -18,7 +20,8 @@ type UnifiedReportTableHeaderProps = {
 
 export const UnifiedReportTableHeader = ({ dateSelectionMode }: UnifiedReportTableHeaderProps) => {
   const dateVariant = useUnifiedReportDateVariant()
-  const groupBySetter = useUnifiedReportGroupBy()
+  const groupBySetter = useUnifiedReportGroupByParam()
+  const { report } = useActiveUnifiedReport()
 
   const { expanded, setExpanded } = useContext(ExpandableDataTableContext)
   const shouldCollapse = expanded === true
@@ -32,21 +35,28 @@ export const UnifiedReportTableHeader = ({ dateSelectionMode }: UnifiedReportTab
   }, [setExpanded, shouldCollapse])
 
   return (
-    <HStack fluid justify='space-between' align='center' className='Layer__UnifiedReport__Header'>
-      <HStack pi='md' gap='xs'>
-        {dateVariant === UnifiedReportDateVariant.DateRange
-          ? <CombinedDateRangeSelection mode={dateSelectionMode} />
-          : <CombinedDateSelection mode={dateSelectionMode} />}
-        {dateSelectionMode === 'full' && groupBySetter && (
-          <DateGroupByComboBox value={groupBySetter.groupBy} onValueChange={groupBySetter.setGroupBy} />
-        )}
+    <VStack gap='lg'>
+      <HStack pis='lg' pbs='lg'>
+        {report
+          ? <Header>{report.displayName}</Header>
+          : <SkeletonLoader width='192px' height='24px' />}
       </HStack>
-      <HStack pi='md' className='Layer__UnifiedReport__Header__SecondaryActions'>
-        <Button variant='outlined' onClick={onClickExpandOrCollapse}>
-          {shouldCollapse ? 'Collapse All' : 'Expand All'}
-        </Button>
-        <UnifiedReportDownloadButton dateSelectionMode={dateSelectionMode} />
+      <HStack fluid justify='space-between' align='end' pbe='lg' className='Layer__UnifiedReport__Header'>
+        <HStack pi='lg' gap='xs'>
+          {dateVariant === UnifiedReportDateVariant.DateRange
+            ? <CombinedDateRangeSelection mode={dateSelectionMode} />
+            : <CombinedDateSelection mode={dateSelectionMode} />}
+          {dateSelectionMode === 'full' && groupBySetter && (
+            <DateGroupByComboBox value={groupBySetter.groupBy} onValueChange={groupBySetter.setGroupBy} />
+          )}
+        </HStack>
+        <HStack pi='lg' className='Layer__UnifiedReport__Header__SecondaryActions'>
+          <Button variant='outlined' onClick={onClickExpandOrCollapse}>
+            {shouldCollapse ? 'Collapse All' : 'Expand All'}
+          </Button>
+          <UnifiedReportDownloadButton dateSelectionMode={dateSelectionMode} />
+        </HStack>
       </HStack>
-    </HStack>
+    </VStack>
   )
 }

--- a/src/components/UnifiedReport/UnifiedReportTableHeader.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTableHeader.tsx
@@ -5,7 +5,7 @@ import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateSto
 import { UnifiedReportDateVariant, useActiveUnifiedReport, useUnifiedReportDateVariant, useUnifiedReportGroupByParam } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
-import { Header } from '@ui/Typography/Text'
+import { Span } from '@ui/Typography/Text'
 import { CombinedDateRangeSelection } from '@components/DateSelection/CombinedDateRangeSelection'
 import { CombinedDateSelection } from '@components/DateSelection/CombinedDateSelection'
 import { DateGroupByComboBox } from '@components/DateSelection/DateGroupByComboBox'
@@ -40,7 +40,7 @@ export const UnifiedReportTableHeader = ({ dateSelectionMode }: UnifiedReportTab
     <VStack gap='lg'>
       <HStack pis='lg' pbs='lg'>
         {report
-          ? <Header>{report.displayName}</Header>
+          ? <Span size='lg' weight='bold'>{report.displayName}</Span>
           : <SkeletonLoader width='192px' height='24px' />}
       </HStack>
       <HStack fluid justify='space-between' align='end' pbe='lg' className='Layer__UnifiedReport__Header'>

--- a/src/components/UnifiedReport/UnifiedReportTableHeader.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTableHeader.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useContext } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 import { UnifiedReportDateVariant, useActiveUnifiedReport, useUnifiedReportDateVariant, useUnifiedReportGroupByParam } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
@@ -19,6 +20,7 @@ type UnifiedReportTableHeaderProps = {
 }
 
 export const UnifiedReportTableHeader = ({ dateSelectionMode }: UnifiedReportTableHeaderProps) => {
+  const { t } = useTranslation()
   const dateVariant = useUnifiedReportDateVariant()
   const groupBySetter = useUnifiedReportGroupByParam()
   const { report } = useActiveUnifiedReport()
@@ -52,7 +54,9 @@ export const UnifiedReportTableHeader = ({ dateSelectionMode }: UnifiedReportTab
         </HStack>
         <HStack pi='lg' className='Layer__UnifiedReport__Header__SecondaryActions'>
           <Button variant='outlined' onClick={onClickExpandOrCollapse}>
-            {shouldCollapse ? 'Collapse All' : 'Expand All'}
+            {shouldCollapse
+              ? t('reports:action.collapse_all', 'Collapse All')
+              : t('reports:action.expand_all', 'Expand All')}
           </Button>
           <UnifiedReportDownloadButton dateSelectionMode={dateSelectionMode} />
         </HStack>

--- a/src/components/UnifiedReport/unifiedReport.scss
+++ b/src/components/UnifiedReport/unifiedReport.scss
@@ -1,4 +1,18 @@
 .Layer__UnifiedReport {
   overflow: hidden;
   min-width: clamp(24rem, 100%, 1406px);
+
+  .Layer__view-main.Layer__view-main {
+    padding: 0;
+  }
+}
+
+.Layer__UnifiedReport__Sidebar {
+  flex-shrink: 0;
+  width: 18rem;
+  border-right: 1px solid var(--color-base-300);
+}
+
+.Layer__UnifiedReport__Content {
+  min-width: 0;
 }

--- a/src/components/UnifiedReport/unifiedReportTable.scss
+++ b/src/components/UnifiedReport/unifiedReportTable.scss
@@ -4,10 +4,5 @@
   .Layer__UI__Table-Column,
   .Layer__UI__Table-Cell {
     display: table-cell;
-    text-align: end;
-
-    &__UnifiedReport--displayName {
-      text-align: start;
-    }
   }
 }

--- a/src/components/UnifiedReport/unifiedReportTableHeader.scss
+++ b/src/components/UnifiedReport/unifiedReportTableHeader.scss
@@ -1,5 +1,4 @@
 .Layer__UnifiedReport__Header {
-  height: 4.75rem;
   border-bottom: 1px solid var(--border-color);
 
   @container (width <= 768px) {

--- a/src/components/VirtualizedDataTable/VirtualizedDataTable.tsx
+++ b/src/components/VirtualizedDataTable/VirtualizedDataTable.tsx
@@ -11,6 +11,7 @@ import classNames from 'classnames'
 
 import { HStack } from '@ui/Stack/Stack'
 import { Cell, Column as TableColumn, Row, Table, TableBody, TableHeader } from '@ui/Table/Table'
+import { type Alignment } from '@schemas/reports/unifiedReport'
 import { getColumnDefs, type NestedColumnConfig } from '@components/DataTable/columnUtils'
 import { Loader } from '@components/Loader/Loader'
 
@@ -20,6 +21,7 @@ declare module '@tanstack/react-table' {
   // eslint-disable-next-line unused-imports/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
     isRowHeader: boolean
+    alignment?: Alignment
   }
 }
 

--- a/src/components/VirtualizedDataTable/VirtualizedDataTable.tsx
+++ b/src/components/VirtualizedDataTable/VirtualizedDataTable.tsx
@@ -140,6 +140,7 @@ export const VirtualizedDataTable = <TData extends { id: string }>({
             <TableColumn
               key={header.id}
               isRowHeader={header.column.columnDef.meta?.isRowHeader}
+              alignment={header.column.columnDef.meta?.alignment}
               className={classNames(
                 `${CSS_PREFIX}__header-cell`,
                 `Layer__UI__Table-Column__${componentName}--${header.id}`,
@@ -164,6 +165,7 @@ export const VirtualizedDataTable = <TData extends { id: string }>({
                 {row.getVisibleCells().map(cell => (
                   <Cell
                     key={cell.id}
+                    alignment={cell.column.columnDef.meta?.alignment}
                     className={classNames(
                       `${CSS_PREFIX}__cell`,
                       `Layer__UI__Table-Cell__${componentName}--${cell.column.id}`,

--- a/src/components/VirtualizedDataTable/VirtualizedDataTable.tsx
+++ b/src/components/VirtualizedDataTable/VirtualizedDataTable.tsx
@@ -9,9 +9,9 @@ import {
 import { useVirtualizer } from '@tanstack/react-virtual'
 import classNames from 'classnames'
 
+import { type Alignment } from '@schemas/reports/unifiedReport'
 import { HStack } from '@ui/Stack/Stack'
 import { Cell, Column as TableColumn, Row, Table, TableBody, TableHeader } from '@ui/Table/Table'
-import { type Alignment } from '@schemas/reports/unifiedReport'
 import { getColumnDefs, type NestedColumnConfig } from '@components/DataTable/columnUtils'
 import { Loader } from '@components/Loader/Loader'
 

--- a/src/components/ui/Table/Table.tsx
+++ b/src/components/ui/Table/Table.tsx
@@ -15,6 +15,7 @@ import {
   type TableProps,
 } from 'react-aria-components'
 
+import { Alignment } from '@schemas/reports/unifiedReport'
 import { toDataProperties } from '@utils/styleUtils/toDataProperties'
 import { withRenderProp } from '@components/utility/withRenderProp'
 
@@ -29,6 +30,19 @@ enum TableSubComponent {
   Cell = 'Cell',
 }
 const CSS_PREFIX = 'Layer__UI__Table'
+
+const toAlignmentDataValue = (alignment: Alignment | undefined) => {
+  switch (alignment) {
+    case Alignment.Left:
+      return 'start'
+    case Alignment.Right:
+      return 'end'
+    case Alignment.Center:
+      return 'center'
+    default:
+      return undefined
+  }
+}
 
 const getClassName = (component: TableSubComponent, additionalClassNames?: Argument, withHidden?: boolean) =>
   classNames(`${CSS_PREFIX}-${component}`, withHidden && `${CSS_PREFIX}-${component}--hidden`, additionalClassNames)
@@ -157,13 +171,13 @@ Row.displayName = TableSubComponent.Row
 
 // TABLE COLUMN
 type ColumnStyleProps = {
-  textAlign?: 'left' | 'center' | 'right'
+  alignment?: Alignment
   colSpan?: number
 }
 
 const Column = forwardRef<HTMLTableCellElement, ColumnProps & ColumnStyleProps & TableRenderingProps>(
-  ({ children, className, nonAria, id, textAlign = 'left', colSpan = 1, ...restProps }, ref) => {
-    const dataProperties = toDataProperties({ 'text-align': textAlign })
+  ({ children, className, nonAria, id, alignment = Alignment.Left, colSpan = 1, ...restProps }, ref) => {
+    const dataProperties = toDataProperties({ alignment: toAlignmentDataValue(alignment) })
     const columnClassName = getClassName(TableSubComponent.Column, className)
 
     const ColumnComponent = nonAria
@@ -188,9 +202,14 @@ const Column = forwardRef<HTMLTableCellElement, ColumnProps & ColumnStyleProps &
 Column.displayName = TableSubComponent.Column
 
 // TABLE CELL
+type CellStyleProps = {
+  alignment?: Alignment
+}
 
-const Cell = forwardRef<HTMLTableCellElement, CellProps & TableRenderingProps>(
-  ({ children, className, nonAria, id, ...restProps }, ref) => {
+const Cell = forwardRef<HTMLTableCellElement, CellProps & CellStyleProps & TableRenderingProps>(
+  ({ children, className, nonAria, id, alignment, ...restProps }, ref) => {
+    const dataProperties = toDataProperties({ alignment: toAlignmentDataValue(alignment) })
+
     const CellComponent = nonAria
       ? 'td'
       : ReactAriaCell
@@ -199,6 +218,7 @@ const Cell = forwardRef<HTMLTableCellElement, CellProps & TableRenderingProps>(
       <CellComponent
         className={getClassName(TableSubComponent.Cell, className)}
         {...restProps}
+        {...dataProperties}
         ref={ref}
         id={id?.toString()}
       >

--- a/src/components/ui/Table/Table.tsx
+++ b/src/components/ui/Table/Table.tsx
@@ -177,7 +177,7 @@ type ColumnStyleProps = {
 
 const Column = forwardRef<HTMLTableCellElement, ColumnProps & ColumnStyleProps & TableRenderingProps>(
   ({ children, className, nonAria, id, alignment = Alignment.Left, colSpan = 1, ...restProps }, ref) => {
-    const dataProperties = toDataProperties({ alignment: toAlignmentDataValue(alignment) })
+    const dataProperties = toDataProperties({ align: toAlignmentDataValue(alignment) })
     const columnClassName = getClassName(TableSubComponent.Column, className)
 
     const ColumnComponent = nonAria
@@ -208,7 +208,7 @@ type CellStyleProps = {
 
 const Cell = forwardRef<HTMLTableCellElement, CellProps & CellStyleProps & TableRenderingProps>(
   ({ children, className, nonAria, id, alignment, ...restProps }, ref) => {
-    const dataProperties = toDataProperties({ alignment: toAlignmentDataValue(alignment) })
+    const dataProperties = toDataProperties({ align: toAlignmentDataValue(alignment) })
 
     const CellComponent = nonAria
       ? 'td'

--- a/src/components/ui/Table/table.scss
+++ b/src/components/ui/Table/table.scss
@@ -59,14 +59,6 @@
   &:last-child {
     padding-right: var(--spacing-md);
   }
-
-  $alignments: left, center, right;
-
-  @each $alignment in $alignments {
-    &[data-text-align="#{$alignment}"] {
-      text-align: $alignment;
-    }
-  }
 }
 
 .Layer__UI__Table-Cell {
@@ -87,5 +79,16 @@
 
   &:last-child {
     padding-right: var(--spacing-md);
+  }
+}
+
+.Layer__UI__Table-Column,
+.Layer__UI__Table-Cell {
+  $alignments: start, center, end;
+
+  @each $alignment in $alignments {
+    &[data-alignment="#{$alignment}"] {
+      text-align: $alignment;
+    }
   }
 }

--- a/src/components/ui/Table/table.scss
+++ b/src/components/ui/Table/table.scss
@@ -87,7 +87,7 @@
   $alignments: start, center, end;
 
   @each $alignment in $alignments {
-    &[data-alignment="#{$alignment}"] {
+    &[data-align="#{$alignment}"] {
       text-align: $alignment;
     }
   }

--- a/src/components/ui/Tree/Tree.tsx
+++ b/src/components/ui/Tree/Tree.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, type ReactNode } from 'react'
+import classNames from 'classnames'
 import {
   Tree as ReactAriaTree,
   TreeItem as ReactAriaTreeItem,
@@ -15,12 +16,12 @@ import './tree.scss'
 const TREE_CLASS_NAME = 'Layer__UI__Tree'
 const TREE_ITEM_CLASS_NAME = 'Layer__UI__TreeItem'
 
-type TreeProps<T> = Omit<ReactAriaTreeProps<T>, 'className'>
+type TreeProps<T> = ReactAriaTreeProps<T>
 const TreeInner = <T extends object>(
-  { children, ...restProps }: TreeProps<T>,
+  { children, className, ...restProps }: TreeProps<T>,
   ref: React.Ref<HTMLDivElement>,
 ) => (
-  <ReactAriaTree {...restProps} className={TREE_CLASS_NAME} ref={ref}>
+  <ReactAriaTree {...restProps} className={classNames(TREE_CLASS_NAME, className)} ref={ref}>
     {withRenderProp(children, node => node) as ReactNode}
   </ReactAriaTree>
 )

--- a/src/components/ui/Tree/Tree.tsx
+++ b/src/components/ui/Tree/Tree.tsx
@@ -1,0 +1,58 @@
+import { forwardRef, type ReactNode } from 'react'
+import {
+  Tree as ReactAriaTree,
+  TreeItem as ReactAriaTreeItem,
+  TreeItemContent as ReactAriaTreeItemContent,
+  type TreeItemContentProps as ReactAriaTreeItemContentProps,
+  type TreeItemProps as ReactAriaTreeItemProps,
+  type TreeProps as ReactAriaTreeProps,
+} from 'react-aria-components'
+
+import { withRenderProp } from '@components/utility/withRenderProp'
+
+import './tree.scss'
+
+const TREE_CLASS_NAME = 'Layer__UI__Tree'
+const TREE_ITEM_CLASS_NAME = 'Layer__UI__TreeItem'
+
+type TreeProps<T> = Omit<ReactAriaTreeProps<T>, 'className'>
+const TreeInner = <T extends object>(
+  { children, ...restProps }: TreeProps<T>,
+  ref: React.Ref<HTMLDivElement>,
+) => (
+  <ReactAriaTree {...restProps} className={TREE_CLASS_NAME} ref={ref}>
+    {withRenderProp(children, node => node) as ReactNode}
+  </ReactAriaTree>
+)
+
+export const Tree = forwardRef(TreeInner) as (<T>(
+  props: TreeProps<T> & { ref?: React.Ref<HTMLDivElement> }
+) => React.ReactElement) & { displayName?: string }
+
+Tree.displayName = 'Tree'
+
+type TreeItemProps<T> = Omit<ReactAriaTreeItemProps<T>, 'className'>
+
+const TreeItemInner = <T extends object>(
+  { children, ...restProps }: TreeItemProps<T>,
+  ref: React.Ref<HTMLDivElement>,
+) => (
+  <ReactAriaTreeItem {...restProps} className={TREE_ITEM_CLASS_NAME} ref={ref}>
+    {withRenderProp(children, node => node) as ReactNode}
+  </ReactAriaTreeItem>
+)
+
+export const TreeItem = forwardRef(TreeItemInner) as (<T>(
+  props: TreeItemProps<T> & { ref?: React.Ref<HTMLDivElement> }
+) => React.ReactElement) & { displayName?: string }
+
+TreeItem.displayName = 'TreeItem'
+
+type TreeItemContentProps = ReactAriaTreeItemContentProps
+export const TreeItemContent = ({ children, ...restProps }: TreeItemContentProps) => (
+  <ReactAriaTreeItemContent {...restProps}>
+    {children}
+  </ReactAriaTreeItemContent>
+)
+
+TreeItemContent.displayName = 'TreeItemContent'

--- a/src/components/ui/Tree/tree.scss
+++ b/src/components/ui/Tree/tree.scss
@@ -1,0 +1,9 @@
+.Layer__UI__Tree {
+  display: flex;
+  flex-direction: column;
+  outline: none;
+}
+
+.Layer__UI__TreeItem {
+  outline: none;
+}

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
@@ -2,7 +2,8 @@ import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
-import type { DateGroupBy, ReportEnum, UnifiedReportDateQueryParams } from '@schemas/reports/unifiedReport'
+import type { ReportType } from '@schemas/reports/reportConfig'
+import type { DateGroupBy, UnifiedReportDateQueryParams } from '@schemas/reports/unifiedReport'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
@@ -10,14 +11,14 @@ import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 import {
-  type UnifiedReportState,
-  useUnifiedReportState,
+  type UnifiedReportParams,
+  useUnifiedReportParams,
 } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 type GetUnifiedReportExcelParams = {
   businessId: string
-  report: ReportEnum
+  report: ReportType
   groupBy: DateGroupBy | null
 } & UnifiedReportDateQueryParams
 
@@ -30,7 +31,7 @@ const getUnifiedReportExcel = get<
   return `/v1/businesses/${businessId}/reports/unified/${report}/exports/excel?${parameters}`
 })
 
-const getTag = (report: ReportEnum) => `#unified-${report}-report-excel`
+const getTag = (report: ReportType) => `#unified-${report}-report-excel`
 
 const UnifiedReportExcelReturnSchema = Schema.Struct({
   data: S3PresignedUrlSchema,
@@ -45,16 +46,16 @@ function buildKey({
   access_token?: string
   apiUrl?: string
   businessId: string
-  reportState: UnifiedReportState
+  reportState: UnifiedReportParams | null
 }) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      ...reportState,
-      tags: [getTag(reportState.report)],
-    }
+  if (!reportState || !accessToken || !apiUrl) return
+
+  return {
+    accessToken,
+    apiUrl,
+    businessId,
+    ...reportState,
+    tags: [getTag(reportState.report)],
   }
 }
 
@@ -67,7 +68,7 @@ export function useUnifiedReportExcel({ dateSelectionMode, onSuccess }: UseUnifi
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
-  const reportState = useUnifiedReportState({ dateSelectionMode })
+  const reportState = useUnifiedReportParams({ dateSelectionMode })
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
@@ -9,6 +9,7 @@ import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParamet
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
+import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
 import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 import {
   type UnifiedReportParams,
@@ -67,12 +68,14 @@ type UseUnifiedReportExcelOptions = {
 export function useUnifiedReportExcel({ dateSelectionMode, onSuccess }: UseUnifiedReportExcelOptions) {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
+  const { apiUrl } = useEnvironment()
   const { businessId } = useLayerContext()
   const reportState = useUnifiedReportParams({ dateSelectionMode })
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
       ...auth,
+      apiUrl,
       businessId,
       reportState,
     })),

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
@@ -2,7 +2,6 @@ import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
-import type { ReportType } from '@schemas/reports/reportConfig'
 import type { DateGroupBy, UnifiedReportDateQueryParams } from '@schemas/reports/unifiedReport'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
@@ -19,7 +18,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 type GetUnifiedReportExcelParams = {
   businessId: string
-  report: ReportType
+  report: string
   groupBy: DateGroupBy | null
 } & UnifiedReportDateQueryParams
 
@@ -32,7 +31,7 @@ const getUnifiedReportExcel = get<
   return `/v1/businesses/${businessId}/reports/unified/${report}/exports/excel?${parameters}`
 })
 
-const getTag = (report: ReportType) => `#unified-${report}-report-excel`
+const getTag = (report: string) => `#unified-${report}-report-excel`
 
 const UnifiedReportExcelReturnSchema = Schema.Struct({
   data: S3PresignedUrlSchema,

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
@@ -1,7 +1,6 @@
 import { Schema } from 'effect'
 import useSWR from 'swr'
 
-import type { ReportType } from '@schemas/reports/reportConfig'
 import type { DateGroupBy, UnifiedReportDateQueryParams } from '@schemas/reports/unifiedReport'
 import { UnifiedReportSchema } from '@schemas/reports/unifiedReport'
 import { get } from '@utils/api/authenticatedHttp'
@@ -39,7 +38,7 @@ function buildKey({
 
 const getUnifiedReport = get<
   { data: unknown },
-  { businessId: string, report: ReportType, groupBy: DateGroupBy | null } & UnifiedReportDateQueryParams
+  { businessId: string, report: string, groupBy: DateGroupBy | null } & UnifiedReportDateQueryParams
 >(({ businessId, report, groupBy, ...dateParams }) => {
   const parameters = toDefinedSearchParameters({ ...dateParams, groupBy })
 

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
@@ -1,7 +1,8 @@
 import { Schema } from 'effect'
 import useSWR from 'swr'
 
-import type { DateGroupBy, ReportEnum, UnifiedReportDateQueryParams } from '@schemas/reports/unifiedReport'
+import type { ReportType } from '@schemas/reports/reportConfig'
+import type { DateGroupBy, UnifiedReportDateQueryParams } from '@schemas/reports/unifiedReport'
 import { UnifiedReportSchema } from '@schemas/reports/unifiedReport'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
@@ -9,6 +10,7 @@ import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
+import type { UnifiedReportParams } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export const UNIFIED_REPORT_TAG_KEY = '#unified-report'
@@ -17,45 +19,34 @@ function buildKey({
   access_token: accessToken,
   apiUrl,
   businessId,
-  report,
-  groupBy,
-  ...dateParams
+  reportState,
 }: {
   access_token?: string
   apiUrl?: string
   businessId: string
-  report: ReportEnum
-  groupBy: DateGroupBy | null
-} & UnifiedReportDateQueryParams,
-) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      report,
-      groupBy,
-      tags: [UNIFIED_REPORT_TAG_KEY],
-      ...dateParams,
-    } as const
-  }
+  reportState: UnifiedReportParams | null
+}) {
+  if (!reportState || !accessToken || !apiUrl) return
+
+  return {
+    accessToken,
+    apiUrl,
+    businessId,
+    ...reportState,
+    tags: [UNIFIED_REPORT_TAG_KEY],
+  } as const
 }
 
 const getUnifiedReport = get<
   { data: unknown },
-  { businessId: string, report: ReportEnum, groupBy: DateGroupBy | null } & UnifiedReportDateQueryParams
+  { businessId: string, report: ReportType, groupBy: DateGroupBy | null } & UnifiedReportDateQueryParams
 >(({ businessId, report, groupBy, ...dateParams }) => {
   const parameters = toDefinedSearchParameters({ ...dateParams, groupBy })
 
   return `/v1/businesses/${businessId}/reports/unified/${report}?${parameters}`
 })
 
-type UseUnifiedReportParameters = {
-  report: ReportEnum
-  groupBy: DateGroupBy | null
-} & UnifiedReportDateQueryParams
-
-export function useUnifiedReport({ report, groupBy, ...dateParams }: UseUnifiedReportParameters) {
+export function useUnifiedReport(reportState: UnifiedReportParams | null) {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { apiUrl } = useEnvironment()
@@ -66,12 +57,10 @@ export function useUnifiedReport({ report, groupBy, ...dateParams }: UseUnifiedR
       ...auth,
       apiUrl,
       businessId,
-      report,
-      groupBy,
-      ...dateParams,
+      reportState,
     })),
-    ({ accessToken, apiUrl, businessId }) => getUnifiedReport(apiUrl, accessToken, {
-      params: { businessId, report, groupBy, ...dateParams },
+    ({ accessToken, apiUrl, businessId, tags, ...params }) => getUnifiedReport(apiUrl, accessToken, {
+      params: { businessId, ...params },
     })().then(({ data }) => Schema.decodeUnknownPromise(UnifiedReportSchema)(data)),
   )
 

--- a/src/providers/UnifiedReportStore/UnifiedReportStoreProvider.tsx
+++ b/src/providers/UnifiedReportStore/UnifiedReportStoreProvider.tsx
@@ -1,7 +1,7 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react'
 import { createStore, type StoreApi, useStore } from 'zustand'
 
-import { type ReportConfig, ReportControl, type ReportGroup, type ReportType } from '@schemas/reports/reportConfig'
+import { type ReportConfig, ReportControl, type ReportGroup } from '@schemas/reports/reportConfig'
 import { DateGroupBy, type DateQueryParams, type DateRangeQueryParams } from '@schemas/reports/unifiedReport'
 import { unsafeAssertUnreachable } from '@utils/switch/assertUnreachable'
 import { useReportConfig } from '@hooks/api/businesses/[business-id]/reports/config/useReportConfig'
@@ -32,7 +32,7 @@ const hasGroupByControl = (report: ReportConfig): boolean =>
   report.controls.includes(ReportControl.GroupBy)
 
 export type UnifiedReportParams = {
-  report: ReportType
+  report: string
   groupBy: DateGroupBy | null
 } & (DateQueryParams | DateRangeQueryParams)
 

--- a/src/providers/UnifiedReportStore/UnifiedReportStoreProvider.tsx
+++ b/src/providers/UnifiedReportStore/UnifiedReportStoreProvider.tsx
@@ -128,7 +128,8 @@ const createUnifiedReportStore = () =>
 
 function useHydrateUnifiedReportStore(store: StoreApi<UnifiedReportStoreShape>) {
   const { data } = useReportConfig()
-  const { report, setReport } = useActiveUnifiedReport()
+  const report = useStore(store, state => state.report)
+  const setReport = useStore(store, state => state.actions.setReport)
 
   useEffect(() => {
     if (!data) return
@@ -136,7 +137,7 @@ function useHydrateUnifiedReportStore(store: StoreApi<UnifiedReportStoreShape>) 
 
     const firstLeaf = findFirstLeaf(data)
     if (firstLeaf) setReport(firstLeaf)
-  }, [report, data, store, setReport])
+  }, [report, data, setReport])
 }
 
 export function UnifiedReportStoreProvider({ children }: PropsWithChildren) {

--- a/src/providers/UnifiedReportStore/UnifiedReportStoreProvider.tsx
+++ b/src/providers/UnifiedReportStore/UnifiedReportStoreProvider.tsx
@@ -1,19 +1,19 @@
-import { createContext, type PropsWithChildren, useContext, useMemo, useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { createStore, useStore } from 'zustand'
+import { createContext, type PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react'
+import { createStore, type StoreApi, useStore } from 'zustand'
 
-import { DateGroupBy, type DateQueryParams, type DateRangeQueryParams, ReportEnum } from '@schemas/reports/unifiedReport'
-import { translationKey } from '@utils/i18n/translationKey'
+import { type ReportConfig, ReportControl, type ReportGroup, type ReportType } from '@schemas/reports/reportConfig'
+import { DateGroupBy, type DateQueryParams, type DateRangeQueryParams } from '@schemas/reports/unifiedReport'
 import { unsafeAssertUnreachable } from '@utils/switch/assertUnreachable'
+import { useReportConfig } from '@hooks/api/businesses/[business-id]/reports/config/useReportConfig'
 import { type DateSelectionMode, useGlobalDate, useGlobalDateRange } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 
 type UnifiedReportStoreActions = {
-  setReport: (report: ReportEnum) => void
+  setReport: (report: ReportConfig) => void
   setGroupBy: (groupBy: DateGroupBy | null) => void
 }
 
 type UnifiedReportStoreShape = {
-  report: ReportEnum
+  report: ReportConfig | null
   groupBy: DateGroupBy | null
   actions: UnifiedReportStoreActions
 }
@@ -23,30 +23,22 @@ export enum UnifiedReportDateVariant {
   DateRange = 'DateRange',
 }
 
-const reportToDateVariantMap = {
-  [ReportEnum.BalanceSheet]: UnifiedReportDateVariant.Date,
-  [ReportEnum.CashflowStatement]: UnifiedReportDateVariant.DateRange,
-  [ReportEnum.ProfitAndLoss]: UnifiedReportDateVariant.DateRange,
-} as const
+const getDateVariant = (report: ReportConfig): UnifiedReportDateVariant =>
+  report.controls.includes(ReportControl.DateRange)
+    ? UnifiedReportDateVariant.DateRange
+    : UnifiedReportDateVariant.Date
 
-export type UnifiedReportWithDateParams =
-  | {
-    report: ReportEnum.BalanceSheet
-  } & DateQueryParams
-  | {
-    report: ReportEnum.CashflowStatement
-  } & DateRangeQueryParams
-  | {
-    report: ReportEnum.ProfitAndLoss
-  } & DateRangeQueryParams
+const hasGroupByControl = (report: ReportConfig): boolean =>
+  report.controls.includes(ReportControl.GroupBy)
 
-export type UnifiedReportState = UnifiedReportWithDateParams & {
+export type UnifiedReportParams = {
+  report: ReportType
   groupBy: DateGroupBy | null
-}
+} & (DateQueryParams | DateRangeQueryParams)
 
 const UnifiedReportStoreContext = createContext(
   createStore<UnifiedReportStoreShape>(() => ({
-    report: ReportEnum.ProfitAndLoss,
+    report: null,
     groupBy: DateGroupBy.AllTime,
     actions: {
       setReport: () => {},
@@ -55,51 +47,39 @@ const UnifiedReportStoreContext = createContext(
   })),
 )
 
-const UNIFIED_REPORT_NAME_TRANSLATIONS = {
-  [ReportEnum.BalanceSheet]: translationKey('reports:label.balance_sheet_report', 'Balance Sheet Report'),
-  [ReportEnum.CashflowStatement]: translationKey('reports:label.statement_cash_flow_report', 'Statement of Cash Flow Report'),
-  [ReportEnum.ProfitAndLoss]: translationKey('reports:label.profit_loss_report', 'Profit & Loss Report'),
-}
-
-export function useUnifiedReportName() {
-  const store = useContext(UnifiedReportStoreContext)
-  const { t } = useTranslation()
-
-  const report = useStore(store, state => state.report)
-
-  const { i18nKey, defaultValue } = UNIFIED_REPORT_NAME_TRANSLATIONS[report]
-  return t(i18nKey, defaultValue)
-}
-
-export function useUnifiedReportDateVariant(): UnifiedReportDateVariant {
-  const store = useContext(UnifiedReportStoreContext)
-
-  const report = useStore(store, state => state.report)
-  return reportToDateVariantMap[report]
-}
-
-export function useUnifiedReportGroupBy() {
+export function useActiveUnifiedReport() {
   const store = useContext(UnifiedReportStoreContext)
   const report = useStore(store, state => state.report)
+  const setReport = useStore(store, state => state.actions.setReport)
+  return useMemo(() => ({ report, setReport }), [report, setReport])
+}
+
+export function useUnifiedReportDateVariant(): UnifiedReportDateVariant | null {
+  const { report } = useActiveUnifiedReport()
+  return report ? getDateVariant(report) : null
+}
+
+export function useUnifiedReportGroupByParam() {
+  const { report } = useActiveUnifiedReport()
+  const store = useContext(UnifiedReportStoreContext)
   const groupBy = useStore(store, state => state.groupBy)
   const setGroupBy = useStore(store, state => state.actions.setGroupBy)
 
   const groupByState = useMemo(() => ({ groupBy, setGroupBy }), [groupBy, setGroupBy])
 
-  if (report === ReportEnum.ProfitAndLoss) {
+  if (report && hasGroupByControl(report)) {
     return groupByState
   }
 
   return null
 }
 
-export function useUnifiedReportDateParams({ dateSelectionMode }: { dateSelectionMode: DateSelectionMode }): DateQueryParams | DateRangeQueryParams {
-  const store = useContext(UnifiedReportStoreContext)
+export function useUnifiedReportDateParams({ dateSelectionMode }: { dateSelectionMode: DateSelectionMode }): DateQueryParams | DateRangeQueryParams | null {
+  const dateVariant = useUnifiedReportDateVariant()
   const { date: effectiveDate } = useGlobalDate({ dateSelectionMode })
   const { startDate, endDate } = useGlobalDateRange({ dateSelectionMode })
 
-  const report = useStore(store, state => state.report)
-  const dateVariant = reportToDateVariantMap[report]
+  if (dateVariant === null) return null
 
   switch (dateVariant) {
     case UnifiedReportDateVariant.Date:
@@ -114,31 +94,58 @@ export function useUnifiedReportDateParams({ dateSelectionMode }: { dateSelectio
   }
 }
 
-export function useUnifiedReportState({ dateSelectionMode }: { dateSelectionMode: DateSelectionMode }): UnifiedReportState {
-  const store = useContext(UnifiedReportStoreContext)
-  const report = useStore(store, state => state.report)
-
-  const groupByParam = useUnifiedReportGroupBy()
+export function useUnifiedReportParams({ dateSelectionMode }: { dateSelectionMode: DateSelectionMode }): UnifiedReportParams | null {
+  const { report } = useActiveUnifiedReport()
+  const groupByParam = useUnifiedReportGroupByParam()
   const dateParams = useUnifiedReportDateParams({ dateSelectionMode })
 
-  return { report, groupBy: groupByParam?.groupBy ?? null, ...dateParams } as UnifiedReportState
+  if (!report || !dateParams) return null
+
+  return { report: report.reportType, groupBy: groupByParam?.groupBy ?? null, ...dateParams } as UnifiedReportParams
 }
 
-export function UnifiedReportStoreProvider(props: PropsWithChildren) {
-  const [store] = useState(() =>
-    createStore<UnifiedReportStoreShape>(set => ({
-      report: ReportEnum.ProfitAndLoss,
-      groupBy: DateGroupBy.AllTime,
-      actions: {
-        setReport: (report: ReportEnum) => set({ report }),
-        setGroupBy: (groupBy: DateGroupBy | null) => set({ groupBy }),
-      },
-    })),
-  )
+const findFirstLeaf = (groups: ReadonlyArray<ReportGroup>): ReportConfig | null => {
+  for (const group of groups) {
+    if (group.reports.length > 0) {
+      return group.reports[0]
+    }
+  }
+  return null
+}
+
+const hasLeafWithKey = (groups: ReadonlyArray<ReportGroup>, key: string): boolean =>
+  groups.some(group => group.reports.some(report => report.key === key))
+
+const createUnifiedReportStore = () =>
+  createStore<UnifiedReportStoreShape>(set => ({
+    report: null,
+    groupBy: DateGroupBy.AllTime,
+    actions: {
+      setReport: (report: ReportConfig) => set({ report }),
+      setGroupBy: (groupBy: DateGroupBy | null) => set({ groupBy }),
+    },
+  }))
+
+function useHydrateUnifiedReportStore(store: StoreApi<UnifiedReportStoreShape>) {
+  const { data } = useReportConfig()
+  const { report, setReport } = useActiveUnifiedReport()
+
+  useEffect(() => {
+    if (!data) return
+    if (report && hasLeafWithKey(data, report.key)) return
+
+    const firstLeaf = findFirstLeaf(data)
+    if (firstLeaf) setReport(firstLeaf)
+  }, [report, data, store, setReport])
+}
+
+export function UnifiedReportStoreProvider({ children }: PropsWithChildren) {
+  const [store] = useState(createUnifiedReportStore)
+  useHydrateUnifiedReportStore(store)
 
   return (
     <UnifiedReportStoreContext.Provider value={store}>
-      {props.children}
+      {children}
     </UnifiedReportStoreContext.Provider>
   )
 }

--- a/src/schemas/reports/reportConfig.ts
+++ b/src/schemas/reports/reportConfig.ts
@@ -3,20 +3,21 @@ import { pipe, Schema } from 'effect'
 import { createTransformedEnumSchema } from '@schemas/utils'
 
 export enum ReportControl {
-  DATE_RANGE = 'date_range',
-  GROUP_BY = 'group_by',
-  UNKNOWN = 'unknown',
+  DateRange = 'date_range',
+  GroupBy = 'group_by',
+  Unknown = 'unknown',
 }
 
 export enum ReportType {
-  PROFIT_AND_LOSS = 'profit-and-loss',
-  CASHFLOW_STATEMENT = 'cashflow-statement',
-  UNKNOWN = 'unknown',
+  ProfitAndLoss = 'profit-and-loss',
+  BalanceSheet = 'balance-sheet',
+  CashflowStatement = 'cashflow-statement',
+  Unknown = 'unknown',
 }
 
 export enum ReportGroupType {
-  ACCOUNTING = 'accounting',
-  UNKNOWN = 'unknown',
+  Accounting = 'accounting',
+  Unknown = 'unknown',
 }
 
 const ReportControlSchema = Schema.Enums(ReportControl)
@@ -26,19 +27,19 @@ const ReportGroupTypeSchema = Schema.Enums(ReportGroupType)
 const TransformedReportControlSchema = createTransformedEnumSchema(
   ReportControlSchema,
   ReportControl,
-  ReportControl.UNKNOWN,
+  ReportControl.Unknown,
 )
 
 const TransformedReportTypeSchema = createTransformedEnumSchema(
   ReportTypeSchema,
   ReportType,
-  ReportType.UNKNOWN,
+  ReportType.Unknown,
 )
 
 const TransformedReportGroupTypeSchema = createTransformedEnumSchema(
   ReportGroupTypeSchema,
   ReportGroupType,
-  ReportGroupType.UNKNOWN,
+  ReportGroupType.Unknown,
 )
 
 export const ReportConfigSchema = Schema.Struct({

--- a/src/schemas/reports/reportConfig.ts
+++ b/src/schemas/reports/reportConfig.ts
@@ -12,6 +12,7 @@ export enum ReportType {
   ProfitAndLoss = 'profit-and-loss',
   BalanceSheet = 'balance-sheet',
   CashflowStatement = 'cashflow-statement',
+  TrialBalance = 'trial-balance',
   Unknown = 'unknown',
 }
 

--- a/src/schemas/reports/reportConfig.ts
+++ b/src/schemas/reports/reportConfig.ts
@@ -8,33 +8,18 @@ export enum ReportControl {
   Unknown = 'unknown',
 }
 
-export enum ReportType {
-  ProfitAndLoss = 'profit-and-loss',
-  BalanceSheet = 'balance-sheet',
-  CashflowStatement = 'cashflow-statement',
-  TrialBalance = 'trial-balance',
-  Unknown = 'unknown',
-}
-
 export enum ReportGroupType {
   Accounting = 'accounting',
   Unknown = 'unknown',
 }
 
 const ReportControlSchema = Schema.Enums(ReportControl)
-const ReportTypeSchema = Schema.Enums(ReportType)
 const ReportGroupTypeSchema = Schema.Enums(ReportGroupType)
 
 const TransformedReportControlSchema = createTransformedEnumSchema(
   ReportControlSchema,
   ReportControl,
   ReportControl.Unknown,
-)
-
-const TransformedReportTypeSchema = createTransformedEnumSchema(
-  ReportTypeSchema,
-  ReportType,
-  ReportType.Unknown,
 )
 
 const TransformedReportGroupTypeSchema = createTransformedEnumSchema(
@@ -46,7 +31,7 @@ const TransformedReportGroupTypeSchema = createTransformedEnumSchema(
 export const ReportConfigSchema = Schema.Struct({
   key: Schema.String,
   reportType: pipe(
-    Schema.propertySignature(TransformedReportTypeSchema),
+    Schema.propertySignature(Schema.String),
     Schema.fromKey('report_type'),
   ),
   displayName: pipe(

--- a/src/schemas/reports/unifiedReport.ts
+++ b/src/schemas/reports/unifiedReport.ts
@@ -1,16 +1,26 @@
 import { pipe, Schema } from 'effect'
 
-export enum ReportEnum {
-  BalanceSheet = 'balance-sheet',
-  CashflowStatement = 'cashflow-statement',
-  ProfitAndLoss = 'profit-and-loss',
-}
+import { createTransformedEnumSchema } from '@schemas/utils'
 
 export enum DateGroupBy {
   AllTime = 'ALL_TIME',
   Month = 'MONTH',
   Year = 'YEAR',
 }
+
+export enum Alignment {
+  Left = 'LEFT',
+  Right = 'RIGHT',
+  Center = 'CENTER',
+}
+
+const AlignmentSchema = Schema.Enums(Alignment)
+
+const TransformedAlignmentSchema = createTransformedEnumSchema(
+  AlignmentSchema,
+  Alignment,
+  Alignment.Left,
+)
 
 export const DateQueryParamsSchema = Schema.Struct({
   effectiveDate: pipe(
@@ -47,6 +57,8 @@ const unifiedReportColumnFields = {
     Schema.propertySignature(Schema.String),
     Schema.fromKey('display_name'),
   ),
+  isRowHeader: Schema.optional(Schema.Boolean).pipe(Schema.fromKey('is_row_header')),
+  alignment: Schema.optional(TransformedAlignmentSchema),
 }
 
 export interface UnifiedReportColumn extends Schema.Struct.Type<typeof unifiedReportColumnFields> {
@@ -108,10 +120,6 @@ const unifiedReportRowFields = {
   rowKey: pipe(
     Schema.propertySignature(Schema.String),
     Schema.fromKey('row_key'),
-  ),
-  displayName: pipe(
-    Schema.propertySignature(Schema.String),
-    Schema.fromKey('display_name'),
   ),
   cells: Schema.Record({
     key: Schema.String,


### PR DESCRIPTION
## Description
This PR fixes some schema definition issues in the `useUnifiedReport` hook, as well as creates a `View` layout for the Unified Reports table and side navigation. 

Then, it implements a navigation component using the `Tree` structure from React Aria components to display nested reports that, when selected, populate in the Unified Reports table.

  
<img width="1290" height="608" alt="Screenshot 2026-04-20 at 6 33 17 PM" src="https://github.com/user-attachments/assets/300deadf-6156-4c3c-9eae-2cea1ee900ed" />

> [!NOTE]
> **Medium Risk**
> Medium risk because it refactors unified report state/query parameter plumbing and changes report schema/enums, which can affect report fetching/export URLs and table rendering/alignment across the reports UI.
> 
> **Overview**
> Adds a new **Unified Reports sidebar navigation** (`ReportsNavigation` + generic `TreeNavigation`) that loads report groups from `useReportConfig`, lets users switch the active report, and includes loading/error states.
> 
> Refactors unified report state to be **config-driven**: the store now holds a selected `ReportConfig`, derives date variant/group-by availability from `controls`, hydrates the default selection from the fetched config, and updates report fetch/export hooks to accept a single `UnifiedReportParams | null` payload.
> 
> Introduces **column alignment/row-header metadata** end-to-end: adds `Alignment` to the unified report schema, propagates `alignment`/`isRowHeader` through `columnUtils` into table header/cell components, and updates table CSS to align via `data-alignment` instead of hardcoded report-specific styles. Also updates report/common i18n strings (including new navigation and expand/collapse labels).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c050245337c1e019c2da59f0840ae2ce9225dd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->