### PR TITLE
feat: add bold and date formatting to unified reports, refactor a bit

### DIFF
--- a/src/components/ExpandButton/expandButton.scss
+++ b/src/components/ExpandButton/expandButton.scss
@@ -1,13 +1,12 @@
 .Layer__ExpandButton {
   height: 16px;
   min-width: 16px;
-  transition: transform 0.1s ease-in-out;
 
   &--collapsed {
-    transform: rotate(0deg);
+    transform: rotate(-90deg);
   }
 
   &--expanded {
-    transform: rotate(180deg);
+    transform: rotate(0deg);
   }
 }

--- a/src/components/UnifiedReport/UnifiedReport.tsx
+++ b/src/components/UnifiedReport/UnifiedReport.tsx
@@ -15,19 +15,19 @@ type UnifiedReportProps = {
   dateSelectionMode?: DateSelectionMode
 }
 
-export const UnifiedReport = ({ dateSelectionMode = 'full' }: UnifiedReportProps) => {
+export const UnifiedReport = ({ dateSelectionMode }: UnifiedReportProps) => {
   const { t } = useTranslation()
   return (
     <View title={t('reports:label.reports', 'Reports')} viewClassName='Layer__UnifiedReport'>
-      <UnifiedReportStoreProvider>
+      <UnifiedReportStoreProvider dateSelectionMode={dateSelectionMode}>
         <ExpandableDataTableProvider>
           <HStack>
             <VStack className='Layer__UnifiedReport__Sidebar'>
               <ReportsNavigation />
             </VStack>
             <VStack fluid className='Layer__UnifiedReport__Content'>
-              <UnifiedReportTableHeader dateSelectionMode={dateSelectionMode} />
-              <UnifiedReportTable dateSelectionMode={dateSelectionMode} />
+              <UnifiedReportTableHeader />
+              <UnifiedReportTable />
             </VStack>
           </HStack>
         </ExpandableDataTableProvider>

--- a/src/components/UnifiedReport/UnifiedReportDownloadButton.tsx
+++ b/src/components/UnifiedReport/UnifiedReportDownloadButton.tsx
@@ -1,22 +1,16 @@
 import { useTranslation } from 'react-i18next'
 
 import { useUnifiedReportExcel } from '@hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel'
-import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 import DownloadCloud from '@icons/DownloadCloud'
 import RefreshCcw from '@icons/RefreshCcw'
 import { Button } from '@ui/Button/Button'
 import InvisibleDownload, { useInvisibleDownload } from '@components/utility/InvisibleDownload'
 
-type UnifiedReportDownloadButtonProps = {
-  dateSelectionMode: DateSelectionMode
-}
-
-export function UnifiedReportDownloadButton({ dateSelectionMode }: UnifiedReportDownloadButtonProps) {
+export function UnifiedReportDownloadButton() {
   const { t } = useTranslation()
   const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
 
   const { trigger, isMutating, isError } = useUnifiedReportExcel({
-    dateSelectionMode,
     onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
   })
 

--- a/src/components/UnifiedReport/UnifiedReportTable.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTable.tsx
@@ -1,82 +1,29 @@
 import { useCallback, useContext, useEffect, useMemo } from 'react'
-import { type Row } from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
 
-import { isAmountCellValue, isEmptyCellValue, type UnifiedReportColumn, type UnifiedReportRow } from '@schemas/reports/unifiedReport'
 import { asMutable } from '@utils/asMutable'
 import { useUnifiedReport } from '@hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport'
-import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
-import { useActiveUnifiedReport, useUnifiedReportParams } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
-import { MoneySpan } from '@ui/Typography/MoneySpan'
-import { Span } from '@ui/Typography/Text'
+import { useActiveUnifiedReport } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
-import { type ColumnNode, type GroupColumn, type LeafColumn } from '@components/DataTable/columnUtils'
 import { ExpandableDataTable } from '@components/ExpandableDataTable/ExpandableDataTable'
 import { ExpandableDataTableContext } from '@components/ExpandableDataTable/ExpandableDataTableProvider'
+import { buildNestedColumnConfig, getSubRows } from '@components/UnifiedReport/utils'
 
 import './unifiedReportTable.scss'
 
 const COMPONENT_NAME = 'UnifiedReport'
 
-const makeBaseColumn = (col: UnifiedReportColumn) => ({
-  id: col.columnKey,
-  header: col.displayName,
-  isRowHeader: col.isRowHeader,
-  alignment: col.alignment,
-})
-
-const makeLeafColumn = (col: UnifiedReportColumn): LeafColumn<UnifiedReportRow> => ({
-  ...makeBaseColumn(col),
-  cell: (row: RowType) => {
-    const cellValue = row.original.cells[col.columnKey]?.value
-
-    if (!cellValue || isEmptyCellValue(cellValue)) {
-      return null
-    }
-
-    if (isAmountCellValue(cellValue)) {
-      return <MoneySpan ellipsis amount={cellValue.value} />
-    }
-
-    return <Span ellipsis>{String(cellValue.value)}</Span>
-  },
-})
-
-type UnifiedReportColumnWithRequiredColumns = UnifiedReportColumn & Required<Pick<UnifiedReportColumn, 'columns'>>
-const makeGroupColumn = (col: UnifiedReportColumnWithRequiredColumns): GroupColumn<UnifiedReportRow> => ({
-  ...makeBaseColumn(col),
-  columns: buildNestedColumnConfig(col.columns),
-})
-
-type RowType = Row<UnifiedReportRow>
-const isGroupColumn = (col: UnifiedReportColumn): col is UnifiedReportColumnWithRequiredColumns =>
-  col.columns !== undefined && col.columns.length > 0
-
-const buildNestedColumnConfig = (columns: ReadonlyArray<UnifiedReportColumn>): ColumnNode<UnifiedReportRow>[] => {
-  return columns.map((col): ColumnNode<UnifiedReportRow> => {
-    if (isGroupColumn(col)) {
-      return makeGroupColumn(col)
-    }
-
-    return makeLeafColumn(col)
-  })
-}
-
-const getSubRows = (row: UnifiedReportRow) => row.rows ? asMutable(row.rows) : undefined
-
-type UnifiedReportTableProps = {
-  dateSelectionMode: DateSelectionMode
-}
-
-export const UnifiedReportTable = ({ dateSelectionMode }: UnifiedReportTableProps) => {
+export const UnifiedReportTable = () => {
   const { t } = useTranslation()
   const { report } = useActiveUnifiedReport()
-  const reportState = useUnifiedReportParams({ dateSelectionMode })
-  const { data, isLoading, isError, refetch } = useUnifiedReport(reportState)
+  const { data, isLoading, isError, refetch } = useUnifiedReport()
   const { setExpanded } = useContext(ExpandableDataTableContext)
   const mutableRows = data?.rows ? asMutable(data.rows) : undefined
 
-  const columnConfig = useMemo(() => data ? buildNestedColumnConfig(data.columns) : [], [data])
+  const columnConfig = useMemo(
+    () => data ? buildNestedColumnConfig(data.columns) : [],
+    [data],
+  )
 
   useEffect(() => {
     // Expand the top-level rows on initial data load

--- a/src/components/UnifiedReport/UnifiedReportTableCellContent.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTableCellContent.tsx
@@ -1,0 +1,35 @@
+import { isAmountCellValue, isDateCellValue, isEmptyCellValue, type UnifiedReportCell } from '@schemas/reports/unifiedReport'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { MoneySpan } from '@ui/Typography/MoneySpan'
+import { Span } from '@ui/Typography/Text'
+
+type UnifiedReportTableCellContentProps = {
+  cell: UnifiedReportCell | null | undefined
+}
+
+export const UnifiedReportTableCellContent = ({ cell }: UnifiedReportTableCellContentProps) => {
+  const { formatDate } = useIntlFormatter()
+
+  if (!cell) return
+
+  const cellValue = cell.value
+  const isBold = cell.format?.bold
+  const weight = isBold ? 'bold' : 'normal'
+  const variant = isBold ? undefined : 'placeholder'
+
+  let content
+  if (isAmountCellValue(cellValue)) {
+    content = <MoneySpan ellipsis weight={weight} variant={variant} amount={cellValue.value} />
+  }
+  else if (isDateCellValue(cellValue)) {
+    content = <Span ellipsis weight={weight} variant={variant}>{formatDate(cellValue.value)}</Span>
+  }
+  else if (isEmptyCellValue(cellValue)) {
+    return null
+  }
+  else {
+    content = <Span ellipsis weight={weight} variant={variant}>{String(cellValue.value)}</Span>
+  }
+
+  return content
+}

--- a/src/components/UnifiedReport/UnifiedReportTableHeader.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTableHeader.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
-import { UnifiedReportDateVariant, useActiveUnifiedReport, useUnifiedReportDateVariant, useUnifiedReportGroupByParam } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
+import { ReportControl } from '@schemas/reports/reportConfig'
+import { hasControl, useActiveUnifiedReport, useUnifiedReportDateSelectionMode, useUnifiedReportGroupByParam } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
@@ -15,15 +15,11 @@ import { UnifiedReportDownloadButton } from '@components/UnifiedReport/UnifiedRe
 
 import './unifiedReportTableHeader.scss'
 
-type UnifiedReportTableHeaderProps = {
-  dateSelectionMode: DateSelectionMode
-}
-
-export const UnifiedReportTableHeader = ({ dateSelectionMode }: UnifiedReportTableHeaderProps) => {
+export const UnifiedReportTableHeader = () => {
   const { t } = useTranslation()
-  const dateVariant = useUnifiedReportDateVariant()
-  const groupBySetter = useUnifiedReportGroupByParam()
   const { report } = useActiveUnifiedReport()
+  const { groupBy, setGroupBy } = useUnifiedReportGroupByParam()
+  const dateSelectionMode = useUnifiedReportDateSelectionMode()
 
   const { expanded, setExpanded } = useContext(ExpandableDataTableContext)
   const shouldCollapse = expanded === true
@@ -45,11 +41,14 @@ export const UnifiedReportTableHeader = ({ dateSelectionMode }: UnifiedReportTab
       </HStack>
       <HStack fluid justify='space-between' align='end' pbe='lg' className='Layer__UnifiedReport__Header'>
         <HStack pi='lg' gap='xs'>
-          {dateVariant === UnifiedReportDateVariant.DateRange
-            ? <CombinedDateRangeSelection mode={dateSelectionMode} />
-            : <CombinedDateSelection mode={dateSelectionMode} />}
-          {dateSelectionMode === 'full' && groupBySetter && (
-            <DateGroupByComboBox value={groupBySetter.groupBy} onValueChange={groupBySetter.setGroupBy} />
+          {hasControl(report, ReportControl.DateRange) && (
+            <CombinedDateRangeSelection mode={dateSelectionMode} />
+          )}
+          {hasControl(report, ReportControl.Date) && (
+            <CombinedDateSelection mode={dateSelectionMode} />
+          )}
+          {dateSelectionMode === 'full' && hasControl(report, ReportControl.GroupBy) && (
+            <DateGroupByComboBox value={groupBy} onValueChange={setGroupBy} />
           )}
         </HStack>
         <HStack pi='lg' className='Layer__UnifiedReport__Header__SecondaryActions'>
@@ -58,7 +57,7 @@ export const UnifiedReportTableHeader = ({ dateSelectionMode }: UnifiedReportTab
               ? t('reports:action.collapse_all', 'Collapse All')
               : t('reports:action.expand_all', 'Expand All')}
           </Button>
-          <UnifiedReportDownloadButton dateSelectionMode={dateSelectionMode} />
+          <UnifiedReportDownloadButton />
         </HStack>
       </HStack>
     </VStack>

--- a/src/components/UnifiedReport/utils.tsx
+++ b/src/components/UnifiedReport/utils.tsx
@@ -1,0 +1,46 @@
+import { type Row } from '@tanstack/react-table'
+
+import { type UnifiedReportColumn, type UnifiedReportRow } from '@schemas/reports/unifiedReport'
+import { asMutable } from '@utils/asMutable'
+import { type ColumnNode, type GroupColumn, type LeafColumn } from '@components/DataTable/columnUtils'
+import { UnifiedReportTableCellContent } from '@components/UnifiedReport/UnifiedReportTableCellContent'
+
+type RowType = Row<UnifiedReportRow>
+
+type UnifiedReportColumnWithRequiredColumns = UnifiedReportColumn & Required<Pick<UnifiedReportColumn, 'columns'>>
+
+const isGroupColumn = (col: UnifiedReportColumn): col is UnifiedReportColumnWithRequiredColumns =>
+  col.columns !== undefined && col.columns.length > 0
+
+const makeBaseColumn = (col: UnifiedReportColumn) => ({
+  id: col.columnKey,
+  header: col.displayName,
+  isRowHeader: col.isRowHeader,
+  alignment: col.alignment,
+})
+
+const makeLeafColumn = (col: UnifiedReportColumn): LeafColumn<UnifiedReportRow> => ({
+  ...makeBaseColumn(col),
+  cell: (row: RowType) => (
+    <UnifiedReportTableCellContent cell={row.original.cells[col.columnKey]} />
+  ),
+})
+
+const makeGroupColumn = (col: UnifiedReportColumnWithRequiredColumns): GroupColumn<UnifiedReportRow> => ({
+  ...makeBaseColumn(col),
+  columns: buildNestedColumnConfig(col.columns),
+})
+
+export const buildNestedColumnConfig = (
+  columns: ReadonlyArray<UnifiedReportColumn>,
+): ColumnNode<UnifiedReportRow>[] => {
+  return columns.map((col): ColumnNode<UnifiedReportRow> => {
+    if (isGroupColumn(col)) {
+      return makeGroupColumn(col)
+    }
+
+    return makeLeafColumn(col)
+  })
+}
+
+export const getSubRows = (row: UnifiedReportRow) => row.rows ? asMutable(row.rows) : undefined

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
@@ -2,15 +2,14 @@ import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
-import type { DateGroupBy, UnifiedReportDateQueryParams } from '@schemas/reports/unifiedReport'
 import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { type QueryParams, toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 import {
+  type UnifiedReportControlParams,
   type UnifiedReportParams,
   useUnifiedReportParams,
 } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
@@ -18,17 +17,16 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 type GetUnifiedReportExcelParams = {
   businessId: string
-  report: string
-  groupBy: DateGroupBy | null
-} & UnifiedReportDateQueryParams
+  route: string
+} & UnifiedReportControlParams & QueryParams
 
 const getUnifiedReportExcel = get<
   { data: S3PresignedUrlSchemaType },
   GetUnifiedReportExcelParams
->(({ businessId, report, groupBy, ...dateParams }) => {
-  const parameters = toDefinedSearchParameters({ ...dateParams, groupBy })
+>(({ businessId, route, ...restParams }) => {
+  const parameters = toDefinedSearchParameters({ ...restParams })
 
-  return `/v1/businesses/${businessId}/reports/unified/${report}/exports/excel?${parameters}`
+  return `/v1/businesses/${businessId}/reports/unified/${route}/exports/excel?${parameters}`
 })
 
 const getTag = (report: string) => `#unified-${report}-report-excel`
@@ -41,46 +39,45 @@ function buildKey({
   access_token: accessToken,
   apiUrl,
   businessId,
-  reportState,
+  params,
 }: {
   access_token?: string
   apiUrl?: string
   businessId: string
-  reportState: UnifiedReportParams | null
+  params: UnifiedReportParams | null
 }) {
-  if (!reportState || !accessToken || !apiUrl) return
+  if (!params || !accessToken || !apiUrl) return
 
   return {
     accessToken,
     apiUrl,
     businessId,
-    ...reportState,
-    tags: [getTag(reportState.report)],
+    ...params,
+    tags: [getTag(params.route)],
   }
 }
 
 type UseUnifiedReportExcelOptions = {
-  dateSelectionMode: DateSelectionMode
   onSuccess?: (url: S3PresignedUrlSchemaType) => Promise<void> | void
 }
 
-export function useUnifiedReportExcel({ dateSelectionMode, onSuccess }: UseUnifiedReportExcelOptions) {
+export function useUnifiedReportExcel({ onSuccess }: UseUnifiedReportExcelOptions = {}) {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { apiUrl } = useEnvironment()
   const { businessId } = useLayerContext()
-  const reportState = useUnifiedReportParams({ dateSelectionMode })
+  const params = useUnifiedReportParams()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
       ...auth,
       apiUrl,
       businessId,
-      reportState,
+      params,
     })),
-    ({ accessToken, apiUrl, businessId, tags, ...reportParams }) =>
+    ({ accessToken, apiUrl, businessId, tags, ...restParams }) =>
       getUnifiedReportExcel(apiUrl, accessToken, {
-        params: { businessId, ...reportParams },
+        params: { businessId, ...restParams },
       })()
         .then(Schema.decodeUnknownPromise(UnifiedReportExcelReturnSchema))
         .then(async ({ data }) => {

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
@@ -1,65 +1,65 @@
 import { Schema } from 'effect'
 import useSWR from 'swr'
 
-import type { DateGroupBy, UnifiedReportDateQueryParams } from '@schemas/reports/unifiedReport'
 import { UnifiedReportSchema } from '@schemas/reports/unifiedReport'
 import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { type QueryParams, toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import type { UnifiedReportParams } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
+import { type UnifiedReportControlParams, type UnifiedReportParams, useUnifiedReportParams } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
-export const UNIFIED_REPORT_TAG_KEY = '#unified-report'
+const getTag = (report: string) => `#unified-${report}-report`
 
 function buildKey({
   access_token: accessToken,
   apiUrl,
   businessId,
-  reportState,
+  params,
 }: {
   access_token?: string
   apiUrl?: string
   businessId: string
-  reportState: UnifiedReportParams | null
+  params: UnifiedReportParams | null
 }) {
-  if (!reportState || !accessToken || !apiUrl) return
+  if (!params || !accessToken || !apiUrl) return
 
   return {
     accessToken,
     apiUrl,
     businessId,
-    ...reportState,
-    tags: [UNIFIED_REPORT_TAG_KEY],
+    ...params,
+    tags: [getTag(params.route)],
   } as const
 }
 
 const getUnifiedReport = get<
   { data: unknown },
-  { businessId: string, report: string, groupBy: DateGroupBy | null } & UnifiedReportDateQueryParams
->(({ businessId, report, groupBy, ...dateParams }) => {
-  const parameters = toDefinedSearchParameters({ ...dateParams, groupBy })
+  { businessId: string, route: string } & UnifiedReportControlParams & QueryParams
+>(({ businessId, route, ...restParams }) => {
+  const parameters = toDefinedSearchParameters({ ...restParams })
 
-  return `/v1/businesses/${businessId}/reports/unified/${report}?${parameters}`
+  return `/v1/businesses/${businessId}/reports/unified/${route}?${parameters}`
 })
 
-export function useUnifiedReport(reportState: UnifiedReportParams | null) {
+export function useUnifiedReport() {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { apiUrl } = useEnvironment()
   const { businessId } = useLayerContext()
+  const params = useUnifiedReportParams()
 
   const swrResponse = useSWR(
     () => withLocale(buildKey({
       ...auth,
       apiUrl,
       businessId,
-      reportState,
+      params,
     })),
-    ({ accessToken, apiUrl, businessId, tags, ...params }) => getUnifiedReport(apiUrl, accessToken, {
-      params: { businessId, ...params },
+    ({ accessToken, apiUrl, businessId, tags, ...restParams }) => getUnifiedReport(apiUrl, accessToken, {
+      params: { businessId, ...restParams },
     })().then(({ data }) => Schema.decodeUnknownPromise(UnifiedReportSchema)(data)),
   )
 

--- a/src/providers/UnifiedReportStore/UnifiedReportStoreProvider.tsx
+++ b/src/providers/UnifiedReportStore/UnifiedReportStoreProvider.tsx
@@ -19,11 +19,6 @@ type UnifiedReportStoreShape = {
   actions: UnifiedReportStoreActions
 }
 
-export enum UnifiedReportDateVariant {
-  Date = 'Date',
-  DateRange = 'DateRange',
-}
-
 export const hasControl = (report: ReportConfig | null, control: ReportControl): boolean =>
   report?.controls.includes(control) ?? false
 
@@ -100,13 +95,18 @@ export function useUnifiedReportParams(): UnifiedReportParams | null {
 }
 
 const findDefaultReport = (groups: ReadonlyArray<ReportGroup>): ReportConfig | null => {
+  let firstReport: ReportConfig | null = null
   for (const group of groups) {
     for (const report of group.reports) {
       if (report.isDefaultReport) return report
+      if (!firstReport) firstReport = report
     }
   }
-  return null
+  return firstReport
 }
+
+const hasReportWithKey = (groups: ReadonlyArray<ReportGroup>, key: string): boolean =>
+  groups.some(group => group.reports.some(report => report.key === key))
 
 const createUnifiedReportStore = (dateSelectionMode: DateSelectionMode) =>
   createStore<UnifiedReportStoreShape>(set => ({
@@ -121,14 +121,16 @@ const createUnifiedReportStore = (dateSelectionMode: DateSelectionMode) =>
 
 function useHydrateUnifiedReportStore(store: StoreApi<UnifiedReportStoreShape>) {
   const { data } = useReportConfig()
+  const report = useStore(store, state => state.report)
   const setReport = useStore(store, state => state.actions.setReport)
 
   useEffect(() => {
     if (!data) return
+    if (report && hasReportWithKey(data, report.key)) return
 
     const defaultReport = findDefaultReport(data)
     if (defaultReport) setReport(defaultReport)
-  }, [data, setReport])
+  }, [data, report, setReport])
 }
 
 function useSyncExternalDateSelectionMode(store: StoreApi<UnifiedReportStoreShape>, dateSelectionMode: DateSelectionMode) {

--- a/src/providers/UnifiedReportStore/UnifiedReportStoreProvider.tsx
+++ b/src/providers/UnifiedReportStore/UnifiedReportStoreProvider.tsx
@@ -3,7 +3,7 @@ import { createStore, type StoreApi, useStore } from 'zustand'
 
 import { type ReportConfig, ReportControl, type ReportGroup } from '@schemas/reports/reportConfig'
 import { DateGroupBy, type DateQueryParams, type DateRangeQueryParams } from '@schemas/reports/unifiedReport'
-import { unsafeAssertUnreachable } from '@utils/switch/assertUnreachable'
+import type { QueryParams } from '@utils/request/toDefinedSearchParameters'
 import { useReportConfig } from '@hooks/api/businesses/[business-id]/reports/config/useReportConfig'
 import { type DateSelectionMode, useGlobalDate, useGlobalDateRange } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 
@@ -15,6 +15,7 @@ type UnifiedReportStoreActions = {
 type UnifiedReportStoreShape = {
   report: ReportConfig | null
   groupBy: DateGroupBy | null
+  dateSelectionMode: DateSelectionMode
   actions: UnifiedReportStoreActions
 }
 
@@ -23,23 +24,30 @@ export enum UnifiedReportDateVariant {
   DateRange = 'DateRange',
 }
 
-const getDateVariant = (report: ReportConfig): UnifiedReportDateVariant =>
-  report.controls.includes(ReportControl.DateRange)
-    ? UnifiedReportDateVariant.DateRange
-    : UnifiedReportDateVariant.Date
+export const hasControl = (report: ReportConfig | null, control: ReportControl): boolean =>
+  report?.controls.includes(control) ?? false
 
-const hasGroupByControl = (report: ReportConfig): boolean =>
-  report.controls.includes(ReportControl.GroupBy)
+export type ReportControlParams = {
+  [ReportControl.Date]: DateQueryParams
+  [ReportControl.DateRange]: DateRangeQueryParams
+  [ReportControl.GroupBy]: { groupBy: DateGroupBy }
+}
+
+export type UnifiedReportControlParams = Partial<
+  & ReportControlParams[ReportControl.Date]
+  & ReportControlParams[ReportControl.DateRange]
+  & ReportControlParams[ReportControl.GroupBy]
+>
 
 export type UnifiedReportParams = {
-  report: string
-  groupBy: DateGroupBy | null
-} & (DateQueryParams | DateRangeQueryParams)
+  route: string
+} & UnifiedReportControlParams & QueryParams
 
 const UnifiedReportStoreContext = createContext(
   createStore<UnifiedReportStoreShape>(() => ({
     report: null,
     groupBy: DateGroupBy.AllTime,
+    dateSelectionMode: 'full',
     actions: {
       setReport: () => {},
       setGroupBy: () => {},
@@ -47,79 +55,64 @@ const UnifiedReportStoreContext = createContext(
   })),
 )
 
+export function useUnifiedReportDateSelectionMode() {
+  const store = useContext(UnifiedReportStoreContext)
+  return useStore(store, state => state.dateSelectionMode)
+}
+
 export function useActiveUnifiedReport() {
   const store = useContext(UnifiedReportStoreContext)
+
   const report = useStore(store, state => state.report)
   const setReport = useStore(store, state => state.actions.setReport)
+
   return useMemo(() => ({ report, setReport }), [report, setReport])
 }
 
-export function useUnifiedReportDateVariant(): UnifiedReportDateVariant | null {
-  const { report } = useActiveUnifiedReport()
-  return report ? getDateVariant(report) : null
-}
-
 export function useUnifiedReportGroupByParam() {
-  const { report } = useActiveUnifiedReport()
   const store = useContext(UnifiedReportStoreContext)
+
   const groupBy = useStore(store, state => state.groupBy)
   const setGroupBy = useStore(store, state => state.actions.setGroupBy)
 
   const groupByState = useMemo(() => ({ groupBy, setGroupBy }), [groupBy, setGroupBy])
 
-  if (report && hasGroupByControl(report)) {
-    return groupByState
-  }
-
-  return null
+  return groupByState
 }
 
-export function useUnifiedReportDateParams({ dateSelectionMode }: { dateSelectionMode: DateSelectionMode }): DateQueryParams | DateRangeQueryParams | null {
-  const dateVariant = useUnifiedReportDateVariant()
+export function useUnifiedReportParams(): UnifiedReportParams | null {
+  const { report } = useActiveUnifiedReport()
+  const store = useContext(UnifiedReportStoreContext)
+  const groupBy = useStore(store, state => state.groupBy)
+  const dateSelectionMode = useUnifiedReportDateSelectionMode()
   const { date: effectiveDate } = useGlobalDate({ dateSelectionMode })
   const { startDate, endDate } = useGlobalDateRange({ dateSelectionMode })
 
-  if (dateVariant === null) return null
+  if (!report) return null
 
-  switch (dateVariant) {
-    case UnifiedReportDateVariant.Date:
-      return { effectiveDate }
-    case UnifiedReportDateVariant.DateRange:
-      return { startDate, endDate }
-    default:
-      unsafeAssertUnreachable({
-        value: dateVariant,
-        message: 'Unexpected date variant',
-      })
+  return {
+    route: report.reportRoute,
+    ...report.baseQueryParameters,
+    ...(hasControl(report, ReportControl.Date) && { effectiveDate }),
+    ...(hasControl(report, ReportControl.DateRange) && { startDate, endDate }),
+    ...(hasControl(report, ReportControl.GroupBy) && groupBy != null && { groupBy }),
   }
 }
 
-export function useUnifiedReportParams({ dateSelectionMode }: { dateSelectionMode: DateSelectionMode }): UnifiedReportParams | null {
-  const { report } = useActiveUnifiedReport()
-  const groupByParam = useUnifiedReportGroupByParam()
-  const dateParams = useUnifiedReportDateParams({ dateSelectionMode })
-
-  if (!report || !dateParams) return null
-
-  return { report: report.reportType, groupBy: groupByParam?.groupBy ?? null, ...dateParams } as UnifiedReportParams
-}
-
-const findFirstLeaf = (groups: ReadonlyArray<ReportGroup>): ReportConfig | null => {
+const findDefaultReport = (groups: ReadonlyArray<ReportGroup>): ReportConfig | null => {
   for (const group of groups) {
-    if (group.reports.length > 0) {
-      return group.reports[0]
+    for (const report of group.reports) {
+      if (report.isDefaultReport) return report
     }
   }
   return null
 }
 
-const hasLeafWithKey = (groups: ReadonlyArray<ReportGroup>, key: string): boolean =>
-  groups.some(group => group.reports.some(report => report.key === key))
-
-const createUnifiedReportStore = () =>
+const createUnifiedReportStore = (dateSelectionMode: DateSelectionMode) =>
   createStore<UnifiedReportStoreShape>(set => ({
     report: null,
     groupBy: DateGroupBy.AllTime,
+    dateSelectionMode,
     actions: {
       setReport: (report: ReportConfig) => set({ report }),
       setGroupBy: (groupBy: DateGroupBy | null) => set({ groupBy }),
@@ -128,21 +121,30 @@ const createUnifiedReportStore = () =>
 
 function useHydrateUnifiedReportStore(store: StoreApi<UnifiedReportStoreShape>) {
   const { data } = useReportConfig()
-  const report = useStore(store, state => state.report)
   const setReport = useStore(store, state => state.actions.setReport)
 
   useEffect(() => {
     if (!data) return
-    if (report && hasLeafWithKey(data, report.key)) return
 
-    const firstLeaf = findFirstLeaf(data)
-    if (firstLeaf) setReport(firstLeaf)
-  }, [report, data, setReport])
+    const defaultReport = findDefaultReport(data)
+    if (defaultReport) setReport(defaultReport)
+  }, [data, setReport])
 }
 
-export function UnifiedReportStoreProvider({ children }: PropsWithChildren) {
-  const [store] = useState(createUnifiedReportStore)
+function useSyncExternalDateSelectionMode(store: StoreApi<UnifiedReportStoreShape>, dateSelectionMode: DateSelectionMode) {
+  useEffect(() => {
+    store.setState({ dateSelectionMode })
+  }, [store, dateSelectionMode])
+}
+
+type UnifiedReportStoreProviderProps = {
+  dateSelectionMode?: DateSelectionMode
+}
+
+export function UnifiedReportStoreProvider({ children, dateSelectionMode = 'full' }: PropsWithChildren<UnifiedReportStoreProviderProps>) {
+  const [store] = useState(() => createUnifiedReportStore(dateSelectionMode))
   useHydrateUnifiedReportStore(store)
+  useSyncExternalDateSelectionMode(store, dateSelectionMode)
 
   return (
     <UnifiedReportStoreContext.Provider value={store}>

--- a/src/providers/UnifiedReportStore/UnifiedReportStoreProvider.tsx
+++ b/src/providers/UnifiedReportStore/UnifiedReportStoreProvider.tsx
@@ -75,9 +75,7 @@ export function useUnifiedReportGroupByParam() {
   const groupBy = useStore(store, state => state.groupBy)
   const setGroupBy = useStore(store, state => state.actions.setGroupBy)
 
-  const groupByState = useMemo(() => ({ groupBy, setGroupBy }), [groupBy, setGroupBy])
-
-  return groupByState
+  return useMemo(() => ({ groupBy, setGroupBy }), [groupBy, setGroupBy])
 }
 
 export function useUnifiedReportParams(): UnifiedReportParams | null {
@@ -88,15 +86,17 @@ export function useUnifiedReportParams(): UnifiedReportParams | null {
   const { date: effectiveDate } = useGlobalDate({ dateSelectionMode })
   const { startDate, endDate } = useGlobalDateRange({ dateSelectionMode })
 
-  if (!report) return null
+  return useMemo(() => {
+    if (!report) return null
 
-  return {
-    route: report.reportRoute,
-    ...report.baseQueryParameters,
-    ...(hasControl(report, ReportControl.Date) && { effectiveDate }),
-    ...(hasControl(report, ReportControl.DateRange) && { startDate, endDate }),
-    ...(hasControl(report, ReportControl.GroupBy) && groupBy != null && { groupBy }),
-  }
+    return {
+      route: report.reportRoute,
+      ...report.baseQueryParameters,
+      ...(hasControl(report, ReportControl.Date) && { effectiveDate }),
+      ...(hasControl(report, ReportControl.DateRange) && { startDate, endDate }),
+      ...(hasControl(report, ReportControl.GroupBy) && groupBy != null && { groupBy }),
+    }
+  }, [effectiveDate, endDate, groupBy, report, startDate])
 }
 
 const findDefaultReport = (groups: ReadonlyArray<ReportGroup>): ReportConfig | null => {

--- a/src/schemas/reports/reportConfig.ts
+++ b/src/schemas/reports/reportConfig.ts
@@ -3,6 +3,7 @@ import { pipe, Schema } from 'effect'
 import { createTransformedEnumSchema } from '@schemas/utils'
 
 export enum ReportControl {
+  Date = 'date',
   DateRange = 'date_range',
   GroupBy = 'group_by',
   Unknown = 'unknown',
@@ -30,9 +31,9 @@ const TransformedReportGroupTypeSchema = createTransformedEnumSchema(
 
 export const ReportConfigSchema = Schema.Struct({
   key: Schema.String,
-  reportType: pipe(
+  reportRoute: pipe(
     Schema.propertySignature(Schema.String),
-    Schema.fromKey('report_type'),
+    Schema.fromKey('report_route'),
   ),
   displayName: pipe(
     Schema.propertySignature(Schema.String),
@@ -43,6 +44,7 @@ export const ReportConfigSchema = Schema.Struct({
     Schema.propertySignature(Schema.Record({ key: Schema.String, value: Schema.String })),
     Schema.fromKey('base_query_parameters'),
   ),
+  isDefaultReport: Schema.optional(Schema.Boolean).pipe(Schema.fromKey('is_default_report')),
 })
 export type ReportConfig = typeof ReportConfigSchema.Type
 

--- a/src/schemas/reports/unifiedReport.ts
+++ b/src/schemas/reports/unifiedReport.ts
@@ -86,6 +86,11 @@ const UnifiedCellValueAmountSchema = Schema.Struct({
   value: Schema.Number,
 })
 
+const UnifiedCellValueDateSchema = Schema.Struct({
+  type: Schema.Literal('Date'),
+  value: Schema.Date,
+})
+
 const UnifiedCellValueEmptySchema = Schema.Struct({
   type: Schema.Literal('Empty'),
 })
@@ -97,24 +102,38 @@ const UnifiedCellValueUnknownSchema = Schema.Struct({
 
 const UnifiedCellValueSchema = Schema.Union(
   UnifiedCellValueAmountSchema,
+  UnifiedCellValueDateSchema,
   UnifiedCellValueEmptySchema,
   UnifiedCellValueUnknownSchema,
 )
 
 export type UnifiedCellValue = typeof UnifiedCellValueSchema.Type
 export type UnifiedCellValueAmount = typeof UnifiedCellValueAmountSchema.Type
+export type UnifiedCellValueDate = typeof UnifiedCellValueDateSchema.Type
 export type UnifiedCellValueEmpty = typeof UnifiedCellValueEmptySchema.Type
 export type UnifiedCellValueUnknown = typeof UnifiedCellValueUnknownSchema.Type
 
 export const isAmountCellValue = (value: UnifiedCellValue): value is UnifiedCellValueAmount =>
   value.type === 'Amount'
 
+export const isDateCellValue = (value: UnifiedCellValue): value is UnifiedCellValueDate =>
+  value.type === 'Date'
+
 export const isEmptyCellValue = (value: UnifiedCellValue): value is UnifiedCellValueEmpty =>
   value.type === 'Empty'
 
+const UnifiedCellFormatSchema = Schema.Struct({
+  bold: Schema.optional(Schema.Boolean),
+})
+
+export type UnifiedCellFormat = typeof UnifiedCellFormatSchema.Type
+
 const UnifiedReportCellSchema = Schema.Struct({
   value: UnifiedCellValueSchema,
+  format: Schema.optional(UnifiedCellFormatSchema),
 })
+
+export type UnifiedReportCell = typeof UnifiedReportCellSchema.Type
 
 const unifiedReportRowFields = {
   rowKey: pipe(

--- a/src/utils/request/toDefinedSearchParameters.ts
+++ b/src/utils/request/toDefinedSearchParameters.ts
@@ -21,9 +21,10 @@ const ParameterValuesSchema = Schema.Union(
   Schema.Boolean,
 )
 export type ParameterValues = typeof ParameterValuesSchema.Type
+export type QueryParams = Record<string, ParameterValues | null | undefined>
 
 export function toDefinedSearchParameters(
-  input: Record<string, ParameterValues | null | undefined>,
+  input: QueryParams,
 ) {
   const definedParameterPairs = Object.entries(input)
     .flatMap(([key, value]) => {


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes unified report query/route construction and moves date/group-by logic into the store, which can affect which reports load and what parameters are sent to the backend.
> 
> **Overview**
> **Unified reports now render richer cell content** by adding schema support for `Date` cell values and optional `format.bold`, and using a new `UnifiedReportTableCellContent` helper to format dates and apply bold styling.
> 
> **Unified report fetching and controls were refactored to be config-driven.** API hooks now build requests from centralized `useUnifiedReportParams()` (including `report_route`, `baseQueryParameters`, and only the controls a report supports), and `UnifiedReportTableHeader`/download no longer take `dateSelectionMode` props.
> 
> Also updates default-report selection to prefer `is_default_report`, adjusts SWR cache tags per-report route, and tweaks expand button rotation styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fdbcea91b6fc272f2998ba1750d4601036e0574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->