### PR TITLE
Add tax code selection UI

### DIFF
--- a/src/components/ActionableList/ActionableList.tsx
+++ b/src/components/ActionableList/ActionableList.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 
 import CheckIcon from '@icons/Check'
 import ChevronRight from '@icons/ChevronRight'
+import { VStack } from '@ui/Stack/Stack'
 import { Text, TextSize } from '@components/Typography/Text'
 
 import './actionableList.scss'
@@ -32,18 +33,19 @@ export const ActionableList = <T,>({
 }: ActionableListProps<T>) => {
   return (
     <ul className={classNames('Layer__actionable-list', className)}>
-      {options.map((x, idx) => (
+      {options.map(x => (
         <li
           role='button'
           onClick={() => onClick(x)}
-          key={`actionable-list-item-${idx}`}
+          key={x.id}
           className={classNames(
-            x.secondary && 'Layer__actionable-list-item--secondary',
-            x.asLink && 'Layer__actionable-list-item--as-link',
+            'Layer__actionable-list__item',
+            x.secondary && 'Layer__actionable-list__item--secondary',
+            x.asLink && 'Layer__actionable-list__item--as-link',
             selectedId === x.id && 'Layer__actionable-list__item--selected',
           )}
         >
-          <div className='Layer__actionable-list__content'>
+          <VStack gap='2xs' align='start' className='Layer__actionable-list__content'>
             <Text size={TextSize.sm}>{x.label}</Text>
             {
               showDescriptions
@@ -57,13 +59,12 @@ export const ActionableList = <T,>({
                 </Text>
               )
             }
-          </div>
+          </VStack>
           {!x.asLink && selectedId && selectedId === x.id
             ? (
               <span className='Layer__actionable-list__select Layer__actionable-list__select--selected'>
                 <CheckIcon
                   size={14}
-                  className='Layer__actionable-list__selected-icon'
                 />
               </span>
             )
@@ -76,7 +77,6 @@ export const ActionableList = <T,>({
           {x.asLink && (
             <ChevronRight
               size={16}
-              className='Layer__actionable-list__link-icon'
             />
           )}
         </li>

--- a/src/components/ActionableList/actionableList.scss
+++ b/src/components/ActionableList/actionableList.scss
@@ -3,7 +3,7 @@
   margin: 0;
   list-style: none;
 
-  li {
+  &__item {
     box-sizing: border-box;
     display: flex;
     gap: var(--spacing-2xs);
@@ -16,39 +16,35 @@
     cursor: pointer;
     font-size: 12px;
 
-    .Layer__actionable-list__content {
-      display: flex;
-      flex-direction: column;
-      gap: var(--spacing-2xs);
-      align-items: flex-start;
-      max-width: 36ch;
-
-      .Layer__actionable-list__content-description {
-        color: var(--color-base-500);
-      }
-    }
-
-    &.Layer__actionable-list-item--secondary {
+    &--secondary {
       color: var(--color-base-500);
 
-      &.Layer__actionable-list-item--as-link:hover {
+      &.Layer__actionable-list__item--as-link:hover {
         color: var(--color-base-1000);
       }
     }
 
-    &.Layer__actionable-list__item--selected {
+    &--selected {
       background-color: var(--color-base-50);
     }
   }
 
-  .Layer__actionable-list__select {
+  &__content {
+    max-width: 36ch;
+  }
+
+  &__content-description {
+    color: var(--color-base-500);
+  }
+
+  &__select {
     display: flex;
     height: 18px;
     width: 18px;
     border-radius: 50%;
     border: 1px solid var(--color-base-300);
 
-    &.Layer__actionable-list__select--selected {
+    &--selected {
       align-items: center;
       justify-content: center;
       border: 1px solid var(--color-info-success);

--- a/src/components/BusinessForm/BusinessFormMobile.tsx
+++ b/src/components/BusinessForm/BusinessFormMobile.tsx
@@ -1,30 +1,28 @@
 import { useCallback } from 'react'
 import { GridList } from 'react-aria-components'
-import { useTranslation } from 'react-i18next'
-
-import { VStack } from '@ui/Stack/Stack'
-import { Span } from '@ui/Typography/Text'
 
 import './businessFormMobile.scss'
 
-import { BusinessFormMobileItem, type BusinessFormMobileItemOption } from './BusinessFormMobileItem'
+import { BusinessFormMobileItem, type BusinessFormMobileItemOption, type BusinessFormOptionValue } from './BusinessFormMobileItem'
 
-interface BusinessFormMobileProps {
-  options: BusinessFormMobileItemOption[]
+interface BusinessFormMobileProps<T extends BusinessFormOptionValue> {
+  options: BusinessFormMobileItemOption<T>[]
   selectedId?: string
   showDescriptions?: boolean
-  onSelect: (option: BusinessFormMobileItemOption) => void
+  onSelect: (option: BusinessFormMobileItemOption<T>) => void
   readOnly?: boolean
+  ariaLabel: string
 }
 
-export const BusinessFormMobile = ({
+export const BusinessFormMobile = <T extends BusinessFormOptionValue,>({
   options,
   selectedId,
   onSelect,
   readOnly,
-}: BusinessFormMobileProps) => {
-  const { t } = useTranslation()
+  ariaLabel,
+}: BusinessFormMobileProps<T>) => {
   const handleSelectionChange = useCallback((keys: Set<string | number> | 'all') => {
+    if (keys === 'all') return
     if (readOnly) return
 
     const selectedKey = [...keys][0]
@@ -35,24 +33,19 @@ export const BusinessFormMobile = ({
   }, [options, onSelect, readOnly])
 
   return (
-    <VStack gap='sm'>
-      <Span size='sm' weight='bold'>
-        {t('bankTransactions:action.select_category', 'Select category')}
-      </Span>
-      <GridList
-        aria-label={t('bankTransactions:action.select_a_category', 'Select a category')}
-        selectionMode='single'
-        selectedKeys={selectedId ? new Set([selectedId]) : new Set()}
-        onSelectionChange={handleSelectionChange}
-        className='Layer__BusinessFormMobile'
-      >
-        {options.map(option => (
-          <BusinessFormMobileItem
-            key={option.value.value}
-            option={option}
-          />
-        ))}
-      </GridList>
-    </VStack>
+    <GridList
+      aria-label={ariaLabel}
+      selectionMode='single'
+      selectedKeys={selectedId ? new Set([selectedId]) : new Set()}
+      onSelectionChange={handleSelectionChange}
+      className='Layer__BusinessFormMobile'
+    >
+      {options.map(option => (
+        <BusinessFormMobileItem<T>
+          key={option.value.value}
+          option={option}
+        />
+      ))}
+    </GridList>
   )
 }

--- a/src/components/BusinessForm/BusinessFormMobileItem.tsx
+++ b/src/components/BusinessForm/BusinessFormMobileItem.tsx
@@ -4,24 +4,26 @@ import ChevronRight from '@icons/ChevronRight'
 import { Checkbox } from '@ui/Checkbox/Checkbox'
 import { HStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
-import { type BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 
 import './businessFormMobileItem.scss'
 
-export type BusinessFormOptionValue = BankTransactionCategoryComboBoxOption
+export interface BusinessFormOptionValue {
+  label: string
+  value: string
+}
 
-export interface BusinessFormMobileItemOption {
-  value: BusinessFormOptionValue
+export interface BusinessFormMobileItemOption<T extends BusinessFormOptionValue = BusinessFormOptionValue> {
+  value: T
   asLink?: boolean
 }
 
-interface BusinessFormMobileItemProps {
-  option: BusinessFormMobileItemOption
+interface BusinessFormMobileItemProps<T extends BusinessFormOptionValue> {
+  option: BusinessFormMobileItemOption<T>
 }
 
-export const BusinessFormMobileItem = ({
+export const BusinessFormMobileItem = <T extends BusinessFormOptionValue,>({
   option,
-}: BusinessFormMobileItemProps) => {
+}: BusinessFormMobileItemProps<T>) => {
   const value = option.value.value
   const label = option.value.label
 
@@ -45,7 +47,6 @@ export const BusinessFormMobileItem = ({
         {option.asLink && (
           <ChevronRight
             size={16}
-            className='Layer__BusinessFormMobileItem__link-icon'
           />
         )}
       </HStack>

--- a/src/components/CategorySelect/CategorySelectDrawerWithTrigger.tsx
+++ b/src/components/CategorySelect/CategorySelectDrawerWithTrigger.tsx
@@ -8,8 +8,6 @@ import { Span } from '@ui/Typography/Text'
 import type { BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { CategorySelectDrawer } from '@components/CategorySelect/CategorySelectDrawer'
 
-import './categorySelectDrawerWithTrigger.scss'
-
 type Props = {
   value: BankTransactionCategoryComboBoxOption | null
   onChange: (newValue: BankTransactionCategoryComboBoxOption | null) => void
@@ -22,15 +20,20 @@ export const CategorySelectDrawerWithTrigger = ({ value, onChange, showTooltips 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
 
   return (
-    <HStack fluid className='Layer__CategorySelectDrawerWithTrigger'>
+    <HStack fluid>
       <Button
+        flex
         fullWidth
         aria-label={t('bankTransactions:action.select_category', 'Select category')}
         onClick={() => { setIsDrawerOpen(true) }}
         variant='outlined'
       >
-        <Span ellipsis>{value?.label ?? t('common:action.select_label', 'Select...')}</Span>
-        <ChevronDown size={16} />
+        <HStack fluid align='center' justify='space-between' gap='2xs'>
+          <Span ellipsis variant={value ? undefined : 'placeholder'}>
+            {value?.label ?? t('common:action.select_label', 'Select...')}
+          </Span>
+          <ChevronDown size={16} />
+        </HStack>
       </Button>
 
       <CategorySelectDrawer

--- a/src/components/CategorySelect/categorySelectDrawerWithTrigger.scss
+++ b/src/components/CategorySelect/categorySelectDrawerWithTrigger.scss
@@ -1,5 +1,0 @@
-.Layer__CategorySelectDrawerWithTrigger {
-  .Layer__UI__Button {
-    justify-content: space-between;
-  }
-}

--- a/src/components/MatchForm/MatchFormMobileItem.tsx
+++ b/src/components/MatchForm/MatchFormMobileItem.tsx
@@ -1,7 +1,7 @@
 import { GridListItem } from 'react-aria-components'
 
 import { type BankTransaction, type SuggestedMatch } from '@internal-types/bankTransactions'
-import { isCredit } from '@utils/bankTransactions'
+import { isCredit } from '@utils/bankTransactions/shared'
 import { Checkbox } from '@ui/Checkbox/Checkbox'
 import { HStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'

--- a/src/components/Onboarding/ConnectAccount.tsx
+++ b/src/components/Onboarding/ConnectAccount.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { DisplayState } from '@internal-types/bankTransactions'
 import { type OnboardingStep } from '@internal-types/layerContext'
-import { countTransactionsToReview } from '@utils/bankTransactions'
+import { countTransactionsToReview } from '@utils/bankTransactions/shared'
 import { useAugmentedBankTransactions } from '@hooks/features/bankTransactions/useAugmentedBankTransactions'
 import { useBankTransactionsFilters } from '@contexts/BankTransactionsFiltersContext/useBankTransactionsFilters'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'

--- a/src/components/TaxCodeSelect/TaxCodeSelectDrawer.tsx
+++ b/src/components/TaxCodeSelect/TaxCodeSelectDrawer.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Drawer } from '@ui/Modal/Modal'
+import { ModalHeading, ModalTitleWithClose } from '@ui/Modal/ModalSlots'
+import { VStack } from '@ui/Stack/Stack'
+import { ActionableList, type ActionableListOption } from '@components/ActionableList/ActionableList'
+import { SearchField } from '@components/SearchField/SearchField'
+
+import { NO_TAX_CODE } from './constants'
+
+export type TaxCodeSelectOption = {
+  label: string
+  value: string
+}
+
+type TaxCodeSelectDrawerProps = {
+  options: TaxCodeSelectOption[]
+  selectedId?: string
+  onSelect: (value: TaxCodeSelectOption | null) => void
+  isOpen: boolean
+  onOpenChange: (isOpen: boolean) => void
+}
+
+export const TaxCodeSelectDrawer = ({
+  options,
+  selectedId,
+  onSelect,
+  isOpen,
+  onOpenChange,
+}: TaxCodeSelectDrawerProps) => {
+  const { t } = useTranslation()
+  const [query, setQuery] = useState('')
+
+  const listOptions: ActionableListOption<TaxCodeSelectOption | null>[] = useMemo(() => {
+    return [
+      ...options.map(option => ({
+        id: option.value,
+        label: option.label,
+        value: option,
+      })),
+      {
+        id: NO_TAX_CODE,
+        label: t('bankTransactions:action.no_tax_code', 'No tax code'),
+        value: null,
+      },
+    ]
+  }, [options, t])
+
+  const queryTrimmed = query.trim().toLowerCase()
+  const filteredListOptions = useMemo(
+    () => queryTrimmed
+      ? listOptions.filter(opt => opt.label.toLowerCase().includes(queryTrimmed))
+      : listOptions,
+    [listOptions, queryTrimmed],
+  )
+
+  const handleOpenChange = useCallback((nextIsOpen: boolean) => {
+    if (!nextIsOpen) {
+      setQuery('')
+    }
+    onOpenChange(nextIsOpen)
+  }, [onOpenChange])
+
+  const Header = useCallback(({ close }: { close: () => void }) => (
+    <ModalTitleWithClose
+      heading={<ModalHeading size='sm' weight='bold'>{t('bankTransactions:action.select_tax_code', 'Select tax code')}</ModalHeading>}
+      onClose={close}
+      hideBottomPadding
+    />
+  ), [t])
+
+  return (
+    <Drawer
+      slots={{ Header }}
+      isOpen={isOpen}
+      onOpenChange={handleOpenChange}
+      variant='mobile-drawer'
+      fixedHeight
+      isDismissable
+    >
+      {({ close }) => (
+        <VStack className='Layer__bank-transaction-mobile-list-item__categories_list-container' pb='md' gap='md'>
+          <SearchField value={query} onChange={setQuery} label={t('bankTransactions:action.search_tax_codes', 'Search tax codes...')} />
+          <ActionableList<TaxCodeSelectOption | null>
+            options={filteredListOptions}
+            onClick={(item) => {
+              if (item.id === NO_TAX_CODE) {
+                onSelect(null)
+              }
+              else {
+                onSelect(item.value)
+              }
+              close()
+            }}
+            selectedId={selectedId}
+            className='Layer__bank-transaction-mobile-list-item__categories_list'
+          />
+        </VStack>
+      )}
+    </Drawer>
+  )
+}

--- a/src/components/TaxCodeSelect/TaxCodeSelectDrawerWithTrigger.tsx
+++ b/src/components/TaxCodeSelect/TaxCodeSelectDrawerWithTrigger.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import ChevronDown from '@icons/ChevronDown'
+import { Button } from '@ui/Button/Button'
+import { HStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+import { NO_TAX_CODE } from '@components/TaxCodeSelect/constants'
+import { TaxCodeSelectDrawer, type TaxCodeSelectOption } from '@components/TaxCodeSelect/TaxCodeSelectDrawer'
+
+type Props = {
+  options: TaxCodeSelectOption[]
+  value: TaxCodeSelectOption | null
+  onChange: (newValue: TaxCodeSelectOption | null) => void
+  isDisabled?: boolean
+  hasSelection?: boolean
+  className?: string
+  placeholder?: string
+}
+
+export const TaxCodeSelectDrawerWithTrigger = ({
+  options,
+  value,
+  onChange,
+  isDisabled = false,
+  hasSelection = true,
+  className,
+  placeholder,
+}: Props) => {
+  const { t } = useTranslation()
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+
+  return (
+    <HStack fluid className={className}>
+      <Button
+        flex
+        fullWidth
+        aria-label={t('bankTransactions:action.select_tax_code', 'Select tax code')}
+        onClick={() => {
+          setIsDrawerOpen(true)
+        }}
+        variant='outlined'
+        isDisabled={isDisabled}
+      >
+        <HStack fluid align='center' justify='space-between' gap='2xs'>
+          <Span ellipsis variant={hasSelection ? undefined : 'placeholder'}>
+            {!hasSelection
+              ? (placeholder ?? t('bankTransactions:action.select_tax_code', 'Select tax code'))
+              : (value?.label ?? t('bankTransactions:action.no_tax_code', 'No tax code'))}
+          </Span>
+          <ChevronDown size={16} />
+        </HStack>
+      </Button>
+
+      <TaxCodeSelectDrawer
+        options={options}
+        onSelect={onChange}
+        selectedId={value?.value ?? (hasSelection ? NO_TAX_CODE : undefined)}
+        isOpen={isDrawerOpen}
+        onOpenChange={setIsDrawerOpen}
+      />
+    </HStack>
+  )
+}

--- a/src/components/TaxCodeSelect/constants.ts
+++ b/src/components/TaxCodeSelect/constants.ts
@@ -1,0 +1,1 @@
+export const NO_TAX_CODE = '__no_tax_code__'

--- a/src/components/ui/Modal/ModalSlots.tsx
+++ b/src/components/ui/Modal/ModalSlots.tsx
@@ -4,7 +4,7 @@ import { X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@ui/Button/Button'
-import { VStack } from '@ui/Stack/Stack'
+import { HStack, VStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
 import { P } from '@ui/Typography/Text'
 import { Separator } from '@components/Separator/Separator'
@@ -66,15 +66,19 @@ export const ModalTitleWithClose = forwardRef<
           {description}
         </VStack>
         {!hideCloseButton && (
-          <Button
-            icon
-            variant='outlined'
+          <HStack
             slot='close'
-            onPress={onClose}
-            aria-label={t('ui:action.close_modal', 'Close Modal')}
+            className='Layer__ModalTitleWithClose__CloseButtonWrapper'
           >
-            <X size={16} />
-          </Button>
+            <Button
+              icon
+              variant='outlined'
+              onPress={onClose}
+              aria-label={t('ui:action.close_modal', 'Close Modal')}
+            >
+              <X size={16} />
+            </Button>
+          </HStack>
         )}
       </div>
       <Separator mbe={hideBottomPadding ? undefined : 'md'} />

--- a/src/components/ui/Modal/modalSlots.scss
+++ b/src/components/ui/Modal/modalSlots.scss
@@ -22,7 +22,7 @@
   }
 }
 
-.Layer__ModalTitleWithClose > .Layer__UI__Button {
+.Layer__ModalTitleWithClose__CloseButtonWrapper {
   margin: 0 0 auto;
 }
 
@@ -39,4 +39,5 @@
 
 .Layer__ModalActions {
   margin-block-start: var(--spacing-3xl);
+  margin-block-end: var(--spacing-3xs);
 }


### PR DESCRIPTION
## Description
Adds reusable mobile tax-code selection components and supporting UI cleanup needed by the later desktop, mobile, and bulk bank transaction tax-code flows.

## Changes
- Add `TaxCodeSelectDrawer`, trigger, and `NO_TAX_CODE` constant
- Update `ActionableList` to use stable option IDs and BEM class names
- Adjust category drawer trigger layout and placeholder styling
- Add modal close-button wrapper/action spacing support used by the drawer
- Genericize mobile business form item typing for categorization option reuse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new mobile tax-code selection UI and refactors shared components (`ActionableList`, modal header) that may subtly affect styling/behavior wherever they are reused.
> 
> **Overview**
> Adds a reusable mobile **tax code selection** flow via `TaxCodeSelectDrawer` (search + “No tax code” option) and `TaxCodeSelectDrawerWithTrigger`, backed by a shared `NO_TAX_CODE` sentinel.
> 
> Refactors `ActionableList` to use stable `id` keys and BEM-style class names/layout, updates `CategorySelectDrawerWithTrigger` button content to handle placeholder styling without custom SCSS, and tweaks `ModalTitleWithClose`/`ModalActions` layout to better support drawer headers.
> 
> Also genericizes `BusinessFormMobile`/`BusinessFormMobileItem` option typing for reuse and updates a couple of bank-transaction helpers imports to `@utils/bankTransactions/shared`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7916da2974408c75865af1ace70639c2c42d4e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->