### PR TITLE
Split 3/3: clean up tax code review styles and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,18 +15,30 @@
   - **`useCallback`**: Only for functions passed as props to `memo()`-wrapped children or used in Hook dependency arrays. Not needed for handlers on plain HTML elements.
   - **`useMemo`**: Only when (a) the computation is expensive (>1ms), (b) the result is an object/array prop to a `memo()`-wrapped child, or (c) the result is used in a Hook dependency array. Never memoize primitives.
 
+# CSS Styles
+
+- Do not use the `style` prop or write raw utility/atomic class strings in `className`
+- Do not re-state styles the target component or its parent stack already set
+- Use the following spacing scale: (`4xs|3xs|2xs|xs|sm|md|lg|xl|2xl|3xl|5xl`)
+
+## CSS Selectors
+
+- DRY: Use existing design-system props instead of new SCSS selectors when possible
+- `ComponentName.tsx` should add CSS selectors useing `import './componentName.scss'` (camelCase)
+- For any styling that component props can't express, create a new CSS class following name guidelines below
+- Nest selectors that share a block prefix under one `&__` root; do not nest more than one level (excluding pseudo-classes, pseudo-elements, and media queries): `.Layer__<ComponentName> { &__Element { … } }`
+- Only use descendant combinator selectors when the element can't own a class.
+
+### CSS Selector Naming
+- Follow BEM style: `Layer__Block__Element--modifier`
+  - `Block` and `Element` are in PascalCase
+  - `Layer__` is a namespace
+
 # Components
 
 - Use `Span` from `@ui/Typography/Text` instead of `<span>`
 - Use `<HStack>` and `<VStack>` from `@ui/Stack/Stack` instead of `<div>`
-- Build on existing components in `@ui` before creating new ones
-
-# Style
-
-- Do not use inline styles
-- Create `.scss` file matching component name but with lowercase first letter and import directly
-- Use design system spacing scale
-- For css class names, use BEM in PascalCase
+- Build on existing components in `@ui` before creating new ones 
 
 # Abstractions
 

--- a/docs/ai/state-management.md
+++ b/docs/ai/state-management.md
@@ -1,7 +1,7 @@
 # State Management
 
 - **SWR:** Server state (fetching, caching) — `useBankTransactions`, `useProfitAndLossReport`
-- **Zustand:** UI state (selections, filters) — `BankTransactionsCategoryStoreProvider`
+- **Zustand:** UI state (selections, filters) — `BankTransactionsCategorizationStoreProvider`
 - **React Context:** DI (config, auth, business data) — `LayerProvider`, `BankTransactionsProvider`
 
 ## Key Patterns

--- a/src/components/ActionableList/ActionableList.tsx
+++ b/src/components/ActionableList/ActionableList.tsx
@@ -2,6 +2,8 @@ import classNames from 'classnames'
 
 import CheckIcon from '@icons/Check'
 import ChevronRight from '@icons/ChevronRight'
+import { VStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
 import { Text, TextSize } from '@components/Typography/Text'
 
 import './actionableList.scss'
@@ -31,52 +33,51 @@ export const ActionableList = <T,>({
   className,
 }: ActionableListProps<T>) => {
   return (
-    <ul className={classNames('Layer__actionable-list', className)}>
-      {options.map((x, idx) => (
+    <ul className={classNames('Layer__ActionableList', className)}>
+      {options.map(x => (
         <li
           role='button'
           onClick={() => onClick(x)}
-          key={`actionable-list-item-${idx}`}
+          key={x.id}
           className={classNames(
-            x.secondary && 'Layer__actionable-list-item--secondary',
-            x.asLink && 'Layer__actionable-list-item--as-link',
-            selectedId === x.id && 'Layer__actionable-list__item--selected',
+            'Layer__ActionableList__Item',
+            x.secondary && 'Layer__ActionableList__Item--Secondary',
+            x.asLink && 'Layer__ActionableList__Item--AsLink',
+            selectedId === x.id && 'Layer__ActionableList__Item--Selected',
           )}
         >
-          <div className='Layer__actionable-list__content'>
+          <VStack gap='2xs' align='start' className='Layer__ActionableList__Content'>
             <Text size={TextSize.sm}>{x.label}</Text>
             {
               showDescriptions
               && x.description
               && (
                 <Text
-                  className='Layer__actionable-list__content-description'
+                  className='Layer__ActionableList__ContentDescription'
                   size={TextSize.sm}
                 >
                   {x.description}
                 </Text>
               )
             }
-          </div>
+          </VStack>
           {!x.asLink && selectedId && selectedId === x.id
             ? (
-              <span className='Layer__actionable-list__select Layer__actionable-list__select--selected'>
+              <Span className='Layer__ActionableList__Select Layer__ActionableList__Select--Selected'>
                 <CheckIcon
                   size={14}
-                  className='Layer__actionable-list__selected-icon'
                 />
-              </span>
+              </Span>
             )
             : null}
           {!x.asLink && (!selectedId || selectedId !== x.id)
             ? (
-              <span className='Layer__actionable-list__select' />
+              <Span className='Layer__ActionableList__Select' />
             )
             : null}
           {x.asLink && (
             <ChevronRight
               size={16}
-              className='Layer__actionable-list__link-icon'
             />
           )}
         </li>

--- a/src/components/ActionableList/actionableList.scss
+++ b/src/components/ActionableList/actionableList.scss
@@ -1,9 +1,9 @@
-.Layer__actionable-list {
+.Layer__ActionableList {
   padding: 0;
   margin: 0;
   list-style: none;
 
-  li {
+  &__Item {
     box-sizing: border-box;
     display: flex;
     gap: var(--spacing-2xs);
@@ -16,39 +16,35 @@
     cursor: pointer;
     font-size: 12px;
 
-    .Layer__actionable-list__content {
-      display: flex;
-      flex-direction: column;
-      gap: var(--spacing-2xs);
-      align-items: flex-start;
-      max-width: 36ch;
-
-      .Layer__actionable-list__content-description {
-        color: var(--color-base-500);
-      }
-    }
-
-    &.Layer__actionable-list-item--secondary {
+    &--Secondary {
       color: var(--color-base-500);
 
-      &.Layer__actionable-list-item--as-link:hover {
+      &.Layer__ActionableList__Item--AsLink:hover {
         color: var(--color-base-1000);
       }
     }
 
-    &.Layer__actionable-list__item--selected {
+    &--Selected {
       background-color: var(--color-base-50);
     }
   }
 
-  .Layer__actionable-list__select {
+  &__Content {
+    max-width: 36ch;
+  }
+
+  &__ContentDescription {
+    color: var(--color-base-500);
+  }
+
+  &__Select {
     display: flex;
     height: 18px;
     width: 18px;
     border-radius: 50%;
     border: 1px solid var(--color-base-300);
 
-    &.Layer__actionable-list__select--selected {
+    &--Selected {
       align-items: center;
       justify-content: center;
       border: 1px solid var(--color-info-success);

--- a/src/components/BankTransactionRow/bankTransactionRow.scss
+++ b/src/components/BankTransactionRow/bankTransactionRow.scss
@@ -1,12 +1,14 @@
-.Layer__bank-transaction-row__category-hstack {
-  max-width: 100%;
-}
+.Layer__bank-transaction-row {
+  &__category-hstack {
+    max-width: 100%;
+  }
 
-.Layer__bank-transaction-row__category-open {
-  padding-block-start: 0.875rem;
-}
+  &__category-open {
+    padding-block-start: 0.875rem;
+  }
 
-.Layer__bank-transaction-row__category {
-  overflow: hidden;
-  width: 100%;
+  &__category {
+    overflow: hidden;
+    width: 100%;
+  }
 }

--- a/src/components/BankTransactions/BankTransactionsListItemCategory/bankTransactionsListItemCategory.scss
+++ b/src/components/BankTransactions/BankTransactionsListItemCategory/bankTransactionsListItemCategory.scss
@@ -1,11 +1,10 @@
-.Layer__bankTransactionsListItemCategory__List {
+.Layer__bankTransactionsListItemCategory__List,
+.Layer__bankTransactionsListItemCategory__Mobile {
   padding-block: var(--spacing-xs);
   padding-inline: var(--spacing-md);
 }
 
 .Layer__bankTransactionsListItemCategory__Mobile {
-  padding-block: var(--spacing-xs);
-  padding-inline: var(--spacing-md);
   border-radius: 0 0 var(--border-radius-sm) var(--border-radius-sm);
   border-top: 1px solid var(--color-base-400);
   background-color: var(--color-base-100);

--- a/src/components/BankTransactionsMobileList/bankTransactionsMobileListSplitForm.scss
+++ b/src/components/BankTransactionsMobileList/bankTransactionsMobileListSplitForm.scss
@@ -1,8 +1,18 @@
-.Layer__BankTransactionsMobileSplitForm__SplitRow {
-  max-inline-size: 100%;
-}
+.Layer__BankTransactionsMobileSplitForm {
+  &__SplitGridContainer {
+    display: grid;
+    grid-template-columns: 5.5rem 1fr;
+    gap: var(--spacing-xs);
+    align-items: center;
+  }
 
-.Layer__BankTransactionsMobileSplitForm__AmountInput {
-  flex-shrink: 0;
-  inline-size: 6rem;
+  &__AmountInput {
+    inline-size: 100%;
+    text-align: right;
+  }
+
+  &__TotalAmountInput {
+    width: 5.5rem;
+    text-align: right;
+  }
 }

--- a/src/components/CategorySelect/CategorySelectDrawerWithTrigger.tsx
+++ b/src/components/CategorySelect/CategorySelectDrawerWithTrigger.tsx
@@ -8,8 +8,6 @@ import { Span } from '@ui/Typography/Text'
 import type { BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { CategorySelectDrawer } from '@components/CategorySelect/CategorySelectDrawer'
 
-import './categorySelectDrawerWithTrigger.scss'
-
 type Props = {
   value: BankTransactionCategoryComboBoxOption | null
   onChange: (newValue: BankTransactionCategoryComboBoxOption | null) => void
@@ -22,15 +20,20 @@ export const CategorySelectDrawerWithTrigger = ({ value, onChange, showTooltips 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
 
   return (
-    <HStack fluid className='Layer__CategorySelectDrawerWithTrigger'>
+    <HStack fluid>
       <Button
+        flex
         fullWidth
         aria-label={t('bankTransactions:action.select_category', 'Select category')}
         onClick={() => { setIsDrawerOpen(true) }}
         variant='outlined'
       >
-        <Span ellipsis>{value?.label ?? t('common:action.select_label', 'Select...')}</Span>
-        <ChevronDown size={16} />
+        <HStack fluid align='center' justify='space-between' gap='2xs'>
+          <Span ellipsis variant={value ? undefined : 'placeholder'}>
+            {value?.label ?? t('common:action.select_label', 'Select...')}
+          </Span>
+          <ChevronDown size={16} />
+        </HStack>
       </Button>
 
       <CategorySelectDrawer

--- a/src/components/CategorySelect/categorySelectDrawerWithTrigger.scss
+++ b/src/components/CategorySelect/categorySelectDrawerWithTrigger.scss
@@ -1,5 +1,0 @@
-.Layer__CategorySelectDrawerWithTrigger {
-  .Layer__UI__Button {
-    justify-content: space-between;
-  }
-}

--- a/src/components/ExpandedBankTransactionRow/expandedBankTransactionRow.scss
+++ b/src/components/ExpandedBankTransactionRow/expandedBankTransactionRow.scss
@@ -8,3 +8,12 @@
     padding-inline-end: var(--spacing-md);
   }
 }
+
+.Layer__Stack.Layer__expanded-bank-transaction-row__table-cell--split-entry__tax-code__Container {
+  flex: 0 0 12.5rem;
+}
+
+.Layer__expanded-bank-transaction-row__total-and-btns--ListItem {
+  flex-direction: column;
+  align-items: stretch;
+}

--- a/src/components/ui/Modal/ModalSlots.tsx
+++ b/src/components/ui/Modal/ModalSlots.tsx
@@ -4,7 +4,7 @@ import { X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@ui/Button/Button'
-import { VStack } from '@ui/Stack/Stack'
+import { HStack, VStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
 import { P } from '@ui/Typography/Text'
 import { Separator } from '@components/Separator/Separator'
@@ -66,15 +66,19 @@ export const ModalTitleWithClose = forwardRef<
           {description}
         </VStack>
         {!hideCloseButton && (
-          <Button
-            icon
-            variant='outlined'
+          <HStack
             slot='close'
-            onPress={onClose}
-            aria-label={t('ui:action.close_modal', 'Close Modal')}
+            className='Layer__ModalTitleWithClose__CloseButtonWrapper'
           >
-            <X size={16} />
-          </Button>
+            <Button
+              icon
+              variant='outlined'
+              onPress={onClose}
+              aria-label={t('ui:action.close_modal', 'Close Modal')}
+            >
+              <X size={16} />
+            </Button>
+          </HStack>
         )}
       </div>
       <Separator mbe={hideBottomPadding ? undefined : 'md'} />

--- a/src/components/ui/Modal/modalSlots.scss
+++ b/src/components/ui/Modal/modalSlots.scss
@@ -22,7 +22,7 @@
   }
 }
 
-.Layer__ModalTitleWithClose > .Layer__UI__Button {
+.Layer__ModalTitleWithClose__CloseButtonWrapper {
   margin: 0 0 auto;
 }
 
@@ -39,4 +39,5 @@
 
 .Layer__ModalActions {
   margin-block-start: var(--spacing-3xl);
+  margin-block-end: var(--spacing-3xs);
 }

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -343,15 +343,6 @@
   }
 }
 
-.Layer__expanded-bank-transaction-row__description {
-  padding: 0 var(--spacing-md);
-
-  & textarea {
-    height: 100px;
-    width: 100%;
-  }
-}
-
 .Layer__expanded-bank-transaction-row__file-upload {
   display: flex;
   flex-direction: column;
@@ -875,6 +866,12 @@
     }
 
     .Layer__input {
+      max-width: 100%;
+    }
+  }
+
+  .Layer__expanded-bank-transaction-row__total-and-btns--ListItem {
+    .Layer__input-tooltip {
       max-width: 100%;
     }
   }

--- a/src/styles/bank_transactions_mobile_list.scss
+++ b/src/styles/bank_transactions_mobile_list.scss
@@ -77,7 +77,7 @@
 .Layer__bank-transaction-mobile-list-item__business-form {
   width: 100%;
 
-  .Layer__actionable-list {
+  .Layer__ActionableList {
     margin-bottom: var(--spacing-md);
   }
 }


### PR DESCRIPTION
## Scope
- Clean up ActionableList and modal slot styling used by tax-code review flows.
- Move component-specific SCSS toward local BEM selectors.
- Update local agent and state-management docs touched by the original review branch.

## Verification
- npm run typecheck && npm run lint

Root: #1329
Base: #1330
Next: None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly styling and structural UI refactors, but it renames CSS selectors/classes (notably `ActionableList`) and adjusts modal slot markup, which could cause regressions in bank transaction/tax-code review layouts if any selectors are missed.
> 
> **Overview**
> Cleans up tax-code review related UI styling by **refactoring `ActionableList` to BEM/PascalCase selectors**, switching inner layout to `VStack`/`Span`, and updating downstream styles that reference the list.
> 
> Simplifies a few bank-transaction SCSS blocks (nesting/duplication cleanup), tweaks mobile split-form layout styles, and adjusts `ModalTitleWithClose` markup to style the close button via a dedicated wrapper class (plus minor spacing tweaks).
> 
> Updates internal docs (`AGENTS.md`, `docs/ai/state-management.md`) with CSS selector conventions and a corrected store provider name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48c51dcfb4c21b5bf79350793648ba2ac5c6e1ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->