### PR TITLE
Taylor/embedded onboarding/UI fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,18 +15,25 @@
   - **`useCallback`**: Only for functions passed as props to `memo()`-wrapped children or used in Hook dependency arrays. Not needed for handlers on plain HTML elements.
   - **`useMemo`**: Only when (a) the computation is expensive (>1ms), (b) the result is an object/array prop to a `memo()`-wrapped child, or (c) the result is used in a Hook dependency array. Never memoize primitives.
 
+# CSS Styles
+
+- Do not use the `style` prop or write raw utility/atomic class strings in `className`
+- Do not re-state styles the target component or its parent stack already set
+- Use design-system props exposed by components instead of a new declaration. For any styling that component props can't express, add a BEM class in PascalCase: `Layer__ComponentName__Element--modifier`
+- Put component rules in a side-effect imported `.scss` file with camelCased component name: `componentName.scss`
+- Use the following spacing scale: (`4xs|3xs|2xs|xs|sm|md|lg|xl|2xl|3xl|5xl`)
+
+## CSS Selectors
+
+- Nest selectors that share a block prefix under one `&__` root; do not nest more than one level (excluding pseudo-classes, pseudo-elements, and media queries): `.Layer__<ComponentName> { &__Element { … } }`
+- Only use descendant combinator selectors when the element can't own a class.
+- Do not target another component's internal classes. Instead, add a prop or exposed class to that component
+
 # Components
 
 - Use `Span` from `@ui/Typography/Text` instead of `<span>`
 - Use `<HStack>` and `<VStack>` from `@ui/Stack/Stack` instead of `<div>`
 - Build on existing components in `@ui` before creating new ones
-
-# Style
-
-- Do not use inline styles
-- Create `.scss` file matching component name but with lowercase first letter and import directly
-- Use design system spacing scale
-- For css class names, use BEM in PascalCase
 
 # Abstractions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,25 +15,18 @@
   - **`useCallback`**: Only for functions passed as props to `memo()`-wrapped children or used in Hook dependency arrays. Not needed for handlers on plain HTML elements.
   - **`useMemo`**: Only when (a) the computation is expensive (>1ms), (b) the result is an object/array prop to a `memo()`-wrapped child, or (c) the result is used in a Hook dependency array. Never memoize primitives.
 
-# CSS Styles
-
-- Do not use the `style` prop or write raw utility/atomic class strings in `className`
-- Do not re-state styles the target component or its parent stack already set
-- Use design-system props exposed by components instead of a new declaration. For any styling that component props can't express, add a BEM class in PascalCase: `Layer__ComponentName__Element--modifier`
-- Put component rules in a side-effect imported `.scss` file with camelCased component name: `componentName.scss`
-- Use the following spacing scale: (`4xs|3xs|2xs|xs|sm|md|lg|xl|2xl|3xl|5xl`)
-
-## CSS Selectors
-
-- Nest selectors that share a block prefix under one `&__` root; do not nest more than one level (excluding pseudo-classes, pseudo-elements, and media queries): `.Layer__<ComponentName> { &__Element { … } }`
-- Only use descendant combinator selectors when the element can't own a class.
-- Do not target another component's internal classes. Instead, add a prop or exposed class to that component
-
 # Components
 
 - Use `Span` from `@ui/Typography/Text` instead of `<span>`
 - Use `<HStack>` and `<VStack>` from `@ui/Stack/Stack` instead of `<div>`
 - Build on existing components in `@ui` before creating new ones
+
+# Style
+
+- Do not use inline styles
+- Create `.scss` file matching component name but with lowercase first letter and import directly
+- Use design system spacing scale
+- For css class names, use BEM in PascalCase
 
 # Abstractions
 

--- a/src/assets/locales/en-US/callBookings.json
+++ b/src/assets/locales/en-US/callBookings.json
@@ -33,9 +33,6 @@
     "call_in_count_days_other": "in {{displayCount}} days",
     "call_in_count_hours_one": "in {{displayCount}} hour",
     "call_in_count_hours_other": "in {{displayCount}} hours",
-    "call_in_count_minutes_one": "in {{displayCount}} minute",
-    "call_in_count_minutes_other": "in {{displayCount}} minutes",
-    "in_progress": "in progress",
     "starting_soon": "starting soon"
   }
 }

--- a/src/assets/locales/en-US/callBookings.json
+++ b/src/assets/locales/en-US/callBookings.json
@@ -8,6 +8,9 @@
   "label": {
     "ad_hoc_call": "Ad hoc call",
     "book_call_with_bookkeeper": "Book a call with your bookkeeper",
+    "cover_accounts_and_documents": "Connect your accounts and documents",
+    "cover_business_and_books": "Walk through your business and books",
+    "cover_first_month_expectations": "Set expectations for our first month",
     "date": "Date",
     "date_colon": "Date:",
     "google_calendar": "Google Calendar",
@@ -19,9 +22,20 @@
     "purpose": "Purpose",
     "purpose_colon": "Purpose:",
     "upcoming_call": "Upcoming Call",
+    "what_well_cover": "What we'll cover",
     "yahoo_calendar": "Yahoo Calendar"
   },
   "prompt": {
     "ready_to_get_started": "Ready to get started?"
+  },
+  "state": {
+    "call_in_count_days_one": "in {{displayCount}} day",
+    "call_in_count_days_other": "in {{displayCount}} days",
+    "call_in_count_hours_one": "in {{displayCount}} hour",
+    "call_in_count_hours_other": "in {{displayCount}} hours",
+    "call_in_count_minutes_one": "in {{displayCount}} minute",
+    "call_in_count_minutes_other": "in {{displayCount}} minutes",
+    "in_progress": "in progress",
+    "starting_soon": "starting soon"
   }
 }

--- a/src/assets/locales/fr-CA/callBookings.json
+++ b/src/assets/locales/fr-CA/callBookings.json
@@ -8,6 +8,9 @@
   "label": {
     "ad_hoc_call": "Appel ponctuel",
     "book_call_with_bookkeeper": "Réservez un appel avec votre teneur de livres",
+    "cover_accounts_and_documents": "",
+    "cover_business_and_books": "",
+    "cover_first_month_expectations": "",
     "date": "Date",
     "date_colon": "Date :",
     "google_calendar": "Google Calendar",
@@ -19,9 +22,20 @@
     "purpose": "Objet",
     "purpose_colon": "Objet :",
     "upcoming_call": "Appel à venir",
+    "what_well_cover": "",
     "yahoo_calendar": "Yahoo Calendar"
   },
   "prompt": {
     "ready_to_get_started": ""
+  },
+  "state": {
+    "call_in_count_days_one": "",
+    "call_in_count_days_other": "",
+    "call_in_count_hours_one": "",
+    "call_in_count_hours_other": "",
+    "call_in_count_minutes_one": "",
+    "call_in_count_minutes_other": "",
+    "in_progress": "",
+    "starting_soon": ""
   }
 }

--- a/src/assets/locales/fr-CA/callBookings.json
+++ b/src/assets/locales/fr-CA/callBookings.json
@@ -33,9 +33,6 @@
     "call_in_count_days_other": "",
     "call_in_count_hours_one": "",
     "call_in_count_hours_other": "",
-    "call_in_count_minutes_one": "",
-    "call_in_count_minutes_other": "",
-    "in_progress": "",
     "starting_soon": ""
   }
 }

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -109,10 +109,10 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
     }
   })()
   const timeLabel = formatDate(callBooking.eventStartAt, DateFormat.MonthDayWithTimeReadable)
-  const whatWeWillCoverItems = [
-    t('callBookings:label.cover_business_and_books', 'Walk through your business and books'),
-    t('callBookings:label.cover_accounts_and_documents', 'Connect your accounts and documents'),
-    t('callBookings:label.cover_first_month_expectations', 'Set expectations for our first month'),
+  const whatWeWillCoverItems: Array<[string, string]> = [
+    ['business_and_books', t('callBookings:label.cover_business_and_books', 'Walk through your business and books')],
+    ['accounts_and_documents', t('callBookings:label.cover_accounts_and_documents', 'Connect your accounts and documents')],
+    ['first_month_expectations', t('callBookings:label.cover_first_month_expectations', 'Set expectations for our first month')],
   ]
 
   return (
@@ -169,9 +169,9 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
             {t('callBookings:label.what_well_cover', 'What we\'ll cover')}
           </Span>
           <VStack role='list' gap='xs'>
-            {whatWeWillCoverItems.map(item => (
+            {whatWeWillCoverItems.map(([key, label]) => (
               <HStack
-                key={item}
+                key={key}
                 className='Layer__CallBooking__CoverageItem'
                 align='start'
                 gap='sm'
@@ -181,7 +181,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
                   <Check size={12} strokeWidth={2.5} />
                 </Span>
                 <Span size='sm' className='Layer__CallBooking__CoverageText'>
-                  {item}
+                  {label}
                 </Span>
               </HStack>
             ))}

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -83,9 +83,9 @@ const OnboardingCallCoverage = () => {
               gap='sm'
               role='listitem'
             >
-              <Span nonAria className='Layer__CallBooking__CoverageBadge'>
+              <HStack className='Layer__CallBooking__CoverageBadge' align='center' justify='center'>
                 <Check size={12} strokeWidth={2.5} />
-              </Span>
+              </HStack>
               <Span size='sm' className='Layer__CallBooking__CoverageText'>
                 {t(translationKey, defaultLabel)}
               </Span>
@@ -143,7 +143,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
               {subtitle}
             </Span>
             <VStack gap='xs' pbs='sm'>
-              <HStack className='Layer__CallBooking__LocationRow' align='center' gap='sm'>
+              <HStack className='Layer__CallBooking__LocationRow' align='center' gap='sm' pb='xs' pi='sm'>
                 <Video size={14} />
                 <Span size='sm' className='Layer__CallBooking__LocationLabel'>
                   {callPlatform}

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 
 import { type CallBooking as CallBookingData, CallBookingPurpose, CallBookingType } from '@schemas/callBooking'
 import { DateFormat } from '@utils/i18n/date/patterns'
-import { tPlural } from '@utils/i18n/plural'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { Button } from '@ui/Button/Button'
 import { LinkButton } from '@ui/Button/LinkButton'
@@ -15,14 +14,12 @@ import { Container } from '@components/Container/Container'
 
 import './callBooking.scss'
 
+import { useCallBookingCountdownLabel } from './useCallBookingCountdownLabel'
+
 export interface CallBookingProps {
   callBooking?: CallBookingData
   onBookCall?: () => void
 }
-
-type CountdownDescriptor =
-  | { kind: 'days' | 'hours', value: number }
-  | { kind: 'startingSoon' | 'none' }
 
 const EmptyState = ({ onBookCall }: { onBookCall?: () => void }) => {
   const { t } = useTranslation()
@@ -42,34 +39,55 @@ const EmptyState = ({ onBookCall }: { onBookCall?: () => void }) => {
   )
 }
 
-const getCountdownDescriptor = (now: number, startAt: Date): CountdownDescriptor => {
-  const startTime = startAt.getTime()
+const OnboardingCallCoverage = () => {
+  const { t } = useTranslation()
+  const whatWeWillCoverItems: Array<[string, string]> = [
+    ['business_and_books', t('callBookings:label.cover_business_and_books', 'Walk through your business and books')],
+    ['accounts_and_documents', t('callBookings:label.cover_accounts_and_documents', 'Connect your accounts and documents')],
+    ['first_month_expectations', t('callBookings:label.cover_first_month_expectations', 'Set expectations for our first month')],
+  ]
 
-  if (now >= startTime) {
-    return { kind: 'none' }
-  }
+  return (
+    <>
+      <Span nonAria className='Layer__CallBooking__Divider' />
 
-  const millisecondsUntilStart = startTime - now
-
-  if (millisecondsUntilStart < 60 * 60 * 1000) {
-    return { kind: 'startingSoon' }
-  }
-
-  const hoursUntilStart = millisecondsUntilStart / (60 * 60 * 1000)
-
-  if (hoursUntilStart < 24) {
-    return { kind: 'hours', value: Math.floor(hoursUntilStart) }
-  }
-
-  return {
-    kind: 'days',
-    value: Math.floor(millisecondsUntilStart / (24 * 60 * 60 * 1000)),
-  }
+      <VStack pbe='md'>
+        <Span
+          nonAria
+          size='2xs'
+          variant='subtle'
+          pbe='sm'
+          className='Layer__CallBooking__CoverageEyebrow'
+        >
+          {t('callBookings:label.what_well_cover', 'What we\'ll cover')}
+        </Span>
+        <VStack role='list' gap='xs'>
+          {whatWeWillCoverItems.map(([key, label]) => (
+            <HStack
+              key={key}
+              className='Layer__CallBooking__CoverageItem'
+              align='start'
+              gap='sm'
+              role='listitem'
+            >
+              <Span nonAria className='Layer__CallBooking__CoverageBadge'>
+                <Check size={12} strokeWidth={2.5} />
+              </Span>
+              <Span size='sm' className='Layer__CallBooking__CoverageText'>
+                {label}
+              </Span>
+            </HStack>
+          ))}
+        </VStack>
+      </VStack>
+    </>
+  )
 }
 
 export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
   const { t } = useTranslation()
   const { formatDate } = useIntlFormatter()
+  const countdownLabel = useCallBookingCountdownLabel(callBooking?.eventStartAt)
 
   if (callBooking == null) {
     return (
@@ -86,35 +104,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
   const subtitle = t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team')
   const callPlatform = callBooking.callType === CallBookingType.ZOOM ? 'Zoom' : 'Google Meet'
   const callLink = callBooking.callLink.toString()
-  const countdownDescriptor = getCountdownDescriptor(Date.now(), callBooking.eventStartAt)
-  const countdownLabel = (() => {
-    switch (countdownDescriptor.kind) {
-      case 'days':
-        return tPlural(t, 'callBookings:state.call_in_count_days', {
-          count: countdownDescriptor.value,
-          displayCount: countdownDescriptor.value,
-          one: 'in {{displayCount}} day',
-          other: 'in {{displayCount}} days',
-        })
-      case 'hours':
-        return tPlural(t, 'callBookings:state.call_in_count_hours', {
-          count: countdownDescriptor.value,
-          displayCount: countdownDescriptor.value,
-          one: 'in {{displayCount}} hour',
-          other: 'in {{displayCount}} hours',
-        })
-      case 'startingSoon':
-        return t('callBookings:state.starting_soon', 'starting soon')
-      case 'none':
-        return ''
-    }
-  })()
   const timeLabel = formatDate(callBooking.eventStartAt, DateFormat.MonthDayWithTimeReadable)
-  const whatWeWillCoverItems: Array<[string, string]> = [
-    ['business_and_books', t('callBookings:label.cover_business_and_books', 'Walk through your business and books')],
-    ['accounts_and_documents', t('callBookings:label.cover_accounts_and_documents', 'Connect your accounts and documents')],
-    ['first_month_expectations', t('callBookings:label.cover_first_month_expectations', 'Set expectations for our first month')],
-  ]
 
   return (
     <Container name='CallBooking'>
@@ -157,41 +147,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
           </Span>
         </HStack>
 
-        {isOnboardingCall && (
-          <>
-            <Span nonAria className='Layer__CallBooking__Divider' />
-
-            <VStack pbe='md'>
-              <Span
-                nonAria
-                size='2xs'
-                variant='subtle'
-                pbe='sm'
-                className='Layer__CallBooking__CoverageEyebrow'
-              >
-                {t('callBookings:label.what_well_cover', 'What we\'ll cover')}
-              </Span>
-              <VStack role='list' gap='xs'>
-                {whatWeWillCoverItems.map(([key, label]) => (
-                  <HStack
-                    key={key}
-                    className='Layer__CallBooking__CoverageItem'
-                    align='start'
-                    gap='sm'
-                    role='listitem'
-                  >
-                    <Span nonAria className='Layer__CallBooking__CoverageBadge'>
-                      <Check size={12} strokeWidth={2.5} />
-                    </Span>
-                    <Span size='sm' className='Layer__CallBooking__CoverageText'>
-                      {label}
-                    </Span>
-                  </HStack>
-                ))}
-              </VStack>
-            </VStack>
-          </>
-        )}
+        {isOnboardingCall && <OnboardingCallCoverage />}
 
         <HStack className='Layer__CallBooking__ActionRow' align='center' gap='xs'>
           <HStack className='Layer__CallBooking__JoinAction'>

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -63,7 +63,7 @@ const getCountdownDescriptor = (now: number, startAt: Date): CountdownDescriptor
 
   return {
     kind: 'days',
-    value: Math.ceil(millisecondsUntilStart / (24 * 60 * 60 * 1000)),
+    value: Math.floor(millisecondsUntilStart / (24 * 60 * 60 * 1000)),
   }
 }
 
@@ -79,7 +79,8 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
     )
   }
 
-  const purpose = callBooking.purpose === CallBookingPurpose.BOOKKEEPING_ONBOARDING
+  const isOnboardingCall = callBooking.purpose === CallBookingPurpose.BOOKKEEPING_ONBOARDING
+  const purpose = isOnboardingCall
     ? t('callBookings:label.onboarding_call', 'Onboarding call')
     : t('callBookings:label.ad_hoc_call', 'Ad hoc call')
   const subtitle = t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team')
@@ -156,37 +157,41 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
           </Span>
         </HStack>
 
-        <Span nonAria className='Layer__CallBooking__Divider' />
+        {isOnboardingCall && (
+          <>
+            <Span nonAria className='Layer__CallBooking__Divider' />
 
-        <VStack pbe='md'>
-          <Span
-            nonAria
-            size='2xs'
-            variant='subtle'
-            pbe='sm'
-            className='Layer__CallBooking__CoverageEyebrow'
-          >
-            {t('callBookings:label.what_well_cover', 'What we\'ll cover')}
-          </Span>
-          <VStack role='list' gap='xs'>
-            {whatWeWillCoverItems.map(([key, label]) => (
-              <HStack
-                key={key}
-                className='Layer__CallBooking__CoverageItem'
-                align='start'
-                gap='sm'
-                role='listitem'
+            <VStack pbe='md'>
+              <Span
+                nonAria
+                size='2xs'
+                variant='subtle'
+                pbe='sm'
+                className='Layer__CallBooking__CoverageEyebrow'
               >
-                <Span nonAria className='Layer__CallBooking__CoverageBadge'>
-                  <Check size={12} strokeWidth={2.5} />
-                </Span>
-                <Span size='sm' className='Layer__CallBooking__CoverageText'>
-                  {label}
-                </Span>
-              </HStack>
-            ))}
-          </VStack>
-        </VStack>
+                {t('callBookings:label.what_well_cover', 'What we\'ll cover')}
+              </Span>
+              <VStack role='list' gap='xs'>
+                {whatWeWillCoverItems.map(([key, label]) => (
+                  <HStack
+                    key={key}
+                    className='Layer__CallBooking__CoverageItem'
+                    align='start'
+                    gap='sm'
+                    role='listitem'
+                  >
+                    <Span nonAria className='Layer__CallBooking__CoverageBadge'>
+                      <Check size={12} strokeWidth={2.5} />
+                    </Span>
+                    <Span size='sm' className='Layer__CallBooking__CoverageText'>
+                      {label}
+                    </Span>
+                  </HStack>
+                ))}
+              </VStack>
+            </VStack>
+          </>
+        )}
 
         <HStack className='Layer__CallBooking__ActionRow' align='center' gap='xs'>
           <HStack className='Layer__CallBooking__JoinAction'>

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -118,11 +118,11 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
   return (
     <Container name='CallBooking'>
       <VStack pi='lg' pb='lg'>
-        <HStack className='Layer__CallBooking__HeaderRow' align='start'>
+        <HStack className='Layer__CallBooking__HeaderRow' align='start' gap='xl'>
           <VStack className='Layer__CallBooking__DateColumn'>
             <DateTile date={callBooking.eventStartAt} />
           </VStack>
-          <VStack className='Layer__CallBooking__HeaderDetails' pbs='3xs'>
+          <VStack className='Layer__CallBooking__HeaderDetails' fluid pbs='3xs'>
             <HStack className='Layer__CallBooking__TitleRow' align='baseline' gap='xs'>
               <Heading size='xs' className='Layer__CallBooking__Title'>
                 {purpose}
@@ -139,7 +139,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
               {subtitle}
             </Span>
             <VStack gap='xs' pbs='sm'>
-              <HStack className='Layer__CallBooking__LocationRow' align='center'>
+              <HStack className='Layer__CallBooking__LocationRow' align='center' gap='sm'>
                 <Video size={14} />
                 <Span size='sm' className='Layer__CallBooking__LocationLabel'>
                   {callPlatform}
@@ -149,7 +149,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
           </VStack>
         </HStack>
 
-        <HStack className='Layer__CallBooking__DateTimeRow' align='center'>
+        <HStack className='Layer__CallBooking__DateTimeRow' align='center' gap='sm' pbs='md'>
           <Clock3 size={16} strokeWidth={2} />
           <Span nonAria noWrap className='Layer__CallBooking__TimeLabel'>
             {timeLabel}
@@ -163,6 +163,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
             nonAria
             size='2xs'
             variant='subtle'
+            pbe='sm'
             className='Layer__CallBooking__CoverageEyebrow'
           >
             {t('callBookings:label.what_well_cover', 'What we\'ll cover')}
@@ -173,6 +174,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
                 key={item}
                 className='Layer__CallBooking__CoverageItem'
                 align='start'
+                gap='sm'
                 role='listitem'
               >
                 <Span nonAria className='Layer__CallBooking__CoverageBadge'>

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -80,7 +80,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
           <VStack
             className='Layer__CallBooking__MetaColumn'
             align='center'
-            gap='md'
+            gap='sm'
           >
             <HStack className='Layer__CallBooking__DetailRow'>
               <Video size={16} color='var(--color-base-500)' />

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -117,7 +117,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
 
   return (
     <Container name='CallBooking'>
-      <VStack className='Layer__CallBooking__Content'>
+      <VStack pi='lg' pb='lg'>
         <HStack className='Layer__CallBooking__HeaderRow' align='start'>
           <VStack className='Layer__CallBooking__DateColumn'>
             <DateTile date={callBooking.eventStartAt} />

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -69,6 +69,7 @@ const OnboardingCallCoverage = () => {
           nonAria
           size='2xs'
           variant='subtle'
+          weight='bold'
           pbe='sm'
           className='Layer__CallBooking__CoverageHeading'
         >
@@ -83,10 +84,14 @@ const OnboardingCallCoverage = () => {
               gap='sm'
               role='listitem'
             >
-              <HStack className='Layer__CallBooking__CoverageBadge' align='center' justify='center'>
+              <HStack
+                className='Layer__CallBooking__CoverageBadge'
+                align='center'
+                justify='center'
+              >
                 <Check size={12} strokeWidth={2.5} />
               </HStack>
-              <Span size='sm' className='Layer__CallBooking__CoverageText'>
+              <Span size='sm'>
                 {t(translationKey, defaultLabel)}
               </Span>
             </HStack>
@@ -123,12 +128,10 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
     <Container name='CallBooking'>
       <VStack pi='lg' pb='lg'>
         <HStack className='Layer__CallBooking__HeaderRow' align='start' gap='xl'>
-          <VStack className='Layer__CallBooking__DateColumn'>
-            <DateTile date={callBooking.eventStartAt} />
-          </VStack>
+          <DateTile date={callBooking.eventStartAt} />
           <VStack className='Layer__CallBooking__HeaderDetails' fluid pbs='3xs'>
             <HStack className='Layer__CallBooking__TitleRow' align='baseline' gap='xs'>
-              <Heading size='xs' className='Layer__CallBooking__Title'>
+              <Heading size='sm'>
                 {purpose}
               </Heading>
               {countdownLabel && (
@@ -139,13 +142,19 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
                 </Span>
               )}
             </HStack>
-            <Span size='sm' variant='subtle' className='Layer__CallBooking__Subtitle'>
+            <Span size='sm' variant='subtle' pbs='3xs'>
               {subtitle}
             </Span>
-            <VStack gap='xs' pbs='sm'>
-              <HStack className='Layer__CallBooking__LocationRow' align='center' gap='sm' pb='xs' pi='sm'>
+            <VStack gap='xs' align='start' pbs='sm'>
+              <HStack
+                className='Layer__CallBooking__LocationRow'
+                align='center'
+                gap='sm'
+                pb='xs'
+                pi='sm'
+              >
                 <Video size={14} />
-                <Span size='sm' className='Layer__CallBooking__LocationLabel'>
+                <Span size='sm' weight='bold' variant='placeholder'>
                   {callPlatform}
                 </Span>
               </HStack>
@@ -155,16 +164,16 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
 
         <HStack className='Layer__CallBooking__DateTimeRow' align='center' gap='sm' pbs='md'>
           <Clock3 size={16} strokeWidth={2} />
-          <Span nonAria noWrap className='Layer__CallBooking__TimeLabel'>
+          <Span nonAria noWrap size='lg' weight='bold'>
             {timeLabel}
           </Span>
         </HStack>
 
         {isOnboardingCall && <OnboardingCallCoverage />}
 
-        <HStack className='Layer__CallBooking__ActionRow' align='center' gap='xs'>
+        <HStack align='center' gap='xs'>
           <HStack className='Layer__CallBooking__JoinAction'>
-            <LinkButton href={callLink} external variant='solid'>
+            <LinkButton href={callLink} external variant='solid' fullWidth>
               <Video size={15} />
               {t('callBookings:action.join_call', 'Join call')}
             </LinkButton>

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -62,11 +62,10 @@ const OnboardingCallCoverage = () => {
 
   return (
     <>
-      <Span nonAria className='Layer__CallBooking__Divider' />
+      <Span className='Layer__CallBooking__Divider' />
 
       <VStack pbe='md'>
         <Span
-          nonAria
           size='2xs'
           variant='subtle'
           weight='bold'
@@ -135,7 +134,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
                 {purpose}
               </Heading>
               {countdownLabel && (
-                <Span nonAria size='xs' variant='subtle'>
+                <Span size='xs' variant='subtle'>
                   ·
                   {' '}
                   {countdownLabel}
@@ -164,7 +163,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
 
         <HStack className='Layer__CallBooking__DateTimeRow' align='center' gap='sm' pbs='md'>
           <Clock3 size={16} strokeWidth={2} />
-          <Span nonAria noWrap size='lg' weight='bold'>
+          <Span noWrap size='lg' weight='bold'>
             {timeLabel}
           </Span>
         </HStack>

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -1,9 +1,9 @@
-import { Clock, Link as LinkIcon, Users, Video } from 'lucide-react'
+import { Check, Clock3, Video } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { useIntl } from 'react-intl'
 
 import { type CallBooking as CallBookingData, CallBookingPurpose, CallBookingType } from '@schemas/callBooking'
-import { DateFormat } from '@utils/i18n/date/patterns'
-import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { tPlural } from '@utils/i18n/plural'
 import { Button } from '@ui/Button/Button'
 import { LinkButton } from '@ui/Button/LinkButton'
 import { HStack, VStack } from '@ui/Stack/Stack'
@@ -17,6 +17,12 @@ export interface CallBookingProps {
   callBooking?: CallBookingData
   onBookCall?: () => void
 }
+
+type CountdownDescriptor =
+  | { kind: 'days' | 'hours', value: number }
+  | { kind: 'startingSoon' | 'inProgress' | 'none' }
+
+const DEFAULT_CALL_DURATION_MS = 30 * 60 * 1000
 
 const EmptyState = ({ onBookCall }: { onBookCall?: () => void }) => {
   const { t } = useTranslation()
@@ -36,9 +42,43 @@ const EmptyState = ({ onBookCall }: { onBookCall?: () => void }) => {
   )
 }
 
+const getEffectiveEndAt = (startAt: Date, endAt?: Date | null) => {
+  return endAt ?? new Date(startAt.getTime() + DEFAULT_CALL_DURATION_MS)
+}
+
+const getCountdownDescriptor = (now: number, startAt: Date, endAt: Date): CountdownDescriptor => {
+  const startTime = startAt.getTime()
+  const endTime = endAt.getTime()
+
+  if (now >= startTime && now <= endTime) {
+    return { kind: 'inProgress' }
+  }
+
+  if (now > endTime) {
+    return { kind: 'none' }
+  }
+
+  const millisecondsUntilStart = startTime - now
+
+  if (millisecondsUntilStart < 60 * 60 * 1000) {
+    return { kind: 'startingSoon' }
+  }
+
+  const hoursUntilStart = millisecondsUntilStart / (60 * 60 * 1000)
+
+  if (hoursUntilStart < 24) {
+    return { kind: 'hours', value: Math.floor(hoursUntilStart) }
+  }
+
+  return {
+    kind: 'days',
+    value: Math.ceil(millisecondsUntilStart / (24 * 60 * 60 * 1000)),
+  }
+}
+
 export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
   const { t } = useTranslation()
-  const { formatDate } = useIntlFormatter()
+  const intl = useIntl()
 
   if (callBooking == null) {
     return (
@@ -51,65 +91,143 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
   const purpose = callBooking.purpose === CallBookingPurpose.BOOKKEEPING_ONBOARDING
     ? t('callBookings:label.onboarding_call', 'Onboarding call')
     : t('callBookings:label.ad_hoc_call', 'Ad hoc call')
+  const subtitle = t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team')
   const callPlatform = callBooking.callType === CallBookingType.ZOOM ? 'Zoom' : 'Google Meet'
   const callLink = callBooking.callLink.toString()
+  const eventEndAt = getEffectiveEndAt(callBooking.eventStartAt, callBooking.eventEndAt)
+  const countdownDescriptor = getCountdownDescriptor(Date.now(), callBooking.eventStartAt, eventEndAt)
+  const countdownLabel = (() => {
+    switch (countdownDescriptor.kind) {
+      case 'days':
+        return tPlural(t, 'callBookings:state.call_in_count_days', {
+          count: countdownDescriptor.value,
+          displayCount: countdownDescriptor.value,
+          one: 'in {{displayCount}} day',
+          other: 'in {{displayCount}} days',
+        })
+      case 'hours':
+        return tPlural(t, 'callBookings:state.call_in_count_hours', {
+          count: countdownDescriptor.value,
+          displayCount: countdownDescriptor.value,
+          one: 'in {{displayCount}} hour',
+          other: 'in {{displayCount}} hours',
+        })
+      case 'startingSoon':
+        return t('callBookings:state.starting_soon', 'starting soon')
+      case 'inProgress':
+        return t('callBookings:state.in_progress', 'in progress')
+      case 'none':
+        return ''
+    }
+  })()
+  const dateTileMonthLabel = new Intl.DateTimeFormat(intl.locale, {
+    month: 'short',
+    year: 'numeric',
+  }).format(callBooking.eventStartAt).toUpperCase()
+  const dateTileDayLabel = new Intl.DateTimeFormat(intl.locale, {
+    day: 'numeric',
+  }).format(callBooking.eventStartAt)
+  const dateTileWeekdayLabel = new Intl.DateTimeFormat(intl.locale, {
+    weekday: 'short',
+  }).format(callBooking.eventStartAt).toUpperCase()
+  const timeLabel = new Intl.DateTimeFormat(intl.locale, {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(callBooking.eventStartAt)
+  const whatWeWillCoverItems = [
+    t('callBookings:label.cover_business_and_books', 'Walk through your business and books'),
+    t('callBookings:label.cover_accounts_and_documents', 'Connect your accounts and documents'),
+    t('callBookings:label.cover_first_month_expectations', 'Set expectations for our first month'),
+  ]
 
   return (
     <Container name='CallBooking'>
-      <VStack gap='lg' align='center' pi='lg' pb='lg'>
-        <HStack
-          className='Layer__CallBooking__DetailsSideBySide'
-          align='center'
-          gap='lg'
-        >
-          <VStack
-            gap='xs'
-            align='center'
-            className='Layer__CallBooking__HeaderColumn'
-          >
-            <div className='Layer__CallBooking__Icon'>
-              <Users size={24} strokeWidth={1.5} />
-            </div>
-            <Heading size='sm' align='center'>
-              {purpose}
-            </Heading>
-            <Span variant='subtle' size='sm' align='center'>
-              {t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team')}
-            </Span>
+      <VStack className='Layer__CallBooking__Content'>
+        <HStack className='Layer__CallBooking__HeaderRow' align='start'>
+          <VStack className='Layer__CallBooking__DateColumn'>
+            <VStack className='Layer__CallBooking__DateTile'>
+              <Span nonAria className='Layer__CallBooking__DateTileMonth'>
+                {dateTileMonthLabel}
+              </Span>
+              <VStack className='Layer__CallBooking__DateTileBody'>
+                <Span nonAria className='Layer__CallBooking__DateTileDay'>
+                  {dateTileDayLabel}
+                </Span>
+                <Span nonAria className='Layer__CallBooking__DateTileWeekday'>
+                  {dateTileWeekdayLabel}
+                </Span>
+              </VStack>
+            </VStack>
+            <HStack className='Layer__CallBooking__TimeRow' align='center'>
+              <Clock3 size={16} strokeWidth={2} />
+              <Span nonAria noWrap className='Layer__CallBooking__TimeLabel'>
+                {timeLabel}
+              </Span>
+            </HStack>
           </VStack>
-          <VStack
-            className='Layer__CallBooking__MetaColumn'
-            align='center'
-            gap='sm'
-          >
-            <HStack className='Layer__CallBooking__DetailRow'>
-              <Video size={16} color='var(--color-base-500)' />
-              <Span variant='subtle' size='sm' noWrap>
-                {t('callBookings:label.location', 'Location')}
-              </Span>
-              <Span size='sm'>{callPlatform}</Span>
+          <VStack className='Layer__CallBooking__HeaderDetails'>
+            <HStack className='Layer__CallBooking__TitleRow' align='baseline'>
+              <Heading size='xs' className='Layer__CallBooking__Title'>
+                {purpose}
+              </Heading>
+              {countdownLabel && (
+                <Span nonAria size='xs' className='Layer__CallBooking__Countdown'>
+                  ·
+                  {' '}
+                  {countdownLabel}
+                </Span>
+              )}
             </HStack>
-            <HStack className='Layer__CallBooking__DetailRow'>
-              <Clock size={16} color='var(--color-base-500)' />
-              <Span variant='subtle' size='sm' noWrap>
-                {t('callBookings:label.date', 'Date')}
-              </Span>
-              <Span size='sm'>
-                {formatDate(callBooking.eventStartAt, DateFormat.DateWithTimeReadableWithTimezone)}
-              </Span>
-            </HStack>
+            <Span size='sm' className='Layer__CallBooking__Subtitle'>
+              {subtitle}
+            </Span>
+            <VStack className='Layer__CallBooking__MetaList'>
+              <HStack className='Layer__CallBooking__LocationRow' align='center'>
+                <Video size={14} />
+                <Span size='sm' className='Layer__CallBooking__LocationLabel'>
+                  {callPlatform}
+                </Span>
+              </HStack>
+            </VStack>
           </VStack>
         </HStack>
-        <HStack
-          gap='sm'
-          align='center'
-          justify='center'
-          className='Layer__CallBooking__Actions'
-        >
-          <LinkButton href={callLink} external variant='outlined'>
-            <LinkIcon size={16} />
-            {t('callBookings:action.join_call', 'Join call')}
-          </LinkButton>
+
+        <Span nonAria className='Layer__CallBooking__Divider' />
+
+        <VStack className='Layer__CallBooking__CoverageSection'>
+          <Span
+            nonAria
+            size='2xs'
+            className='Layer__CallBooking__CoverageEyebrow'
+          >
+            {t('callBookings:label.what_well_cover', 'What we\'ll cover')}
+          </Span>
+          <VStack className='Layer__CallBooking__CoverageList' role='list'>
+            {whatWeWillCoverItems.map(item => (
+              <HStack
+                key={item}
+                className='Layer__CallBooking__CoverageItem'
+                align='start'
+                role='listitem'
+              >
+                <Span nonAria className='Layer__CallBooking__CoverageBadge'>
+                  <Check size={12} strokeWidth={2.5} />
+                </Span>
+                <Span size='sm' className='Layer__CallBooking__CoverageText'>
+                  {item}
+                </Span>
+              </HStack>
+            ))}
+          </VStack>
+        </VStack>
+
+        <HStack className='Layer__CallBooking__ActionRow' align='center'>
+          <HStack className='Layer__CallBooking__JoinAction'>
+            <LinkButton href={callLink} external variant='solid'>
+              <Video size={15} />
+              {t('callBookings:action.join_call', 'Join call')}
+            </LinkButton>
+          </HStack>
         </HStack>
       </VStack>
     </Container>

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -16,6 +16,24 @@ import './callBooking.scss'
 
 import { useCallBookingCountdownLabel } from './useCallBookingCountdownLabel'
 
+const ONBOARDING_CALL_COVERAGE_ITEMS = [
+  {
+    key: 'business_and_books',
+    translationKey: 'callBookings:label.cover_business_and_books',
+    defaultLabel: 'Walk through your business and books',
+  },
+  {
+    key: 'accounts_and_documents',
+    translationKey: 'callBookings:label.cover_accounts_and_documents',
+    defaultLabel: 'Connect your accounts and documents',
+  },
+  {
+    key: 'first_month_expectations',
+    translationKey: 'callBookings:label.cover_first_month_expectations',
+    defaultLabel: 'Set expectations for our first month',
+  },
+] as const
+
 export interface CallBookingProps {
   callBooking?: CallBookingData
   onBookCall?: () => void
@@ -41,11 +59,6 @@ const EmptyState = ({ onBookCall }: { onBookCall?: () => void }) => {
 
 const OnboardingCallCoverage = () => {
   const { t } = useTranslation()
-  const whatWeWillCoverItems: Array<[string, string]> = [
-    ['business_and_books', t('callBookings:label.cover_business_and_books', 'Walk through your business and books')],
-    ['accounts_and_documents', t('callBookings:label.cover_accounts_and_documents', 'Connect your accounts and documents')],
-    ['first_month_expectations', t('callBookings:label.cover_first_month_expectations', 'Set expectations for our first month')],
-  ]
 
   return (
     <>
@@ -57,12 +70,12 @@ const OnboardingCallCoverage = () => {
           size='2xs'
           variant='subtle'
           pbe='sm'
-          className='Layer__CallBooking__CoverageEyebrow'
+          className='Layer__CallBooking__CoverageHeading'
         >
           {t('callBookings:label.what_well_cover', 'What we\'ll cover')}
         </Span>
         <VStack role='list' gap='xs'>
-          {whatWeWillCoverItems.map(([key, label]) => (
+          {ONBOARDING_CALL_COVERAGE_ITEMS.map(({ key, translationKey, defaultLabel }) => (
             <HStack
               key={key}
               className='Layer__CallBooking__CoverageItem'
@@ -74,7 +87,7 @@ const OnboardingCallCoverage = () => {
                 <Check size={12} strokeWidth={2.5} />
               </Span>
               <Span size='sm' className='Layer__CallBooking__CoverageText'>
-                {label}
+                {t(translationKey, defaultLabel)}
               </Span>
             </HStack>
           ))}

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -1,11 +1,13 @@
 import { Check, Clock3, Video } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { useIntl } from 'react-intl'
 
 import { type CallBooking as CallBookingData, CallBookingPurpose, CallBookingType } from '@schemas/callBooking'
+import { DateFormat } from '@utils/i18n/date/patterns'
 import { tPlural } from '@utils/i18n/plural'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { Button } from '@ui/Button/Button'
 import { LinkButton } from '@ui/Button/LinkButton'
+import { DateTile } from '@ui/DateTile/DateTile'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
 import { Span } from '@ui/Typography/Text'
@@ -20,9 +22,7 @@ export interface CallBookingProps {
 
 type CountdownDescriptor =
   | { kind: 'days' | 'hours', value: number }
-  | { kind: 'startingSoon' | 'inProgress' | 'none' }
-
-const DEFAULT_CALL_DURATION_MS = 30 * 60 * 1000
+  | { kind: 'startingSoon' | 'none' }
 
 const EmptyState = ({ onBookCall }: { onBookCall?: () => void }) => {
   const { t } = useTranslation()
@@ -42,19 +42,10 @@ const EmptyState = ({ onBookCall }: { onBookCall?: () => void }) => {
   )
 }
 
-const getEffectiveEndAt = (startAt: Date, endAt?: Date | null) => {
-  return endAt ?? new Date(startAt.getTime() + DEFAULT_CALL_DURATION_MS)
-}
-
-const getCountdownDescriptor = (now: number, startAt: Date, endAt: Date): CountdownDescriptor => {
+const getCountdownDescriptor = (now: number, startAt: Date): CountdownDescriptor => {
   const startTime = startAt.getTime()
-  const endTime = endAt.getTime()
 
-  if (now >= startTime && now <= endTime) {
-    return { kind: 'inProgress' }
-  }
-
-  if (now > endTime) {
+  if (now >= startTime) {
     return { kind: 'none' }
   }
 
@@ -78,7 +69,7 @@ const getCountdownDescriptor = (now: number, startAt: Date, endAt: Date): Countd
 
 export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
   const { t } = useTranslation()
-  const intl = useIntl()
+  const { formatDate } = useIntlFormatter()
 
   if (callBooking == null) {
     return (
@@ -94,8 +85,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
   const subtitle = t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team')
   const callPlatform = callBooking.callType === CallBookingType.ZOOM ? 'Zoom' : 'Google Meet'
   const callLink = callBooking.callLink.toString()
-  const eventEndAt = getEffectiveEndAt(callBooking.eventStartAt, callBooking.eventEndAt)
-  const countdownDescriptor = getCountdownDescriptor(Date.now(), callBooking.eventStartAt, eventEndAt)
+  const countdownDescriptor = getCountdownDescriptor(Date.now(), callBooking.eventStartAt)
   const countdownLabel = (() => {
     switch (countdownDescriptor.kind) {
       case 'days':
@@ -114,26 +104,11 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
         })
       case 'startingSoon':
         return t('callBookings:state.starting_soon', 'starting soon')
-      case 'inProgress':
-        return t('callBookings:state.in_progress', 'in progress')
       case 'none':
         return ''
     }
   })()
-  const dateTileMonthLabel = new Intl.DateTimeFormat(intl.locale, {
-    month: 'short',
-    year: 'numeric',
-  }).format(callBooking.eventStartAt).toUpperCase()
-  const dateTileDayLabel = new Intl.DateTimeFormat(intl.locale, {
-    day: 'numeric',
-  }).format(callBooking.eventStartAt)
-  const dateTileWeekdayLabel = new Intl.DateTimeFormat(intl.locale, {
-    weekday: 'short',
-  }).format(callBooking.eventStartAt).toUpperCase()
-  const timeLabel = new Intl.DateTimeFormat(intl.locale, {
-    hour: 'numeric',
-    minute: '2-digit',
-  }).format(callBooking.eventStartAt)
+  const timeLabel = formatDate(callBooking.eventStartAt, DateFormat.MonthDayWithTimeReadable)
   const whatWeWillCoverItems = [
     t('callBookings:label.cover_business_and_books', 'Walk through your business and books'),
     t('callBookings:label.cover_accounts_and_documents', 'Connect your accounts and documents'),
@@ -145,43 +120,25 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
       <VStack className='Layer__CallBooking__Content'>
         <HStack className='Layer__CallBooking__HeaderRow' align='start'>
           <VStack className='Layer__CallBooking__DateColumn'>
-            <VStack className='Layer__CallBooking__DateTile'>
-              <Span nonAria className='Layer__CallBooking__DateTileMonth'>
-                {dateTileMonthLabel}
-              </Span>
-              <VStack className='Layer__CallBooking__DateTileBody'>
-                <Span nonAria className='Layer__CallBooking__DateTileDay'>
-                  {dateTileDayLabel}
-                </Span>
-                <Span nonAria className='Layer__CallBooking__DateTileWeekday'>
-                  {dateTileWeekdayLabel}
-                </Span>
-              </VStack>
-            </VStack>
-            <HStack className='Layer__CallBooking__TimeRow' align='center'>
-              <Clock3 size={16} strokeWidth={2} />
-              <Span nonAria noWrap className='Layer__CallBooking__TimeLabel'>
-                {timeLabel}
-              </Span>
-            </HStack>
+            <DateTile date={callBooking.eventStartAt} />
           </VStack>
-          <VStack className='Layer__CallBooking__HeaderDetails'>
-            <HStack className='Layer__CallBooking__TitleRow' align='baseline'>
+          <VStack className='Layer__CallBooking__HeaderDetails' pbs='3xs'>
+            <HStack className='Layer__CallBooking__TitleRow' align='baseline' gap='xs'>
               <Heading size='xs' className='Layer__CallBooking__Title'>
                 {purpose}
               </Heading>
               {countdownLabel && (
-                <Span nonAria size='xs' className='Layer__CallBooking__Countdown'>
+                <Span nonAria size='xs' variant='subtle'>
                   ·
                   {' '}
                   {countdownLabel}
                 </Span>
               )}
             </HStack>
-            <Span size='sm' className='Layer__CallBooking__Subtitle'>
+            <Span size='sm' variant='subtle' className='Layer__CallBooking__Subtitle'>
               {subtitle}
             </Span>
-            <VStack className='Layer__CallBooking__MetaList'>
+            <VStack gap='xs' pbs='sm'>
               <HStack className='Layer__CallBooking__LocationRow' align='center'>
                 <Video size={14} />
                 <Span size='sm' className='Layer__CallBooking__LocationLabel'>
@@ -192,17 +149,25 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
           </VStack>
         </HStack>
 
+        <HStack className='Layer__CallBooking__DateTimeRow' align='center'>
+          <Clock3 size={16} strokeWidth={2} />
+          <Span nonAria noWrap className='Layer__CallBooking__TimeLabel'>
+            {timeLabel}
+          </Span>
+        </HStack>
+
         <Span nonAria className='Layer__CallBooking__Divider' />
 
-        <VStack className='Layer__CallBooking__CoverageSection'>
+        <VStack pbe='md'>
           <Span
             nonAria
             size='2xs'
+            variant='subtle'
             className='Layer__CallBooking__CoverageEyebrow'
           >
             {t('callBookings:label.what_well_cover', 'What we\'ll cover')}
           </Span>
-          <VStack className='Layer__CallBooking__CoverageList' role='list'>
+          <VStack role='list' gap='xs'>
             {whatWeWillCoverItems.map(item => (
               <HStack
                 key={item}
@@ -221,7 +186,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
           </VStack>
         </VStack>
 
-        <HStack className='Layer__CallBooking__ActionRow' align='center'>
+        <HStack className='Layer__CallBooking__ActionRow' align='center' gap='xs'>
           <HStack className='Layer__CallBooking__JoinAction'>
             <LinkButton href={callLink} external variant='solid'>
               <Video size={15} />

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -1,4 +1,4 @@
-import { Clock, Link as LinkIcon, Milestone, Users, Video } from 'lucide-react'
+import { Clock, Link as LinkIcon, Users, Video } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { type CallBooking as CallBookingData, CallBookingPurpose, CallBookingType } from '@schemas/callBooking'
@@ -9,9 +9,7 @@ import { LinkButton } from '@ui/Button/LinkButton'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
 import { Span } from '@ui/Typography/Text'
-import { AddToCalendar } from '@components/AddToCalendar/AddToCalendar'
 import { Container } from '@components/Container/Container'
-import { Separator } from '@components/Separator/Separator'
 
 import './callBooking.scss'
 
@@ -24,7 +22,7 @@ const EmptyState = ({ onBookCall }: { onBookCall?: () => void }) => {
   const { t } = useTranslation()
 
   return (
-    <VStack gap='md' align='center' pb='md'>
+    <VStack gap='md' align='center' pi='lg' pb='lg'>
       <Heading size='sm' align='center'>
         {t('callBookings:prompt.ready_to_get_started', 'Ready to get started?')}
       </Heading>
@@ -58,51 +56,56 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
 
   return (
     <Container name='CallBooking'>
-      <VStack gap='md' align='center'>
-        <VStack gap='xs' align='center'>
-          <div className='Layer__CallBooking__Icon'>
-            <Users size={24} strokeWidth={1.5} />
-          </div>
-          <Heading size='sm'>{t('callBookings:label.upcoming_call', 'Upcoming Call')}</Heading>
-          <Span variant='subtle' size='sm'>
-            {t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team')}
-          </Span>
-        </VStack>
-        <Separator mbs='2xs' mbe='2xs' />
-        <VStack align='start' gap='sm'>
-          <HStack className='Layer__CallBooking__DetailRow'>
-            <Milestone size={16} color='var(--color-base-500)' />
-            <Span variant='subtle' size='sm' noWrap>
-              {t('callBookings:label.purpose', 'Purpose')}
+      <VStack gap='lg' align='center' pi='lg' pb='lg'>
+        <HStack
+          className='Layer__CallBooking__DetailsSideBySide'
+          align='start'
+          gap='lg'
+        >
+          <VStack
+            gap='xs'
+            align='center'
+            className='Layer__CallBooking__HeaderColumn'
+          >
+            <div className='Layer__CallBooking__Icon'>
+              <Users size={24} strokeWidth={1.5} />
+            </div>
+            <Heading size='sm' align='center'>
+              {purpose}
+            </Heading>
+            <Span variant='subtle' size='sm' align='center'>
+              {t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team')}
             </Span>
-            <Span size='sm'>{purpose}</Span>
-          </HStack>
-          <HStack className='Layer__CallBooking__DetailRow'>
-            <Video size={16} color='var(--color-base-500)' />
-            <Span variant='subtle' size='sm' noWrap>
-              {t('callBookings:label.location', 'Location')}
-            </Span>
-            <Span size='sm'>{callPlatform}</Span>
-          </HStack>
-          <HStack className='Layer__CallBooking__DetailRow'>
-            <Clock size={16} color='var(--color-base-500)' />
-            <Span variant='subtle' size='sm' noWrap>
-              {t('callBookings:label.date', 'Date')}
-            </Span>
-            <Span size='sm'>
-              {formatDate(callBooking.eventStartAt, DateFormat.DateWithTimeReadableWithTimezone)}
-            </Span>
-          </HStack>
-        </VStack>
-        <HStack gap='sm' align='center' className='Layer__CallBooking__Actions'>
-          <AddToCalendar
-            title={purpose}
-            description={callPlatform}
-            location={callLink}
-            startDate={callBooking.eventStartAt}
-            endDate={callBooking.eventEndAt}
-            organizer={{ name: callBooking.bookkeeperName, email: callBooking.bookkeeperEmail }}
-          />
+          </VStack>
+          <VStack
+            className='Layer__CallBooking__MetaColumn'
+            align='center'
+            gap='sm'
+          >
+            <HStack className='Layer__CallBooking__DetailRow'>
+              <Video size={16} color='var(--color-base-500)' />
+              <Span variant='subtle' size='sm' noWrap>
+                {t('callBookings:label.location', 'Location')}
+              </Span>
+              <Span size='sm'>{callPlatform}</Span>
+            </HStack>
+            <HStack className='Layer__CallBooking__DetailRow'>
+              <Clock size={16} color='var(--color-base-500)' />
+              <Span variant='subtle' size='sm' noWrap>
+                {t('callBookings:label.date', 'Date')}
+              </Span>
+              <Span size='sm'>
+                {formatDate(callBooking.eventStartAt, DateFormat.DateWithTimeReadableWithTimezone)}
+              </Span>
+            </HStack>
+          </VStack>
+        </HStack>
+        <HStack
+          gap='sm'
+          align='center'
+          justify='center'
+          className='Layer__CallBooking__Actions'
+        >
           <LinkButton href={callLink} external variant='outlined'>
             <LinkIcon size={16} />
             {t('callBookings:action.join_call', 'Join call')}

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -59,7 +59,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
       <VStack gap='lg' align='center' pi='lg' pb='lg'>
         <HStack
           className='Layer__CallBooking__DetailsSideBySide'
-          align='start'
+          align='center'
           gap='lg'
         >
           <VStack
@@ -80,7 +80,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
           <VStack
             className='Layer__CallBooking__MetaColumn'
             align='center'
-            gap='sm'
+            gap='md'
           >
             <HStack className='Layer__CallBooking__DetailRow'>
               <Video size={16} color='var(--color-base-500)' />

--- a/src/components/CallBooking/callBooking.scss
+++ b/src/components/CallBooking/callBooking.scss
@@ -1,7 +1,7 @@
 .Layer__CallBooking {
-  padding: var(--spacing-lg);
+  box-sizing: border-box;
 
-  .Layer__CallBooking__Icon {
+  &__Icon {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -12,26 +12,46 @@
     color: var(--color-base-900);
   }
 
-  .Layer__CallBooking__DetailRow {
-    display: grid;
-    grid-template-columns: 16px 72px 1fr;
-    column-gap: var(--spacing-sm);
-    align-items: center;
-    width: 100%;
-  }
-
-  .Layer__CallBooking__Actions {
+  &__DetailsSideBySide {
+    align-self: stretch;
     width: 100%;
 
-    > * {
-      flex: 1;
-      min-width: 0;
+    @media (width <= 480px) {
+      &[data-direction='row'] {
+        flex-direction: column;
+      }
     }
   }
-}
 
-@media (width <= 480px) {
-  .Layer__CallBooking {
-    padding: var(--spacing-md);
+  &__HeaderColumn {
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+
+  &__MetaColumn {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  &__DetailRow {
+    display: grid;
+    grid-template-columns: 16px minmax(4.5rem, auto) 1fr;
+    column-gap: var(--spacing-md);
+    align-items: center;
+    width: 100%;
+    padding-block: var(--spacing-2xs);
+  }
+
+  &__Actions {
+    align-self: stretch;
+    width: 100%;
+  }
+
+  @media (width <= 480px) {
+    &__HeaderColumn,
+    &__MetaColumn {
+      width: 100%;
+      max-width: none;
+    }
   }
 }

--- a/src/components/CallBooking/callBooking.scss
+++ b/src/components/CallBooking/callBooking.scss
@@ -1,13 +1,4 @@
 .Layer__CallBooking {
-  .Layer__Span {
-    max-inline-size: none;
-  }
-
-  &__DateColumn {
-    flex: 0 0 auto;
-    min-width: 5.5rem;
-  }
-
   &__HeaderDetails {
     min-width: 0;
   }
@@ -16,104 +7,56 @@
     flex-wrap: wrap;
   }
 
-  &__Title {
-    font-size: 1rem;
-    line-height: 1.35;
-    font-weight: 600;
-    color: #0f172a;
-    letter-spacing: -0.01em;
-  }
-
-  &__Subtitle {
-    margin-top: 0.1875rem;
-    line-height: 1.45;
-  }
-
   &__DateTimeRow,
   &__LocationRow,
-  &__CoverageItem,
-  &__ActionRow {
+  &__CoverageItem {
     min-width: 0;
   }
 
   &__DateTimeRow {
     align-self: flex-start;
-    color: #1f2937;
-  }
-
-  &__TimeLabel {
-    font-size: 1rem;
-    line-height: 1.35;
-    font-weight: 600;
-    color: #0f172a;
-    letter-spacing: -0.005em;
+    color: var(--color-base-800);
   }
 
   &__LocationRow {
-    align-self: flex-start;
-    border-radius: 999px;
-    background: #eef0f3;
-    color: #64748b;
-  }
-
-  &__LocationLabel {
-    line-height: 1.45;
-    font-weight: 600;
-    color: #334155;
+    border-radius: var(--border-radius-5xl);
+    background: var(--bg-muted);
+    color: var(--fg-subtle);
   }
 
   &__Divider {
     display: block;
     height: 1px;
     width: 100%;
-    margin-block: 1.125rem;
-    background: #eef0f3;
+    margin-block: var(--spacing-md);
+    background: var(--bg-muted);
   }
 
   &__CoverageHeading {
     display: block;
     line-height: 1.2;
-    font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
   }
 
   &__CoverageBadge {
     flex: 0 0 auto;
-    height: 1.125rem;
-    width: 1.125rem;
-    border-radius: 999px;
-    margin-top: 0.0625rem;
-    background: #eef7dc;
-    color: #5b8a12;
-  }
-
-  &__CoverageText {
-    line-height: 1.45;
-    color: #1f2937;
+    height: var(--spacing-md);
+    width: var(--spacing-md);
+    border-radius: var(--border-radius-5xl);
+    margin-top: var(--spacing-4xs);
+    background: var(--color-info-success-bg);
+    color: var(--color-info-success-fg);
   }
 
   @container (width <= 400px) {
     &__HeaderRow {
-      gap: 1.5rem;
-    }
-
-    &__DateColumn {
-      min-width: 4.5rem;
-    }
-
-    &__TimeLabel {
-      font-size: 0.9375rem;
+      gap: var(--spacing-lg);
     }
   }
 
   @container (width <= 360px) {
     &__JoinAction {
       flex: 1 1 100%;
-    }
-
-    &__JoinAction .Layer__UI__Button {
-      width: 100%;
     }
   }
 }

--- a/src/components/CallBooking/callBooking.scss
+++ b/src/components/CallBooking/callBooking.scss
@@ -71,7 +71,7 @@
     background: #eef0f3;
   }
 
-  &__CoverageEyebrow {
+  &__CoverageHeading {
     display: block;
     line-height: 1.2;
     font-weight: 600;

--- a/src/components/CallBooking/callBooking.scss
+++ b/src/components/CallBooking/callBooking.scss
@@ -3,20 +3,12 @@
     max-inline-size: none;
   }
 
-  &__HeaderRow {
-    gap: 2rem;
-    width: 100%;
-  }
-
   &__DateColumn {
     flex: 0 0 auto;
-    gap: 0;
     min-width: 5.5rem;
   }
 
   &__HeaderDetails {
-    flex: 1 1 0;
-    gap: 0;
     min-width: 0;
   }
 
@@ -37,7 +29,6 @@
     line-height: 1.45;
   }
 
-  &__TimeRow,
   &__DateTimeRow,
   &__LocationRow,
   &__CoverageItem,
@@ -45,20 +36,8 @@
     min-width: 0;
   }
 
-  &__TimeRow,
-  &__DateTimeRow,
-  &__LocationRow {
-    gap: 0.625rem;
-  }
-
-  &__TimeRow {
-    align-self: flex-start;
-    color: #1f2937;
-  }
-
   &__DateTimeRow {
     align-self: flex-start;
-    margin-top: 0.875rem;
     color: #1f2937;
   }
 
@@ -66,7 +45,6 @@
     font-size: 1rem;
     line-height: 1.35;
     font-weight: 600;
-    white-space: nowrap;
     color: #0f172a;
     letter-spacing: -0.005em;
   }
@@ -95,15 +73,10 @@
 
   &__CoverageEyebrow {
     display: block;
-    margin-bottom: 0.625rem;
     line-height: 1.2;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-  }
-
-  &__CoverageItem {
-    gap: 0.625rem;
   }
 
   &__CoverageBadge {
@@ -122,10 +95,6 @@
   &__CoverageText {
     line-height: 1.45;
     color: #1f2937;
-  }
-
-  &__JoinAction {
-    display: flex;
   }
 
   @container (width <= 400px) {

--- a/src/components/CallBooking/callBooking.scss
+++ b/src/components/CallBooking/callBooking.scss
@@ -1,57 +1,247 @@
 .Layer__CallBooking {
   box-sizing: border-box;
+  border-radius: 10px;
+  box-shadow: 0 1px 2px rgb(15 23 42 / 3%);
+  background: #fff;
+  border-color: #e5e7eb;
 
-  &__Icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 3rem;
-    width: 3rem;
-    border-radius: 50%;
-    background-color: var(--color-base-50);
-    color: var(--color-base-900);
+  &__Content {
+    gap: 0;
+    padding: 1.25rem;
   }
 
-  &__DetailsSideBySide {
-    align-self: stretch;
+  &__HeaderRow {
+    gap: 1.25rem;
     width: 100%;
+  }
 
-    @media (width <= 480px) {
-      &[data-direction='row'] {
-        flex-direction: column;
-      }
+  &__DateColumn {
+    flex: 0 0 auto;
+    gap: 1rem;
+    min-width: 6.75rem;
+  }
+
+  &__HeaderDetails {
+    flex: 1 1 0;
+    gap: 0;
+    min-width: 0;
+    padding-top: 0.25rem;
+  }
+
+  &__TitleRow {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  &__Title {
+    font-size: 1rem;
+    line-height: 1.35;
+    font-weight: 600;
+    color: #0f172a;
+    letter-spacing: -0.01em;
+  }
+
+  &__Countdown,
+  &__Subtitle,
+  &__CoverageEyebrow,
+  &__LocationLabel {
+    max-inline-size: none;
+  }
+
+  &__Countdown {
+    line-height: 1.4;
+    color: #64748b;
+  }
+
+  &__Subtitle {
+    margin-top: 0.1875rem;
+    line-height: 1.45;
+    color: #64748b;
+  }
+
+  &__DateTile {
+    gap: 0;
+    overflow: hidden;
+    width: 5.5rem;
+    border-radius: 10px;
+    border: 1px solid #e5e7eb;
+    background: #fff;
+  }
+
+  &__DateTileMonth,
+  &__DateTileDay,
+  &__DateTileWeekday {
+    display: block;
+    max-inline-size: none;
+    text-align: center;
+  }
+
+  &__DateTileMonth {
+    padding: 0.3125rem 0;
+    background: #0b2239;
+    font-size: 0.625rem;
+    line-height: 1.2;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: #fff;
+    letter-spacing: 0.14em;
+  }
+
+  &__DateTileBody {
+    gap: 0;
+    align-items: center;
+    justify-content: center;
+    padding: 0.375rem 0 0.5rem;
+  }
+
+  &__DateTileDay {
+    font-size: 2rem;
+    line-height: 1;
+    font-weight: 700;
+    color: #0f172a;
+    letter-spacing: -0.02em;
+  }
+
+  &__DateTileWeekday {
+    margin-top: 0.25rem;
+    font-size: 0.6875rem;
+    line-height: 1.2;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: #64748b;
+    letter-spacing: 0.06em;
+  }
+
+  &__MetaList {
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+  }
+
+  &__TimeRow,
+  &__LocationRow,
+  &__CoverageItem,
+  &__ActionRow {
+    min-width: 0;
+  }
+
+  &__TimeRow,
+  &__LocationRow {
+    gap: 0.625rem;
+  }
+
+  &__TimeRow {
+    align-self: flex-start;
+    color: #1f2937;
+  }
+
+  &__TimeLabel {
+    max-inline-size: none;
+    font-size: 1rem;
+    line-height: 1.35;
+    font-weight: 600;
+    white-space: nowrap;
+    color: #0f172a;
+    letter-spacing: -0.005em;
+  }
+
+  &__LocationRow {
+    align-self: flex-start;
+    padding: 0.5rem 0.875rem;
+    border-radius: 999px;
+    background: #eef0f3;
+    color: #64748b;
+  }
+
+  &__LocationLabel {
+    line-height: 1.45;
+    font-weight: 600;
+    color: #334155;
+  }
+
+  &__Divider {
+    display: block;
+    height: 1px;
+    width: 100%;
+    max-inline-size: none;
+    margin-block: 1.125rem;
+    background: #eef0f3;
+  }
+
+  &__CoverageSection {
+    gap: 0;
+    margin-bottom: 1rem;
+  }
+
+  &__CoverageEyebrow {
+    display: block;
+    margin-bottom: 0.625rem;
+    line-height: 1.2;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: #64748b;
+    letter-spacing: 0.06em;
+  }
+
+  &__CoverageList {
+    gap: 0.5rem;
+  }
+
+  &__CoverageItem {
+    gap: 0.625rem;
+  }
+
+  &__CoverageBadge {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    height: 1.125rem;
+    width: 1.125rem;
+    border-radius: 999px;
+    margin-top: 0.0625rem;
+    background: #eef7dc;
+    color: #5b8a12;
+  }
+
+  &__CoverageText {
+    max-inline-size: none;
+    line-height: 1.45;
+    color: #1f2937;
+  }
+
+  &__ActionRow {
+    gap: 0.5rem;
+  }
+
+  &__JoinAction {
+    display: flex;
+  }
+
+  @container (width <= 400px) {
+    &__HeaderRow {
+      gap: 1rem;
+    }
+
+    &__DateColumn {
+      min-width: 6.25rem;
+    }
+
+    &__DateTileDay {
+      font-size: 1.75rem;
+    }
+
+    &__TimeLabel {
+      font-size: 0.9375rem;
     }
   }
 
-  &__HeaderColumn {
-    flex: 0 1 auto;
-    min-width: 0;
-  }
+  @container (width <= 360px) {
+    &__JoinAction {
+      flex: 1 1 100%;
+    }
 
-  &__MetaColumn {
-    flex: 1 1 0;
-    min-width: 0;
-  }
-
-  &__DetailRow {
-    display: grid;
-    grid-template-columns: 16px minmax(4.5rem, auto) 1fr;
-    column-gap: var(--spacing-md);
-    align-items: center;
-    width: 100%;
-    padding-block: var(--spacing-2xs);
-  }
-
-  &__Actions {
-    align-self: stretch;
-    width: 100%;
-  }
-
-  @media (width <= 480px) {
-    &__HeaderColumn,
-    &__MetaColumn {
+    &__JoinAction .Layer__UI__Button {
       width: 100%;
-      max-width: none;
     }
   }
 }

--- a/src/components/CallBooking/callBooking.scss
+++ b/src/components/CallBooking/callBooking.scss
@@ -51,7 +51,6 @@
 
   &__LocationRow {
     align-self: flex-start;
-    padding: 0.5rem 0.875rem;
     border-radius: 999px;
     background: #eef0f3;
     color: #64748b;
@@ -80,10 +79,7 @@
   }
 
   &__CoverageBadge {
-    display: inline-flex;
     flex: 0 0 auto;
-    align-items: center;
-    justify-content: center;
     height: 1.125rem;
     width: 1.125rem;
     border-radius: 999px;

--- a/src/components/CallBooking/callBooking.scss
+++ b/src/components/CallBooking/callBooking.scss
@@ -3,11 +3,6 @@
     max-inline-size: none;
   }
 
-  &__Content {
-    gap: 0;
-    padding: 1.25rem;
-  }
-
   &__HeaderRow {
     gap: 2rem;
     width: 100%;

--- a/src/components/CallBooking/callBooking.scss
+++ b/src/components/CallBooking/callBooking.scss
@@ -1,9 +1,7 @@
 .Layer__CallBooking {
-  box-sizing: border-box;
-  border-radius: 10px;
-  box-shadow: 0 1px 2px rgb(15 23 42 / 3%);
-  background: #fff;
-  border-color: #e5e7eb;
+  .Layer__Span {
+    max-inline-size: none;
+  }
 
   &__Content {
     gap: 0;
@@ -11,26 +9,24 @@
   }
 
   &__HeaderRow {
-    gap: 1.25rem;
+    gap: 2rem;
     width: 100%;
   }
 
   &__DateColumn {
     flex: 0 0 auto;
-    gap: 1rem;
-    min-width: 6.75rem;
+    gap: 0;
+    min-width: 5.5rem;
   }
 
   &__HeaderDetails {
     flex: 1 1 0;
     gap: 0;
     min-width: 0;
-    padding-top: 0.25rem;
   }
 
   &__TitleRow {
     flex-wrap: wrap;
-    gap: 0.5rem;
   }
 
   &__Title {
@@ -41,83 +37,13 @@
     letter-spacing: -0.01em;
   }
 
-  &__Countdown,
-  &__Subtitle,
-  &__CoverageEyebrow,
-  &__LocationLabel {
-    max-inline-size: none;
-  }
-
-  &__Countdown {
-    line-height: 1.4;
-    color: #64748b;
-  }
-
   &__Subtitle {
     margin-top: 0.1875rem;
     line-height: 1.45;
-    color: #64748b;
-  }
-
-  &__DateTile {
-    gap: 0;
-    overflow: hidden;
-    width: 5.5rem;
-    border-radius: 10px;
-    border: 1px solid #e5e7eb;
-    background: #fff;
-  }
-
-  &__DateTileMonth,
-  &__DateTileDay,
-  &__DateTileWeekday {
-    display: block;
-    max-inline-size: none;
-    text-align: center;
-  }
-
-  &__DateTileMonth {
-    padding: 0.3125rem 0;
-    background: #0b2239;
-    font-size: 0.625rem;
-    line-height: 1.2;
-    font-weight: 700;
-    text-transform: uppercase;
-    color: #fff;
-    letter-spacing: 0.14em;
-  }
-
-  &__DateTileBody {
-    gap: 0;
-    align-items: center;
-    justify-content: center;
-    padding: 0.375rem 0 0.5rem;
-  }
-
-  &__DateTileDay {
-    font-size: 2rem;
-    line-height: 1;
-    font-weight: 700;
-    color: #0f172a;
-    letter-spacing: -0.02em;
-  }
-
-  &__DateTileWeekday {
-    margin-top: 0.25rem;
-    font-size: 0.6875rem;
-    line-height: 1.2;
-    font-weight: 600;
-    text-transform: uppercase;
-    color: #64748b;
-    letter-spacing: 0.06em;
-  }
-
-  &__MetaList {
-    gap: 0.5rem;
-    margin-top: 0.75rem;
   }
 
   &__TimeRow,
+  &__DateTimeRow,
   &__LocationRow,
   &__CoverageItem,
   &__ActionRow {
@@ -125,6 +51,7 @@
   }
 
   &__TimeRow,
+  &__DateTimeRow,
   &__LocationRow {
     gap: 0.625rem;
   }
@@ -134,8 +61,13 @@
     color: #1f2937;
   }
 
+  &__DateTimeRow {
+    align-self: flex-start;
+    margin-top: 0.875rem;
+    color: #1f2937;
+  }
+
   &__TimeLabel {
-    max-inline-size: none;
     font-size: 1rem;
     line-height: 1.35;
     font-weight: 600;
@@ -162,14 +94,8 @@
     display: block;
     height: 1px;
     width: 100%;
-    max-inline-size: none;
     margin-block: 1.125rem;
     background: #eef0f3;
-  }
-
-  &__CoverageSection {
-    gap: 0;
-    margin-bottom: 1rem;
   }
 
   &__CoverageEyebrow {
@@ -178,12 +104,7 @@
     line-height: 1.2;
     font-weight: 600;
     text-transform: uppercase;
-    color: #64748b;
     letter-spacing: 0.06em;
-  }
-
-  &__CoverageList {
-    gap: 0.5rem;
   }
 
   &__CoverageItem {
@@ -204,13 +125,8 @@
   }
 
   &__CoverageText {
-    max-inline-size: none;
     line-height: 1.45;
     color: #1f2937;
-  }
-
-  &__ActionRow {
-    gap: 0.5rem;
   }
 
   &__JoinAction {
@@ -219,15 +135,11 @@
 
   @container (width <= 400px) {
     &__HeaderRow {
-      gap: 1rem;
+      gap: 1.5rem;
     }
 
     &__DateColumn {
-      min-width: 6.25rem;
-    }
-
-    &__DateTileDay {
-      font-size: 1.75rem;
+      min-width: 4.5rem;
     }
 
     &__TimeLabel {

--- a/src/components/CallBooking/useCallBookingCountdownLabel.ts
+++ b/src/components/CallBooking/useCallBookingCountdownLabel.ts
@@ -2,32 +2,42 @@ import { useTranslation } from 'react-i18next'
 
 import { tPlural } from '@utils/i18n/plural'
 
+const MS_PER_HOUR = 60 * 60 * 1000
+const MS_PER_DAY = 24 * MS_PER_HOUR
+
+enum CountdownKind {
+  Days = 'days',
+  Hours = 'hours',
+  StartingSoon = 'startingSoon',
+  None = 'none',
+}
+
 type CountdownDescriptor =
-  | { kind: 'days' | 'hours', value: number }
-  | { kind: 'startingSoon' | 'none' }
+  | { kind: CountdownKind.Days | CountdownKind.Hours, value: number }
+  | { kind: CountdownKind.StartingSoon | CountdownKind.None }
 
 const getCountdownDescriptor = (now: number, startAt: Date): CountdownDescriptor => {
   const startTime = startAt.getTime()
 
   if (now >= startTime) {
-    return { kind: 'none' }
+    return { kind: CountdownKind.None }
   }
 
   const millisecondsUntilStart = startTime - now
 
-  if (millisecondsUntilStart < 60 * 60 * 1000) {
-    return { kind: 'startingSoon' }
+  if (millisecondsUntilStart < MS_PER_HOUR) {
+    return { kind: CountdownKind.StartingSoon }
   }
 
-  const hoursUntilStart = millisecondsUntilStart / (60 * 60 * 1000)
+  const hoursUntilStart = millisecondsUntilStart / MS_PER_HOUR
 
   if (hoursUntilStart < 24) {
-    return { kind: 'hours', value: Math.floor(hoursUntilStart) }
+    return { kind: CountdownKind.Hours, value: Math.floor(hoursUntilStart) }
   }
 
   return {
-    kind: 'days',
-    value: Math.floor(millisecondsUntilStart / (24 * 60 * 60 * 1000)),
+    kind: CountdownKind.Days,
+    value: Math.floor(millisecondsUntilStart / MS_PER_DAY),
   }
 }
 
@@ -41,23 +51,24 @@ export const useCallBookingCountdownLabel = (eventStartAt: Date | undefined) => 
   const descriptor = getCountdownDescriptor(Date.now(), eventStartAt)
 
   switch (descriptor.kind) {
-    case 'days':
+    case CountdownKind.Days:
       return tPlural(t, 'callBookings:state.call_in_count_days', {
         count: descriptor.value,
         displayCount: descriptor.value,
         one: 'in {{displayCount}} day',
         other: 'in {{displayCount}} days',
       })
-    case 'hours':
+    case CountdownKind.Hours:
       return tPlural(t, 'callBookings:state.call_in_count_hours', {
         count: descriptor.value,
         displayCount: descriptor.value,
         one: 'in {{displayCount}} hour',
         other: 'in {{displayCount}} hours',
       })
-    case 'startingSoon':
+    case CountdownKind.StartingSoon:
       return t('callBookings:state.starting_soon', 'starting soon')
-    case 'none':
+    case CountdownKind.None:
+    default:
       return ''
   }
 }

--- a/src/components/CallBooking/useCallBookingCountdownLabel.ts
+++ b/src/components/CallBooking/useCallBookingCountdownLabel.ts
@@ -1,0 +1,63 @@
+import { useTranslation } from 'react-i18next'
+
+import { tPlural } from '@utils/i18n/plural'
+
+type CountdownDescriptor =
+  | { kind: 'days' | 'hours', value: number }
+  | { kind: 'startingSoon' | 'none' }
+
+const getCountdownDescriptor = (now: number, startAt: Date): CountdownDescriptor => {
+  const startTime = startAt.getTime()
+
+  if (now >= startTime) {
+    return { kind: 'none' }
+  }
+
+  const millisecondsUntilStart = startTime - now
+
+  if (millisecondsUntilStart < 60 * 60 * 1000) {
+    return { kind: 'startingSoon' }
+  }
+
+  const hoursUntilStart = millisecondsUntilStart / (60 * 60 * 1000)
+
+  if (hoursUntilStart < 24) {
+    return { kind: 'hours', value: Math.floor(hoursUntilStart) }
+  }
+
+  return {
+    kind: 'days',
+    value: Math.floor(millisecondsUntilStart / (24 * 60 * 60 * 1000)),
+  }
+}
+
+export const useCallBookingCountdownLabel = (eventStartAt: Date | undefined) => {
+  const { t } = useTranslation()
+
+  if (eventStartAt == null) {
+    return ''
+  }
+
+  const descriptor = getCountdownDescriptor(Date.now(), eventStartAt)
+
+  switch (descriptor.kind) {
+    case 'days':
+      return tPlural(t, 'callBookings:state.call_in_count_days', {
+        count: descriptor.value,
+        displayCount: descriptor.value,
+        one: 'in {{displayCount}} day',
+        other: 'in {{displayCount}} days',
+      })
+    case 'hours':
+      return tPlural(t, 'callBookings:state.call_in_count_hours', {
+        count: descriptor.value,
+        displayCount: descriptor.value,
+        one: 'in {{displayCount}} hour',
+        other: 'in {{displayCount}} hours',
+      })
+    case 'startingSoon':
+      return t('callBookings:state.starting_soon', 'starting soon')
+    case 'none':
+      return ''
+  }
+}

--- a/src/components/Panel/panel.scss
+++ b/src/components/Panel/panel.scss
@@ -48,7 +48,6 @@
     height: 100%;
     width: 480px;
     min-width: 480px;
-    background: var(--color-base-0);
     opacity: 0.2;
     transition: opacity 180ms ease-in-out;
   }

--- a/src/components/Tasks/TasksHeader.tsx
+++ b/src/components/Tasks/TasksHeader.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import { Heading, HeadingSize } from '@components/Typography/Heading'
+import { Heading } from '@ui/Typography/Heading'
 
 export const TasksHeader = ({
   tasksHeader,
@@ -10,7 +10,7 @@ export const TasksHeader = ({
   const { t } = useTranslation()
   return (
     <div className='Layer__tasks-header'>
-      <Heading size={HeadingSize.secondary} align='left'>
+      <Heading size='sm'>
         {tasksHeader ?? t('bookkeeping:label.bookkeeping_tasks', 'Bookkeeping Tasks')}
       </Heading>
     </div>

--- a/src/components/Tasks/TasksHeader.tsx
+++ b/src/components/Tasks/TasksHeader.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import { Text, TextSize } from '@components/Typography/Text'
+import { Heading, HeadingSize } from '@components/Typography/Heading'
 
 export const TasksHeader = ({
   tasksHeader,
@@ -10,7 +10,9 @@ export const TasksHeader = ({
   const { t } = useTranslation()
   return (
     <div className='Layer__tasks-header'>
-      <Text size={TextSize.lg}>{tasksHeader ?? t('bookkeeping:label.bookkeeping_tasks', 'Bookkeeping Tasks')}</Text>
+      <Heading size={HeadingSize.secondary} align='left'>
+        {tasksHeader ?? t('bookkeeping:label.bookkeeping_tasks', 'Bookkeeping Tasks')}
+      </Heading>
     </div>
   )
 }

--- a/src/components/Tasks/TasksHeader.tsx
+++ b/src/components/Tasks/TasksHeader.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
+import { HStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
 
 export const TasksHeader = ({
@@ -9,10 +10,17 @@ export const TasksHeader = ({
 }) => {
   const { t } = useTranslation()
   return (
-    <div className='Layer__tasks-header'>
+    <HStack
+      className='Layer__tasks-header'
+      align='center'
+      justify='space-between'
+      gap='md'
+      pb='md'
+      pi='lg'
+    >
       <Heading size='sm'>
         {tasksHeader ?? t('bookkeeping:label.bookkeeping_tasks', 'Bookkeeping Tasks')}
       </Heading>
-    </div>
+    </HStack>
   )
 }

--- a/src/components/ui/DateTile/DateTile.tsx
+++ b/src/components/ui/DateTile/DateTile.tsx
@@ -16,7 +16,7 @@ export const DateTile = ({ date }: DateTileProps) => {
   const weekdayLabel = formatDate(date, DateFormat.WeekdayShort)
 
   return (
-    <VStack className='Layer__UI__DateTile'>
+    <VStack className='Layer__UI__DateTile' overflow='hidden'>
       <Span className='Layer__UI__DateTile__Month'>
         {monthLabel}
       </Span>

--- a/src/components/ui/DateTile/DateTile.tsx
+++ b/src/components/ui/DateTile/DateTile.tsx
@@ -17,14 +17,14 @@ export const DateTile = ({ date }: DateTileProps) => {
 
   return (
     <VStack className='Layer__UI__DateTile'>
-      <Span nonAria className='Layer__UI__DateTile__Month'>
+      <Span className='Layer__UI__DateTile__Month'>
         {monthLabel}
       </Span>
       <VStack className='Layer__UI__DateTile__Body' align='center' justify='center' pbs='2xs' pbe='xs'>
-        <Span nonAria className='Layer__UI__DateTile__Day'>
+        <Span className='Layer__UI__DateTile__Day'>
           {dayLabel}
         </Span>
-        <Span nonAria className='Layer__UI__DateTile__Weekday'>
+        <Span className='Layer__UI__DateTile__Weekday'>
           {weekdayLabel}
         </Span>
       </VStack>

--- a/src/components/ui/DateTile/DateTile.tsx
+++ b/src/components/ui/DateTile/DateTile.tsx
@@ -11,7 +11,7 @@ export type DateTileProps = {
 
 export const DateTile = ({ date }: DateTileProps) => {
   const { formatDate } = useIntlFormatter()
-  const monthLabel = formatDate(date, DateFormat.MonthYearShort)
+  const monthLabel = formatDate(date, DateFormat.MonthShort)
   const dayLabel = formatDate(date, DateFormat.Day)
   const weekdayLabel = formatDate(date, DateFormat.WeekdayShort)
 

--- a/src/components/ui/DateTile/DateTile.tsx
+++ b/src/components/ui/DateTile/DateTile.tsx
@@ -1,0 +1,33 @@
+import { DateFormat } from '@utils/i18n/date/patterns'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { VStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+
+import './dateTile.scss'
+
+export type DateTileProps = {
+  date: Date
+}
+
+export const DateTile = ({ date }: DateTileProps) => {
+  const { formatDate } = useIntlFormatter()
+  const monthLabel = formatDate(date, DateFormat.MonthYearShort)
+  const dayLabel = formatDate(date, DateFormat.Day)
+  const weekdayLabel = formatDate(date, DateFormat.WeekdayShort)
+
+  return (
+    <VStack className='Layer__UI__DateTile'>
+      <Span nonAria className='Layer__UI__DateTile__Month'>
+        {monthLabel}
+      </Span>
+      <VStack className='Layer__UI__DateTile__Body' align='center' justify='center' pbs='2xs' pbe='xs'>
+        <Span nonAria className='Layer__UI__DateTile__Day'>
+          {dayLabel}
+        </Span>
+        <Span nonAria className='Layer__UI__DateTile__Weekday'>
+          {weekdayLabel}
+        </Span>
+      </VStack>
+    </VStack>
+  )
+}

--- a/src/components/ui/DateTile/DateTile.tsx
+++ b/src/components/ui/DateTile/DateTile.tsx
@@ -17,14 +17,32 @@ export const DateTile = ({ date }: DateTileProps) => {
 
   return (
     <VStack className='Layer__UI__DateTile' overflow='hidden'>
-      <Span className='Layer__UI__DateTile__Month'>
+      <Span
+        className='Layer__UI__DateTile__Month'
+        align='center'
+        size='2xs'
+        weight='bold'
+        pbs='2xs'
+        pbe='2xs'
+      >
         {monthLabel}
       </Span>
-      <VStack className='Layer__UI__DateTile__Body' align='center' justify='center' pbs='2xs' pbe='xs'>
-        <Span className='Layer__UI__DateTile__Day'>
+      <VStack align='center' justify='center' pbs='2xs' pbe='xs'>
+        <Span
+          className='Layer__UI__DateTile__Day'
+          align='center'
+          weight='bold'
+        >
           {dayLabel}
         </Span>
-        <Span className='Layer__UI__DateTile__Weekday'>
+        <Span
+          className='Layer__UI__DateTile__Weekday'
+          align='center'
+          size='xs'
+          weight='bold'
+          variant='subtle'
+          pbs='3xs'
+        >
           {weekdayLabel}
         </Span>
       </VStack>

--- a/src/components/ui/DateTile/dateTile.scss
+++ b/src/components/ui/DateTile/dateTile.scss
@@ -6,7 +6,7 @@
   gap: 0;
   overflow: hidden;
   width: 5.5rem;
-  border-radius: 10px;
+  border-radius: 0.625rem;
   border: 1px solid #e5e7eb;
   background: #fff;
 

--- a/src/components/ui/DateTile/dateTile.scss
+++ b/src/components/ui/DateTile/dateTile.scss
@@ -1,11 +1,6 @@
 .Layer__UI__DateTile {
-  .Layer__Span {
-    max-inline-size: none;
-  }
-
-  gap: 0;
   width: 5.5rem;
-  border-radius: 0.625rem;
+  border-radius: var(--border-radius-xs);
   border: 1px solid var(--color-base-200);
   background: var(--color-base-0);
 
@@ -13,45 +8,29 @@
   &__Day,
   &__Weekday {
     display: block;
-    text-align: center;
   }
 
   &__Month {
-    padding: 0.3125rem 0;
     background: var(--color-base-1000);
-    font-size: var(--text-2xs);
     line-height: 1.2;
-    font-weight: var(--font-weight-bold);
     text-transform: uppercase;
     color: var(--color-base-0);
-    letter-spacing: 0.14em;
-  }
-
-  &__Body {
-    gap: 0;
   }
 
   &__Day {
-    font-size: 2rem;
+    font-size: var(--text-heading-lg);
     line-height: 1;
-    font-weight: var(--font-weight-bold);
     color: var(--color-base-900);
-    letter-spacing: -0.02em;
   }
 
   &__Weekday {
-    margin-top: 0.25rem;
-    font-size: var(--text-xs);
     line-height: 1.2;
-    font-weight: var(--font-weight-bold);
     text-transform: uppercase;
-    color: var(--fg-subtle);
-    letter-spacing: 0.06em;
   }
 
   @container (width <= 400px) {
     &__Day {
-      font-size: 1.75rem;
+      font-size: var(--text-heading);
     }
   }
 }

--- a/src/components/ui/DateTile/dateTile.scss
+++ b/src/components/ui/DateTile/dateTile.scss
@@ -7,8 +7,8 @@
   overflow: hidden;
   width: 5.5rem;
   border-radius: 0.625rem;
-  border: 1px solid #e5e7eb;
-  background: #fff;
+  border: 1px solid var(--color-base-200);
+  background: var(--color-base-0);
 
   &__Month,
   &__Day,
@@ -19,12 +19,12 @@
 
   &__Month {
     padding: 0.3125rem 0;
-    background: #0b2239;
-    font-size: 0.625rem;
+    background: var(--color-base-1000);
+    font-size: var(--text-2xs);
     line-height: 1.2;
-    font-weight: 700;
+    font-weight: var(--font-weight-bold);
     text-transform: uppercase;
-    color: #fff;
+    color: var(--color-base-0);
     letter-spacing: 0.14em;
   }
 
@@ -35,18 +35,18 @@
   &__Day {
     font-size: 2rem;
     line-height: 1;
-    font-weight: 700;
-    color: #0f172a;
+    font-weight: var(--font-weight-bold);
+    color: var(--color-base-900);
     letter-spacing: -0.02em;
   }
 
   &__Weekday {
     margin-top: 0.25rem;
-    font-size: 0.6875rem;
+    font-size: var(--text-xs);
     line-height: 1.2;
-    font-weight: 600;
+    font-weight: var(--font-weight-bold);
     text-transform: uppercase;
-    color: #64748b;
+    color: var(--fg-subtle);
     letter-spacing: 0.06em;
   }
 

--- a/src/components/ui/DateTile/dateTile.scss
+++ b/src/components/ui/DateTile/dateTile.scss
@@ -4,7 +4,6 @@
   }
 
   gap: 0;
-  overflow: hidden;
   width: 5.5rem;
   border-radius: 0.625rem;
   border: 1px solid var(--color-base-200);

--- a/src/components/ui/DateTile/dateTile.scss
+++ b/src/components/ui/DateTile/dateTile.scss
@@ -1,0 +1,58 @@
+.Layer__UI__DateTile {
+  .Layer__Span {
+    max-inline-size: none;
+  }
+
+  gap: 0;
+  overflow: hidden;
+  width: 5.5rem;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+
+  &__Month,
+  &__Day,
+  &__Weekday {
+    display: block;
+    text-align: center;
+  }
+
+  &__Month {
+    padding: 0.3125rem 0;
+    background: #0b2239;
+    font-size: 0.625rem;
+    line-height: 1.2;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: #fff;
+    letter-spacing: 0.14em;
+  }
+
+  &__Body {
+    gap: 0;
+  }
+
+  &__Day {
+    font-size: 2rem;
+    line-height: 1;
+    font-weight: 700;
+    color: #0f172a;
+    letter-spacing: -0.02em;
+  }
+
+  &__Weekday {
+    margin-top: 0.25rem;
+    font-size: 0.6875rem;
+    line-height: 1.2;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: #64748b;
+    letter-spacing: 0.06em;
+  }
+
+  @container (width <= 400px) {
+    &__Day {
+      font-size: 1.75rem;
+    }
+  }
+}

--- a/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
+++ b/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
@@ -25,16 +25,9 @@ export const useBookkeepingOnboardingCallBooking = () => {
 
   const [embedDismissed, setEmbedDismissed] = useState(false)
   const [hasScheduledCallInSession, setHasScheduledCallInSession] = useState(false)
-  const [persistedOnboardingCallUrl, setPersistedOnboardingCallUrl] = useState<string>()
-
-  useEffect(() => {
-    if (bookkeepingStatus?.onboardingCallUrl != null) {
-      setPersistedOnboardingCallUrl(bookkeepingStatus.onboardingCallUrl)
-    }
-  }, [bookkeepingStatus?.onboardingCallUrl])
 
   const onboardingCallUrl = bookkeepingStatus?.showEmbeddedOnboarding
-    ? bookkeepingStatus.onboardingCallUrl ?? persistedOnboardingCallUrl
+    ? bookkeepingStatus.onboardingCallUrl
     : undefined
 
   const recordCalendlyScheduled = useCallback(async (payload: CalendlyPayload) => {

--- a/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
+++ b/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
@@ -78,7 +78,7 @@ export const useBookkeepingOnboardingCallBooking = () => {
     && shouldShowEmbeddedOnboarding
     && !embedDismissed
   const showScheduledCallBooking = hasResolvedCallBooking && callBooking != null
-  const showEmptyCallBooking = shouldOfferOnboarding
+  const showEmptyCallBooking = shouldOfferOnboarding && shouldShowEmbeddedOnboarding
 
   const handleBookCall = useCallback(() => {
     if (onboardingCallUrl != null) {

--- a/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
+++ b/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
@@ -78,7 +78,7 @@ export const useBookkeepingOnboardingCallBooking = () => {
     && shouldShowEmbeddedOnboarding
     && !embedDismissed
   const showScheduledCallBooking = hasResolvedCallBooking && callBooking != null
-  const showEmptyCallBooking = shouldOfferOnboarding && shouldShowEmbeddedOnboarding
+  const showEmptyCallBooking = shouldOfferOnboarding
 
   const handleBookCall = useCallback(() => {
     if (onboardingCallUrl != null) {

--- a/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
+++ b/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
@@ -6,9 +6,9 @@ import { useCallBookings } from '@hooks/api/businesses/[business-id]/call-bookin
 import { useCreateCallBooking } from '@hooks/api/businesses/[business-id]/call-bookings/useCreateCallBooking'
 import { type CalendlyPayload, useCalendly } from '@hooks/features/calendly/useCalendly'
 
-const getExternalIdFromCalendlyPayload = (payload: CalendlyPayload) => {
+const getUuidFromCalendlyUri = (uri: string) => {
   try {
-    const segments = new URL(payload.event.uri).pathname.split('/').filter(Boolean)
+    const segments = new URL(uri).pathname.split('/').filter(Boolean)
 
     return segments.at(-1)
   }
@@ -31,15 +31,22 @@ export const useBookkeepingOnboardingCallBooking = () => {
     : undefined
 
   const recordCalendlyScheduled = useCallback(async (payload: CalendlyPayload) => {
-    const externalId = getExternalIdFromCalendlyPayload(payload)
+    const externalId = getUuidFromCalendlyUri(payload.event.uri)
 
     if (externalId == null) {
+      return
+    }
+
+    const inviteeId = getUuidFromCalendlyUri(payload.invitee.uri)
+
+    if (inviteeId == null) {
       return
     }
 
     try {
       await createCallBooking({
         external_id: externalId,
+        invitee_id: inviteeId,
         purpose: CallBookingPurpose.BOOKKEEPING_ONBOARDING,
         call_type: CallBookingType.GOOGLE_MEET,
       })

--- a/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
+++ b/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
@@ -58,7 +58,6 @@ export const useBookkeepingOnboardingCallBooking = () => {
   const { isCalendlyVisible, calendlyLink, calendlyRef, openCalendly, closeCalendly } = useCalendly({
     onEventScheduled: recordCalendlyScheduled,
     onClose: handleCalendlyClose,
-    closeOnEventScheduled: true,
   })
 
   const callBooking: CallBooking | null = callBookings?.[0]?.data[0] ?? null
@@ -71,7 +70,7 @@ export const useBookkeepingOnboardingCallBooking = () => {
 
   const shouldAutoOpenEmbed = shouldOfferOnboarding && !embedDismissed
   const showScheduledCallBooking = hasResolvedCallBooking && callBooking != null
-  const showEmptyCallBooking = shouldOfferOnboarding && embedDismissed
+  const showEmptyCallBooking = shouldOfferOnboarding
 
   const handleBookCall = useCallback(() => {
     if (onboardingCallUrl != null) {

--- a/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
+++ b/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
@@ -70,7 +70,10 @@ export const useBookkeepingOnboardingCallBooking = () => {
 
   const shouldAutoOpenEmbed = shouldOfferOnboarding && !embedDismissed
   const showScheduledCallBooking = hasResolvedCallBooking && callBooking != null
-  const showEmptyCallBooking = bookkeepingStatus?.showEmbeddedOnboarding === true
+  const showEmptyCallBooking =
+    bookkeepingStatus?.showEmbeddedOnboarding === true
+    && hasResolvedCallBooking
+    && callBooking == null
 
   const handleBookCall = useCallback(() => {
     if (onboardingCallUrl != null) {

--- a/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
+++ b/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
@@ -33,8 +33,9 @@ export const useBookkeepingOnboardingCallBooking = () => {
     }
   }, [bookkeepingStatus?.onboardingCallUrl])
 
-  const onboardingCallUrl = bookkeepingStatus?.onboardingCallUrl ?? persistedOnboardingCallUrl
-  const shouldShowEmbeddedOnboarding = bookkeepingStatus?.showEmbeddedOnboarding === true
+  const onboardingCallUrl = bookkeepingStatus?.showEmbeddedOnboarding
+    ? bookkeepingStatus.onboardingCallUrl ?? persistedOnboardingCallUrl
+    : undefined
 
   const recordCalendlyScheduled = useCallback(async (payload: CalendlyPayload) => {
     const externalId = getExternalIdFromCalendlyPayload(payload)
@@ -50,16 +51,16 @@ export const useBookkeepingOnboardingCallBooking = () => {
         call_type: CallBookingType.GOOGLE_MEET,
       })
       setHasScheduledCallInSession(true)
+      void forceReloadBookkeepingStatus()
     }
     catch (error: unknown) {
       console.error('Failed to record onboarding call booking', error)
     }
-  }, [createCallBooking])
+  }, [createCallBooking, forceReloadBookkeepingStatus])
 
   const handleCalendlyClose = useCallback(() => {
     setEmbedDismissed(true)
-    void forceReloadBookkeepingStatus()
-  }, [forceReloadBookkeepingStatus])
+  }, [])
 
   const { isCalendlyVisible, calendlyLink, calendlyRef, openCalendly, closeCalendly } = useCalendly({
     onEventScheduled: recordCalendlyScheduled,
@@ -74,11 +75,9 @@ export const useBookkeepingOnboardingCallBooking = () => {
     && onboardingCallUrl != null
     && !hasScheduledCallInSession
 
-  const shouldAutoOpenEmbed = shouldOfferOnboarding
-    && shouldShowEmbeddedOnboarding
-    && !embedDismissed
+  const shouldAutoOpenEmbed = shouldOfferOnboarding && !embedDismissed
   const showScheduledCallBooking = hasResolvedCallBooking && callBooking != null
-  const showEmptyCallBooking = shouldOfferOnboarding
+  const showEmptyCallBooking = bookkeepingStatus?.showEmbeddedOnboarding === true
 
   const handleBookCall = useCallback(() => {
     if (onboardingCallUrl != null) {

--- a/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
+++ b/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
@@ -25,10 +25,16 @@ export const useBookkeepingOnboardingCallBooking = () => {
 
   const [embedDismissed, setEmbedDismissed] = useState(false)
   const [hasScheduledCallInSession, setHasScheduledCallInSession] = useState(false)
+  const [persistedOnboardingCallUrl, setPersistedOnboardingCallUrl] = useState<string>()
 
-  const onboardingCallUrl = bookkeepingStatus?.showEmbeddedOnboarding
-    ? bookkeepingStatus.onboardingCallUrl ?? undefined
-    : undefined
+  useEffect(() => {
+    if (bookkeepingStatus?.onboardingCallUrl != null) {
+      setPersistedOnboardingCallUrl(bookkeepingStatus.onboardingCallUrl)
+    }
+  }, [bookkeepingStatus?.onboardingCallUrl])
+
+  const onboardingCallUrl = bookkeepingStatus?.onboardingCallUrl ?? persistedOnboardingCallUrl
+  const shouldShowEmbeddedOnboarding = bookkeepingStatus?.showEmbeddedOnboarding === true
 
   const recordCalendlyScheduled = useCallback(async (payload: CalendlyPayload) => {
     const externalId = getExternalIdFromCalendlyPayload(payload)
@@ -68,7 +74,9 @@ export const useBookkeepingOnboardingCallBooking = () => {
     && onboardingCallUrl != null
     && !hasScheduledCallInSession
 
-  const shouldAutoOpenEmbed = shouldOfferOnboarding && !embedDismissed
+  const shouldAutoOpenEmbed = shouldOfferOnboarding
+    && shouldShowEmbeddedOnboarding
+    && !embedDismissed
   const showScheduledCallBooking = hasResolvedCallBooking && callBooking != null
   const showEmptyCallBooking = shouldOfferOnboarding
 

--- a/src/schemas/callBooking.ts
+++ b/src/schemas/callBooking.ts
@@ -145,6 +145,11 @@ const CreateCallBookingBodySchemaDefinition = Schema.Struct({
     Schema.fromKey('external_id'),
   ),
 
+  inviteeId: pipe(
+    Schema.optional(Schema.String),
+    Schema.fromKey('invitee_id'),
+  ),
+
   purpose: CallBookingPurposeSchema,
 
   callType: pipe(

--- a/src/styles/tasks.scss
+++ b/src/styles/tasks.scss
@@ -63,7 +63,7 @@
   align-items: center;
   justify-content: space-between;
   min-height: 36px;
-  padding: var(--spacing-md);
+  padding: var(--spacing-lg) var(--spacing-lg) var(--spacing-md);
   container-type: inline-size;
 }
 

--- a/src/styles/tasks.scss
+++ b/src/styles/tasks.scss
@@ -63,7 +63,7 @@
   align-items: center;
   justify-content: space-between;
   min-height: 36px;
-  padding: var(--spacing-lg) var(--spacing-lg) var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
   container-type: inline-size;
 }
 

--- a/src/styles/tasks.scss
+++ b/src/styles/tasks.scss
@@ -58,12 +58,7 @@
 }
 
 .Layer__tasks-header {
-  display: flex;
-  gap: var(--spacing-md);
-  align-items: center;
-  justify-content: space-between;
   min-height: 36px;
-  padding: var(--spacing-md) var(--spacing-lg);
   container-type: inline-size;
 }
 

--- a/src/utils/i18n/date/options.ts
+++ b/src/utils/i18n/date/options.ts
@@ -32,6 +32,13 @@ const DATE_FORMAT_WITH_TIME_READABLE_WITH_TIMEZONE_OPTIONS: Intl.DateTimeFormatO
   timeZoneName: 'short',
 }
 
+const MONTH_DAY_WITH_TIME_READABLE_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: 'long',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+}
+
 const MONTH_DAY_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   month: 'short',
   day: 'numeric',
@@ -68,6 +75,14 @@ const TIME_ONLY_OPTIONS: Intl.DateTimeFormatOptions = {
   minute: '2-digit',
 }
 
+const DAY_ONLY_OPTIONS: Intl.DateTimeFormatOptions = {
+  day: 'numeric',
+}
+
+const WEEKDAY_SHORT_OPTIONS: Intl.DateTimeFormatOptions = {
+  weekday: 'short',
+}
+
 const FORMAT_OPTIONS_BY_PATTERN: Record<DateFormat, Intl.DateTimeFormatOptions> = {
   [DateFormat.Month]: MONTH_FORMAT_OPTIONS,
   [DateFormat.MonthShort]: MONTH_FORMAT_SHORT_OPTIONS,
@@ -80,8 +95,11 @@ const FORMAT_OPTIONS_BY_PATTERN: Record<DateFormat, Intl.DateTimeFormatOptions> 
   [DateFormat.DateNumericPadded]: DATE_FORMAT_SHORT_PADDED_OPTIONS,
   [DateFormat.DateWithTimeReadable]: DATE_FORMAT_WITH_TIME_READABLE_OPTIONS,
   [DateFormat.DateWithTimeReadableWithTimezone]: DATE_FORMAT_WITH_TIME_READABLE_WITH_TIMEZONE_OPTIONS,
+  [DateFormat.MonthDayWithTimeReadable]: MONTH_DAY_WITH_TIME_READABLE_OPTIONS,
   [DateFormat.Time]: TIME_ONLY_OPTIONS,
   [DateFormat.Year]: YEAR_ONLY_OPTIONS,
+  [DateFormat.Day]: DAY_ONLY_OPTIONS,
+  [DateFormat.WeekdayShort]: WEEKDAY_SHORT_OPTIONS,
 }
 
 export const getDateFormatOptions = (pattern: DateFormat = DateFormat.DateShort): Intl.DateTimeFormatOptions => {

--- a/src/utils/i18n/date/patterns.ts
+++ b/src/utils/i18n/date/patterns.ts
@@ -19,9 +19,18 @@ export enum DatePattern {
   DateNumericPadded = 'dateNumericPadded', // 01/05/2026
 }
 
+export enum DayPattern {
+  Day = 'day', // 5
+}
+
+export enum WeekdayPattern {
+  WeekdayShort = 'weekdayShort', // Mon
+}
+
 export enum DateWithTimePattern {
   DateWithTimeReadable = 'dateWithTimeReadable', // January 5, 2026 at 3:30 PM
   DateWithTimeReadableWithTimezone = 'dateWithTimeReadableWithTimezone', // January 5, 2026, 3:30 PM PST
+  MonthDayWithTimeReadable = 'monthDayWithTimeReadable', // January 5 at 3:30 PM
 }
 
 export enum TimePattern {
@@ -37,6 +46,8 @@ export const DateFormat = {
   ...MonthDayPattern,
   ...MonthYearPattern,
   ...DatePattern,
+  ...DayPattern,
+  ...WeekdayPattern,
   ...DateWithTimePattern,
   ...TimePattern,
   ...YearPattern,

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import { PopupModal } from 'react-calendly'
 import { useTranslation } from 'react-i18next'
 
+import { type CallBooking as CallBookingData } from '@schemas/callBooking'
 import { type Variants } from '@utils/styleUtils/sizeVariants'
 import { useBookkeepingOnboardingCallBooking } from '@hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking'
 import { useSizeClass, useWindowSize } from '@hooks/utils/size/useWindowSize'
@@ -19,6 +20,59 @@ import { type ProfitAndLossSummariesStringOverrides } from '@components/ProfitAn
 import { Tasks, type TasksStringOverrides } from '@components/Tasks/Tasks'
 import { View } from '@components/View/View'
 import { useKeepInMobileViewport } from '@views/BookkeepingOverview/useKeepInMobileViewport'
+
+type BookkeepingOverviewTasksContentProps = {
+  callBooking?: CallBookingData
+  showCallBookingCard: boolean
+  tasksMobile: boolean
+  tasksStringOverrides?: TasksStringOverrides
+  onBookCall: () => void
+  onClickReconnectAccounts?: () => void
+}
+
+const BookkeepingOverviewTasksContent = ({
+  callBooking,
+  showCallBookingCard,
+  tasksMobile,
+  tasksStringOverrides,
+  onBookCall,
+  onClickReconnectAccounts,
+}: BookkeepingOverviewTasksContentProps) => {
+  const callBookingEmptyPromptFirst =
+    showCallBookingCard && callBooking == null
+
+  if (callBookingEmptyPromptFirst) {
+    return (
+      <>
+        <CallBooking
+          callBooking={callBooking}
+          onBookCall={onBookCall}
+        />
+        <Tasks
+          mobile={tasksMobile}
+          stringOverrides={tasksStringOverrides}
+          onClickReconnectAccounts={onClickReconnectAccounts}
+        />
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Tasks
+        mobile={tasksMobile}
+        stringOverrides={tasksStringOverrides}
+        onClickReconnectAccounts={onClickReconnectAccounts}
+      />
+      {showCallBookingCard && (
+        <CallBooking
+          callBooking={callBooking}
+          onBookCall={onBookCall}
+        />
+      )}
+    </>
+  )
+}
 
 export interface BookkeepingOverviewProps {
   showTitle?: boolean
@@ -73,40 +127,6 @@ export const BookkeepingOverview = ({
     closeCalendly,
   } = useBookkeepingOnboardingCallBooking()
 
-  const callBookingEmptyPromptFirst =
-    showCallBookingCard && callBooking == null
-
-  const callBookingWithTasks = (tasksMobile: boolean) =>
-    callBookingEmptyPromptFirst
-      ? (
-        <>
-          <CallBooking
-            callBooking={callBooking}
-            onBookCall={handleBookCall}
-          />
-          <Tasks
-            mobile={tasksMobile}
-            stringOverrides={stringOverrides?.tasks}
-            onClickReconnectAccounts={onClickReconnectAccounts}
-          />
-        </>
-      )
-      : (
-        <>
-          <Tasks
-            mobile={tasksMobile}
-            stringOverrides={stringOverrides?.tasks}
-            onClickReconnectAccounts={onClickReconnectAccounts}
-          />
-          {showCallBookingCard && (
-            <CallBooking
-              callBooking={callBooking}
-              onBookCall={handleBookCall}
-            />
-          )}
-        </>
-      )
-
   return (
     <ProfitAndLoss asContainer={false}>
       <View
@@ -123,7 +143,16 @@ export const BookkeepingOverview = ({
         )}
         withSidebar={width > 1100}
         sidebar={(
-          <VStack gap='lg'>{callBookingWithTasks(false)}</VStack>
+          <VStack gap='lg'>
+            <BookkeepingOverviewTasksContent
+              callBooking={callBooking}
+              showCallBookingCard={showCallBookingCard}
+              tasksMobile={false}
+              tasksStringOverrides={stringOverrides?.tasks}
+              onBookCall={handleBookCall}
+              onClickReconnectAccounts={onClickReconnectAccounts}
+            />
+          </VStack>
         )}
         showHeader={showTitle}
       >
@@ -132,7 +161,16 @@ export const BookkeepingOverview = ({
             ref={upperContentRef}
             onClick={() => (upperElementInFocus.current = true)}
           >
-            <VStack gap='lg'>{callBookingWithTasks(true)}</VStack>
+            <VStack gap='lg'>
+              <BookkeepingOverviewTasksContent
+                callBooking={callBooking}
+                showCallBookingCard={showCallBookingCard}
+                tasksMobile
+                tasksStringOverrides={stringOverrides?.tasks}
+                onBookCall={handleBookCall}
+                onClickReconnectAccounts={onClickReconnectAccounts}
+              />
+            </VStack>
           </div>
         )}
         <div

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -73,6 +73,40 @@ export const BookkeepingOverview = ({
     closeCalendly,
   } = useBookkeepingOnboardingCallBooking()
 
+  const callBookingEmptyPromptFirst =
+    showCallBookingCard && callBooking == null
+
+  const callBookingWithTasks = (tasksMobile: boolean) =>
+    callBookingEmptyPromptFirst
+      ? (
+        <>
+          <CallBooking
+            callBooking={callBooking}
+            onBookCall={handleBookCall}
+          />
+          <Tasks
+            mobile={tasksMobile}
+            stringOverrides={stringOverrides?.tasks}
+            onClickReconnectAccounts={onClickReconnectAccounts}
+          />
+        </>
+      )
+      : (
+        <>
+          <Tasks
+            mobile={tasksMobile}
+            stringOverrides={stringOverrides?.tasks}
+            onClickReconnectAccounts={onClickReconnectAccounts}
+          />
+          {showCallBookingCard && (
+            <CallBooking
+              callBooking={callBooking}
+              onBookCall={handleBookCall}
+            />
+          )}
+        </>
+      )
+
   return (
     <ProfitAndLoss asContainer={false}>
       <View
@@ -89,18 +123,7 @@ export const BookkeepingOverview = ({
         )}
         withSidebar={width > 1100}
         sidebar={(
-          <VStack gap='lg'>
-            {showCallBookingCard && (
-              <CallBooking
-                callBooking={callBooking}
-                onBookCall={handleBookCall}
-              />
-            )}
-            <Tasks
-              stringOverrides={stringOverrides?.tasks}
-              onClickReconnectAccounts={onClickReconnectAccounts}
-            />
-          </VStack>
+          <VStack gap='lg'>{callBookingWithTasks(false)}</VStack>
         )}
         showHeader={showTitle}
       >
@@ -109,19 +132,7 @@ export const BookkeepingOverview = ({
             ref={upperContentRef}
             onClick={() => (upperElementInFocus.current = true)}
           >
-            <VStack gap='lg'>
-              {showCallBookingCard && (
-                <CallBooking
-                  callBooking={callBooking}
-                  onBookCall={handleBookCall}
-                />
-              )}
-              <Tasks
-                mobile
-                stringOverrides={stringOverrides?.tasks}
-                onClickReconnectAccounts={onClickReconnectAccounts}
-              />
-            </VStack>
+            <VStack gap='lg'>{callBookingWithTasks(true)}</VStack>
           </div>
         )}
         <div


### PR DESCRIPTION
## Description
<img width="599" height="421" alt="Screenshot 2026-04-23 at 5 41 05 PM" src="https://github.com/user-attachments/assets/8f37278d-7bf9-419e-92cd-ba7e7f2083b5" />



## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the Calendly booking flow and the create-call-booking request payload (`invitee_id`) while also reworking call booking UI layout; could impact scheduling behavior and backend expectations.
> 
> **Overview**
> Updates the *bookkeeping onboarding call booking* experience: the `CallBooking` card is redesigned (new `DateTile`, countdown label, onboarding “What we’ll cover” list, updated spacing/styles) and the previous add-to-calendar/join-link actions are simplified to a single primary join button.
> 
> Adjusts embedded onboarding booking logic to send both Calendly event and invitee UUIDs (`external_id`, new optional `invitee_id`) when recording a scheduled call, and tweaks when the empty call-booking prompt is shown and how Tasks vs CallBooking are ordered in `BookkeepingOverview`.
> 
> Adds new i18n strings for the coverage section and countdown states (French-Canadian entries left blank), plus new date formatting patterns to support the updated UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6652015ec6db098211e346c2e70bb415b045164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->