### PR TITLE
Add mobile bank transaction tax code flows

### DIFF
--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
@@ -5,11 +5,17 @@ import { useTranslation } from 'react-i18next'
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { CategorizationType } from '@internal-types/categories'
 import { ApiCategorizationAsOption, PlaceholderAsOption } from '@internal-types/categorizationOption'
-import { hasReceipts } from '@utils/bankTransactions'
-import { isCategorized } from '@utils/bankTransactions'
+import {
+  hasReceipts,
+  isCategorized,
+} from '@utils/bankTransactions/shared'
+import { getBankTransactionTaxCodeOptions, getCategoryPayloadTaxCode } from '@utils/bankTransactions/taxCode'
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
-import { useBankTransactionsCategoryActions, useGetBankTransactionCategory } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import {
+  useBankTransactionsCategorizationActions,
+  useGetBankTransactionCategorization,
+} from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import PaperclipIcon from '@icons/Paperclip'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
@@ -19,20 +25,22 @@ import { BankTransactionFormFields } from '@components/BankTransactionFormFields
 import { BankTransactionReceipts } from '@components/BankTransactionReceipts/BankTransactionReceipts'
 import { type BankTransactionReceiptsHandle } from '@components/BankTransactionReceipts/BankTransactionReceipts'
 import { BusinessFormMobile } from '@components/BusinessForm/BusinessFormMobile'
-import { type BusinessFormMobileItemOption, type BusinessFormOptionValue } from '@components/BusinessForm/BusinessFormMobileItem'
+import { type BusinessFormMobileItemOption } from '@components/BusinessForm/BusinessFormMobileItem'
 import { CategorySelectDrawer } from '@components/CategorySelect/CategorySelectDrawer'
 import { FileInput } from '@components/Input/FileInput'
+import type { TaxCodeSelectOption } from '@components/TaxCodeSelect/TaxCodeSelectDrawer'
+import { TaxCodeSelectDrawerWithTrigger } from '@components/TaxCodeSelect/TaxCodeSelectDrawerWithTrigger'
 import { ErrorText } from '@components/Typography/ErrorText'
 
 const SELECT_CATEGORY_VALUE = 'SELECT_CATEGORY'
 
 export const isSelectCategoryOption = (
-  value: BusinessFormOptionValue,
+  value: BankTransactionCategoryComboBoxOption,
 ): boolean => {
   return isPlaceholderAsOption(value) && value.value === SELECT_CATEGORY_VALUE
 }
 
-type DisplayOption = BusinessFormMobileItemOption
+type DisplayOption = BusinessFormMobileItemOption<BankTransactionCategoryComboBoxOption>
 
 interface BankTransactionsMobileListBusinessFormProps {
   bankTransaction: BankTransaction
@@ -76,11 +84,19 @@ export const BankTransactionsMobileListBusinessForm = ({
     return initialMap
   })
 
-  const { selectedCategory } = useGetBankTransactionCategory(bankTransaction.id)
-  const { setTransactionCategory } = useBankTransactionsCategoryActions()
+  const { selectedCategorization } = useGetBankTransactionCategorization(bankTransaction.id)
+  const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
+  const selectedCategory = selectedCategorization?.category
 
   const [showRetry, setShowRetry] = useState(false)
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+
+  const taxCodeOptions = useMemo<TaxCodeSelectOption[]>(
+    () => getBankTransactionTaxCodeOptions(bankTransaction),
+    [bankTransaction],
+  )
+
+  const showTaxCodeSelector = taxCodeOptions.length > 0
 
   useEffect(() => {
     if (isErrorCategorizing) {
@@ -119,10 +135,13 @@ export const BankTransactionsMobileListBusinessForm = ({
         selectedCategory
         && option.value === selectedCategory.value
       ) {
-        setTransactionCategory(bankTransaction.id, null)
+        setTransactionCategorization(bankTransaction.id, { category: null, taxCode: null })
       }
       else {
-        setTransactionCategory(bankTransaction.id, option)
+        setTransactionCategorization(bankTransaction.id, {
+          category: option,
+          taxCode: option.classification?.type === 'Exclusion' ? null : selectedCategorization?.taxCode ?? null,
+        })
       }
     }
   }
@@ -140,6 +159,7 @@ export const BankTransactionsMobileListBusinessForm = ({
       {
         type: 'Category',
         category: payload,
+        taxCode: getCategoryPayloadTaxCode(payload, selectedCategorization?.taxCode?.value),
       },
       true,
     )
@@ -149,8 +169,15 @@ export const BankTransactionsMobileListBusinessForm = ({
     if (!category) return
 
     setSessionCategories(prev => new Map(prev).set(category.value, category))
-    setTransactionCategory(bankTransaction.id, category)
-  }, [bankTransaction.id, setTransactionCategory])
+    setTransactionCategorization(bankTransaction.id, {
+      category,
+      taxCode: category.classification?.type === 'Exclusion' ? null : selectedCategorization?.taxCode ?? null,
+    })
+  }, [bankTransaction.id, selectedCategorization?.taxCode, setTransactionCategorization])
+
+  const handleTaxCodeChange = useCallback((taxCode: TaxCodeSelectOption | null) => {
+    setTransactionCategorization(bankTransaction.id, { taxCode })
+  }, [bankTransaction.id, setTransactionCategorization])
 
   return (
     <>
@@ -161,8 +188,19 @@ export const BankTransactionsMobileListBusinessForm = ({
               options={options}
               onSelect={onCategorySelect}
               selectedId={selectedCategory?.value}
+              ariaLabel={t('bankTransactions:label.category', 'Category')}
             />
           )}
+        {showCategorization && showTaxCodeSelector && (
+          <TaxCodeSelectDrawerWithTrigger
+            options={taxCodeOptions}
+            value={selectedCategorization?.taxCode ?? null}
+            onChange={handleTaxCodeChange}
+            isDisabled={selectedCategory?.classification?.type === 'Exclusion'}
+            hasSelection={selectedCategorization?.taxCode !== undefined}
+            placeholder={t('bankTransactions:action.select_tax_code', 'Select tax code')}
+          />
+        )}
         <BankTransactionFormFields
           bankTransaction={bankTransaction}
           showDescriptions={showDescriptions}

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListItem.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListItem.tsx
@@ -4,8 +4,7 @@ import classNames from 'classnames'
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { CategorizationStatus } from '@schemas/bankTransactions/bankTransaction'
 import { convertMatchDetailsToLinkingMetadata, decodeMatchDetails } from '@schemas/bankTransactions/match'
-import { hasReceipts, isCredit } from '@utils/bankTransactions'
-import { isCategorized } from '@utils/bankTransactions'
+import { hasReceipts, isCategorized, isCredit } from '@utils/bankTransactions/shared'
 import { useDelayedRemoveBankTransaction } from '@hooks/features/bankTransactions/useDelayedRemoveBankTransaction'
 import { useDelayedVisibility } from '@hooks/utils/visibility/useDelayedVisibility'
 import { useBulkSelectionActions, useIdIsSelected } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
@@ -208,11 +207,9 @@ export const BankTransactionsMobileListItem = ({
                 )}
                 <HStack gap='2xs' align='center'>
                   <Span size='sm' ellipsis>
-                    <Span ellipsis size='sm'>
-                      {bankTransaction.account_institution?.name && `${bankTransaction.account_institution.name} — `}
-                      {bankTransaction.account_name}
-                      {bankTransaction.account_mask && ` ${bankTransaction.account_mask}`}
-                    </Span>
+                    {bankTransaction.account_institution?.name && `${bankTransaction.account_institution.name} — `}
+                    {bankTransaction.account_name}
+                    {bankTransaction.account_mask && ` ${bankTransaction.account_mask}`}
                   </Span>
                   {hasReceipts(bankTransaction) ? <FileIcon size={12} /> : null}
                 </HStack>

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListItemExpandedRow.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListItemExpandedRow.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { CategorizationStatus } from '@schemas/bankTransactions/bankTransaction'
-import { hasMatch } from '@utils/bankTransactions'
+import { hasMatch } from '@utils/bankTransactions/shared'
 import { translationKey } from '@utils/i18n/translationKey'
 import { VStack } from '@ui/Stack/Stack'
 import { Toggle } from '@ui/Toggle/Toggle'

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm.tsx
@@ -5,7 +5,7 @@ import { type BankTransaction, type SuggestedMatch } from '@internal-types/bankT
 import {
   getBankTransactionFirstSuggestedMatch,
   getBankTransactionMatchAsSuggestedMatch,
-} from '@utils/bankTransactions'
+} from '@utils/bankTransactions/shared'
 import { useMatchBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useMatchBankTransactionWithCacheUpdate'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
 import PaperclipIcon from '@icons/Paperclip'

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListPersonalForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListPersonalForm.tsx
@@ -4,8 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { CategorizationStatus } from '@schemas/bankTransactions/bankTransaction'
-import { hasReceipts, isCredit } from '@utils/bankTransactions'
-import { isCategorized } from '@utils/bankTransactions'
+import { hasReceipts, isCategorized, isCredit } from '@utils/bankTransactions/shared'
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
 import PaperclipIcon from '@icons/Paperclip'
@@ -95,6 +94,7 @@ export const BankTransactionsMobileListPersonalForm = ({
             ? PersonalStableName.CREDIT
             : PersonalStableName.DEBIT,
         },
+        taxCode: null,
       },
       true,
     )

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitAndMatchForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitAndMatchForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
-import { hasMatch } from '@utils/bankTransactions'
+import { hasMatch } from '@utils/bankTransactions/shared'
 import { BankTransactionsMobileListMatchForm } from '@components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm'
 import { BankTransactionsMobileListSplitForm } from '@components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm'
 import { TextButton } from '@components/Button/TextButton'

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
@@ -1,20 +1,20 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
-import { hasReceipts } from '@utils/bankTransactions'
-import { buildCategorizeBankTransactionPayloadForSplit } from '@utils/bankTransactions'
-import { isCategorized } from '@utils/bankTransactions'
+import { buildCategorizeBankTransactionPayloadForSplit, getBankTransactionTaxCodeOptions, hasReceipts, isCategorized } from '@utils/bankTransactions/shared'
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
 import { useSplitsForm } from '@hooks/features/bankTransactions/useSplitsForm'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
-import { useGetBankTransactionCategory } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { useGetBankTransactionCategorization } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import PaperclipIcon from '@icons/Paperclip'
 import Scissors from '@icons/Scissors'
 import Trash from '@icons/Trash'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
 import { type BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { BankTransactionFormFields } from '@components/BankTransactionFormFields/BankTransactionFormFields'
 import { BankTransactionReceipts } from '@components/BankTransactionReceipts/BankTransactionReceipts'
@@ -22,8 +22,10 @@ import { type BankTransactionReceiptsHandle } from '@components/BankTransactionR
 import { CategorySelectDrawerWithTrigger } from '@components/CategorySelect/CategorySelectDrawerWithTrigger'
 import { AmountInput } from '@components/Input/AmountInput'
 import { FileInput } from '@components/Input/FileInput'
+import { Input } from '@components/Input/Input'
+import type { TaxCodeSelectOption } from '@components/TaxCodeSelect/TaxCodeSelectDrawer'
+import { TaxCodeSelectDrawerWithTrigger } from '@components/TaxCodeSelect/TaxCodeSelectDrawerWithTrigger'
 import { ErrorText } from '@components/Typography/ErrorText'
-import { Text, TextSize, TextWeight } from '@components/Typography/Text'
 
 import './bankTransactionsMobileListSplitForm.scss'
 
@@ -43,6 +45,7 @@ export const BankTransactionsMobileListSplitForm = ({
   showDescriptions,
 }: BankTransactionsMobileListSplitFormProps) => {
   const { t } = useTranslation()
+  const { formatCurrencyFromCents } = useIntlFormatter()
   const receiptsRef = useRef<BankTransactionReceiptsHandle>(null)
 
   const {
@@ -51,7 +54,7 @@ export const BankTransactionsMobileListSplitForm = ({
     isError: isErrorCategorizing,
   } = useCategorizeBankTransactionWithCacheUpdate()
 
-  const { selectedCategory } = useGetBankTransactionCategory(bankTransaction.id)
+  const { selectedCategorization } = useGetBankTransactionCategorization(bankTransaction.id)
   const [showRetry, setShowRetry] = useState(false)
 
   const {
@@ -62,20 +65,20 @@ export const BankTransactionsMobileListSplitForm = ({
     removeSplit,
     updateSplitAmount,
     changeCategoryForSplitAtIndex,
+    updateSplitAtIndex,
     getInputValueForSplitAtIndex,
     onBlurSplitAmount,
   } = useSplitsForm({
     bankTransaction,
-    selectedCategory,
+    selectedCategorization,
   })
 
-  const effectiveSplits = showCategorization
-    ? localSplits
-    : []
+  const taxCodeOptions = useMemo<TaxCodeSelectOption[]>(
+    () => getBankTransactionTaxCodeOptions(bankTransaction),
+    [bankTransaction],
+  )
 
-  const addSplitButtonText = effectiveSplits.length > 1
-    ? t('bankTransactions:action.add_new_split', 'Add new split')
-    : t('bankTransactions:action.split_label', 'Split')
+  const showTaxCodeSelector = taxCodeOptions.length > 0
 
   useEffect(() => {
     if (isErrorCategorizing) {
@@ -98,61 +101,148 @@ export const BankTransactionsMobileListSplitForm = ({
     changeCategoryForSplitAtIndex(index, value)
   }, [changeCategoryForSplitAtIndex])
 
+  const getSelectedTaxCodeOption = useCallback(
+    (taxCode: string | null): TaxCodeSelectOption | null => {
+      if (!taxCode) {
+        return null
+      }
+
+      return taxCodeOptions.find(option => option.value === taxCode) ?? null
+    },
+    [taxCodeOptions],
+  )
+
+  const handleTaxCodeChange = useCallback(
+    (index: number) => (option: TaxCodeSelectOption | null) => {
+      updateSplitAtIndex(index, split => ({
+        ...split,
+        taxCode: option?.value ?? null,
+      }))
+    },
+    [updateSplitAtIndex],
+  )
+
   return (
     <VStack gap='sm'>
       {showCategorization
         && (
           <VStack gap='sm'>
-            <Text weight={TextWeight.bold} size={TextSize.sm}>
-              {t('bankTransactions:action.split_transaction', 'Split transaction')}
-            </Text>
-            <VStack gap='sm'>
-              {localSplits.map((split, index) => (
-                <HStack
-                  key={`split-${index}`}
+            {localSplits.map((split, index) => (
+              <VStack
+                key={`split-${index}`}
+                gap='3xs'
+                pbs='sm'
+              >
+                {index === 0 && localSplits.length > 1 && (
+                  <Span size='sm'>
+                    {t('bankTransactions:label.split_label', 'Splits')}
+                  </Span>
+                )}
+                <VStack
                   gap='xs'
-                  align='center'
-                  justify='space-between'
-                  className='Layer__BankTransactionsMobileSplitForm__SplitRow'
                 >
-                  <CategorySelectDrawerWithTrigger
-                    value={split.category}
-                    onChange={handleCategoryChange(index)}
-                    showTooltips={showTooltips}
-                  />
-                  <AmountInput
-                    name={`split-${index}`}
-                    disabled={index === 0 || !showCategorization}
-                    onChange={updateSplitAmount(index)}
-                    value={getInputValueForSplitAtIndex(index, split)}
-                    onBlur={onBlurSplitAmount}
-                    isInvalid={split.amount < 0}
-                    className='Layer__BankTransactionsMobileSplitForm__AmountInput'
+                  <div className='Layer__BankTransactionsMobileSplitForm__SplitGridContainer'>
+                    <AmountInput
+                      name={`split-${index}`}
+                      disabled={index === 0 || !showCategorization}
+                      onChange={updateSplitAmount(index)}
+                      value={getInputValueForSplitAtIndex(index, split)}
+                      onBlur={onBlurSplitAmount}
+                      isInvalid={split.amount < 0}
+                      className='Layer__BankTransactionsMobileSplitForm__AmountInput'
+                    />
+
+                    <HStack
+                      align='center'
+                      gap='xs'
+                      fluid
+                    >
+                      <CategorySelectDrawerWithTrigger
+                        value={split.category}
+                        onChange={handleCategoryChange(index)}
+                        showTooltips={showTooltips}
+                      />
+                      {index > 0 && (
+                        <Button
+                          onClick={() => removeSplit(index)}
+                          variant='outlined'
+                          icon
+                          inset
+                          aria-label={t('common:action.remove', 'Remove')}
+                        >
+                          <Trash size={14} />
+                        </Button>
+                      )}
+                    </HStack>
+
+                    {showTaxCodeSelector && (
+                      <>
+                        <HStack pis='3xs'>
+                          <Span>
+                          </Span>
+                        </HStack>
+                        <TaxCodeSelectDrawerWithTrigger
+                          options={taxCodeOptions}
+                          value={getSelectedTaxCodeOption(split.taxCode ?? null)}
+                          onChange={handleTaxCodeChange(index)}
+                          isDisabled={
+                            !showCategorization
+                            || split.category?.classification?.type === 'Exclusion'
+                          }
+                        />
+                      </>
+                    )}
+                  </div>
+                </VStack>
+              </VStack>
+            ))}
+
+            {localSplits.length > 1 && (
+              <VStack pbs='xs' gap='3xs'>
+                <Span size='sm'>
+                  {t('common:label.total', 'Total')}
+                </Span>
+                <HStack justify='space-between'>
+                  <Input
+                    disabled={true}
+                    inputMode='numeric'
+                    value={formatCurrencyFromCents(localSplits.reduce((total, { amount }) => total + amount, 0))}
+                    className='Layer__BankTransactionsMobileSplitForm__TotalAmountInput'
                   />
                   <Button
-                    onClick={() => removeSplit(index)}
+                    onClick={addSplit}
                     variant='outlined'
-                    icon
-                    isDisabled={index == 0}
                   >
-                    <Trash size={16} />
+                    <HStack align='center' gap='2xs' pis='2xs' pie='2xs'>
+                      {t('bankTransactions:action.split_label', 'Split')}
+                      <Scissors size={14} />
+                    </HStack>
                   </Button>
-
                 </HStack>
-              ))}
-            </VStack>
-            <HStack justify='end'>
-              <Button
-                onClick={addSplit}
-                variant='outlined'
-              >
-                <Scissors size={14} />
-                {addSplitButtonText}
-              </Button>
-            </HStack>
-            {splitFormError && <HStack pbe='sm'><ErrorText>{splitFormError}</ErrorText></HStack>}
+              </VStack>
+            )}
+
+            {localSplits.length === 1 && (
+              <HStack justify='end'>
+                <Button
+                  onClick={addSplit}
+                  variant='outlined'
+                >
+                  <HStack align='center' gap='2xs' pis='2xs' pie='2xs'>
+                    {t('bankTransactions:action.split_label', 'Split')}
+                    <Scissors size={14} />
+                  </HStack>
+                </Button>
+              </HStack>
+            )}
+            {splitFormError && (
+              <ErrorText>
+                {splitFormError}
+              </ErrorText>
+            )}
           </VStack>
         )}
+
       <BankTransactionFormFields
         bankTransaction={bankTransaction}
         showDescriptions={showDescriptions}
@@ -160,6 +250,7 @@ export const BankTransactionsMobileListSplitForm = ({
         hideTags
         isMobile
       />
+
       <div
         className={classNames(
           'Layer__bank-transaction-mobile-list-item__receipts',

--- a/src/components/BankTransactionsMobileList/bankTransactionsMobileListSplitForm.scss
+++ b/src/components/BankTransactionsMobileList/bankTransactionsMobileListSplitForm.scss
@@ -1,8 +1,18 @@
-.Layer__BankTransactionsMobileSplitForm__SplitRow {
-  max-inline-size: 100%;
-}
+.Layer__BankTransactionsMobileSplitForm {
+  &__SplitGridContainer {
+    display: grid;
+    grid-template-columns: 5.5rem 1fr;
+    gap: var(--spacing-xs);
+    align-items: center;
+  }
 
-.Layer__BankTransactionsMobileSplitForm__AmountInput {
-  flex-shrink: 0;
-  inline-size: 6rem;
+  &__AmountInput {
+    inline-size: 100%;
+    text-align: right;
+  }
+
+  &__TotalAmountInput {
+    width: 5.5rem;
+    text-align: right;
+  }
 }


### PR DESCRIPTION
## Description
Adds tax-code selection to mobile bank transaction categorization and split flows, while updating the mobile split layout so category, amount, tax code, remove, and total controls remain usable together.

## Changes
- Add tax-code selector to mobile business categorization
- Add tax-code selector to mobile split rows
- Disable tax-code selection for exclusion categories
- Include null tax codes for personal categorization payloads
- Update mobile split form layout, total amount field, and icon-only remove action
- Clean up mobile bank transaction text/import usage after the shared helper move

Shared payload and categorization-store hunks for mobile tax-code behavior landed in earlier PRs because they are foundational dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new tax-code selection UI and threads `taxCode` through mobile categorization and split payloads, which can affect how transactions are classified/saved. Risk is moderate due to expanded request payload/state handling and new conditional UI (e.g., exclusion categories disable tax codes).
> 
> **Overview**
> Enables **tax-code selection on mobile bank transactions** during business categorization and per-split categorization, including disabling tax-code selection for *Exclusion* categories.
> 
> Updates mobile forms to use the newer `BankTransactionsCategorizationStore` shape (category + tax code), includes `taxCode` in categorization requests (and explicitly sends `taxCode: null` for personal categorization), and refactors bank-transaction helpers imports to `@utils/bankTransactions/shared`.
> 
> Improves the mobile split form layout to keep amount/category/tax code/remove controls usable together, adds a read-only total amount field, and changes the remove action to an icon-only button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10e4b0e7edcaeaf97270312609a1c886add7b40c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->