### PR TITLE
Add desktop bank transaction tax code flows

### DIFF
--- a/src/components/BankTransactionRow/MatchBadge.tsx
+++ b/src/components/BankTransactionRow/MatchBadge.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { CategorizationStatus } from '@schemas/bankTransactions/bankTransaction'
-import { isTransferMatch } from '@utils/bankTransactions'
+import { isTransferMatch } from '@utils/bankTransactions/shared'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import MinimizeTwo from '@icons/MinimizeTwo'
 import { Badge } from '@components/Badge/Badge'

--- a/src/components/BankTransactionRow/bankTransactionRow.scss
+++ b/src/components/BankTransactionRow/bankTransactionRow.scss
@@ -1,12 +1,14 @@
-.Layer__bank-transaction-row__category-hstack {
-  max-width: 100%;
-}
+.Layer__bank-transaction-row {
+  &__category-hstack {
+    max-width: 100%;
+  }
 
-.Layer__bank-transaction-row__category-open {
-  padding-block-start: 0.875rem;
-}
+  &__category-open {
+    padding-block-start: 0.875rem;
+  }
 
-.Layer__bank-transaction-row__category {
-  overflow: hidden;
-  width: 100%;
+  &__category {
+    overflow: hidden;
+    width: 100%;
+  }
 }

--- a/src/components/BankTransactions/BankTransactionsHeader.tsx
+++ b/src/components/BankTransactions/BankTransactionsHeader.tsx
@@ -6,7 +6,7 @@ import type { Key } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
 
 import { DisplayState } from '@internal-types/bankTransactions'
-import { BankTransactionsDateFilterMode } from '@utils/bankTransactions'
+import { BankTransactionsDateFilterMode } from '@utils/bankTransactions/shared'
 import { translationKey } from '@utils/i18n/translationKey'
 import { convertDateToZonedDateTime } from '@utils/time/timeUtils'
 import { useHandleDownloadTransactions } from '@hooks/features/bankTransactions/useHandleBankTransactionsDownload'

--- a/src/components/BankTransactions/BankTransactionsListItemCategory/bankTransactionsListItemCategory.scss
+++ b/src/components/BankTransactions/BankTransactionsListItemCategory/bankTransactionsListItemCategory.scss
@@ -1,11 +1,10 @@
-.Layer__bankTransactionsListItemCategory__List {
+.Layer__bankTransactionsListItemCategory__List,
+.Layer__bankTransactionsListItemCategory__Mobile {
   padding-block: var(--spacing-xs);
   padding-inline: var(--spacing-md);
 }
 
 .Layer__bankTransactionsListItemCategory__Mobile {
-  padding-block: var(--spacing-xs);
-  padding-inline: var(--spacing-md);
   border-radius: 0 0 var(--border-radius-sm) var(--border-radius-sm);
   border-top: 1px solid var(--color-base-400);
   background-color: var(--color-base-100);

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -16,21 +17,27 @@ import { SplitAsOption, SuggestedMatchAsOption } from '@internal-types/categoriz
 import { type CustomerVendorSchema } from '@schemas/customerVendor'
 import { type Tag } from '@schemas/tag'
 import {
+  getBankTransactionFirstSuggestedMatch,
+  getBankTransactionTaxCodeOptions,
   hasMatch,
-} from '@utils/bankTransactions'
-import { getBankTransactionFirstSuggestedMatch } from '@utils/bankTransactions'
+} from '@utils/bankTransactions/shared'
 import { useSetMetadataOnBankTransaction } from '@hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useSetMetadataOnBankTransaction'
 import { useRemoveTagFromBankTransaction } from '@hooks/api/businesses/[business-id]/bank-transactions/tags/useRemoveTagFromBankTransaction'
 import { useTagBankTransaction } from '@hooks/api/businesses/[business-id]/bank-transactions/tags/useTagBankTransaction'
 import { useSplitsForm } from '@hooks/features/bankTransactions/useSplitsForm'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
-import { useBankTransactionsCategoryActions, useGetBankTransactionCategory } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import {
+  useBankTransactionsCategorizationActions,
+  useGetBankTransactionCategorization,
+} from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useBankTransactionsIsCategorizationEnabledContext } from '@contexts/BankTransactionsIsCategorizationEnabledContext/BankTransactionsIsCategorizationEnabledContext'
 import Scissors from '@icons/ScissorsFullOpen'
 import Trash from '@icons/Trash'
 import { Button } from '@ui/Button/Button'
+import { ComboBox } from '@ui/ComboBox/ComboBox'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Toggle, ToggleSize } from '@ui/Toggle/Toggle'
+import { Span } from '@ui/Typography/Text'
 import { BankTransactionCategoryComboBox } from '@components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox'
 import { useBankTransactionCustomerVendorVisibility } from '@components/BankTransactionCustomerVendorSelector/BankTransactionCustomerVendorVisibilityProvider'
 import { BankTransactionFormFields } from '@components/BankTransactionFormFields/BankTransactionFormFields'
@@ -82,6 +89,11 @@ type ExpandedBankTransactionRowProps = {
   onValidityChange?: (isValid: boolean) => void
 }
 
+type TaxCodeOption = {
+  label: string
+  value: string
+}
+
 export const ExpandedBankTransactionRow = ({
   bankTransaction,
   isOpen = false,
@@ -93,8 +105,8 @@ export const ExpandedBankTransactionRow = ({
 }: ExpandedBankTransactionRowProps) => {
   const { t } = useTranslation()
   const { formatCurrencyFromCents } = useIntlFormatter()
-  const { selectedCategory } = useGetBankTransactionCategory(bankTransaction.id)
-  const { setTransactionCategory } = useBankTransactionsCategoryActions()
+  const { selectedCategorization } = useGetBankTransactionCategorization(bankTransaction.id)
+  const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
   // Hooks for auto-saving tags and customer/vendor in unsplit state
   const { trigger: tagBankTransaction } = useTagBankTransaction({ bankTransactionId: bankTransaction.id })
   const { trigger: removeTagFromBankTransaction } = useRemoveTagFromBankTransaction({ bankTransactionId: bankTransaction.id })
@@ -129,7 +141,7 @@ export const ExpandedBankTransactionRow = ({
     onBlurSplitAmount,
     getInputValueForSplitAtIndex,
     setSplitFormError,
-  } = useSplitsForm({ bankTransaction, selectedCategory, isOpen })
+  } = useSplitsForm({ bankTransaction, selectedCategorization, isOpen })
 
   useEffect(() => {
     const isValid = purpose === Purpose.match
@@ -146,11 +158,17 @@ export const ExpandedBankTransactionRow = ({
     setPurpose(newPurpose)
 
     if (newPurpose === Purpose.match) {
-      setTransactionCategory(bankTransaction.id, selectedMatch ? new SuggestedMatchAsOption(selectedMatch) : null)
+      setTransactionCategorization(bankTransaction.id, {
+        category: selectedMatch ? new SuggestedMatchAsOption(selectedMatch) : null,
+        taxCode: null,
+      })
     }
 
     else if (newPurpose === Purpose.categorize && isSplitsValid) {
-      setTransactionCategory(bankTransaction.id, new SplitAsOption(localSplits))
+      setTransactionCategorization(bankTransaction.id, {
+        category: new SplitAsOption(localSplits),
+        taxCode: null,
+      })
     }
 
     setSplitFormError(undefined)
@@ -200,6 +218,24 @@ export const ExpandedBankTransactionRow = ({
   }
 
   const isCategorizationEnabled = useBankTransactionsIsCategorizationEnabledContext()
+
+  const taxCodeOptions = useMemo<TaxCodeOption[]>(
+    () => getBankTransactionTaxCodeOptions(bankTransaction),
+    [bankTransaction],
+  )
+
+  const showTaxCodeSelector = taxCodeOptions.length > 0
+
+  const getSelectedTaxCodeOption = useCallback(
+    (taxCode: string | null): TaxCodeOption | null => {
+      if (!taxCode) {
+        return null
+      }
+
+      return taxCodeOptions.find(option => option.value === taxCode) ?? null
+    },
+    [taxCodeOptions],
+  )
 
   const toggleOptions = useMemo(() => [
     {
@@ -265,9 +301,12 @@ export const ExpandedBankTransactionRow = ({
                         setSelectedMatch={(suggestedMatch) => {
                           setSelectedMatch(suggestedMatch)
                           setMatchFormError(!suggestedMatch ? t('bankTransactions:error.select_option_match_transaction', 'Select an option to match the transaction') : undefined)
-                          setTransactionCategory(
+                          setTransactionCategorization(
                             bankTransaction.id,
-                            suggestedMatch ? new SuggestedMatchAsOption(suggestedMatch) : null,
+                            {
+                              category: suggestedMatch ? new SuggestedMatchAsOption(suggestedMatch) : null,
+                              taxCode: null,
+                            },
                           )
                         }}
                         matchFormError={matchFormError}
@@ -286,66 +325,104 @@ export const ExpandedBankTransactionRow = ({
                   >
                     <div className={`${className}__content-panel-container`}>
                       <div className={`${className}__splits-inputs`}>
-                        {effectiveSplits.map((split, index) => (
-                          <div
-                            className={`${className}__table-cell--split-entry`}
-                            key={`split-${index}`}
-                          >
-                            <AmountInput
-                              name={`split-${index}${asListItem ? '-li' : ''}`}
-                              disabled={
-                                index === 0 || !isCategorizationEnabled
-                              }
-                              onChange={updateSplitAmount(index)}
-                              value={getInputValueForSplitAtIndex(index, split)}
-                              onBlur={onBlurSplitAmount}
-                              className={`${className}__table-cell--split-entry__amount`}
-                              isInvalid={split.amount < 0}
-                            />
-                            <BankTransactionCategoryComboBox
-                              bankTransaction={bankTransaction}
-                              selectedValue={split.category}
-                              onSelectedValueChange={(value) => {
-                                changeCategoryForSplitAtIndex(index, value)
-                              }}
-                              isDisabled={!isCategorizationEnabled}
-                              includeSuggestedMatches={false}
-                            />
-                            {showTags && (
-                              <TagDimensionsGroup
-                                value={split.tags}
-                                onChange={tags => changeTags(index, tags)}
-                                showLabels={false}
-                                isReadOnly={!isCategorizationEnabled}
-                                className={`${className}__table-cell--split-entry__tags`}
-                              />
-                            )}
-                            {showCustomerVendor && (
-                              <div className='Layer__expanded-bank-transaction-row__table-cell--split-entry__customer'>
-                                <CustomerVendorSelector
-                                  selectedCustomerVendor={split.customerVendor}
-                                  onSelectedCustomerVendorChange={customerVendor => changeCustomerVendor(index, customerVendor)}
-                                  placeholder={t('customerVendor:action.set_customer_vendor', 'Set customer or vendor')}
-                                  isReadOnly={!isCategorizationEnabled}
-                                  showLabel={false}
+                        {effectiveSplits.map((split, index) => {
+                          const isTaxCodeSelectorDisabled = !isCategorizationEnabled
+                            || split.category === null
+                            || split.category.classification?.type === 'Exclusion'
+
+                          return (
+                            <VStack
+                              className={`${className}__split-section`}
+                              gap='xs'
+                              pbs={asListItem && effectiveSplits.length === 1 ? 'sm' : undefined}
+                              pbe={asListItem && effectiveSplits.length > 1 ? 'sm' : undefined}
+                              key={`split-${index}`}
+                            >
+                              {asListItem && effectiveSplits.length > 1 && (
+                                <Span>
+                                  {t('bankTransactions:action.split_number_label', 'Split #{{number}}', { number: index + 1 })}
+                                </Span>
+                              )}
+                              <div className={`${className}__table-cell--split-entry`}>
+                                <AmountInput
+                                  name={`split-${index}${asListItem ? '-li' : ''}`}
+                                  disabled={
+                                    index === 0 || !isCategorizationEnabled
+                                  }
+                                  onChange={updateSplitAmount(index)}
+                                  value={getInputValueForSplitAtIndex(index, split)}
+                                  onBlur={onBlurSplitAmount}
+                                  className={`${className}__table-cell--split-entry__amount`}
+                                  isInvalid={split.amount < 0}
                                 />
+                                <BankTransactionCategoryComboBox
+                                  bankTransaction={bankTransaction}
+                                  selectedValue={split.category}
+                                  onSelectedValueChange={(value) => {
+                                    changeCategoryForSplitAtIndex(index, value)
+                                  }}
+                                  isDisabled={!isCategorizationEnabled}
+                                  includeSuggestedMatches={false}
+                                />
+                                {showTaxCodeSelector && (
+                                  <ComboBox<TaxCodeOption>
+                                    selectedValue={getSelectedTaxCodeOption(split.taxCode)}
+                                    onSelectedValueChange={(option) => {
+                                      updateSplitAtIndex(index, currentSplit => ({
+                                        ...currentSplit,
+                                        taxCode: option?.value ?? null,
+                                      }))
+                                    }}
+                                    options={taxCodeOptions}
+                                    isDisabled={isTaxCodeSelectorDisabled}
+                                    isSearchable={false}
+                                    isClearable
+                                    placeholder={t('bankTransactions:action.select_tax_code', 'Select tax code')}
+                                    className={`${className}__table-cell--split-entry__tax-code`}
+                                  />
+                                )}
+                                {showTags && (
+                                  <TagDimensionsGroup
+                                    value={split.tags}
+                                    onChange={tags => changeTags(index, tags)}
+                                    showLabels={false}
+                                    isReadOnly={!isCategorizationEnabled}
+                                    className={`${className}__table-cell--split-entry__tags`}
+                                  />
+                                )}
+                                {showCustomerVendor && (
+                                  <div className='Layer__expanded-bank-transaction-row__table-cell--split-entry__customer'>
+                                    <CustomerVendorSelector
+                                      selectedCustomerVendor={split.customerVendor}
+                                      onSelectedCustomerVendorChange={customerVendor => changeCustomerVendor(index, customerVendor)}
+                                      placeholder={t('customerVendor:action.set_customer_vendor', 'Set customer or vendor')}
+                                      isReadOnly={!isCategorizationEnabled}
+                                      showLabel={false}
+                                    />
+                                  </div>
+                                )}
+                                <div className='Layer__expanded-bank-transaction-row__table-cell--split-entry__button'>
+                                  <Button
+                                    onPress={() => removeSplit(index)}
+                                    variant='outlined'
+                                    icon
+                                    isDisabled={index === 0}
+                                  >
+                                    <Trash size={18} />
+                                  </Button>
+                                </div>
                               </div>
-                            )}
-                            <div className='Layer__expanded-bank-transaction-row__table-cell--split-entry__button'>
-                              <Button
-                                onPress={() => removeSplit(index)}
-                                variant='outlined'
-                                icon
-                                isDisabled={index === 0}
-                              >
-                                <Trash size={18} />
-                              </Button>
-                            </div>
-                          </div>
-                        ))}
+                            </VStack>
+                          )
+                        })}
                       </div>
                       {splitFormError && <HStack pb='sm'><ErrorText>{splitFormError}</ErrorText></HStack>}
-                      <div className={`${className}__total-and-btns`}>
+                      <div
+                        className={classNames(
+                          `${className}__total-and-btns`,
+                          asListItem && `${className}__total-and-btns--list-item`,
+                        )}
+                      >
                         {effectiveSplits.length > 1 && (
                           <Input
                             disabled={true}

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -343,13 +343,9 @@
   }
 }
 
-.Layer__expanded-bank-transaction-row__description {
-  padding: 0 var(--spacing-md);
-
-  & textarea {
-    height: 100px;
-    width: 100%;
-  }
+.Layer__expanded-bank-transaction-row__total-and-btns--list-item {
+  flex-direction: column;
+  align-items: stretch;
 }
 
 .Layer__expanded-bank-transaction-row__file-upload {
@@ -417,6 +413,10 @@
 
   &__button {
     grid-area: button;
+  }
+
+  & > &__tax-code__Container {
+    flex: 0 0 12.5rem;
   }
 
   @container (max-width: 768px) {
@@ -875,6 +875,15 @@
     }
 
     .Layer__input {
+      max-width: 100%;
+    }
+  }
+
+  .Layer__expanded-bank-transaction-row__total-and-btns--list-item {
+    flex-direction: column;
+    align-items: stretch;
+
+    .Layer__input-tooltip {
       max-width: 100%;
     }
   }


### PR DESCRIPTION
## Description
Adds tax-code handling to the desktop expanded-row categorization experience, including split rows and list-item layout updates that depend on the earlier shared tax-code utilities and combined categorization store.

## Changes
- Add tax-code ComboBox controls to expanded transaction split rows
- Disable and clear split tax codes for exclusion categories
- Persist tax codes through expanded-row split state
- Add split section labeling for list-item expanded rows
- Adjust desktop/list bank transaction styling for the new tax-code column and split layout

Tax-code payload and split-state helper changes landed in earlier foundational PRs because later UI branches depend on them to compile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new tax-code selection UI and persists it through the expanded-row split/categorization flow; mistakes could cause incorrect tax code assignment or unexpected clearing/disablement (especially for exclusion categories). Styling/layout changes are moderate but could regress list-item/desktop presentation.
> 
> **Overview**
> Adds a **tax code selection flow** to the desktop expanded bank transaction row: split entries now render a non-searchable, clearable `ComboBox` when tax codes are available, and the selector is disabled (and tax codes cleared) when the split’s category is an *Exclusion*.
> 
> Refactors expanded-row categorization state usage to the combined `BankTransactionsCategorizationStore` shape (`{ category, taxCode }`) and updates related utilities/imports to use `@utils/bankTransactions/shared`. Includes layout/styling updates for list-item expanded rows (split section labels, total/button stacking, and new tax-code column sizing) plus minor SCSS cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0e85030766a17d8f721a43d98b356d61ab7710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->