### PR TITLE
feat: include pinned columns on unified reports, polish

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -9,6 +9,7 @@ import {
   TableBody,
   TableHeader,
 } from '@ui/Table/Table'
+import { useColumnPinningStyles } from '@hooks/utils/tables/useColumnPinningStyles'
 import { Loader } from '@components/Loader/Loader'
 
 import './dataTable.scss'
@@ -53,8 +54,9 @@ export const DataTable = <TData extends object>({
   withClickableRow,
 }: DataTableProps<TData>) => {
   const nonAria = headerGroups.length > 1
-
   const { EmptyState, ErrorState } = slots
+
+  const { headerRef, pinningStyles } = useColumnPinningStyles(headerGroups)
 
   const isEmptyTable = data?.length === 0
   const renderTableBody = useMemo(() => {
@@ -110,6 +112,8 @@ export const DataTable = <TData extends object>({
                   key={`${row.id}-${cell.id}`}
                   className={`Layer__UI__Table-Cell__${componentName}--${cell.column.id}`}
                   alignment={cell.column.columnDef.meta?.alignment}
+                  pinned={cell.column.getIsPinned()}
+                  style={pinningStyles.get(cell.column.id)}
                   nonAria={nonAria}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -120,35 +124,39 @@ export const DataTable = <TData extends object>({
         })}
       </>
     )
-  }, [isError, isLoading, isEmptyTable, data, nonAria, numColumns, ErrorState, EmptyState, withClickableRow, componentName])
+  }, [isError, isLoading, isEmptyTable, data, nonAria, numColumns, ErrorState, EmptyState, withClickableRow, componentName, pinningStyles])
 
   return (
-    <Table aria-label={ariaLabel} className={`Layer__UI__Table__${componentName}`} nonAria={nonAria}>
-      <TableHeader hideHeader={hideHeader} nonAria={nonAria}>
-        {headerGroups.map(headerGroup => (
-          <Row key={headerGroup.id} nonAria={nonAria}>
-            {headerGroup.headers.map(header => (
-              <Column
-                key={header.id}
-                isRowHeader={header.column.columnDef.meta?.isRowHeader}
-                className={`Layer__UI__Table-Column__${componentName}--${header.id}`}
-                alignment={header.column.columnDef.meta?.alignment}
-                nonAria={nonAria}
-                colSpan={header.colSpan}
-              >
-                {header.isPlaceholder
-                  ? null
-                  : (typeof header.column.columnDef.header === 'function'
-                    ? header.column.columnDef.header(header.getContext())
-                    : header.column.columnDef.header)}
-              </Column>
-            ))}
-          </Row>
-        ))}
-      </TableHeader>
-      <TableBody dependencies={dependencies} nonAria={nonAria}>
-        {renderTableBody}
-      </TableBody>
-    </Table>
+    <div className='Layer__UI__Table-ScrollContainer'>
+      <Table aria-label={ariaLabel} className={`Layer__UI__Table__${componentName}`} nonAria={nonAria}>
+        <TableHeader ref={headerRef} hideHeader={hideHeader} nonAria={nonAria}>
+          {headerGroups.map(headerGroup => (
+            <Row key={headerGroup.id} nonAria={nonAria}>
+              {headerGroup.headers.map(header => (
+                <Column
+                  key={header.id}
+                  isRowHeader={header.column.columnDef.meta?.isRowHeader}
+                  className={`Layer__UI__Table-Column__${componentName}--${header.id}`}
+                  alignment={header.column.columnDef.meta?.alignment}
+                  pinned={header.column.getIsPinned()}
+                  style={pinningStyles.get(header.column.id)}
+                  nonAria={nonAria}
+                  colSpan={header.colSpan}
+                >
+                  {header.isPlaceholder
+                    ? null
+                    : (typeof header.column.columnDef.header === 'function'
+                      ? header.column.columnDef.header(header.getContext())
+                      : header.column.columnDef.header)}
+                </Column>
+              ))}
+            </Row>
+          ))}
+        </TableHeader>
+        <TableBody dependencies={dependencies} nonAria={nonAria}>
+          {renderTableBody}
+        </TableBody>
+      </Table>
+    </div>
   )
 }

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { flexRender, type HeaderGroup, type Row as RowType } from '@tanstack/react-table'
 
+import { useColumnPinningStyles } from '@hooks/utils/tables/useColumnPinningStyles'
 import {
   Cell,
   Column,
@@ -9,7 +10,6 @@ import {
   TableBody,
   TableHeader,
 } from '@ui/Table/Table'
-import { useColumnPinningStyles } from '@hooks/utils/tables/useColumnPinningStyles'
 import { Loader } from '@components/Loader/Loader'
 
 import './dataTable.scss'

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -28,7 +28,6 @@ export interface BaseDataTableProps {
     EmptyState: React.FC
     ErrorState: React.FC
   }
-  hideHeader?: boolean
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   dependencies?: readonly any[]
 }
@@ -46,7 +45,6 @@ export const DataTable = <TData extends object>({
   componentName,
   ariaLabel,
   slots,
-  hideHeader,
   dependencies,
   data,
   headerGroups,
@@ -129,7 +127,7 @@ export const DataTable = <TData extends object>({
   return (
     <div className='Layer__UI__Table-ScrollContainer'>
       <Table aria-label={ariaLabel} className={`Layer__UI__Table__${componentName}`} nonAria={nonAria}>
-        <TableHeader ref={headerRef} hideHeader={hideHeader} nonAria={nonAria}>
+        <TableHeader ref={headerRef} nonAria={nonAria}>
           {headerGroups.map(headerGroup => (
             <Row key={headerGroup.id} nonAria={nonAria}>
               {headerGroup.headers.map(header => (

--- a/src/components/DataTable/columnUtils.ts
+++ b/src/components/DataTable/columnUtils.ts
@@ -1,6 +1,10 @@
-import { type ColumnDef, createColumnHelper, type Row } from '@tanstack/react-table'
+import { type ColumnDef, createColumnHelper, type HeaderGroup, type Row } from '@tanstack/react-table'
+import type { CSSProperties } from 'react'
 
 import { type Alignment } from '@schemas/reports/unifiedReport'
+import type { ColumnHeaderWidths } from '@hooks/utils/tables/useColumnHeaderWidths'
+
+export type ColumnPinningSide = 'left' | 'right'
 
 type BaseColumn = {
   id: string
@@ -11,6 +15,7 @@ type BaseColumn = {
 
 export type LeafColumn<TData> = BaseColumn & {
   cell: (row: Row<TData>) => React.ReactNode
+  pinning?: ColumnPinningSide
 }
 
 export type GroupColumn<TData> = BaseColumn & {
@@ -21,10 +26,6 @@ export type ColumnNode<TData> = LeafColumn<TData> | GroupColumn<TData>
 
 export const isLeafColumn = <TData>(col: ColumnNode<TData>): col is LeafColumn<TData> => {
   return 'cell' in col
-}
-
-export const isGroupColumn = <TData>(col: ColumnNode<TData>): col is GroupColumn<TData> => {
-  return 'columns' in col
 }
 
 export type NestedColumnConfig<TData> = ColumnNode<TData>[]
@@ -56,4 +57,47 @@ export const getColumnDefs = <TData>(
       meta: getColumnMeta(col),
     })
   })
+}
+
+export const computePinningStyles = <TData>(
+  headerGroups: HeaderGroup<TData>[],
+  widths: ColumnHeaderWidths,
+): ReadonlyMap<string, CSSProperties> => {
+  const leafHeaders = headerGroups.at(-1)?.headers ?? []
+  const styles = new Map<string, CSSProperties>()
+
+  const accumulate = (headersInOrder: typeof leafHeaders, side: ColumnPinningSide) => {
+    let offset = 0
+    for (const header of headersInOrder) {
+      if (header.column.getIsPinned() !== side) continue
+      styles.set(header.column.id, { position: 'sticky', [side]: `${offset}px` })
+      offset += widths[header.column.id] ?? 0
+    }
+  }
+
+  accumulate(leafHeaders, 'left')
+  accumulate([...leafHeaders].reverse(), 'right')
+
+  return styles
+}
+
+export const getColumnPinning = <TData>(
+  columnConfig: NestedColumnConfig<TData>,
+): { left: string[], right: string[] } => {
+  const left: string[] = []
+  const right: string[] = []
+
+  for (const col of columnConfig) {
+    if (isLeafColumn(col)) {
+      if (col.pinning === 'left') left.push(col.id)
+      else if (col.pinning === 'right') right.push(col.id)
+    }
+    else {
+      const nested = getColumnPinning(col.columns)
+      left.push(...nested.left)
+      right.push(...nested.right)
+    }
+  }
+
+  return { left, right }
 }

--- a/src/components/ExpandableDataTable/ExpandableDataTable.tsx
+++ b/src/components/ExpandableDataTable/ExpandableDataTable.tsx
@@ -43,7 +43,6 @@ export function ExpandableDataTable<TData extends object>({
   componentName,
   ariaLabel,
   slots,
-  hideHeader,
   getSubRows,
   getRowId,
 }: ExpandableDataTableProps<TData>) {
@@ -125,7 +124,6 @@ export function ExpandableDataTable<TData extends object>({
       isError={isError}
       componentName={componentName}
       slots={slots}
-      hideHeader={hideHeader}
       dependencies={dependencies}
       headerGroups={headerGroups}
       withClickableRow={withClickableRow}

--- a/src/components/ExpandableDataTable/ExpandableDataTable.tsx
+++ b/src/components/ExpandableDataTable/ExpandableDataTable.tsx
@@ -9,6 +9,7 @@ import {
 import { HStack } from '@ui/Stack/Stack'
 import {
   getColumnDefs,
+  getColumnPinning,
   isLeafColumn,
   type NestedColumnConfig,
 } from '@components/DataTable/columnUtils'
@@ -78,13 +79,18 @@ export function ExpandableDataTable<TData extends object>({
 
   const columnDefs = getColumnDefs<TData>(wrappedColumnConfig)
 
+  const columnPinning = useMemo(
+    () => getColumnPinning(wrappedColumnConfig),
+    [wrappedColumnConfig],
+  )
+
   const table = useReactTable<TData>({
     data: data ?? EMPTY_ARRAY,
     columns: columnDefs,
     getSubRows,
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
-    state: { expanded },
+    state: { expanded, columnPinning },
     onExpandedChange: setExpanded,
     autoResetPageIndex: false,
     getRowId,

--- a/src/components/ReportsNavigation/ReportsNavigation.tsx
+++ b/src/components/ReportsNavigation/ReportsNavigation.tsx
@@ -1,14 +1,9 @@
-import { type ComponentType, useMemo } from 'react'
-import { Landmark } from 'lucide-react'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { ReportConfig, ReportGroup } from '@schemas/reports/reportConfig'
-import { ReportGroupType } from '@schemas/reports/reportConfig'
 import { useReportConfig } from '@hooks/api/businesses/[business-id]/reports/config/useReportConfig'
 import { useBaseUnifiedReport } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
-import Folder from '@icons/Folder'
-import type { IconSvgProps } from '@icons/types'
-import { HStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
 import {
@@ -18,8 +13,6 @@ import {
 } from '@components/TreeNavigation/TreeNavigation'
 import { TreeNavigationSkeleton } from '@components/TreeNavigation/TreeNavigationSkeleton'
 import { ConditionalBlock } from '@components/utility/ConditionalBlock'
-
-import './reportsNavigation.scss'
 
 const ReportsNavigationError = () => {
   const { t } = useTranslation()
@@ -33,11 +26,6 @@ const ReportsNavigationError = () => {
   )
 }
 
-const REPORT_GROUP_ICON: Record<ReportGroupType, ComponentType<IconSvgProps>> = {
-  [ReportGroupType.Accounting]: Landmark,
-  [ReportGroupType.Unknown]: Folder,
-}
-
 const isReportGroup = (item: ReportGroup | ReportConfig): item is ReportGroup =>
   'reports' in item
 
@@ -46,13 +34,7 @@ const groupConfig: TreeNavigationGroupConfig<ReportGroup, ReportConfig> = {
   getTextValue: group => group.displayName,
   getChildren: group => group.reports,
   renderLabel: (group) => {
-    const Icon = REPORT_GROUP_ICON[group.groupType]
-    return (
-      <HStack className='Layer__ReportsNavigation__GroupLabel' gap='sm' align='center'>
-        <Icon className='Layer__ReportsNavigation__GroupIcon' strokeWidth={1.5} size={16} />
-        <Span ellipsis variant='subtle' weight='bold'>{group.displayName}</Span>
-      </HStack>
-    )
+    return <Span ellipsis weight='bold'>{group.displayName}</Span>
   },
 }
 

--- a/src/components/ReportsNavigation/reportsNavigation.scss
+++ b/src/components/ReportsNavigation/reportsNavigation.scss
@@ -1,7 +1,0 @@
-.Layer__ReportsNavigation__GroupLabel {
-  min-width: 0;
-}
-
-.Layer__ReportsNavigation__GroupIcon {
-  color: var(--color-base-500);
-}

--- a/src/components/TreeNavigation/TreeNavigation.tsx
+++ b/src/components/TreeNavigation/TreeNavigation.tsx
@@ -87,7 +87,7 @@ const renderTreeLeaf = <TLeaf extends object>({ leaf, leafConfig }: RenderTreeLe
     <TreeItemContent>
       <HStack align='center' justify='space-between'>
         {leafConfig.renderLabel(leaf)}
-        <Check className='Layer__TreeNavigation__Check' width={14} height={14} />
+        <Check className='Layer__TreeNavigation__Check' />
       </HStack>
     </TreeItemContent>
   </TreeItem>

--- a/src/components/TreeNavigation/treeNavigation.scss
+++ b/src/components/TreeNavigation/treeNavigation.scss
@@ -3,7 +3,7 @@
   align-content: center;
   height: var(--spacing-5xl);
 
-  padding-inline-start: calc(4px + var(--spacing-sm) * var(--tree-item-level));
+  padding-inline-start: calc(var(--spacing-3xs) + var(--spacing-sm) * var(--tree-item-level));
   padding-inline-end: var(--spacing-md);
 
   border-bottom: 1px solid var(--color-base-300);
@@ -11,8 +11,8 @@
 
   .Layer__TreeNavigation__Check {
     visibility: hidden;
-    height: 16px;
-    min-width: 16px;
+    height: 1rem;
+    min-width: 1rem;
   }
 
   &[aria-level='1'] {

--- a/src/components/TreeNavigation/treeNavigation.scss
+++ b/src/components/TreeNavigation/treeNavigation.scss
@@ -3,7 +3,7 @@
   align-content: center;
   height: var(--spacing-5xl);
 
-  padding-inline-start: calc(var(--spacing-sm) * calc(var(--tree-item-level) - 1) + var(--spacing-md) * var(--tree-item-level));
+  padding-inline-start: calc(4px + var(--spacing-sm) * var(--tree-item-level));
   padding-inline-end: var(--spacing-md);
 
   border-bottom: 1px solid var(--color-base-300);
@@ -11,6 +11,8 @@
 
   .Layer__TreeNavigation__Check {
     visibility: hidden;
+    height: 16px;
+    min-width: 16px;
   }
 
   &[aria-level='1'] {

--- a/src/components/UnifiedReport/UnifiedReportBaseHeader.tsx
+++ b/src/components/UnifiedReport/UnifiedReportBaseHeader.tsx
@@ -34,12 +34,20 @@ export const UnifiedReportBaseHeader = () => {
 
   return (
     <VStack gap='lg'>
-      <HStack pis='lg' pbs='lg'>
+      <HStack pi='lg' pbs='lg' align='center' justify='space-between'>
         {baseReport
           ? <Span size='lg' weight='bold'>{baseReport.displayName}</Span>
           : <SkeletonLoader width='192px' height='24px' />}
+        <HStack gap='xs'>
+          <Button variant='outlined' onClick={onClickExpandOrCollapse}>
+            {shouldCollapse
+              ? t('reports:action.collapse_all', 'Collapse All')
+              : t('reports:action.expand_all', 'Expand All')}
+          </Button>
+          <UnifiedReportDownloadButton />
+        </HStack>
       </HStack>
-      <HStack fluid justify='space-between' align='end' pbe='lg' className='Layer__UnifiedReport__Header'>
+      <HStack fluid align='end' pbe='lg' className='Layer__UnifiedReport__Header'>
         <HStack pi='lg' gap='xs'>
           {hasControl(baseReport, ReportControl.DateRange) && (
             <CombinedDateRangeSelection mode={dateSelectionMode} />
@@ -50,14 +58,6 @@ export const UnifiedReportBaseHeader = () => {
           {dateSelectionMode === 'full' && hasControl(baseReport, ReportControl.GroupBy) && (
             <DateGroupByComboBox value={groupBy} onValueChange={setGroupBy} />
           )}
-        </HStack>
-        <HStack pi='lg' className='Layer__UnifiedReport__Header__SecondaryActions'>
-          <Button variant='outlined' onClick={onClickExpandOrCollapse}>
-            {shouldCollapse
-              ? t('reports:action.collapse_all', 'Collapse All')
-              : t('reports:action.expand_all', 'Expand All')}
-          </Button>
-          <UnifiedReportDownloadButton />
         </HStack>
       </HStack>
     </VStack>

--- a/src/components/UnifiedReport/unifiedReport.scss
+++ b/src/components/UnifiedReport/unifiedReport.scss
@@ -9,7 +9,7 @@
 
 .Layer__UnifiedReport__Sidebar {
   flex-shrink: 0;
-  width: 18rem;
+  width: 15rem;
   border-right: 1px solid var(--color-base-300);
 }
 

--- a/src/components/UnifiedReport/unifiedReportBaseHeader.scss
+++ b/src/components/UnifiedReport/unifiedReportBaseHeader.scss
@@ -17,11 +17,3 @@
     }
   }
 }
-
-.Layer__UnifiedReport__Header__SecondaryActions {
-  gap: var(--spacing-xs);
-
-  @media (width <= 500px) {
-    gap: var(--spacing-3xs);
-  }
-}

--- a/src/components/UnifiedReport/unifiedReportTable.scss
+++ b/src/components/UnifiedReport/unifiedReportTable.scss
@@ -4,5 +4,6 @@
   .Layer__UI__Table-Column,
   .Layer__UI__Table-Cell {
     display: table-cell;
+    min-width: 6rem;
   }
 }

--- a/src/components/UnifiedReport/utils.tsx
+++ b/src/components/UnifiedReport/utils.tsx
@@ -1,8 +1,8 @@
 import { type Row } from '@tanstack/react-table'
 
-import { type UnifiedReportColumn, type UnifiedReportRow } from '@schemas/reports/unifiedReport'
+import { Pinning, type UnifiedReportColumn, type UnifiedReportRow } from '@schemas/reports/unifiedReport'
 import { asMutable } from '@utils/asMutable'
-import { type ColumnNode, type GroupColumn, type LeafColumn } from '@components/DataTable/columnUtils'
+import { type ColumnNode, type ColumnPinningSide, type GroupColumn, type LeafColumn } from '@components/DataTable/columnUtils'
 import { UnifiedReportTableCellContent } from '@components/UnifiedReport/UnifiedReportTableCellContent'
 
 type RowType = Row<UnifiedReportRow>
@@ -14,6 +14,17 @@ const getCell = (row: Row<UnifiedReportRow>, col: UnifiedReportColumn) => row.or
 const isGroupColumn = (col: UnifiedReportColumn): col is UnifiedReportColumnWithRequiredColumns =>
   col.columns !== undefined && col.columns.length > 0
 
+const toPinningSide = (pinning: Pinning | undefined): ColumnPinningSide | undefined => {
+  switch (pinning) {
+    case Pinning.Left:
+      return 'left'
+    case Pinning.Right:
+      return 'right'
+    default:
+      return undefined
+  }
+}
+
 const makeBaseColumn = (col: UnifiedReportColumn) => ({
   id: col.columnKey,
   header: col.displayName,
@@ -23,6 +34,7 @@ const makeBaseColumn = (col: UnifiedReportColumn) => ({
 
 const makeLeafColumn = (col: UnifiedReportColumn): LeafColumn<UnifiedReportRow> => ({
   ...makeBaseColumn(col),
+  pinning: toPinningSide(col.pinning),
   cell: (row: RowType) => {
     const cell = getCell(row, col)
     const cellConfig = cell?.reportConfig ?? null

--- a/src/components/ui/Table/Table.tsx
+++ b/src/components/ui/Table/Table.tsx
@@ -46,8 +46,8 @@ const toAlignmentDataValue = (alignment: Alignment | undefined) => {
   }
 }
 
-const getClassName = (component: TableSubComponent, additionalClassNames?: Argument, withHidden?: boolean) =>
-  classNames(`${CSS_PREFIX}-${component}`, withHidden && `${CSS_PREFIX}-${component}--hidden`, additionalClassNames)
+const getClassName = (component: TableSubComponent, additionalClassNames?: Argument) =>
+  classNames(`${CSS_PREFIX}-${component}`, additionalClassNames)
 
 type TableRenderingProps = {
   nonAria?: boolean
@@ -76,12 +76,8 @@ const Table = forwardRef<HTMLTableElement, TableProps & TableRenderingProps>(
 Table.displayName = TableSubComponent.Table
 
 // TABLE HEADER
-type TableHeaderStyleProps = {
-  hideHeader?: boolean
-}
-
 const TableHeaderInner = <T extends object>(
-  { children, className, hideHeader, nonAria, ...restProps }: TableHeaderProps<T> & TableHeaderStyleProps & TableRenderingProps,
+  { children, className, nonAria, ...restProps }: TableHeaderProps<T> & TableRenderingProps,
   ref: React.Ref<HTMLTableSectionElement>,
 ) => {
   const TableHeaderComponent = nonAria
@@ -90,7 +86,7 @@ const TableHeaderInner = <T extends object>(
 
   return (
     <TableHeaderComponent
-      className={getClassName(TableSubComponent.TableHeader, className, hideHeader)}
+      className={getClassName(TableSubComponent.TableHeader, className)}
       {...restProps}
       ref={ref}
     >
@@ -100,7 +96,7 @@ const TableHeaderInner = <T extends object>(
 }
 
 const TableHeader = forwardRef(TableHeaderInner) as (<T>(
-  props: TableHeaderProps<T> & TableHeaderStyleProps & TableRenderingProps & { ref?: React.Ref<HTMLTableSectionElement> }
+  props: TableHeaderProps<T> & TableRenderingProps & { ref?: React.Ref<HTMLTableSectionElement> }
 ) => React.ReactElement) & { displayName?: string }
 
 TableHeader.displayName = TableSubComponent.TableHeader

--- a/src/components/ui/Table/Table.tsx
+++ b/src/components/ui/Table/Table.tsx
@@ -21,6 +21,8 @@ import { withRenderProp } from '@components/utility/withRenderProp'
 
 import './table.scss'
 
+type PinnedSide = 'left' | 'right' | false
+
 enum TableSubComponent {
   Table = 'Table',
   TableHeader = 'TableHeader',
@@ -173,11 +175,12 @@ Row.displayName = TableSubComponent.Row
 type ColumnStyleProps = {
   alignment?: Alignment
   colSpan?: number
+  pinned?: PinnedSide
 }
 
 const Column = forwardRef<HTMLTableCellElement, ColumnProps & ColumnStyleProps & TableRenderingProps>(
-  ({ children, className, nonAria, id, alignment = Alignment.Left, colSpan = 1, ...restProps }, ref) => {
-    const dataProperties = toDataProperties({ align: toAlignmentDataValue(alignment) })
+  ({ children, className, nonAria, id, alignment = Alignment.Left, colSpan = 1, pinned, ...restProps }, ref) => {
+    const dataProperties = toDataProperties({ align: toAlignmentDataValue(alignment), pinned })
     const columnClassName = getClassName(TableSubComponent.Column, className)
 
     const ColumnComponent = nonAria
@@ -204,11 +207,12 @@ Column.displayName = TableSubComponent.Column
 // TABLE CELL
 type CellStyleProps = {
   alignment?: Alignment
+  pinned?: PinnedSide
 }
 
 const Cell = forwardRef<HTMLTableCellElement, CellProps & CellStyleProps & TableRenderingProps>(
-  ({ children, className, nonAria, id, alignment, ...restProps }, ref) => {
-    const dataProperties = toDataProperties({ align: toAlignmentDataValue(alignment) })
+  ({ children, className, nonAria, id, alignment, pinned, ...restProps }, ref) => {
+    const dataProperties = toDataProperties({ align: toAlignmentDataValue(alignment), pinned })
 
     const CellComponent = nonAria
       ? 'td'

--- a/src/components/ui/Table/table.scss
+++ b/src/components/ui/Table/table.scss
@@ -1,5 +1,6 @@
 .Layer__UI__Table-Table {
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 .Layer__UI__Table-TableHeader {

--- a/src/components/ui/Table/table.scss
+++ b/src/components/ui/Table/table.scss
@@ -92,3 +92,19 @@
     }
   }
 }
+
+.Layer__UI__Table-ScrollContainer {
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+.Layer__UI__Table-Column[data-pinned],
+.Layer__UI__Table-Cell[data-pinned] {
+  z-index: 1;
+  background-color: inherit;
+}
+
+.Layer__UI__Table-TableHeader .Layer__UI__Table-Column[data-pinned] {
+  z-index: 2;
+  background-color: var(--color-base-0);
+}

--- a/src/components/ui/Table/table.scss
+++ b/src/components/ui/Table/table.scss
@@ -12,10 +12,6 @@
   > tr {
     height: inherit;
   }
-
-  &--hidden {
-    display: none;
-  }
 }
 
 .Layer__UI__Table-Row {

--- a/src/hooks/utils/tables/useColumnHeaderWidths.ts
+++ b/src/hooks/utils/tables/useColumnHeaderWidths.ts
@@ -1,0 +1,56 @@
+import { type RefObject, useLayoutEffect, useState } from 'react'
+
+export type ColumnHeaderWidths = Readonly<Record<string, number>>
+
+type WidthsState = Record<string, number>
+
+const WIDTH_CHANGE_THRESHOLD_PX = 0.5
+
+const getLeafHeaderCells = (header: HTMLElement | null): HTMLElement[] | null => {
+  const leafRow = header?.lastElementChild
+  if (!leafRow) return null
+  return Array.from(leafRow.children) as HTMLElement[]
+}
+
+const computeUpdatedWidths = (
+  prev: WidthsState,
+  columnIds: readonly string[],
+  cells: readonly HTMLElement[],
+): WidthsState => {
+  let next = prev
+  columnIds.forEach((id, i) => {
+    const cell = cells[i]
+    if (!cell) return
+    const width = cell.getBoundingClientRect().width
+    if (Math.abs((prev[id] ?? 0) - width) < WIDTH_CHANGE_THRESHOLD_PX) return
+    if (next === prev) next = { ...prev }
+    next[id] = width
+  })
+  return next
+}
+
+export const useColumnHeaderWidths = (
+  headerRef: RefObject<HTMLElement | null>,
+  columnIds: readonly string[],
+): ColumnHeaderWidths => {
+  const [widths, setWidths] = useState<WidthsState>({})
+  const idsKey = columnIds.join('|')
+
+  useLayoutEffect(() => {
+    const cells = getLeafHeaderCells(headerRef.current)
+    if (!cells) return
+
+    const measure = () => {
+      setWidths(prev => computeUpdatedWidths(prev, columnIds, cells))
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    cells.forEach(cell => observer.observe(cell))
+    return () => observer.disconnect()
+  // `columnIds` array identity changes per render; its content is tracked via `idsKey`.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [headerRef, idsKey])
+
+  return widths
+}

--- a/src/hooks/utils/tables/useColumnPinningStyles.ts
+++ b/src/hooks/utils/tables/useColumnPinningStyles.ts
@@ -1,0 +1,25 @@
+import { useMemo, useRef } from 'react'
+import type { HeaderGroup } from '@tanstack/react-table'
+
+import { useColumnHeaderWidths } from '@hooks/utils/tables/useColumnHeaderWidths'
+import { computePinningStyles } from '@components/DataTable/columnUtils'
+
+export const useColumnPinningStyles = <TData>(
+  headerGroups: HeaderGroup<TData>[],
+) => {
+  const headerRef = useRef<HTMLTableSectionElement>(null)
+
+  const leafColumnIds = useMemo(
+    () => headerGroups.at(-1)?.headers.map(h => h.column.id) ?? [],
+    [headerGroups],
+  )
+
+  const headerWidths = useColumnHeaderWidths(headerRef, leafColumnIds)
+
+  const pinningStyles = useMemo(
+    () => computePinningStyles(headerGroups, headerWidths),
+    [headerGroups, headerWidths],
+  )
+
+  return { headerRef, pinningStyles }
+}

--- a/src/schemas/reports/reportConfig.ts
+++ b/src/schemas/reports/reportConfig.ts
@@ -9,24 +9,11 @@ export enum ReportControl {
   Unknown = 'unknown',
 }
 
-export enum ReportGroupType {
-  Accounting = 'accounting',
-  Unknown = 'unknown',
-}
-
 const ReportControlSchema = Schema.Enums(ReportControl)
-const ReportGroupTypeSchema = Schema.Enums(ReportGroupType)
-
 const TransformedReportControlSchema = createTransformedEnumSchema(
   ReportControlSchema,
   ReportControl,
   ReportControl.Unknown,
-)
-
-const TransformedReportGroupTypeSchema = createTransformedEnumSchema(
-  ReportGroupTypeSchema,
-  ReportGroupType,
-  ReportGroupType.Unknown,
 )
 
 export const ReportConfigSchema = Schema.Struct({
@@ -50,7 +37,7 @@ export type ReportConfig = typeof ReportConfigSchema.Type
 
 export const ReportGroupSchema = Schema.Struct({
   groupType: pipe(
-    Schema.propertySignature(TransformedReportGroupTypeSchema),
+    Schema.propertySignature(Schema.String),
     Schema.fromKey('group_type'),
   ),
   displayName: pipe(

--- a/src/schemas/reports/unifiedReport.ts
+++ b/src/schemas/reports/unifiedReport.ts
@@ -23,6 +23,20 @@ const TransformedAlignmentSchema = createTransformedEnumSchema(
   Alignment.Left,
 )
 
+export enum Pinning {
+  Left = 'LEFT',
+  Right = 'RIGHT',
+  Unpinned = 'UNPINNED',
+}
+
+const PinningSchema = Schema.Enums(Pinning)
+
+const TransformedPinningSchema = createTransformedEnumSchema(
+  PinningSchema,
+  Pinning,
+  Pinning.Unpinned,
+)
+
 export const DateQueryParamsSchema = Schema.Struct({
   effectiveDate: pipe(
     Schema.propertySignature(Schema.Date),
@@ -60,6 +74,7 @@ const unifiedReportColumnFields = {
   ),
   isRowHeader: Schema.optional(Schema.Boolean).pipe(Schema.fromKey('is_row_header')),
   alignment: Schema.optional(TransformedAlignmentSchema),
+  pinning: Schema.optional(TransformedPinningSchema),
 }
 
 export interface UnifiedReportColumn extends Schema.Struct.Type<typeof unifiedReportColumnFields> {


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: updates core table rendering/styling to use sticky pinned columns and ResizeObserver-based width measurement, which can affect layout and performance across table consumers.
> 
> **Overview**
> Adds **pinned column support** for unified report tables by introducing `pinning` in the unified report schema, mapping it into `columnConfig`, and wiring TanStack `columnPinning` state through `ExpandableDataTable`/`DataTable`.
> 
> Implements sticky positioning via new hooks (`useColumnHeaderWidths`, `useColumnPinningStyles`) that measure header cell widths with `ResizeObserver` and compute per-column `style` offsets; updates `Table` components/CSS to support horizontal scrolling (`Table-ScrollContainer`) and pinned layering (`data-pinned`, z-index/background).
> 
> Includes UI polish: simplifies report navigation group labels (removes icons and related enum/schema), tweaks tree item padding/check sizing, adjusts unified report header action layout, narrows the sidebar, and enforces a minimum cell width in the unified report table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ff979e78df9c47b8a13bbb74d3a3acc81a307fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->