### PR TITLE
Fixing Time Tracking bugs

### DIFF
--- a/src/assets/locales/en-US/timeTracking.json
+++ b/src/assets/locales/en-US/timeTracking.json
@@ -20,7 +20,7 @@
     "archive_service": "Could not archive this service. Please try again.",
     "cancel_timer": "Failed to cancel timer. Please try again.",
     "complete_timer": "Failed to complete timer. Please try again.",
-    "complete_timer_stale": "This timer was already completed. Reload the page.",
+    "complete_timer_stale": "This timer was already completed or cancelled. Reload the page.",
     "create_service": "Failed to create service. Please try again.",
     "delete_entry": "Failed to delete time entry. Please check your connection and try again.",
     "load_active_timer": "Failed to load active timer. Please check your connection and try again.",

--- a/src/assets/locales/en-US/timeTracking.json
+++ b/src/assets/locales/en-US/timeTracking.json
@@ -50,7 +50,7 @@
     "invoiced": "Invoiced",
     "less_than_one_minute": "< 1 min",
     "memo": "Memo",
-    "no_activity_breakdown": "No activity breakdown available for this period.",
+    "no_activity_breakdown": "No activity this period",
     "no_services": "No services available",
     "other": "Other",
     "select_customer": "Select a customer (optional)",
@@ -58,7 +58,8 @@
     "select_service": "Select a service",
     "service": "Service",
     "time_entries": "Time Entries",
-    "time_tracking": "Time Tracking"
+    "time_tracking": "Time Tracking",
+    "zero_minutes": "0 min"
   },
   "prompt": {
     "delete_entry": "Delete this time entry?",

--- a/src/assets/locales/en-US/timeTracking.json
+++ b/src/assets/locales/en-US/timeTracking.json
@@ -74,6 +74,7 @@
     "archive_confirm_description": "This service will be removed from your active list. Time entries that used it are unchanged.",
     "archive_confirm_title": "Archive this service?",
     "archived": "Archived",
+    "archived_service": "{{name}} (Archived)",
     "cancel": "Cancel",
     "create_service_input_value": "Create service \"{{inputValue}}\"",
     "hourly_rate_optional": "Default hourly rate (optional)",

--- a/src/assets/locales/en-US/timeTracking.json
+++ b/src/assets/locales/en-US/timeTracking.json
@@ -29,6 +29,7 @@
     "load_services": "Failed to load services.",
     "load_summary": "Failed to load time tracking summary",
     "start_timer": "Failed to start timer. Please try again.",
+    "start_timer_already_active": "A timer is already running. Please reload the page.",
     "unarchive_service": "Could not restore this service. Please try again.",
     "update_service": "Could not save this service. Please try again.",
     "update_timer": "Failed to update timer. Please try again."
@@ -51,7 +52,7 @@
     "invoiced": "Invoiced",
     "less_than_one_minute": "< 1 min",
     "memo": "Memo",
-    "no_activity_breakdown": "No activity this period",
+    "no_activity_breakdown": "No activity during this period",
     "no_services": "No services available",
     "other": "Other",
     "select_customer": "Select a customer (optional)",

--- a/src/assets/locales/en-US/timeTracking.json
+++ b/src/assets/locales/en-US/timeTracking.json
@@ -20,6 +20,7 @@
     "archive_service": "Could not archive this service. Please try again.",
     "cancel_timer": "Failed to cancel timer. Please try again.",
     "complete_timer": "Failed to complete timer. Please try again.",
+    "complete_timer_stale": "This timer was already completed. Reload the page.",
     "create_service": "Failed to create service. Please try again.",
     "delete_entry": "Failed to delete time entry. Please check your connection and try again.",
     "load_active_timer": "Failed to load active timer. Please check your connection and try again.",

--- a/src/assets/locales/fr-CA/timeTracking.json
+++ b/src/assets/locales/fr-CA/timeTracking.json
@@ -20,6 +20,7 @@
     "archive_service": "Impossible d'archiver ce service. Veuillez réessayer.",
     "cancel_timer": "Impossible d'annuler le minuteur. Veuillez réessayer.",
     "complete_timer": "Impossible de terminer le minuteur. Veuillez réessayer.",
+    "complete_timer_stale": "",
     "create_service": "Impossible de créer le service. Veuillez réessayer.",
     "delete_entry": "Impossible de supprimer l'entrée de temps. Veuillez vérifier votre connexion et réessayer.",
     "load_active_timer": "Impossible de charger le minuteur actif. Veuillez vérifier votre connexion et réessayer.",

--- a/src/assets/locales/fr-CA/timeTracking.json
+++ b/src/assets/locales/fr-CA/timeTracking.json
@@ -29,6 +29,7 @@
     "load_services": "Impossible de charger les services.",
     "load_summary": "Impossible de charger le sommaire du suivi du temps",
     "start_timer": "Impossible de démarrer le minuteur. Veuillez réessayer.",
+    "start_timer_already_active": "",
     "unarchive_service": "Impossible de restaurer ce service. Veuillez réessayer.",
     "update_service": "Impossible d'enregistrer ce service. Veuillez réessayer.",
     "update_timer": "Impossible de mettre à jour le minuteur. Veuillez réessayer."

--- a/src/assets/locales/fr-CA/timeTracking.json
+++ b/src/assets/locales/fr-CA/timeTracking.json
@@ -74,6 +74,7 @@
     "archive_confirm_description": "Ce service sera retiré de votre liste active. Les entrées de temps qui l'utilisaient ne sont pas modifiées.",
     "archive_confirm_title": "Archiver ce service?",
     "archived": "Archivés",
+    "archived_service": "",
     "cancel": "Annuler",
     "create_service_input_value": "",
     "hourly_rate_optional": "Taux horaire par défaut (facultatif)",

--- a/src/assets/locales/fr-CA/timeTracking.json
+++ b/src/assets/locales/fr-CA/timeTracking.json
@@ -50,7 +50,7 @@
     "invoiced": "Facturé",
     "less_than_one_minute": "",
     "memo": "Note",
-    "no_activity_breakdown": "Aucune répartition des activités n'est disponible pour cette période.",
+    "no_activity_breakdown": "",
     "no_services": "Aucun service disponible",
     "other": "Autre",
     "select_customer": "Sélectionner un client (facultatif)",
@@ -58,7 +58,8 @@
     "select_service": "Sélectionner un service",
     "service": "Service",
     "time_entries": "Entrées de temps",
-    "time_tracking": ""
+    "time_tracking": "",
+    "zero_minutes": ""
   },
   "prompt": {
     "delete_entry": "Supprimer cette entrée de temps?",

--- a/src/components/DataTable/DataTableHeader.tsx
+++ b/src/components/DataTable/DataTableHeader.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
-import { Span } from '@ui/Typography/Text'
+import { Heading } from '@ui/Typography/Heading'
 import { Badge, BadgeVariant } from '@components/Badge/Badge'
 import { BadgeSize } from '@components/Badge/Badge'
 import { BadgeLoader } from '@components/BadgeLoader/BadgeLoader'
@@ -42,7 +42,7 @@ export const DataTableHeader = ({ name, count, slotProps = {}, slots = {} }: Dat
       <HStack justify='space-between' align='center' gap='xs' className='Layer__DataTableHeader__Header'>
         <HStack pis='md' align='center' gap='xl'>
           <HStack align='center' gap='sm'>
-            <Span weight='bold' size='md'>{name}</Span>
+            <Heading size='md'>{name}</Heading>
             {showCount && (totalCount
               ? <Badge variant={BadgeVariant.DEFAULT} size={BadgeSize.MEDIUM}>{totalCount}</Badge>
               : <BadgeLoader />

--- a/src/components/TimeEntries/ActiveTimeTracker/ActiveTimeTrackerBanner.tsx
+++ b/src/components/TimeEntries/ActiveTimeTracker/ActiveTimeTrackerBanner.tsx
@@ -1,14 +1,13 @@
-import { Check } from 'lucide-react'
+import { AlertTriangle, Check } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { type TimeEntry } from '@schemas/timeTracking'
 import { useActiveTimerBannerForm } from '@hooks/features/timeTracking/useActiveTimerBannerForm'
 import { Button } from '@ui/Button/Button'
-import { HStack, VStack } from '@ui/Stack/Stack'
+import { HStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { Container } from '@components/Container/Container'
 import { CustomerSelector } from '@components/CustomerSelector/CustomerSelector'
-import { DataState, DataStateStatus } from '@components/DataState/DataState'
 import { TimeEntryServiceSelector } from '@components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector'
 
 type ActiveTimeTrackerBannerProps = {
@@ -21,16 +20,19 @@ export const ActiveTimeTrackerBanner = ({ activeEntry, timerDisplayValue }: Acti
   const { form, actions, state } = useActiveTimerBannerForm({ activeEntry })
 
   return (
-    <Container name='ActiveTimeTracker'>
+    <Container name='ActiveTimeTracker' className='Layer__ActiveTimeTracker__Shell'>
       {state.actionError && (
-        <VStack pi='md' pbe='2xs'>
-          <DataState
-            className='Layer__ActiveTimeTracker__BannerError'
-            status={DataStateStatus.failed}
-            title={state.actionError}
-            inline
-          />
-        </VStack>
+        <HStack className='Layer__ActiveTimeTracker__ErrorStrip' role='alert'>
+          <HStack className='Layer__ActiveTimeTracker__ErrorStripRow' gap='sm' align='center'>
+            <AlertTriangle
+              aria-hidden
+              className='Layer__ActiveTimeTracker__ErrorStripIcon'
+              size={16}
+              strokeWidth={1.25}
+            />
+            <Span size='sm' className='Layer__ActiveTimeTracker__ErrorStripText'>{state.actionError}</Span>
+          </HStack>
+        </HStack>
       )}
 
       <HStack className='Layer__ActiveTimeTracker__Main' gap='md' justify='space-between' align='center'>

--- a/src/components/TimeEntries/ActiveTimeTracker/ActiveTimeTrackerBanner.tsx
+++ b/src/components/TimeEntries/ActiveTimeTracker/ActiveTimeTrackerBanner.tsx
@@ -20,9 +20,9 @@ export const ActiveTimeTrackerBanner = ({ activeEntry, timerDisplayValue }: Acti
   const { form, actions, state } = useActiveTimerBannerForm({ activeEntry })
 
   return (
-    <Container name='ActiveTimeTracker' className='Layer__ActiveTimeTracker__Shell'>
+    <Container name='ActiveTimeTracker' className='Layer__ActiveTimeTracker__Container'>
       {state.actionError && (
-        <HStack className='Layer__ActiveTimeTracker__ErrorStrip' role='alert'>
+        <HStack className='Layer__ActiveTimeTracker__ErrorStrip' pb='xs' pi='md' role='alert'>
           <HStack className='Layer__ActiveTimeTracker__ErrorStripRow' gap='sm' align='center'>
             <AlertTriangle
               aria-hidden

--- a/src/components/TimeEntries/ActiveTimeTracker/ActiveTimeTrackerBanner.tsx
+++ b/src/components/TimeEntries/ActiveTimeTracker/ActiveTimeTrackerBanner.tsx
@@ -25,6 +25,7 @@ export const ActiveTimeTrackerBanner = ({ activeEntry, timerDisplayValue }: Acti
       {state.actionError && (
         <VStack pi='md' pbe='2xs'>
           <DataState
+            className='Layer__ActiveTimeTracker__BannerError'
             status={DataStateStatus.failed}
             title={state.actionError}
             inline
@@ -83,8 +84,7 @@ export const ActiveTimeTrackerBanner = ({ activeEntry, timerDisplayValue }: Acti
               <Button
                 variant='outlined-light'
                 onPress={actions.completeTimer}
-                isPending={state.isStopping || state.isUpdating}
-                isDisabled={state.isCancelling || !selectedServiceId}
+                isDisabled={state.isCancelling || state.isStopping || state.isUpdating || !selectedServiceId}
               >
                 {t('timeTracking:action.complete_timer', 'Complete')}
                 <Check size={16} />

--- a/src/components/TimeEntries/ActiveTimeTracker/activeTimeTracker.scss
+++ b/src/components/TimeEntries/ActiveTimeTracker/activeTimeTracker.scss
@@ -1,16 +1,36 @@
 .Layer__component-container.Layer__ActiveTimeTracker {
   --border-color: #000;
   --bg-color: #000;
+}
 
-  .Layer__ActiveTimeTracker__BannerError.Layer__data-state--inline {
-    .Layer__data-state__title {
-      color: var(--color-base-0);
-    }
+.Layer__component-container.Layer__ActiveTimeTracker.Layer__ActiveTimeTracker__Shell {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
 
-    .Layer__data-state__description {
-      color: var(--color-base-200);
-    }
-  }
+.Layer__ActiveTimeTracker__ErrorStrip {
+  box-sizing: border-box;
+  flex-shrink: 0;
+  padding-block: var(--spacing-xs);
+  padding-inline: var(--spacing-md);
+  border-block-end: 1px solid rgb(255 255 255 / 14%);
+  background-color: color-mix(in srgb, var(--color-info-error) 32%, transparent);
+}
+
+.Layer__ActiveTimeTracker__ErrorStripRow {
+  min-inline-size: 0;
+}
+
+.Layer__ActiveTimeTracker__ErrorStripIcon {
+  flex-shrink: 0;
+  color: var(--color-base-0);
+}
+
+.Layer__ActiveTimeTracker__ErrorStripText {
+  flex: 1;
+  min-inline-size: 0;
+  color: var(--color-base-0);
 }
 
 .Layer__ActiveTimeTracker__Main {

--- a/src/components/TimeEntries/ActiveTimeTracker/activeTimeTracker.scss
+++ b/src/components/TimeEntries/ActiveTimeTracker/activeTimeTracker.scss
@@ -3,7 +3,7 @@
   --bg-color: #000;
 }
 
-.Layer__component-container.Layer__ActiveTimeTracker.Layer__ActiveTimeTracker__Shell {
+.Layer__component-container.Layer__ActiveTimeTracker.Layer__ActiveTimeTracker__Container {
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -12,8 +12,6 @@
 .Layer__ActiveTimeTracker__ErrorStrip {
   box-sizing: border-box;
   flex-shrink: 0;
-  padding-block: var(--spacing-xs);
-  padding-inline: var(--spacing-md);
   border-block-end: 1px solid rgb(255 255 255 / 14%);
   background-color: color-mix(in srgb, var(--color-info-error) 32%, transparent);
 }

--- a/src/components/TimeEntries/ActiveTimeTracker/activeTimeTracker.scss
+++ b/src/components/TimeEntries/ActiveTimeTracker/activeTimeTracker.scss
@@ -13,7 +13,7 @@
   box-sizing: border-box;
   flex-shrink: 0;
   border-block-end: 1px solid rgb(255 255 255 / 14%);
-  background-color: color-mix(in srgb, var(--color-info-error) 32%, transparent);
+  background-color: color-mix(in srgb, var(--color-info-error), transparent);
 }
 
 .Layer__ActiveTimeTracker__ErrorStripRow {

--- a/src/components/TimeEntries/ActiveTimeTracker/activeTimeTracker.scss
+++ b/src/components/TimeEntries/ActiveTimeTracker/activeTimeTracker.scss
@@ -1,6 +1,16 @@
 .Layer__component-container.Layer__ActiveTimeTracker {
   --border-color: #000;
   --bg-color: #000;
+
+  .Layer__ActiveTimeTracker__BannerError.Layer__data-state--inline {
+    .Layer__data-state__title {
+      color: var(--color-base-0);
+    }
+
+    .Layer__data-state__description {
+      color: var(--color-base-200);
+    }
+  }
 }
 
 .Layer__ActiveTimeTracker__Main {

--- a/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
+++ b/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
@@ -59,7 +59,7 @@ const TimeEntryActionsCell = memo(function TimeEntryActionsCell({ entry }: { ent
         aria-label={t('timeTracking:action.view_entry', 'View Entry')}
         variant='ghost'
       >
-        <Edit size={20} />
+        <Edit size={20} strokeWidth={1.25} />
       </Button>
       {!isLocked && (
         <Button
@@ -69,7 +69,7 @@ const TimeEntryActionsCell = memo(function TimeEntryActionsCell({ entry }: { ent
           aria-label={t('timeTracking:action.delete_entry', 'Delete Entry')}
           variant='ghost'
         >
-          <Trash2 size={20} />
+          <Trash2 size={20} strokeWidth={1.25} />
         </Button>
       )}
     </HStack>

--- a/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTableHeader.tsx
+++ b/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTableHeader.tsx
@@ -21,7 +21,7 @@ export const TimeEntriesTableHeader = () => {
 
   const HeaderActions = useCallback(() => (
     <HStack gap='xs'>
-      <Button onPress={onAddEntry}>
+      <Button variant='outlined-light' onPress={onAddEntry}>
         {t('timeTracking:action.add_entry', 'Add Entry')}
         <Plus size={16} />
       </Button>
@@ -45,6 +45,7 @@ export const TimeEntriesTableHeader = () => {
         className='Layer__TimeEntriesTable__FilterService'
         placeholder={t('timeTracking:label.all_services', 'All Services')}
         showLabel={false}
+        allowArchived
         inline
       />
       <CustomerSelector

--- a/src/components/TimeEntries/TimeEntryDrawer/TimeEntryDrawer.tsx
+++ b/src/components/TimeEntries/TimeEntryDrawer/TimeEntryDrawer.tsx
@@ -107,11 +107,11 @@ export const TimeEntryDrawer = () => {
               {hasEntry && isReadOnly && !isLocked && (
                 <HStack pie='lg' gap='xs' justify='end' pbs='sm'>
                   <Button variant='outlined' onPress={handleDeleteEntry}>
-                    <Trash2 size={16} />
+                    <Trash2 size={16} strokeWidth={1.25} />
                     {t('timeTracking:action.delete_entry', 'Delete Entry')}
                   </Button>
                   <Button onPress={() => setIsEditMode(true)}>
-                    <Edit size={16} />
+                    <Edit size={16} strokeWidth={1.25} />
                     {t('timeTracking:action.edit_entry', 'Edit Entry')}
                   </Button>
                 </HStack>

--- a/src/components/TimeEntries/TimeEntryForm/timeEntryForm.scss
+++ b/src/components/TimeEntries/TimeEntryForm/timeEntryForm.scss
@@ -7,6 +7,7 @@
 
   .Layer__TimeEntryForm__FormError {
     padding-block-end: var(--spacing-xs);
+    margin-block-start: calc(-1 * var(--spacing-md));
   }
 
   .Layer__TimeEntryForm__Field__EntryDate,

--- a/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
+++ b/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
@@ -12,13 +12,19 @@ import { Label, P, Span } from '@ui/Typography/Text'
 
 import './timeEntryServiceSelector.scss'
 
+function getServiceLabel(service: CatalogService, t: TFunction): string {
+  return service.archivedAt
+    ? t('timeTracking:services.archived_service', '{{name}} (Archived)', { name: service.name })
+    : service.name
+}
+
 class ServiceAsOption {
   private internalService: CatalogService
-  private computedLabel: string
+  private t: TFunction
 
-  constructor(service: CatalogService, computedLabel?: string) {
+  constructor(service: CatalogService, t: TFunction) {
     this.internalService = service
-    this.computedLabel = computedLabel ?? service.name
+    this.t = t
   }
 
   get original() {
@@ -26,7 +32,7 @@ class ServiceAsOption {
   }
 
   get label() {
-    return this.computedLabel
+    return getServiceLabel(this.internalService, this.t)
   }
 
   get id() {
@@ -91,12 +97,7 @@ export function TimeEntryServiceSelector({
   const shouldDisableComboBox = isLoadingWithoutFallback || isError
 
   const serviceOptions = useMemo<ServiceAsOption[]>(
-    () => servicesResponse?.data.map((service) => {
-      const label = service.archivedAt
-        ? t('timeTracking:services.archived_service', '{{name}} (Archived)', { name: service.name })
-        : service.name
-      return new ServiceAsOption(service, label)
-    }) ?? [],
+    () => servicesResponse?.data.map(service => new ServiceAsOption(service, t)) ?? [],
     [servicesResponse, t],
   )
 

--- a/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
+++ b/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
@@ -14,11 +14,11 @@ import './timeEntryServiceSelector.scss'
 
 class ServiceAsOption {
   private internalService: CatalogService
-  private labelSuffix: string
+  private computedLabel: string
 
-  constructor(service: CatalogService, labelSuffix = '') {
+  constructor(service: CatalogService, computedLabel?: string) {
     this.internalService = service
-    this.labelSuffix = labelSuffix
+    this.computedLabel = computedLabel ?? service.name
   }
 
   get original() {
@@ -26,7 +26,7 @@ class ServiceAsOption {
   }
 
   get label() {
-    return this.labelSuffix ? `${this.internalService.name}${this.labelSuffix}` : this.internalService.name
+    return this.computedLabel
   }
 
   get id() {
@@ -92,10 +92,10 @@ export function TimeEntryServiceSelector({
 
   const serviceOptions = useMemo<ServiceAsOption[]>(
     () => servicesResponse?.data.map((service) => {
-      const suffix = service.archivedAt
-        ? ` (${t('timeTracking:services.archived', 'Archived')})`
-        : ''
-      return new ServiceAsOption(service, suffix)
+      const label = service.archivedAt
+        ? t('timeTracking:services.archived_service', '{{name}} (Archived)', { name: service.name })
+        : service.name
+      return new ServiceAsOption(service, label)
     }) ?? [],
     [servicesResponse, t],
   )

--- a/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
+++ b/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
@@ -1,21 +1,24 @@
 import { useCallback, useId, useMemo } from 'react'
 import classNames from 'classnames'
 import type { TFunction } from 'i18next'
+import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { type CatalogService } from '@schemas/catalogService'
 import { useListCatalogServices } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
 import { MaybeCreatableComboBox } from '@ui/ComboBox/MaybeCreatableComboBox'
 import { VStack } from '@ui/Stack/Stack'
-import { Label, P } from '@ui/Typography/Text'
+import { Label, P, Span } from '@ui/Typography/Text'
 
 import './timeEntryServiceSelector.scss'
 
 class ServiceAsOption {
   private internalService: CatalogService
+  private labelSuffix: string
 
-  constructor(service: CatalogService) {
+  constructor(service: CatalogService, labelSuffix = '') {
     this.internalService = service
+    this.labelSuffix = labelSuffix
   }
 
   get original() {
@@ -23,7 +26,7 @@ class ServiceAsOption {
   }
 
   get label() {
-    return this.internalService.name
+    return this.labelSuffix ? `${this.internalService.name}${this.labelSuffix}` : this.internalService.name
   }
 
   get id() {
@@ -35,7 +38,7 @@ class ServiceAsOption {
   }
 }
 
-type TimeEntryServiceSelectorBaseProps = {
+type TimeEntryServiceSelectorSharedProps = {
   selectedServiceId: string | null
   onSelectedServiceIdChange: (serviceId: string | null) => void
   placeholder?: string
@@ -46,15 +49,26 @@ type TimeEntryServiceSelectorBaseProps = {
   showLabel?: boolean
 }
 
-type TimeEntryServiceSelectorProps = TimeEntryServiceSelectorBaseProps & (
-  | { isCreatable: true, onCreateService: (name: string) => void }
-  | { isCreatable?: false, onCreateService?: (name: string) => void }
-)
+type TimeEntryServiceSelectorProps =
+  | (TimeEntryServiceSelectorSharedProps & {
+    isCreatable: true
+    onCreateService: (name: string) => void
+    allowArchived?: never
+  })
+  | (TimeEntryServiceSelectorSharedProps & {
+    isCreatable?: false
+    onCreateService?: (name: string) => void
+    allowArchived?: boolean
+  })
 
-const formatCreateLabel = (inputValue: string, t: TFunction) =>
-  inputValue
-    ? t('timeTracking:services.create_service_input_value', 'Create service "{{inputValue}}"', { inputValue })
-    : t('timeTracking:services.add_service', 'Add service')
+const formatCreateLabel = (inputValue: string, t: TFunction) => (
+  <Span variant='inherit' className='Layer__TimeEntryServiceSelector__CreateLabel'>
+    <Plus size={14} aria-hidden='true' />
+    {inputValue
+      ? t('timeTracking:services.create_service_input_value', 'Create service "{{inputValue}}"', { inputValue })
+      : t('timeTracking:services.add_service', 'Add service')}
+  </Span>
+)
 
 export function TimeEntryServiceSelector({
   selectedServiceId,
@@ -65,19 +79,25 @@ export function TimeEntryServiceSelector({
   inline,
   className,
   showLabel = true,
+  allowArchived,
   isCreatable,
   onCreateService,
 }: TimeEntryServiceSelectorProps) {
   const { t } = useTranslation()
 
-  const { data: servicesResponse, isLoading, isError } = useListCatalogServices()
+  const { data: servicesResponse, isLoading, isError } = useListCatalogServices({ allowArchived })
 
   const isLoadingWithoutFallback = isLoading && !servicesResponse
   const shouldDisableComboBox = isLoadingWithoutFallback || isError
 
   const serviceOptions = useMemo<ServiceAsOption[]>(
-    () => servicesResponse?.data.map(service => new ServiceAsOption(service)) ?? [],
-    [servicesResponse],
+    () => servicesResponse?.data.map((service) => {
+      const suffix = service.archivedAt
+        ? ` (${t('timeTracking:services.archived', 'Archived')})`
+        : ''
+      return new ServiceAsOption(service, suffix)
+    }) ?? [],
+    [servicesResponse, t],
   )
 
   const combinedClassName = classNames(

--- a/src/components/TimeEntries/TimeEntryServiceSelector/timeEntryServiceSelector.scss
+++ b/src/components/TimeEntries/TimeEntryServiceSelector/timeEntryServiceSelector.scss
@@ -18,6 +18,6 @@
     gap: var(--spacing-2xs);
     align-items: center;
 
-    color: var(--fg-brand-accent, var(--color-primary));
+    color: var(--color-base-900);
   }
 }

--- a/src/components/TimeEntries/TimeEntryServiceSelector/timeEntryServiceSelector.scss
+++ b/src/components/TimeEntries/TimeEntryServiceSelector/timeEntryServiceSelector.scss
@@ -12,4 +12,12 @@
 
     align-items: center;
   }
+
+  &__CreateLabel.Layer__Span {
+    display: inline-flex;
+    gap: var(--spacing-2xs);
+    align-items: center;
+
+    color: var(--fg-brand-accent, var(--color-primary));
+  }
 }

--- a/src/components/TimeEntries/TimeTrackingServicesDrawer/TimeTrackingServicesDrawer.tsx
+++ b/src/components/TimeEntries/TimeTrackingServicesDrawer/TimeTrackingServicesDrawer.tsx
@@ -128,11 +128,13 @@ function ActiveServicesContent({
   const empty = useMemo(() => showCreateForm
     ? null
     : (
-      <DataState
-        status={DataStateStatus.allDone}
-        title={t('timeTracking:services.no_active', 'No services yet')}
-        spacing
-      />
+      <VStack className='Layer__TimeTrackingServicesDrawer__emptyState'>
+        <DataState
+          status={DataStateStatus.allDone}
+          title={t('timeTracking:services.no_active', 'No services yet')}
+          spacing
+        />
+      </VStack>
     ), [showCreateForm, t])
 
   return (
@@ -217,11 +219,13 @@ function ArchivedServicesContent({ isEnabled, formatHourly, onRestore }: Archive
         <ConditionalList
           list={archivedServices}
           Empty={(
-            <DataState
-              status={DataStateStatus.allDone}
-              title={t('timeTracking:services.no_archived', 'No archived services')}
-              spacing
-            />
+            <VStack className='Layer__TimeTrackingServicesDrawer__emptyState'>
+              <DataState
+                status={DataStateStatus.allDone}
+                title={t('timeTracking:services.no_archived', 'No archived services')}
+                spacing
+              />
+            </VStack>
           )}
           Container={({ children }) => (
             <VStack className='Layer__TimeTrackingServicesDrawer__archivedList'>{children}</VStack>

--- a/src/components/TimeEntries/TimeTrackingServicesDrawer/TimeTrackingServicesDrawer.tsx
+++ b/src/components/TimeEntries/TimeTrackingServicesDrawer/TimeTrackingServicesDrawer.tsx
@@ -128,7 +128,7 @@ function ActiveServicesContent({
   const empty = useMemo(() => showCreateForm
     ? null
     : (
-      <VStack className='Layer__TimeTrackingServicesDrawer__emptyState'>
+      <VStack className='Layer__TimeTrackingServicesDrawer__EmptyState'>
         <DataState
           status={DataStateStatus.allDone}
           title={t('timeTracking:services.no_active', 'No services yet')}
@@ -219,7 +219,7 @@ function ArchivedServicesContent({ isEnabled, formatHourly, onRestore }: Archive
         <ConditionalList
           list={archivedServices}
           Empty={(
-            <VStack className='Layer__TimeTrackingServicesDrawer__emptyState'>
+            <VStack className='Layer__TimeTrackingServicesDrawer__EmptyState'>
               <DataState
                 status={DataStateStatus.allDone}
                 title={t('timeTracking:services.no_archived', 'No archived services')}

--- a/src/components/TimeEntries/TimeTrackingServicesDrawer/timeTrackingServicesDrawer.scss
+++ b/src/components/TimeEntries/TimeTrackingServicesDrawer/timeTrackingServicesDrawer.scss
@@ -27,6 +27,14 @@
   border: 1px solid var(--border-color);
 }
 
+.Layer__TimeTrackingServicesDrawer__emptyState {
+  box-sizing: border-box;
+  overflow: hidden;
+  inline-size: 100%;
+  border-radius: var(--border-radius-2xs);
+  border: 1px solid var(--border-color);
+}
+
 .Layer__TimeTrackingServicesDrawer__accordion {
   overflow: hidden;
   border-radius: var(--border-radius-2xs);

--- a/src/components/TimeEntries/TimeTrackingServicesDrawer/timeTrackingServicesDrawer.scss
+++ b/src/components/TimeEntries/TimeTrackingServicesDrawer/timeTrackingServicesDrawer.scss
@@ -27,7 +27,7 @@
   border: 1px solid var(--border-color);
 }
 
-.Layer__TimeTrackingServicesDrawer__emptyState {
+.Layer__TimeTrackingServicesDrawer__EmptyState {
   box-sizing: border-box;
   overflow: hidden;
   inline-size: 100%;

--- a/src/components/TimeTrackingStats/TimeTrackingStats.tsx
+++ b/src/components/TimeTrackingStats/TimeTrackingStats.tsx
@@ -177,7 +177,7 @@ function TimeTrackingStatsContent({ summary }: { summary: TimeEntrySummary }) {
           <VStack className='Layer__TimeTrackingStats__Chart' gap='md' justify='center' pbs='lg'>
             <HStack className='Layer__TimeTrackingStats__ChartBar Layer__TimeTrackingStats__ChartBar--empty' />
             <Span size='sm' variant='subtle'>
-              {t('timeTracking:label.no_activity_breakdown', 'No activity this period')}
+              {t('timeTracking:label.no_activity_breakdown', 'No activity during this period')}
             </Span>
           </VStack>
         )}

--- a/src/components/TimeTrackingStats/TimeTrackingStats.tsx
+++ b/src/components/TimeTrackingStats/TimeTrackingStats.tsx
@@ -123,12 +123,16 @@ const TimeTrackingStatsBreakdown = memo(function TimeTrackingStatsBreakdown({ en
           <VStack key={key} className='Layer__TimeTrackingStats__LegendItem' gap='2xs'>
             <HStack className='Layer__TimeTrackingStats__LegendLabel' gap='2xs' align='center'>
               <TimeTrackingStatsLegendSwatch color={color} />
-              <Span size='md'>{serviceName}</Span>
+              <Span size='md' ellipsis withTooltip>{serviceName}</Span>
             </HStack>
-            <Span className='Layer__TimeTrackingStats__LegendDuration' size='xl' weight='bold'>{formatMinutesAsDuration(totalMinutes)}</Span>
-            <Span className='Layer__TimeTrackingStats__LegendPercentage' size='sm' variant='subtle'>
-              {formatPercent(percentage, { maximumFractionDigits: 0 })}
-            </Span>
+            <HStack className='Layer__TimeTrackingStats__LegendMeta' gap='2xs' align='baseline'>
+              <Span className='Layer__TimeTrackingStats__LegendDuration' size='sm'>
+                {formatMinutesAsDuration(totalMinutes)}
+              </Span>
+              <Span className='Layer__TimeTrackingStats__LegendPercentage' size='sm' variant='subtle'>
+                {formatPercent(percentage, { maximumFractionDigits: 0 })}
+              </Span>
+            </HStack>
           </VStack>
         ))}
       </HStack>
@@ -145,6 +149,10 @@ function TimeTrackingStatsContent({ summary }: { summary: TimeEntrySummary }) {
     [summary.byService, t],
   )
 
+  const totalDurationDisplay = summary.totalMinutes > 0
+    ? formatMinutesAsDuration(summary.totalMinutes)
+    : t('timeTracking:label.zero_minutes', '0 min')
+
   return (
     <VStack className='Layer__TimeTrackingStats__Content' gap='lg' pb='md' pi='md'>
       <HStack className='Layer__TimeTrackingStats__TopRow' justify='space-between' align='center' gap='md'>
@@ -156,7 +164,7 @@ function TimeTrackingStatsContent({ summary }: { summary: TimeEntrySummary }) {
           <VStack className='Layer__TimeTrackingStats__Summary' gap='3xs' pi='md'>
             <Span size='sm' variant='subtle'>{t('common:label.this_period', 'This Period')}</Span>
             <Span className='Layer__TimeTrackingStats__SummaryValue' weight='bold'>
-              {formatMinutesAsDuration(summary.totalMinutes)}
+              {totalDurationDisplay}
             </Span>
           </VStack>
         </HStack>
@@ -169,7 +177,7 @@ function TimeTrackingStatsContent({ summary }: { summary: TimeEntrySummary }) {
           <VStack className='Layer__TimeTrackingStats__Chart' gap='md' justify='center' pbs='lg'>
             <HStack className='Layer__TimeTrackingStats__ChartBar Layer__TimeTrackingStats__ChartBar--empty' />
             <Span size='sm' variant='subtle'>
-              {t('timeTracking:label.no_activity_breakdown', 'No activity breakdown available for this period.')}
+              {t('timeTracking:label.no_activity_breakdown', 'No activity this period')}
             </Span>
           </VStack>
         )}

--- a/src/components/TimeTrackingStats/timeTrackingStats.scss
+++ b/src/components/TimeTrackingStats/timeTrackingStats.scss
@@ -57,6 +57,15 @@
 
 .Layer__TimeTrackingStats__LegendItem {
   min-inline-size: 10rem;
+  max-inline-size: 10rem;
+}
+
+.Layer__TimeTrackingStats__LegendLabel {
+  min-inline-size: 0;
+
+  > .Layer__Span {
+    min-inline-size: 0;
+  }
 }
 
 .Layer__TimeTrackingStats__LegendSwatch {
@@ -120,11 +129,12 @@
 
   .Layer__TimeTrackingStats__LegendItem {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto auto;
+    grid-template-columns: minmax(0, 1fr) auto;
     row-gap: 0;
     column-gap: var(--spacing-sm);
     align-items: center;
     min-inline-size: 100%;
+    max-inline-size: none;
   }
 
   .Layer__TimeTrackingStats__LegendLabel {
@@ -137,18 +147,12 @@
     white-space: nowrap;
   }
 
+  .Layer__TimeTrackingStats__LegendMeta {
+    justify-self: end;
+  }
+
   .Layer__TimeTrackingStats__LegendDuration,
   .Layer__TimeTrackingStats__LegendPercentage {
     white-space: nowrap;
-  }
-
-  .Layer__TimeTrackingStats__LegendDuration {
-    justify-self: end;
-  }
-
-  .Layer__TimeTrackingStats__LegendPercentage {
-    justify-self: end;
-    min-inline-size: 2.25rem;
-    text-align: right;
   }
 }

--- a/src/components/ui/Stack/Stack.tsx
+++ b/src/components/ui/Stack/Stack.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type PropsWithChildren } from 'react'
+import { type AriaRole, forwardRef, type PropsWithChildren } from 'react'
 import classNames from 'classnames'
 
 import { toDataProperties } from '@utils/styleUtils/toDataProperties'
@@ -20,6 +20,7 @@ export type StackProps = PropsWithChildren<{
   fluid?: boolean
   slot?: string
   className?: string
+  role?: AriaRole
 }>
 
 type InternalStackProps = StackProps & {

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStopTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStopTimeTracker.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
+import { type StopTrackerEncoded } from '@schemas/timeTracking'
 import { post } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
@@ -20,10 +21,11 @@ const StopTimeTrackerResponseSchema = Schema.Struct({
 })
 
 type StopTimeTrackerResponse = typeof StopTimeTrackerResponseSchema.Type
+type StopTimeTrackerBody = StopTrackerEncoded
 
 const stopTimeTracker = post<
   StopTimeTrackerResponse,
-  Record<string, never>,
+  StopTimeTrackerBody,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/time-tracking/tracker/stop`)
 
@@ -59,11 +61,12 @@ export const useStopTimeTracker = () => {
       ...data,
       businessId,
     })),
-    ({ accessToken, apiUrl, businessId }) => stopTimeTracker(
+    ({ accessToken, apiUrl, businessId }, { arg: body }: { arg: StopTimeTrackerBody }) => stopTimeTracker(
       apiUrl,
       accessToken,
       {
         params: { businessId },
+        body,
       },
     ).then(Schema.decodeUnknownPromise(StopTimeTrackerResponseSchema)),
     {

--- a/src/hooks/features/timeTracking/useActiveTimerBannerForm.ts
+++ b/src/hooks/features/timeTracking/useActiveTimerBannerForm.ts
@@ -62,7 +62,7 @@ export const useActiveTimerBannerForm = ({ activeEntry }: UseActiveTimerBannerFo
         setActionError(
           t(
             'timeTracking:error.complete_timer_stale',
-            'This timer was already completed. Reload the page.',
+            'This timer was already completed or cancelled. Reload the page.',
           ),
         )
       }

--- a/src/hooks/features/timeTracking/useActiveTimerBannerForm.ts
+++ b/src/hooks/features/timeTracking/useActiveTimerBannerForm.ts
@@ -4,6 +4,7 @@ import { useStore } from '@tanstack/react-form'
 import { useTranslation } from 'react-i18next'
 
 import { type TimeEntry } from '@schemas/timeTracking'
+import { APIError } from '@utils/api/apiError'
 import { type ActiveTimerDraft, type ActiveTimerDraftWithService, getDraftFromEntry, hasDraftChanges, toUpdatePayload } from '@utils/timeTracking/activeTimerDraft'
 import { useDeleteTimeEntry } from '@hooks/api/businesses/[business-id]/time-tracking/time-entries/[time-entry-id]/useDeleteTimeEntry'
 import { UpsertTimeEntryMode, useUpsertTimeEntry } from '@hooks/api/businesses/[business-id]/time-tracking/time-entries/useUpsertTimeEntry'
@@ -14,6 +15,14 @@ import { useDebounce } from '@hooks/utils/debouncing/useDebounce'
 
 type UseActiveTimerBannerFormProps = {
   activeEntry: TimeEntry
+}
+
+const isNoActiveTimerResponse = (error: unknown) => {
+  if (!(error instanceof APIError)) return false
+  if (error.code === 404) return true
+  return error.messages?.some(
+    m => m.type === 'ResourceNotFound' || m.description === 'No active timer found',
+  ) === true
 }
 
 export const useActiveTimerBannerForm = ({ activeEntry }: UseActiveTimerBannerFormProps) => {
@@ -48,8 +57,18 @@ export const useActiveTimerBannerForm = ({ activeEntry }: UseActiveTimerBannerFo
     try {
       await stopTimeTracker({ date: today(getLocalTimeZone()).toString() })
     }
-    catch {
-      setActionError(t('timeTracking:error.complete_timer', 'Failed to complete timer. Please try again.'))
+    catch (error) {
+      if (isNoActiveTimerResponse(error)) {
+        setActionError(
+          t(
+            'timeTracking:error.complete_timer_stale',
+            'This timer was already completed. Reload the page.',
+          ),
+        )
+      }
+      else {
+        setActionError(t('timeTracking:error.complete_timer', 'Failed to complete timer. Please try again.'))
+      }
     }
   }, [activeEntry, stopTimeTracker, t, updateTimeEntry])
 

--- a/src/hooks/features/timeTracking/useActiveTimerBannerForm.ts
+++ b/src/hooks/features/timeTracking/useActiveTimerBannerForm.ts
@@ -4,7 +4,7 @@ import { useStore } from '@tanstack/react-form'
 import { useTranslation } from 'react-i18next'
 
 import { type TimeEntry } from '@schemas/timeTracking'
-import { APIError } from '@utils/api/apiError'
+import { ApiEnumErrorType, APIError } from '@utils/api/apiError'
 import { type ActiveTimerDraft, type ActiveTimerDraftWithService, getDraftFromEntry, hasDraftChanges, toUpdatePayload } from '@utils/timeTracking/activeTimerDraft'
 import { useDeleteTimeEntry } from '@hooks/api/businesses/[business-id]/time-tracking/time-entries/[time-entry-id]/useDeleteTimeEntry'
 import { UpsertTimeEntryMode, useUpsertTimeEntry } from '@hooks/api/businesses/[business-id]/time-tracking/time-entries/useUpsertTimeEntry'
@@ -21,7 +21,7 @@ const isNoActiveTimerResponse = (error: unknown) => {
   if (!(error instanceof APIError)) return false
   if (error.code === 404) return true
   return error.messages?.some(
-    m => m.type === 'ResourceNotFound' || m.description === 'No active timer found',
+    m => m.error_enum === ApiEnumErrorType.SpecifiedIdNotFound,
   ) === true
 }
 

--- a/src/hooks/features/timeTracking/useActiveTimerBannerForm.ts
+++ b/src/hooks/features/timeTracking/useActiveTimerBannerForm.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { getLocalTimeZone, today } from '@internationalized/date'
 import { useStore } from '@tanstack/react-form'
 import { useTranslation } from 'react-i18next'
 
@@ -45,7 +46,7 @@ export const useActiveTimerBannerForm = ({ activeEntry }: UseActiveTimerBannerFo
     }
 
     try {
-      await stopTimeTracker()
+      await stopTimeTracker({ date: today(getLocalTimeZone()).toString() })
     }
     catch {
       setActionError(t('timeTracking:error.complete_timer', 'Failed to complete timer. Please try again.'))

--- a/src/hooks/features/timeTracking/useStartTimerForm.ts
+++ b/src/hooks/features/timeTracking/useStartTimerForm.ts
@@ -1,12 +1,20 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { ApiEnumErrorType, APIError } from '@utils/api/apiError'
 import { type ActiveTimerDraft, EMPTY_DRAFT, toStartPayload } from '@utils/timeTracking/activeTimerDraft'
 import { useStartTimeTracker } from '@hooks/api/businesses/[business-id]/time-tracking/tracker/useStartTimeTracker'
 import { useAppForm } from '@hooks/features/forms/useForm'
 
 type UseStartTimerFormProps = {
   onStarted: () => void
+}
+
+const isActiveTimerAlreadyExistsError = (error: unknown) => {
+  if (!(error instanceof APIError)) return false
+  return error.messages?.some(
+    m => m.error_enum === ApiEnumErrorType.SpecifiedBadRequest,
+  ) === true
 }
 
 export const useStartTimerForm = ({ onStarted }: UseStartTimerFormProps) => {
@@ -34,8 +42,13 @@ export const useStartTimerForm = ({ onStarted }: UseStartTimerFormProps) => {
       formApi.reset(EMPTY_DRAFT)
       onStarted()
     }
-    catch {
-      setActionError(t('timeTracking:error.start_timer', 'Failed to start timer. Please try again.'))
+    catch (error) {
+      if (isActiveTimerAlreadyExistsError(error)) {
+        setActionError(t('timeTracking:error.start_timer_already_active', 'A timer is already running. Please reload the page.'))
+      }
+      else {
+        setActionError(t('timeTracking:error.start_timer', 'Failed to start timer. Please try again.'))
+      }
     }
   }, [onStarted, startTimeTracker, t])
 

--- a/src/schemas/timeTracking.ts
+++ b/src/schemas/timeTracking.ts
@@ -206,8 +206,15 @@ export const StartTrackerSchema = Schema.Struct({
   metadata: Schema.NullishOr(Schema.Unknown),
 })
 
+export const StopTrackerSchema = Schema.Struct({
+  date: CalendarDateSchema,
+})
+
 export type UpsertTimeEntry = typeof UpsertTimeEntrySchema.Type
 export type UpsertTimeEntryEncoded = typeof UpsertTimeEntrySchema.Encoded
 
 export type StartTracker = typeof StartTrackerSchema.Type
 export type StartTrackerEncoded = typeof StartTrackerSchema.Encoded
+
+export type StopTracker = typeof StopTrackerSchema.Type
+export type StopTrackerEncoded = typeof StopTrackerSchema.Encoded

--- a/src/utils/api/apiError.ts
+++ b/src/utils/api/apiError.ts
@@ -1,6 +1,13 @@
+export const ApiEnumErrorType = {
+  SpecifiedIdNotFound: 'SpecifiedIdNotFound',
+  SpecifiedBadRequest: 'SpecifiedBadRequest',
+} as const
+export type ApiEnumErrorType = typeof ApiEnumErrorType[keyof typeof ApiEnumErrorType]
+
 export type APIErrorMessage = {
   type?: string
   description?: string
+  error_enum?: ApiEnumErrorType
 }
 
 export class APIError extends Error {


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the stop-tracker API mutation to send a dated payload and adds client-side branching on specific API error enums, which could affect timer start/stop behavior if the backend contract differs. Remaining updates are mostly UI/UX polish (labels, styling, icons) with low functional risk.
> 
> **Overview**
> Fixes several time-tracking edge cases and improves the UX around timers, services, and stats.
> 
> The active timer completion flow now posts a `date` body when stopping the tracker, and surfaces a dedicated *stale timer* error when the active timer is already gone; starting a timer now shows a specific message when a timer is already running. The active timer banner error presentation was redesigned into an inline alert strip, and the complete button is disabled while stop/update operations are in flight.
> 
> Service and reporting UI received polish: the time entries service filter can include archived services, archived services are labeled as such in the selector, and the “create service” option is rendered with an icon. Time tracking stats now display `0 min` for empty periods, adjust the empty-state copy, and tighten legend layout/ellipsis behavior; several buttons/icons and empty states were restyled for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7417a6dae9916201715fa41a6fd2697862219184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->