### PR TITLE
Add bulk bank transaction tax code flows

### DIFF
--- a/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsCategorizeAllModal.tsx
+++ b/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsCategorizeAllModal.tsx
@@ -1,16 +1,24 @@
-import { useCallback, useId, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { type BankTransaction } from '@internal-types/bankTransactions'
+import { type Classification } from '@schemas/categorization'
+import { getBankTransactionTaxCodeOptions, getCategoryPayloadTaxCode, hasBankTransactionTaxCode } from '@utils/bankTransactions/shared'
 import { tPlural } from '@utils/i18n/plural'
 import { useBulkCategorize } from '@hooks/api/businesses/[business-id]/bank-transactions/bulk-categorize/useBulkCategorize'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useBulkSelectionActions, useCountSelectedIds, useSelectedIds } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
+import { useBankTransactionsContext } from '@contexts/BankTransactionsContext/BankTransactionsContext'
+import { ComboBox } from '@ui/ComboBox/ComboBox'
 import { VStack } from '@ui/Stack/Stack'
 import { Label, Span } from '@ui/Typography/Text'
 import { BaseConfirmationModal } from '@blocks/BaseConfirmationModal/BaseConfirmationModal'
 import { BankTransactionCategoryComboBox } from '@components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox'
 import { type BankTransactionCategoryComboBoxOption, isApiCategorizationAsOption, isCategoryAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { CategorySelectDrawerWithTrigger } from '@components/CategorySelect/CategorySelectDrawerWithTrigger'
+import { NO_TAX_CODE } from '@components/TaxCodeSelect/constants'
+import { type TaxCodeSelectOption } from '@components/TaxCodeSelect/TaxCodeSelectDrawer'
+import { TaxCodeSelectDrawerWithTrigger } from '@components/TaxCodeSelect/TaxCodeSelectDrawerWithTrigger'
 
 export enum CategorizationMode {
   Categorize = 'Categorize',
@@ -24,6 +32,16 @@ interface BankTransactionsCategorizeAllModalProps {
   isMobileView?: boolean
 }
 
+const resolveBulkTaxCode = (
+  bankTransaction: BankTransaction | undefined,
+  classification: Classification,
+  selectedTaxCode: string | null,
+): string | null => {
+  const taxCode = hasBankTransactionTaxCode(bankTransaction, selectedTaxCode) ? selectedTaxCode : null
+
+  return getCategoryPayloadTaxCode(classification, taxCode)
+}
+
 export const BankTransactionsCategorizeAllModal = ({
   isOpen,
   onOpenChange,
@@ -35,15 +53,80 @@ export const BankTransactionsCategorizeAllModal = ({
   const { count } = useCountSelectedIds()
   const { selectedIds } = useSelectedIds()
   const { clearSelection } = useBulkSelectionActions()
+  const { data: bankTransactions } = useBankTransactionsContext()
   const [selectedCategory, setSelectedCategory] = useState<BankTransactionCategoryComboBoxOption | null>(null)
+  const [selectedTaxCode, setSelectedTaxCode] = useState<TaxCodeSelectOption | null>(null)
   const { trigger, isMutating } = useBulkCategorize()
+
+  const bankTransactionsById = useMemo(
+    () => new Map((bankTransactions ?? []).map(bankTransaction => [bankTransaction.id, bankTransaction])),
+    [bankTransactions],
+  )
+
+  const selectedTransactions = useMemo(() => {
+    return Array.from(selectedIds)
+      .map(transactionId => bankTransactionsById.get(transactionId))
+      .filter((bankTransaction): bankTransaction is BankTransaction => bankTransaction !== undefined)
+  }, [bankTransactionsById, selectedIds])
+
+  // NOTE: Only taking tax codes from one txn for Canada taxes. Need to expand if more tax codes are supported.
+  const taxCodeSelectOptions = useMemo(() => {
+    for (const bankTransaction of selectedTransactions) {
+      const options = getBankTransactionTaxCodeOptions(bankTransaction)
+
+      if (options.length > 0) {
+        return options
+      }
+    }
+
+    return []
+  }, [selectedTransactions])
+
+  const taxCodeComboBoxOptions = useMemo((): TaxCodeSelectOption[] => {
+    return [
+      {
+        label: t('bankTransactions:action.no_tax_code', 'No tax code'),
+        value: NO_TAX_CODE,
+      },
+      ...taxCodeSelectOptions,
+    ]
+  }, [t, taxCodeSelectOptions])
+
+  useEffect(() => {
+    if (!selectedTaxCode || selectedTaxCode.value === NO_TAX_CODE) {
+      return
+    }
+    if (!taxCodeSelectOptions.some(option => option.value === selectedTaxCode.value)) {
+      setSelectedTaxCode(null)
+    }
+  }, [selectedTaxCode, taxCodeSelectOptions])
 
   const handleCategorizeModalClose = useCallback((isOpen: boolean) => {
     onOpenChange(isOpen)
     if (!isOpen) {
       setSelectedCategory(null)
+      setSelectedTaxCode(null)
     }
   }, [onOpenChange])
+
+  const handleCategoryChange = useCallback((nextCategory: BankTransactionCategoryComboBoxOption | null) => {
+    setSelectedCategory(nextCategory)
+
+    if (nextCategory?.classification?.type === 'Exclusion') {
+      setSelectedTaxCode(null)
+    }
+  }, [])
+
+  const handleTaxCodeChange = useCallback((next: TaxCodeSelectOption | null) => {
+    if (next === null) {
+      setSelectedTaxCode({
+        label: t('bankTransactions:action.no_tax_code', 'No tax code'),
+        value: NO_TAX_CODE,
+      })
+      return
+    }
+    setSelectedTaxCode(next)
+  }, [t])
 
   const handleConfirm = useCallback(async () => {
     if (!selectedCategory || selectedCategory.classification === null) {
@@ -54,23 +137,36 @@ export const BankTransactionsCategorizeAllModal = ({
       return
     }
 
-    const transactionIds = Array.from(selectedIds)
+    const classification = selectedCategory.classification
+    const selectedTaxCodeValue = selectedTaxCode?.value === NO_TAX_CODE
+      ? null
+      : selectedTaxCode?.value ?? null
     const categorization = {
       type: 'Category' as const,
-      category: selectedCategory.classification,
+      category: classification,
     }
 
     await trigger({
-      transactions: transactionIds.map(transactionId => ({
+      transactions: Array.from(selectedIds).map(transactionId => ({
         transactionId,
-        categorization,
+        categorization: {
+          ...categorization,
+          taxCode: resolveBulkTaxCode(
+            bankTransactionsById.get(transactionId),
+            classification,
+            selectedTaxCodeValue,
+          ),
+        },
       })),
     })
 
     clearSelection()
-  }, [selectedIds, selectedCategory, trigger, clearSelection])
+  }, [selectedIds, selectedCategory, selectedTaxCode, trigger, clearSelection, bankTransactionsById])
 
   const categorySelectId = useId()
+  const taxCodeSelectId = useId()
+  const showTaxCodeSelector = taxCodeSelectOptions.length > 0
+  const isTaxCodeDisabled = isMutating || selectedCategory?.classification?.type === 'Exclusion'
 
   return (
     <BaseConfirmationModal
@@ -80,13 +176,13 @@ export const BankTransactionsCategorizeAllModal = ({
       content={(
         <VStack gap='xs'>
           <VStack gap='3xs'>
-            <Label size='sm' htmlFor={categorySelectId}>{t('bankTransactions:action.select_category', 'Select category')}</Label>
+            <Label size='sm' htmlFor={categorySelectId}>{t('bankTransactions:label.category', 'Category')}</Label>
             {isMobileView
               ? (
                 <CategorySelectDrawerWithTrigger
                   aria-labelledby={categorySelectId}
                   value={selectedCategory}
-                  onChange={setSelectedCategory}
+                  onChange={handleCategoryChange}
                   showTooltips={false}
                 />
               )
@@ -94,12 +190,40 @@ export const BankTransactionsCategorizeAllModal = ({
                 <BankTransactionCategoryComboBox
                   inputId={categorySelectId}
                   selectedValue={selectedCategory}
-                  onSelectedValueChange={setSelectedCategory}
+                  onSelectedValueChange={handleCategoryChange}
                   includeSuggestedMatches={false}
                   isDisabled={isMutating}
                 />
               )}
           </VStack>
+          {showTaxCodeSelector && (
+            <VStack gap='3xs' pbs='sm'>
+              <Label size='sm' htmlFor={taxCodeSelectId}>{t('bankTransactions:label.tax_code', 'Tax Code')}</Label>
+              {isMobileView
+                ? (
+                  <TaxCodeSelectDrawerWithTrigger
+                    options={taxCodeSelectOptions}
+                    value={selectedTaxCode}
+                    onChange={handleTaxCodeChange}
+                    isDisabled={isTaxCodeDisabled}
+                    hasSelection={selectedTaxCode !== null}
+                    placeholder={t('bankTransactions:action.select_tax_code', 'Select tax code')}
+                  />
+                )
+                : (
+                  <ComboBox<TaxCodeSelectOption>
+                    inputId={taxCodeSelectId}
+                    selectedValue={selectedTaxCode}
+                    onSelectedValueChange={handleTaxCodeChange}
+                    options={taxCodeComboBoxOptions}
+                    isDisabled={isTaxCodeDisabled}
+                    isSearchable={false}
+                    isClearable
+                    placeholder={t('bankTransactions:action.select_tax_code', 'Select tax code')}
+                  />
+                )}
+            </VStack>
+          )}
           {selectedCategory && isCategoryAsOption(selectedCategory) && (
             <Span>
               {mode === CategorizationMode.Categorize


### PR DESCRIPTION
## Description
Adds tax-code support to the bulk categorize modal so selected transactions can be categorized with a tax code when applicable, while safely falling back to no tax code for transactions that do not support the selected option.

## Changes
- Load selected bank transactions for bulk tax-code option resolution
- Add tax-code selection to desktop and mobile bulk categorize UI
- Add a no-tax-code option for bulk categorization
- Clear selected tax code when the category changes to an exclusion
- Resolve and submit tax codes per selected transaction in the bulk categorize payload
- Reset category and tax-code selections when the modal closes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tax-code selection flow and includes per-transaction `taxCode` in the bulk categorization payload, which could change categorization results if option resolution is wrong or mismatched across selected transactions. UI state interactions (exclusions, option invalidation) add moderate complexity but are scoped to the bulk-categorize modal.
> 
> **Overview**
> Adds tax-code support to the bulk categorize/recategorize modal for bank transactions.
> 
> The modal now derives available tax-code options from the currently selected transactions, conditionally shows a Tax Code selector (desktop `ComboBox` and mobile drawer), and supports an explicit *No tax code* choice.
> 
> On confirm, the bulk categorize request now computes `taxCode` per transaction (only applying the selected code when valid for that transaction and category), clears tax code on exclusion categories, and resets both category and tax code when the modal closes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 079a447a75ff0847a2f0ddf80e9e1be6424ab3a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->