### PR TITLE
Tax-code API Contract

### DIFF
--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/useCategorizeBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/useCategorizeBankTransaction.ts
@@ -1,11 +1,10 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 import { useSWRConfig } from 'swr'
 import type { SWRInfiniteKeyedMutator } from 'swr/infinite'
 import useSWRMutation from 'swr/mutation'
 
 import type { BankTransaction } from '@internal-types/bankTransactions'
-import { type CategoryUpdate, type CategoryUpdateEncoded, CategoryUpdateSchema } from '@schemas/bankTransactions/categoryUpdate'
+import { type CategoryUpdate, type CategoryUpdateEncoded, encodeCategoryUpdate } from '@schemas/bankTransactions/categoryUpdate'
 import { put } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
@@ -89,7 +88,7 @@ export function useCategorizeBankTransaction() {
           businessId,
           bankTransactionId,
         },
-        body: Schema.encodeSync(CategoryUpdateSchema)(rest),
+        body: encodeCategoryUpdate(rest),
       },
     ).then(({ data }) => data),
     {

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -8,11 +8,10 @@ import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
 import { useAuth } from '@hooks/utils/auth/useAuth'
-import { type BankTransactionCategorization, useGetAllBankTransactionsCategorizations } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useGetAllBankTransactionsCategories } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
 import { useSelectedIds } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
-import { isApiCategorizationAsOption, isCategoryAsOption, isPlaceholderAsOption, isSplitAsOption, isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
-import { getCategoryPayloadTaxCode } from '@components/BankTransactions/utils'
+import { type BankTransactionCategoryComboBoxOption, isApiCategorizationAsOption, isCategoryAsOption, isPlaceholderAsOption, isSplitAsOption, isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 
 const BULK_MATCH_OR_CATEGORIZE_TAG = '#bulk-match-or-categorize'
 
@@ -20,13 +19,12 @@ type MatchOrCategorizeTransaction = typeof MatchOrCategorizeTransactionRequestSc
 
 const buildBulkMatchOrCategorizePayload = (
   selectedIds: Iterable<string>,
-  categorizations: Map<string, BankTransactionCategorization>,
+  transactionCategories: Map<string, BankTransactionCategoryComboBoxOption | null>,
 ): Record<string, MatchOrCategorizeTransaction> => {
   const transactions: Record<string, MatchOrCategorizeTransaction> = {}
 
   for (const transactionId of selectedIds) {
-    const selectedCategorization = categorizations.get(transactionId)
-    const transactionCategory = selectedCategorization?.category ?? null
+    const transactionCategory = transactionCategories.get(transactionId) ?? null
 
     if (!transactionCategory || isPlaceholderAsOption(transactionCategory)) {
       continue
@@ -52,7 +50,6 @@ const buildBulkMatchOrCategorizePayload = (
           return {
             amount: split.amount,
             category: classification,
-            taxCode: getCategoryPayloadTaxCode(classification, split.taxCode),
             tags: split.tags,
             customerId: split.customerVendor?.customerVendorType === 'CUSTOMER' ? split.customerVendor.id : undefined,
             vendorId: split.customerVendor?.customerVendorType === 'VENDOR' ? split.customerVendor.id : undefined,
@@ -74,13 +71,11 @@ const buildBulkMatchOrCategorizePayload = (
     else if (isCategoryAsOption(transactionCategory) || isApiCategorizationAsOption(transactionCategory)) {
       const classification = transactionCategory.classification
       if (classification) {
-        const selectedTaxCode = selectedCategorization?.taxCode ?? null
         transactions[transactionId] = {
           type: 'categorize',
           categorization: {
             type: 'Category',
             category: classification,
-            taxCode: getCategoryPayloadTaxCode(classification, selectedTaxCode?.value),
           },
         }
       }
@@ -158,15 +153,15 @@ export const useBulkMatchOrCategorize = () => {
   const { data } = useAuth()
   const { businessId, eventCallbacks } = useLayerContext()
   const { selectedIds } = useSelectedIds()
-  const { categorizations } = useGetAllBankTransactionsCategorizations()
+  const { transactionCategories } = useGetAllBankTransactionsCategories()
 
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
 
   const buildTransactionsPayload: () => BulkMatchOrCategorizeRequest = useCallback(() => {
-    const transactions = buildBulkMatchOrCategorizePayload(selectedIds, categorizations)
+    const transactions = buildBulkMatchOrCategorizePayload(selectedIds, transactionCategories)
     return { transactions }
-  }, [selectedIds, categorizations])
+  }, [selectedIds, transactionCategories])
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -8,10 +8,11 @@ import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
 import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useGetAllBankTransactionsCategories } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { type BankTransactionCategorization, useGetAllBankTransactionsCategorizations } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useSelectedIds } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
-import { type BankTransactionCategoryComboBoxOption, isApiCategorizationAsOption, isCategoryAsOption, isPlaceholderAsOption, isSplitAsOption, isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import { isApiCategorizationAsOption, isCategoryAsOption, isPlaceholderAsOption, isSplitAsOption, isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import { getCategoryPayloadTaxCode } from '@components/BankTransactions/utils'
 
 const BULK_MATCH_OR_CATEGORIZE_TAG = '#bulk-match-or-categorize'
 
@@ -19,12 +20,13 @@ type MatchOrCategorizeTransaction = typeof MatchOrCategorizeTransactionRequestSc
 
 const buildBulkMatchOrCategorizePayload = (
   selectedIds: Iterable<string>,
-  transactionCategories: Map<string, BankTransactionCategoryComboBoxOption | null>,
+  categorizations: Map<string, BankTransactionCategorization>,
 ): Record<string, MatchOrCategorizeTransaction> => {
   const transactions: Record<string, MatchOrCategorizeTransaction> = {}
 
   for (const transactionId of selectedIds) {
-    const transactionCategory = transactionCategories.get(transactionId) ?? null
+    const selectedCategorization = categorizations.get(transactionId)
+    const transactionCategory = selectedCategorization?.category ?? null
 
     if (!transactionCategory || isPlaceholderAsOption(transactionCategory)) {
       continue
@@ -50,6 +52,7 @@ const buildBulkMatchOrCategorizePayload = (
           return {
             amount: split.amount,
             category: classification,
+            taxCode: getCategoryPayloadTaxCode(classification, split.taxCode),
             tags: split.tags,
             customerId: split.customerVendor?.customerVendorType === 'CUSTOMER' ? split.customerVendor.id : undefined,
             vendorId: split.customerVendor?.customerVendorType === 'VENDOR' ? split.customerVendor.id : undefined,
@@ -71,11 +74,13 @@ const buildBulkMatchOrCategorizePayload = (
     else if (isCategoryAsOption(transactionCategory) || isApiCategorizationAsOption(transactionCategory)) {
       const classification = transactionCategory.classification
       if (classification) {
+        const selectedTaxCode = selectedCategorization?.taxCode ?? null
         transactions[transactionId] = {
           type: 'categorize',
           categorization: {
             type: 'Category',
             category: classification,
+            taxCode: getCategoryPayloadTaxCode(classification, selectedTaxCode?.value),
           },
         }
       }
@@ -153,15 +158,15 @@ export const useBulkMatchOrCategorize = () => {
   const { data } = useAuth()
   const { businessId, eventCallbacks } = useLayerContext()
   const { selectedIds } = useSelectedIds()
-  const { transactionCategories } = useGetAllBankTransactionsCategories()
+  const { categorizations } = useGetAllBankTransactionsCategorizations()
 
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
 
   const buildTransactionsPayload: () => BulkMatchOrCategorizeRequest = useCallback(() => {
-    const transactions = buildBulkMatchOrCategorizePayload(selectedIds, transactionCategories)
+    const transactions = buildBulkMatchOrCategorizePayload(selectedIds, categorizations)
     return { transactions }
-  }, [selectedIds, transactionCategories])
+  }, [selectedIds, categorizations])
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/schemas/bankTransactions/bankTransaction.ts
+++ b/src/schemas/bankTransactions/bankTransaction.ts
@@ -28,6 +28,19 @@ export const AccountInstitutionSchema = Schema.Struct({
   logo: Schema.NullOr(Schema.String),
 })
 
+export const BankTransactionTaxOptionSchema = Schema.Struct({
+  code: Schema.String,
+  displayName: pipe(
+    Schema.propertySignature(Schema.String),
+    Schema.fromKey('display_name'),
+  ),
+})
+
+export const BankTransactionTaxOptionsSchema = Schema.Record({
+  key: Schema.String,
+  value: Schema.Array(BankTransactionTaxOptionSchema),
+})
+
 export const InputStrategySchema = Schema.Enums(InputStrategy)
 
 export const CategorizationFlowSchema = Schema.Struct({
@@ -73,6 +86,14 @@ export const BankTransactionSchema = Schema.Struct({
   categorizationFlow: pipe(
     Schema.optional(Schema.NullOr(CategorizationFlowSchema)),
     Schema.fromKey('categorization_flow'),
+  ),
+  taxCode: pipe(
+    Schema.optional(Schema.NullOr(Schema.String)),
+    Schema.fromKey('tax_code'),
+  ),
+  taxOptions: pipe(
+    Schema.optional(Schema.NullOr(BankTransactionTaxOptionsSchema)),
+    Schema.fromKey('tax_options'),
   ),
   suggestedMatches: pipe(
     Schema.propertySignature(Schema.Array(SuggestedMatchSchema)),

--- a/src/schemas/bankTransactions/categoryUpdate.ts
+++ b/src/schemas/bankTransactions/categoryUpdate.ts
@@ -6,13 +6,13 @@ import { TagKeyValueSchema } from '@schemas/tag'
 export const SingleCategoryUpdateSchema = Schema.Struct({
   type: Schema.Literal('Category'),
   category: ClassificationSchema,
-  taxCode: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(Schema.fromKey('tax_code')),
+  taxCode: Schema.optional(Schema.NullOr(Schema.String)).pipe(Schema.fromKey('tax_code')),
 })
 
 export const SplitCategoryEntrySchema = Schema.Struct({
   category: ClassificationSchema,
   amount: Schema.Number,
-  taxCode: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(Schema.fromKey('tax_code')),
+  taxCode: Schema.optional(Schema.NullOr(Schema.String)).pipe(Schema.fromKey('tax_code')),
   tags: Schema.optional(Schema.Array(TagKeyValueSchema)),
   customerId: Schema.optional(Schema.UUID).pipe(Schema.fromKey('customer_id')),
   vendorId: Schema.optional(Schema.UUID).pipe(Schema.fromKey('vendor_id')),

--- a/src/schemas/bankTransactions/categoryUpdate.ts
+++ b/src/schemas/bankTransactions/categoryUpdate.ts
@@ -6,11 +6,13 @@ import { TagKeyValueSchema } from '@schemas/tag'
 export const SingleCategoryUpdateSchema = Schema.Struct({
   type: Schema.Literal('Category'),
   category: ClassificationSchema,
+  taxCode: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(Schema.fromKey('tax_code')),
 })
 
 export const SplitCategoryEntrySchema = Schema.Struct({
   category: ClassificationSchema,
   amount: Schema.Number,
+  taxCode: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(Schema.fromKey('tax_code')),
   tags: Schema.optional(Schema.Array(TagKeyValueSchema)),
   customerId: Schema.optional(Schema.UUID).pipe(Schema.fromKey('customer_id')),
   vendorId: Schema.optional(Schema.UUID).pipe(Schema.fromKey('vendor_id')),
@@ -28,3 +30,7 @@ export const CategoryUpdateSchema = Schema.Union(
 
 export type CategoryUpdate = typeof CategoryUpdateSchema.Type
 export type CategoryUpdateEncoded = typeof CategoryUpdateSchema.Encoded
+
+export function encodeCategoryUpdate(categoryUpdate: CategoryUpdate): CategoryUpdateEncoded {
+  return Schema.encodeSync(CategoryUpdateSchema)(categoryUpdate)
+}

--- a/src/schemas/categorization.ts
+++ b/src/schemas/categorization.ts
@@ -50,6 +50,10 @@ export const AccountSplitEntrySchema = Schema.Struct({
   type: Schema.Literal('AccountSplitEntry'),
   amount: Schema.Number,
   category: AccountCategorizationSchema,
+  taxCode: pipe(
+    Schema.optional(Schema.NullOr(Schema.String)),
+    Schema.fromKey('tax_code'),
+  ),
   tags: pipe(
     Schema.propertySignature(Schema.Array(TransactionTagSchema)),
     Schema.fromKey('tags'),
@@ -62,6 +66,10 @@ export const ExclusionSplitEntrySchema = Schema.Struct({
   type: Schema.Literal('ExclusionSplitEntry'),
   amount: Schema.Number,
   category: ExclusionCategorizationSchema,
+  taxCode: pipe(
+    Schema.optional(Schema.NullOr(Schema.String)),
+    Schema.fromKey('tax_code'),
+  ),
   tags: pipe(
     Schema.propertySignature(Schema.Array(TransactionTagSchema)),
     Schema.fromKey('tags'),

--- a/src/types/bankTransactions.ts
+++ b/src/types/bankTransactions.ts
@@ -1,6 +1,10 @@
 import { type Categorization } from '@internal-types/categories'
 import { type Direction, type S3PresignedUrl } from '@internal-types/general'
-import { type CategorizationStatus } from '@schemas/bankTransactions/bankTransaction'
+import {
+  type BankTransactionTaxOptionSchema,
+  type BankTransactionTaxOptionsSchema,
+  type CategorizationStatus,
+} from '@schemas/bankTransactions/bankTransaction'
 import { type UpdateCategorizationRulesSuggestionSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { type MatchDetailsType, type MatchType } from '@schemas/bankTransactions/match'
 import type { CategorizationEncoded } from '@schemas/categorization'
@@ -25,12 +29,8 @@ export interface AccountInstitution {
   logo: string | null
 }
 
-export interface BankTransactionTaxOption {
-  code: string
-  display_name: string
-}
-
-export type BankTransactionTaxOptions = Record<string, BankTransactionTaxOption[]>
+export type BankTransactionTaxOption = typeof BankTransactionTaxOptionSchema.Encoded
+export type BankTransactionTaxOptions = typeof BankTransactionTaxOptionsSchema.Encoded
 
 // This isn't my favorite but BankTransaction contains much
 // more than we're using right now.

--- a/src/types/bankTransactions.ts
+++ b/src/types/bankTransactions.ts
@@ -1,7 +1,6 @@
 import { type Categorization } from '@internal-types/categories'
 import { type Direction, type S3PresignedUrl } from '@internal-types/general'
 import {
-  type BankTransactionTaxOptionSchema,
   type BankTransactionTaxOptionsSchema,
   type CategorizationStatus,
 } from '@schemas/bankTransactions/bankTransaction'
@@ -29,7 +28,6 @@ export interface AccountInstitution {
   logo: string | null
 }
 
-export type BankTransactionTaxOption = typeof BankTransactionTaxOptionSchema.Encoded
 export type BankTransactionTaxOptions = typeof BankTransactionTaxOptionsSchema.Encoded
 
 // This isn't my favorite but BankTransaction contains much

--- a/src/types/bankTransactions.ts
+++ b/src/types/bankTransactions.ts
@@ -95,7 +95,7 @@ export interface DocumentS3Urls {
 export type Split = {
   amount: number
   category: BankTransactionCategoryComboBoxOption | null
-  taxCode: string | null
+  taxCode?: string | null
   tags: readonly Tag[]
   customerVendor: typeof CustomerVendorSchema.Type | null
 }

--- a/src/types/bankTransactions.ts
+++ b/src/types/bankTransactions.ts
@@ -25,6 +25,13 @@ export interface AccountInstitution {
   logo: string | null
 }
 
+export interface BankTransactionTaxOption {
+  code: string
+  display_name: string
+}
+
+export type BankTransactionTaxOptions = Record<string, BankTransactionTaxOption[]>
+
 // This isn't my favorite but BankTransaction contains much
 // more than we're using right now.
 export interface BankTransaction extends Record<string, unknown> {
@@ -45,6 +52,8 @@ export interface BankTransaction extends Record<string, unknown> {
   direction: Direction
   counterparty_name: string
   category: CategorizationEncoded | null
+  tax_code?: string | null
+  tax_options?: BankTransactionTaxOptions | null
   categorization_status: CategorizationStatus
   categorization_flow: Categorization | null
   categorization_method: string
@@ -86,6 +95,7 @@ export interface DocumentS3Urls {
 export type Split = {
   amount: number
   category: BankTransactionCategoryComboBoxOption | null
+  taxCode: string | null
   tags: readonly Tag[]
   customerVendor: typeof CustomerVendorSchema.Type | null
 }


### PR DESCRIPTION
## Description
Introduces the tax-code API and data contract needed by categorization flows.

## Changes
- Adds tax_code and tax_options schema/type support.
- Adds split tax-code contract support.
- Updates categorize and bulk-match payload encoding hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates API encoding/decoding contracts for bank-transaction categorization by introducing optional `tax_code` fields, which could cause integration issues if backend expectations differ or clients rely on previous payload shapes.
> 
> **Overview**
> Adds *tax code* support to the bank-transaction API contract by extending schemas/types to include optional `tax_code` on transactions and on split/category update payloads, plus a new `tax_options` map of available tax codes.
> 
> Refactors `useCategorizeBankTransaction` to encode request bodies via a shared `encodeCategoryUpdate` helper (instead of inline `Schema.encodeSync`), aligning categorize payload serialization with the updated schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7fc35c1efa6f93ef9bbdd15b682514311ef43a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->