### PR TITLE
Fix recursion tracking in constant expression rule and DurationFormat polyfill import

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -84,7 +84,7 @@ const layerNamingPlugin = {
                 if (element.type === 'SpreadElement') {
                   return false
                 }
-                return isStaticConstantExpression(element)
+                return isStaticConstantExpression(element, seenVariables)
               })
             case 'ObjectExpression':
               return node.properties.every((prop) => {

--- a/src/utils/i18n/duration/formatters.ts
+++ b/src/utils/i18n/duration/formatters.ts
@@ -1,7 +1,7 @@
 import type { Duration } from 'date-fns'
 import type { IntlShape } from 'react-intl'
 
-import '@formatjs/intl-durationformat'
+import '@formatjs/intl-durationformat/polyfill.js'
 
 export type DurationFormatStyle = 'long' | 'short' | 'narrow' | 'digital'
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Fixes two regressions flagged in review:
- Preserve `seenVariables` propagation when recursively validating `ArrayExpression` elements in the custom ESLint rule.
- Use the correct FormatJS polyfill side-effect import path so `Intl.DurationFormat` is installed in non-supporting runtimes.

## Changes
- Updated `isStaticConstantExpression` array element recursion in `eslint.config.mjs` to pass `seenVariables`.
- Changed duration formatter import from `@formatjs/intl-durationformat` to `@formatjs/intl-durationformat/polyfill.js`.

## Blockers
None.

## How this has been tested?
- `npm run lint:eslint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-284e4c20-8250-4f33-9d7b-e03b6c74012b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-284e4c20-8250-4f33-9d7b-e03b6c74012b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

