### PR TITLE
feat: mobile controls for unified reports

### DIFF
--- a/src/components/CategorizationRules/CategorizationRulesTable/CategorizationRulesTable.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesTable/CategorizationRulesTable.tsx
@@ -9,7 +9,6 @@ import { Button } from '@ui/Button/Button'
 import { Span } from '@ui/Typography/Text'
 import { ResolvedCategoryName } from '@components/CategorizationRules/ResolvedCategoryName'
 import { getCategorizationRuleDirectionLabel } from '@components/CategorizationRules/utils'
-import { Container } from '@components/Container/Container'
 import type { NestedColumnConfig } from '@components/DataTable/columnUtils'
 import { PaginatedTable, type TablePaginationProps } from '@components/PaginatedDataTable/PaginatedDataTable'
 
@@ -90,17 +89,15 @@ export const CategorizationRulesTable = ({
   ], [t, options, onDeleteRule])
 
   return (
-    <Container name='CategorizationRulesTable'>
-      <PaginatedTable
-        ariaLabel={t('categorizationRules:label.categorization_rules', 'Categorization rules')}
-        data={data}
-        isLoading={isLoading}
-        isError={isError}
-        columnConfig={columnConfig}
-        paginationProps={paginationProps}
-        componentName={COMPONENT_NAME}
-        slots={slots}
-      />
-    </Container>
+    <PaginatedTable
+      ariaLabel={t('categorizationRules:label.categorization_rules', 'Categorization rules')}
+      data={data}
+      isLoading={isLoading}
+      isError={isError}
+      columnConfig={columnConfig}
+      paginationProps={paginationProps}
+      componentName={COMPONENT_NAME}
+      slots={slots}
+    />
   )
 }

--- a/src/components/CategorizationRules/CategorizationRulesTable/categorizationRulesTable.scss
+++ b/src/components/CategorizationRules/CategorizationRulesTable/categorizationRulesTable.scss
@@ -1,7 +1,3 @@
-.Layer__CategorizationRulesTable {
-  border: none;
-}
-
 .Layer__UI__Table__CategorizationRulesTable {
   table-layout: fixed;
   width: 100%;

--- a/src/components/DateSelection/CombinedDateRangeSelection.tsx
+++ b/src/components/DateSelection/CombinedDateRangeSelection.tsx
@@ -5,12 +5,13 @@ import { GlobalMonthPicker } from '@components/GlobalMonthPicker/GlobalMonthPick
 export type CombinedDateRangeSelectionProps = {
   mode: DateSelectionMode
   showLabels?: boolean
+  isCompact?: boolean
 }
 
-export const CombinedDateRangeSelection = ({ mode, showLabels = true }: CombinedDateRangeSelectionProps) => {
+export const CombinedDateRangeSelection = ({ mode, showLabels = true, isCompact = false }: CombinedDateRangeSelectionProps) => {
   if (mode === 'month') {
     return <GlobalMonthPicker showLabel={showLabels} />
   }
 
-  return <GlobalDateRangeSelection showLabels={showLabels} />
+  return <GlobalDateRangeSelection showLabels={showLabels} isCompact={isCompact} />
 }

--- a/src/components/DateSelection/CombinedDateSelection.tsx
+++ b/src/components/DateSelection/CombinedDateSelection.tsx
@@ -5,12 +5,13 @@ import { GlobalMonthPicker } from '@components/GlobalMonthPicker/GlobalMonthPick
 export type CombinedDateSelectionProps = {
   mode: DateSelectionMode
   showLabels?: boolean
+  isCompact?: boolean
 }
 
-export const CombinedDateSelection = ({ mode, showLabels = true }: CombinedDateSelectionProps) => {
+export const CombinedDateSelection = ({ mode, showLabels = true, isCompact = false }: CombinedDateSelectionProps) => {
   if (mode === 'month') {
     return <GlobalMonthPicker showLabel={showLabels} />
   }
 
-  return <GlobalDateSelection showLabels={showLabels} />
+  return <GlobalDateSelection showLabels={showLabels} isCompact={isCompact} />
 }

--- a/src/components/DateSelection/GlobalDateRangeSelection.tsx
+++ b/src/components/DateSelection/GlobalDateRangeSelection.tsx
@@ -1,22 +1,24 @@
 import classNames from 'classnames'
 
-import { useSizeClass } from '@hooks/utils/size/useWindowSize'
-import { HStack } from '@ui/Stack/Stack'
 import { DateSelectionComboBox } from '@components/DateSelection/DateSelectionComboBox'
 import { GlobalDateRangePicker } from '@components/GlobalDateRangePicker/GlobalDateRangePicker'
 
 import './globalDateRangeSelection.scss'
 
-export const GlobalDateRangeSelection = ({ showLabels = false }: { showLabels?: boolean }) => {
-  const { value } = useSizeClass()
+type GlobalDateRangeSelectionProps = {
+  showLabels?: boolean
+  isCompact?: boolean
+}
 
+export const GlobalDateRangeSelection = ({ showLabels = false, isCompact = false }: GlobalDateRangeSelectionProps) => {
   return (
-    <HStack className={classNames('Layer__GlobalDateRangeSelection', {
-      'Layer__GlobalDateRangeSelection--mobile': value === 'mobile',
-    })}
+    <div
+      className={classNames('Layer__GlobalDateRangeSelection', {
+        'Layer__GlobalDateRangeSelection--compact': isCompact,
+      })}
     >
       <DateSelectionComboBox showLabel={showLabels} />
       <GlobalDateRangePicker showLabels={showLabels} />
-    </HStack>
+    </div>
   )
 }

--- a/src/components/DateSelection/GlobalDateSelection.tsx
+++ b/src/components/DateSelection/GlobalDateSelection.tsx
@@ -1,23 +1,24 @@
 import classNames from 'classnames'
 
-import { useSizeClass } from '@hooks/utils/size/useWindowSize'
-import { HStack } from '@ui/Stack/Stack'
 import { DateSelectionComboBox } from '@components/DateSelection/DateSelectionComboBox'
 import { GlobalDatePicker } from '@components/GlobalDatePicker/GlobalDatePicker'
 
 import './globalDateSelection.scss'
 
-export const GlobalDateSelection = ({ showLabels = false }: { showLabels?: boolean }) => {
-  const { value } = useSizeClass()
+type GlobalDateSelectionProps = {
+  showLabels?: boolean
+  isCompact?: boolean
+}
 
+export const GlobalDateSelection = ({ showLabels = false, isCompact = false }: GlobalDateSelectionProps) => {
   return (
-    <HStack
+    <div
       className={classNames('Layer__GlobalDateSelection', {
-        'Layer__GlobalDateSelection--mobile': value === 'mobile',
+        'Layer__GlobalDateSelection--compact': isCompact,
       })}
     >
       <DateSelectionComboBox showLabel={showLabels} />
       <GlobalDatePicker showLabel={showLabels} />
-    </HStack>
+    </div>
   )
 }

--- a/src/components/DateSelection/globalDateRangeSelection.scss
+++ b/src/components/DateSelection/globalDateRangeSelection.scss
@@ -1,11 +1,14 @@
 .Layer__GlobalDateRangeSelection {
   display: grid;
-  grid-template-columns: 9rem repeat(2, minmax(10rem, 12rem));
+  grid-template-columns: repeat(3, minmax(10rem, 1fr));
   gap: var(--spacing-xs);
 
-  &--mobile {
-    grid-template-columns: 8rem repeat(2, minmax(6.75rem, 10rem));
-    gap: var(--spacing-3xs);
+  &--compact {
+    grid-template-columns: repeat(2, minmax(6.75rem, 1fr));
+
+    > :first-child {
+      grid-column: 1 / -1;
+    }
   }
 
   .Layer__tooltip-trigger {

--- a/src/components/DateSelection/globalDateSelection.scss
+++ b/src/components/DateSelection/globalDateSelection.scss
@@ -1,13 +1,13 @@
 .Layer__GlobalDateSelection {
   display: grid;
-  grid-template-columns: repeat(2, minmax(10rem, 12rem));
+  grid-template-columns: repeat(2, minmax(10rem, 1fr));
   gap: var(--spacing-xs);
   min-width: 18.5rem;
 
-  &--mobile {
-    grid-template-columns: repeat(2, minmax(6.75rem, 10rem));
+  &--compact {
+    grid-template-columns: minmax(6.75rem, 1fr);
     gap: var(--spacing-3xs);
-    min-width: 16rem;
+    min-width: 0;
   }
 
   .Layer__tooltip-trigger {

--- a/src/components/ExpandableDataTable/ExpandableDataTableToggleButton.tsx
+++ b/src/components/ExpandableDataTable/ExpandableDataTableToggleButton.tsx
@@ -29,7 +29,12 @@ export const ExpandableDataTableToggleButton = () => {
   const Icon = shouldCollapse ? CollapseIcon : ExpandIcon
 
   return (
-    <Button icon={!isDesktop} variant='outlined' onClick={onClickExpandOrCollapse}>
+    <Button
+      icon={!isDesktop}
+      variant='outlined'
+      onClick={onClickExpandOrCollapse}
+      aria-label={!isDesktop ? buttonText : undefined}
+    >
       {!isDesktop ? <Icon /> : buttonText}
     </Button>
   )

--- a/src/components/ExpandableDataTable/ExpandableDataTableToggleButton.tsx
+++ b/src/components/ExpandableDataTable/ExpandableDataTableToggleButton.tsx
@@ -1,0 +1,36 @@
+import { useCallback, useContext } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import CollapseIcon from '@icons/Collapse'
+import ExpandIcon from '@icons/Expand'
+import { Button } from '@ui/Button/Button'
+import { ExpandableDataTableContext } from '@components/ExpandableDataTable/ExpandableDataTableProvider'
+
+export const ExpandableDataTableToggleButton = () => {
+  const { t } = useTranslation()
+  const { expanded, setExpanded } = useContext(ExpandableDataTableContext)
+  const { isDesktop } = useSizeClass()
+
+  const shouldCollapse = expanded === true
+  const onClickExpandOrCollapse = useCallback(() => {
+    if (shouldCollapse) {
+      setExpanded({})
+    }
+    else {
+      setExpanded(true)
+    }
+  }, [setExpanded, shouldCollapse])
+
+  const buttonText = shouldCollapse
+    ? t('common:action.collapse_all', 'Collapse All')
+    : t('common:action.expand_all', 'Expand All')
+
+  const Icon = shouldCollapse ? CollapseIcon : ExpandIcon
+
+  return (
+    <Button icon={!isDesktop} variant='outlined' onClick={onClickExpandOrCollapse}>
+      {!isDesktop ? <Icon /> : buttonText}
+    </Button>
+  )
+}

--- a/src/components/ReportsNavigation/ReportsMobileSelectionDrawer.tsx
+++ b/src/components/ReportsNavigation/ReportsMobileSelectionDrawer.tsx
@@ -1,0 +1,51 @@
+import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useReportConfig } from '@hooks/api/businesses/[business-id]/reports/config/useReportConfig'
+import { useBaseUnifiedReport } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
+import { MobileSelectionDrawerWithTrigger } from '@ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger'
+import { ReportComboBoxOption } from '@components/ReportsNavigation/reportComboBoxOption'
+
+export function ReportsMobileSelectionDrawer() {
+  const { t } = useTranslation()
+  const { data, isLoading, isError } = useReportConfig()
+  const { baseReport, setBaseReport } = useBaseUnifiedReport()
+
+  const groups = useMemo(() => {
+    if (!data) return []
+
+    return data.map(group => ({
+      label: group.displayName,
+      options: group.reports.map(report => new ReportComboBoxOption(report)),
+    }))
+  }, [data])
+
+  const selectedValue = useMemo(() => {
+    if (!baseReport) return null
+
+    for (const group of groups) {
+      const match = group.options.find(option => option.value === baseReport.key)
+      if (match) return match
+    }
+
+    return null
+  }, [baseReport, groups])
+
+  const onSelectedValueChange = useCallback((value: ReportComboBoxOption | null) => {
+    if (value) setBaseReport(value.original)
+  }, [setBaseReport])
+
+  return (
+    <MobileSelectionDrawerWithTrigger<ReportComboBoxOption>
+      ariaLabel={t('reports:label.reports_navigation', 'Reports navigation')}
+      heading={t('reports:label.select_report', 'Select report')}
+      groups={groups}
+      selectedValue={selectedValue}
+      onSelectedValueChange={onSelectedValueChange}
+      isLoading={isLoading}
+      isError={isError}
+      isSearchable
+      searchPlaceholder={t('reports:action.search_reports', 'Search reports')}
+    />
+  )
+}

--- a/src/components/ReportsNavigation/ReportsNavigation.tsx
+++ b/src/components/ReportsNavigation/ReportsNavigation.tsx
@@ -41,7 +41,7 @@ const groupConfig: TreeNavigationGroupConfig<ReportGroup, ReportConfig> = {
 const buildLeafConfig = (onSelectLeaf: (report: ReportConfig) => void): TreeNavigationLeafConfig<ReportConfig> => ({
   getId: leaf => leaf.key,
   getTextValue: leaf => leaf.displayName,
-  renderLabel: leaf => <Span ellipsis>{leaf.displayName}</Span>,
+  renderLabel: leaf => <Span>{leaf.displayName}</Span>,
   onSelectLeaf,
 })
 

--- a/src/components/ReportsNavigation/reportComboBoxOption.ts
+++ b/src/components/ReportsNavigation/reportComboBoxOption.ts
@@ -1,0 +1,20 @@
+import type { ReportConfig } from '@schemas/reports/reportConfig'
+import { BaseComboBoxOption } from '@ui/ComboBox/baseComboBoxOption'
+
+export class ReportComboBoxOption extends BaseComboBoxOption<ReportConfig> {
+  constructor(report: ReportConfig) {
+    super(report)
+  }
+
+  get original() {
+    return this.internalValue
+  }
+
+  get label() {
+    return this.internalValue.displayName
+  }
+
+  get value() {
+    return this.internalValue.key
+  }
+}

--- a/src/components/TreeNavigation/TreeNavigationSkeleton.tsx
+++ b/src/components/TreeNavigation/TreeNavigationSkeleton.tsx
@@ -16,7 +16,6 @@ export const TreeNavigationSkeleton = ({
     {Array.from({ length: groups }).map((_, groupIndex) => (
       <VStack key={groupIndex}>
         <HStack className='Layer__TreeNavigationSkeleton__Group' align='center' gap='sm'>
-          <SkeletonLoader width='16px' height='16px' />
           <SkeletonLoader width='60%' height='12px' />
         </HStack>
         {Array.from({ length: leavesPerGroup }).map((_, leafIndex) => (

--- a/src/components/TreeNavigation/treeNavigation.scss
+++ b/src/components/TreeNavigation/treeNavigation.scss
@@ -1,7 +1,7 @@
 .Layer__TreeNavigation .Layer__UI__TreeItem {
   position: relative;
   align-content: center;
-  height: var(--spacing-5xl);
+  padding-block: var(--spacing-sm);
 
   padding-inline-start: calc(var(--spacing-3xs) + var(--spacing-sm) * var(--tree-item-level));
   padding-inline-end: var(--spacing-md);

--- a/src/components/TreeNavigation/treeNavigationSkeleton.scss
+++ b/src/components/TreeNavigation/treeNavigationSkeleton.scss
@@ -3,13 +3,17 @@
 
   &__Group,
   &__Leaf {
-    height: var(--spacing-5xl);
-    padding-inline: var(--spacing-md);
+    height: 44px;
+    padding-inline-end: var(--spacing-md);
     border-bottom: 1px solid var(--color-base-300);
   }
 
+  &__Group {
+    padding-inline-start: calc(var(--spacing-3xs) + var(--spacing-sm));
+  }
+
   &__Leaf {
-    padding-inline-start: calc(var(--spacing-lg) + var(--spacing-md));
+    padding-inline-start: calc(var(--spacing-3xs) + var(--spacing-sm) * 2);
     background-color: var(--color-base-50);
   }
 }

--- a/src/components/UnifiedReport/UnifiedReport.tsx
+++ b/src/components/UnifiedReport/UnifiedReport.tsx
@@ -1,10 +1,13 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import type { DateSelectionMode } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 import { UnifiedReportStoreProvider } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { ExpandableDataTableProvider } from '@components/ExpandableDataTable/ExpandableDataTableProvider'
 import { ReportsNavigation } from '@components/ReportsNavigation/ReportsNavigation'
+import { UnifiedReportHeaderButtons } from '@components/UnifiedReport/UnifiedReportHeaderButtons'
 import { UnifiedReportTable } from '@components/UnifiedReport/UnifiedReportTable'
 import { UnifiedReportTableHeader } from '@components/UnifiedReport/UnifiedReportTableHeader'
 import { View } from '@components/View/View'
@@ -15,24 +18,39 @@ type UnifiedReportProps = {
   dateSelectionMode?: DateSelectionMode
 }
 
-export const UnifiedReport = ({ dateSelectionMode }: UnifiedReportProps) => {
+const UnifiedReportContent = () => {
   const { t } = useTranslation()
+  const { isDesktop } = useSizeClass()
+
+  const header = useMemo(() => {
+    if (isDesktop) return null
+
+    return <UnifiedReportHeaderButtons />
+  }, [isDesktop])
 
   return (
-    <View title={t('reports:label.reports', 'Reports')} viewClassName='Layer__UnifiedReport'>
-      <UnifiedReportStoreProvider dateSelectionMode={dateSelectionMode}>
-        <ExpandableDataTableProvider>
-          <HStack>
+    <View title={t('reports:label.reports', 'Reports')} viewClassName='Layer__UnifiedReport' header={header}>
+      <ExpandableDataTableProvider>
+        <HStack>
+          {isDesktop && (
             <VStack className='Layer__UnifiedReport__Sidebar'>
               <ReportsNavigation />
             </VStack>
-            <VStack fluid className='Layer__UnifiedReport__Content'>
-              <UnifiedReportTableHeader />
-              <UnifiedReportTable />
-            </VStack>
-          </HStack>
-        </ExpandableDataTableProvider>
-      </UnifiedReportStoreProvider>
+          )}
+          <VStack fluid className='Layer__UnifiedReport__Content'>
+            <UnifiedReportTableHeader />
+            <UnifiedReportTable />
+          </VStack>
+        </HStack>
+      </ExpandableDataTableProvider>
     </View>
+  )
+}
+
+export const UnifiedReport = ({ dateSelectionMode }: UnifiedReportProps) => {
+  return (
+    <UnifiedReportStoreProvider dateSelectionMode={dateSelectionMode}>
+      <UnifiedReportContent />
+    </UnifiedReportStoreProvider>
   )
 }

--- a/src/components/UnifiedReport/UnifiedReport.tsx
+++ b/src/components/UnifiedReport/UnifiedReport.tsx
@@ -30,19 +30,17 @@ const UnifiedReportContent = () => {
 
   return (
     <View title={t('reports:label.reports', 'Reports')} viewClassName='Layer__UnifiedReport' header={header}>
-      <ExpandableDataTableProvider>
-        <HStack>
-          {isDesktop && (
-            <VStack className='Layer__UnifiedReport__Sidebar'>
-              <ReportsNavigation />
-            </VStack>
-          )}
-          <VStack fluid className='Layer__UnifiedReport__Content'>
-            <UnifiedReportTableHeader />
-            <UnifiedReportTable />
+      <HStack>
+        {isDesktop && (
+          <VStack className='Layer__UnifiedReport__Sidebar'>
+            <ReportsNavigation />
           </VStack>
-        </HStack>
-      </ExpandableDataTableProvider>
+        )}
+        <VStack fluid className='Layer__UnifiedReport__Content'>
+          <UnifiedReportTableHeader />
+          <UnifiedReportTable />
+        </VStack>
+      </HStack>
     </View>
   )
 }
@@ -50,7 +48,9 @@ const UnifiedReportContent = () => {
 export const UnifiedReport = ({ dateSelectionMode }: UnifiedReportProps) => {
   return (
     <UnifiedReportStoreProvider dateSelectionMode={dateSelectionMode}>
-      <UnifiedReportContent />
+      <ExpandableDataTableProvider>
+        <UnifiedReportContent />
+      </ExpandableDataTableProvider>
     </UnifiedReportStoreProvider>
   )
 }

--- a/src/components/UnifiedReport/UnifiedReportBaseHeader.tsx
+++ b/src/components/UnifiedReport/UnifiedReportBaseHeader.tsx
@@ -1,65 +1,28 @@
-import { useCallback, useContext } from 'react'
-import { useTranslation } from 'react-i18next'
-
-import { ReportControl } from '@schemas/reports/reportConfig'
-import { hasControl, useBaseUnifiedReport, useUnifiedReportDateSelectionMode, useUnifiedReportGroupByParam } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
-import { Button } from '@ui/Button/Button'
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import { useBaseUnifiedReport } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
-import { CombinedDateRangeSelection } from '@components/DateSelection/CombinedDateRangeSelection'
-import { CombinedDateSelection } from '@components/DateSelection/CombinedDateSelection'
-import { DateGroupByComboBox } from '@components/DateSelection/DateGroupByComboBox'
-import { ExpandableDataTableContext } from '@components/ExpandableDataTable/ExpandableDataTableProvider'
 import { SkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
-import { UnifiedReportDownloadButton } from '@components/UnifiedReport/UnifiedReportDownloadButton'
+import { UnifiedReportControls } from '@components/UnifiedReport/UnifiedReportControls'
+import { UnifiedReportHeaderButtons } from '@components/UnifiedReport/UnifiedReportHeaderButtons'
 
 import './unifiedReportBaseHeader.scss'
 
 export const UnifiedReportBaseHeader = () => {
-  const { t } = useTranslation()
   const { baseReport } = useBaseUnifiedReport()
-  const { groupBy, setGroupBy } = useUnifiedReportGroupByParam()
-  const dateSelectionMode = useUnifiedReportDateSelectionMode()
-
-  const { expanded, setExpanded } = useContext(ExpandableDataTableContext)
-  const shouldCollapse = expanded === true
-  const onClickExpandOrCollapse = useCallback(() => {
-    if (shouldCollapse) {
-      setExpanded({})
-    }
-    else {
-      setExpanded(true)
-    }
-  }, [setExpanded, shouldCollapse])
+  const { isDesktop } = useSizeClass()
 
   return (
-    <VStack gap='lg'>
-      <HStack pi='lg' pbs='lg' align='center' justify='space-between'>
-        {baseReport
-          ? <Span size='lg' weight='bold'>{baseReport.displayName}</Span>
-          : <SkeletonLoader width='192px' height='24px' />}
-        <HStack gap='xs'>
-          <Button variant='outlined' onClick={onClickExpandOrCollapse}>
-            {shouldCollapse
-              ? t('reports:action.collapse_all', 'Collapse All')
-              : t('reports:action.expand_all', 'Expand All')}
-          </Button>
-          <UnifiedReportDownloadButton />
+    <VStack>
+      {isDesktop && (
+        <HStack pi='lg' pbs='lg' align='center' justify='space-between'>
+          {baseReport
+            ? <Span size='lg' weight='bold'>{baseReport.displayName}</Span>
+            : <SkeletonLoader width='192px' height='24px' />}
+          <UnifiedReportHeaderButtons />
         </HStack>
-      </HStack>
-      <HStack fluid align='end' pbe='lg' className='Layer__UnifiedReport__Header'>
-        <HStack pi='lg' gap='xs'>
-          {hasControl(baseReport, ReportControl.DateRange) && (
-            <CombinedDateRangeSelection mode={dateSelectionMode} />
-          )}
-          {hasControl(baseReport, ReportControl.Date) && (
-            <CombinedDateSelection mode={dateSelectionMode} />
-          )}
-          {dateSelectionMode === 'full' && hasControl(baseReport, ReportControl.GroupBy) && (
-            <DateGroupByComboBox value={groupBy} onValueChange={setGroupBy} />
-          )}
-        </HStack>
-      </HStack>
+      )}
+      <UnifiedReportControls />
     </VStack>
   )
 }

--- a/src/components/UnifiedReport/UnifiedReportControls.tsx
+++ b/src/components/UnifiedReport/UnifiedReportControls.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+
+import { ReportControl } from '@schemas/reports/reportConfig'
+import { useElementSize } from '@hooks/utils/size/useElementSize'
+import { hasControl, useBaseUnifiedReport, useUnifiedReportDateSelectionMode, useUnifiedReportGroupByParam } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
+import { Stack, VStack } from '@ui/Stack/Stack'
+import { CombinedDateRangeSelection } from '@components/DateSelection/CombinedDateRangeSelection'
+import { CombinedDateSelection } from '@components/DateSelection/CombinedDateSelection'
+import { DateGroupByComboBox } from '@components/DateSelection/DateGroupByComboBox'
+
+import './unifiedReportControls.scss'
+
+const SMALL_BREAKPOINT = 560
+const MEDIUM_BREAKPOINT = 760
+
+type ControlsVariant = 'small' | 'medium' | 'large'
+
+const getVariantForWidth = (width: number): ControlsVariant => {
+  if (width >= MEDIUM_BREAKPOINT) return 'large'
+  if (width >= SMALL_BREAKPOINT) return 'medium'
+  return 'small'
+}
+
+const UnifiedReportDateSelection = ({ isCompact }: { isCompact: boolean }) => {
+  const { baseReport } = useBaseUnifiedReport()
+  const dateSelectionMode = useUnifiedReportDateSelectionMode()
+
+  const hasDateRange = hasControl(baseReport, ReportControl.DateRange)
+  const hasDate = hasControl(baseReport, ReportControl.Date)
+
+  if (!hasDateRange && !hasDate) return null
+
+  return (
+    <VStack>
+      {hasDateRange && <CombinedDateRangeSelection mode={dateSelectionMode} isCompact={isCompact} />}
+      {hasDate && <CombinedDateSelection mode={dateSelectionMode} isCompact={isCompact} />}
+    </VStack>
+  )
+}
+
+export const UnifiedReportControls = () => {
+  const { baseReport } = useBaseUnifiedReport()
+  const { groupBy, setGroupBy } = useUnifiedReportGroupByParam()
+  const dateSelectionMode = useUnifiedReportDateSelectionMode()
+  const [size, setSize] = useState(3)
+
+  const containerRef = useElementSize<HTMLDivElement>((size) => {
+    setSize(size.width)
+  })
+
+  const variant = getVariantForWidth(size)
+
+  const hasGroupBy = dateSelectionMode === 'full' && hasControl(baseReport, ReportControl.GroupBy)
+  return (
+    <Stack
+      ref={containerRef}
+      direction={size > MEDIUM_BREAKPOINT ? 'row' : 'column'}
+      pb='md'
+      pi='lg'
+      gap='xs'
+    >
+      <UnifiedReportDateSelection isCompact={variant === 'small'} />
+      {hasGroupBy && (
+        <div className='Layer__UnifiedReport__AdditionalControls' data-variant={variant}>
+          <DateGroupByComboBox value={groupBy} onValueChange={setGroupBy} />
+        </div>
+      )}
+    </Stack>
+  )
+}

--- a/src/components/UnifiedReport/UnifiedReportControls.tsx
+++ b/src/components/UnifiedReport/UnifiedReportControls.tsx
@@ -54,7 +54,7 @@ export const UnifiedReportControls = () => {
   return (
     <Stack
       ref={containerRef}
-      direction={size > MEDIUM_BREAKPOINT ? 'row' : 'column'}
+      direction={variant === 'large' ? 'row' : 'column'}
       pb='md'
       pi='lg'
       gap='xs'

--- a/src/components/UnifiedReport/UnifiedReportDownloadButton.tsx
+++ b/src/components/UnifiedReport/UnifiedReportDownloadButton.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 
 import { useUnifiedReportExcel } from '@hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel'
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import DownloadCloud from '@icons/DownloadCloud'
 import RefreshCcw from '@icons/RefreshCcw'
 import { Button } from '@ui/Button/Button'
@@ -8,11 +9,16 @@ import InvisibleDownload, { useInvisibleDownload } from '@components/utility/Inv
 
 export function UnifiedReportDownloadButton() {
   const { t } = useTranslation()
+  const { isDesktop } = useSizeClass()
   const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
 
   const { trigger, isMutating, isError } = useUnifiedReportExcel({
     onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
   })
+
+  const buttonText = isError
+    ? t('common:action.retry_label', 'Retry')
+    : t('common:action.download_label', 'Download')
 
   return (
     <>
@@ -21,8 +27,9 @@ export function UnifiedReportDownloadButton() {
         onPress={() => { void trigger() }}
         isPending={isMutating}
         isDisabled={isMutating}
+        icon={!isDesktop}
       >
-        {isError ? t('common:action.retry_label', 'Retry') : t('common:action.download_label', 'Download')}
+        {isDesktop && buttonText}
         {isError ? <RefreshCcw size={12} /> : <DownloadCloud size={16} /> }
       </Button>
       <InvisibleDownload ref={invisibleDownloadRef} />

--- a/src/components/UnifiedReport/UnifiedReportDownloadButton.tsx
+++ b/src/components/UnifiedReport/UnifiedReportDownloadButton.tsx
@@ -28,6 +28,7 @@ export function UnifiedReportDownloadButton() {
         isPending={isMutating}
         isDisabled={isMutating}
         icon={!isDesktop}
+        aria-label={!isDesktop ? buttonText : undefined}
       >
         {isDesktop && buttonText}
         {isError ? <RefreshCcw size={12} /> : <DownloadCloud size={16} /> }

--- a/src/components/UnifiedReport/UnifiedReportHeaderButtons.tsx
+++ b/src/components/UnifiedReport/UnifiedReportHeaderButtons.tsx
@@ -1,0 +1,19 @@
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import { HStack } from '@ui/Stack/Stack'
+import { ExpandableDataTableToggleButton } from '@components/ExpandableDataTable/ExpandableDataTableToggleButton'
+import { ReportsMobileSelectionDrawer } from '@components/ReportsNavigation/ReportsMobileSelectionDrawer'
+import { UnifiedReportDownloadButton } from '@components/UnifiedReport/UnifiedReportDownloadButton'
+
+import './unifiedReportHeaderButtons.scss'
+
+export const UnifiedReportHeaderButtons = () => {
+  const { isDesktop } = useSizeClass()
+
+  return (
+    <HStack gap='xs' className='Layer__UnifiedReport__HeaderButtons'>
+      {!isDesktop && <ReportsMobileSelectionDrawer />}
+      <ExpandableDataTableToggleButton />
+      <UnifiedReportDownloadButton />
+    </HStack>
+  )
+}

--- a/src/components/UnifiedReport/unifiedReport.scss
+++ b/src/components/UnifiedReport/unifiedReport.scss
@@ -1,9 +1,13 @@
-.Layer__UnifiedReport {
+.Layer__view.Layer__UnifiedReport {
   overflow: hidden;
-  min-width: clamp(24rem, 100%, 1406px);
+  min-width: clamp(23rem, 100%, 1406px);
 
   .Layer__view-main.Layer__view-main {
     padding: 0;
+  }
+
+  .Layer__view-header__children.Layer__view-header__children {
+    width: max-content;
   }
 }
 

--- a/src/components/UnifiedReport/unifiedReportBaseHeader.scss
+++ b/src/components/UnifiedReport/unifiedReportBaseHeader.scss
@@ -1,19 +1,3 @@
 .Layer__UnifiedReport__Header {
   border-bottom: 1px solid var(--border-color);
-
-  @container (width <= 768px) {
-    display: grid;
-    grid-template-columns: 100%;
-    height: fit-content;
-    padding-block: var(--spacing-md);
-
-    > :last-child {
-      padding-block-start: var(--spacing-md);
-    }
-
-    > :not(:last-child) {
-      padding-block-end: var(--spacing-md);
-      border-bottom: 1px solid var(--border-color);
-    }
-  }
 }

--- a/src/components/UnifiedReport/unifiedReportControls.scss
+++ b/src/components/UnifiedReport/unifiedReportControls.scss
@@ -1,0 +1,25 @@
+.Layer__UnifiedReport__AdditionalControls {
+  display: grid;
+  gap: var(--spacing-xs);
+
+  &[data-variant='small'] {
+    grid-template-columns: 1fr;
+  }
+
+  &[data-variant='medium'] {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  &[data-variant='large'] {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  &[data-variant='small'],
+  &[data-variant='medium'] {
+    > *,
+    .Layer__DateGroupByComboBox__Container {
+      inline-size: 100%;
+      max-inline-size: none;
+    }
+  }
+}

--- a/src/components/UnifiedReport/unifiedReportHeaderButtons.scss
+++ b/src/components/UnifiedReport/unifiedReportHeaderButtons.scss
@@ -1,0 +1,5 @@
+.Layer__UnifiedReport__HeaderButtons {
+  justify-content: flex-end;
+  min-width: 15rem;
+  max-width: 24rem;
+}

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -36,7 +36,7 @@ export type ButtonSize = 'md'
 
 export type ButtonStyleProps = {
   ellipsis?: true
-  icon?: true
+  icon?: boolean
   inset?: true
   size?: ButtonSize
   variant?: ButtonVariant

--- a/src/components/ui/MobileList/MobileList.tsx
+++ b/src/components/ui/MobileList/MobileList.tsx
@@ -82,7 +82,7 @@ export const MobileList = <TData extends { id: string }>({
   }, [EmptyState])
 
   if (isLoading) {
-    return <MobileListSkeleton />
+    return <MobileListSkeleton variant={variant} />
   }
 
   if (isError) {

--- a/src/components/ui/MobileList/MobileList.tsx
+++ b/src/components/ui/MobileList/MobileList.tsx
@@ -2,15 +2,18 @@ import { useCallback } from 'react'
 import { GridList, type Selection } from 'react-aria-components'
 
 import { MobileListItem } from '@ui/MobileList/MobileListItem'
+import { MobileListSection } from '@ui/MobileList/MobileListSection'
 import { MobileListSkeleton } from '@ui/MobileList/MobileListSkeleton'
 
 import './mobileList.scss'
 
-interface SelectionProps {
-  enableSelection?: boolean
-  selectionMode?: 'none' | 'single' | 'multiple'
-  selectedKeys?: Set<string>
-  onSelectionChange?: (keys: Selection) => void
+const EMPTY_ARRAY: never[] = []
+
+export type MobileListVariant = 'default' | 'compact'
+
+export type MobileListGroup<TData> = {
+  label: string
+  items: ReadonlyArray<TData>
 }
 
 interface MobileListBaseProps<TData> {
@@ -21,32 +24,57 @@ interface MobileListBaseProps<TData> {
     EmptyState: React.FC
     ErrorState: React.FC
   }
-  data: ReadonlyArray<TData> | undefined
   renderItem: (item: TData) => React.ReactNode
   onClickItem?: (item: TData) => void
+  variant?: MobileListVariant
 }
 
-export type MobileListProps<TData> = MobileListBaseProps<TData> & SelectionProps
-
-const isSelectionEnabled = (props: SelectionProps) => {
-  return props.selectionMode !== 'none' && props.enableSelection
+interface MobileListSelectionProps {
+  enableSelection?: boolean
+  selectionMode?: 'none' | 'single' | 'multiple'
+  selectedKeys?: Set<string>
+  onSelectionChange?: (keys: Selection) => void
 }
 
-export const MobileList = <TData extends { id: string }>(props: MobileListProps<TData>) => {
-  const {
-    ariaLabel,
-    data,
-    slots,
-    renderItem,
-    onClickItem,
-    isLoading,
-    isError,
-    selectionMode = 'none',
-    ...restSelectionProps
-  } = props
+const isSelectionEnabled = (props: MobileListSelectionProps) =>
+  props.selectionMode !== 'none' && props.enableSelection
+
+const isGrouped = <T,>(
+  data: MobileListData<T> | undefined,
+): data is MobileListGroupedData<T> => !!data && !Array.isArray(data)
+
+export type MobileListGroupedData<TData> = {
+  groups: ReadonlyArray<MobileListGroup<TData>>
+}
+
+export type MobileListData<TData> =
+  | ReadonlyArray<TData>
+  | MobileListGroupedData<TData>
+
+export type MobileListProps<TData> =
+  MobileListBaseProps<TData> & MobileListSelectionProps & {
+    data: MobileListData<TData> | undefined
+  }
+
+export const MobileList = <TData extends { id: string }>({
+  ariaLabel,
+  data,
+  slots,
+  renderItem,
+  onClickItem,
+  isLoading,
+  isError,
+  variant = 'default',
+  enableSelection = false,
+  selectionMode = 'none',
+  selectedKeys,
+  onSelectionChange,
+}: MobileListProps<TData>) => {
   const { EmptyState, ErrorState } = slots
 
-  const resolvedSelectionMode = isSelectionEnabled(props) ? selectionMode : 'none'
+  const resolvedSelectionMode =
+    isSelectionEnabled({ enableSelection, selectionMode }) ? selectionMode : 'none'
+
   const resolvedSelectionBehavior = resolvedSelectionMode === 'none' ? 'toggle' : undefined
 
   const renderEmptyState = useCallback(() => {
@@ -61,17 +89,34 @@ export const MobileList = <TData extends { id: string }>(props: MobileListProps<
     return <ErrorState />
   }
 
+  const renderRow = (item: TData) => (
+    <MobileListItem key={item.id} item={item} onClickItem={onClickItem}>
+      {renderItem(item)}
+    </MobileListItem>
+  )
+
   return (
     <GridList
-      items={data}
-      selectionMode={resolvedSelectionMode}
-      selectionBehavior={resolvedSelectionBehavior}
-      renderEmptyState={renderEmptyState}
       aria-label={ariaLabel}
       className='Layer__MobileList'
-      {...restSelectionProps}
+      data-variant={variant}
+      selectionMode={resolvedSelectionMode}
+      selectionBehavior={resolvedSelectionBehavior}
+      selectedKeys={selectedKeys}
+      onSelectionChange={onSelectionChange}
+      renderEmptyState={renderEmptyState}
     >
-      {item => <MobileListItem onClickItem={onClickItem} item={item}>{renderItem(item)}</MobileListItem>}
+      {isGrouped(data)
+        ? data.groups.map(group => (
+          <MobileListSection
+            key={group.label}
+            label={group.label}
+            items={group.items}
+            renderItem={renderItem}
+            onClickItem={onClickItem}
+          />
+        ))
+        : (data ?? EMPTY_ARRAY).map(renderRow)}
     </GridList>
   )
 }

--- a/src/components/ui/MobileList/MobileListSection.tsx
+++ b/src/components/ui/MobileList/MobileListSection.tsx
@@ -1,0 +1,38 @@
+import { GridListHeader, GridListSection } from 'react-aria-components'
+
+import { MobileListItem } from '@ui/MobileList/MobileListItem'
+import { Span } from '@ui/Typography/Text'
+
+import './mobileListSection.scss'
+
+type MobileListSectionProps<TData extends { id: string }> = {
+  label: string
+  items: ReadonlyArray<TData>
+  renderItem: (item: TData) => React.ReactNode
+  onClickItem?: (item: TData) => void
+}
+
+export const MobileListSection = <TData extends { id: string }>({
+  label,
+  items,
+  renderItem,
+  onClickItem,
+}: MobileListSectionProps<TData>) => (
+  <GridListSection
+    id={`__section:${label}`}
+    className='Layer__MobileListSection'
+  >
+    <GridListHeader className='Layer__MobileListSection__Heading'>
+      <Span size='md' weight='bold'>{label}</Span>
+    </GridListHeader>
+    {items.map(item => (
+      <MobileListItem
+        key={item.id}
+        item={item}
+        onClickItem={onClickItem}
+      >
+        {renderItem(item)}
+      </MobileListItem>
+    ))}
+  </GridListSection>
+)

--- a/src/components/ui/MobileList/MobileListSkeleton.tsx
+++ b/src/components/ui/MobileList/MobileListSkeleton.tsx
@@ -1,3 +1,4 @@
+import type { MobileListVariant } from '@ui/MobileList/MobileList'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { SkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
 
@@ -5,19 +6,29 @@ import './mobileListSkeleton.scss'
 
 interface MobileListSkeletonProps {
   rows?: number
+  variant?: MobileListVariant
 }
 
-export const MobileListSkeleton = ({ rows = 5 }: MobileListSkeletonProps) => {
+export const MobileListSkeleton = ({ rows = 5, variant = 'default' }: MobileListSkeletonProps) => {
   return (
-    <VStack className='Layer__MobileListSkeleton' gap='sm'>
+    <VStack className='Layer__MobileListSkeleton' data-variant={variant} gap='sm'>
       {Array.from({ length: rows }).map((_, index) => (
-        <MobileListSkeletonItem key={index} />
+        <MobileListSkeletonItem key={index} variant={variant} />
       ))}
     </VStack>
   )
 }
 
-const MobileListSkeletonItem = () => {
+const MobileListSkeletonItem = ({ variant }: { variant: MobileListVariant }) => {
+  if (variant === 'compact') {
+    return (
+      <HStack className='Layer__MobileListSkeleton__Item' fluid align='center' justify='space-between' gap='sm'>
+        <SkeletonLoader width='60%' height='16px' />
+        <SkeletonLoader width='16px' height='16px' />
+      </HStack>
+    )
+  }
+
   return (
     <HStack className='Layer__MobileListSkeleton__Item' gap='md' align='center'>
       <VStack gap='xs' fluid>

--- a/src/components/ui/MobileList/MobileListSkeleton.tsx
+++ b/src/components/ui/MobileList/MobileListSkeleton.tsx
@@ -24,7 +24,6 @@ const MobileListSkeletonItem = ({ variant }: { variant: MobileListVariant }) => 
     return (
       <HStack className='Layer__MobileListSkeleton__Item' fluid align='center' justify='space-between' gap='sm'>
         <SkeletonLoader width='60%' height='16px' />
-        <SkeletonLoader width='16px' height='16px' />
       </HStack>
     )
   }

--- a/src/components/ui/MobileList/PaginatedMobileList.tsx
+++ b/src/components/ui/MobileList/PaginatedMobileList.tsx
@@ -6,7 +6,8 @@ import { VStack } from '@ui/Stack/Stack'
 import type { TablePaginationProps } from '@components/PaginatedDataTable/PaginatedDataTable'
 import { Pagination } from '@components/Pagination/Pagination'
 
-type PaginatedMobileListProps<TData> = MobileListProps<TData> & {
+type PaginatedMobileListProps<TData> = Omit<MobileListProps<TData>, 'data'> & {
+  data: ReadonlyArray<TData> | undefined
   paginationProps: TablePaginationProps
 }
 

--- a/src/components/ui/MobileList/mobileList.scss
+++ b/src/components/ui/MobileList/mobileList.scss
@@ -2,4 +2,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-sm);
+
+  &[data-variant='compact'] {
+    gap: 0;
+  }
 }

--- a/src/components/ui/MobileList/mobileListItem.scss
+++ b/src/components/ui/MobileList/mobileListItem.scss
@@ -9,8 +9,6 @@
   border: 1px solid var(--border-color);
   background-color: var(--color-base-0);
 
-  cursor: pointer;
-
   &[data-selection-mode='multiple'],
   &[data-selection-mode='single'] {
     grid-template-areas: 'selection content';

--- a/src/components/ui/MobileList/mobileListItem.scss
+++ b/src/components/ui/MobileList/mobileListItem.scss
@@ -9,9 +9,17 @@
   border: 1px solid var(--border-color);
   background-color: var(--color-base-0);
 
+  cursor: pointer;
+
   &[data-selection-mode='multiple'],
   &[data-selection-mode='single'] {
     grid-template-areas: 'selection content';
     grid-template-columns: auto 1fr;
+  }
+
+  [data-variant='compact'] & {
+    padding-inline: 0;
+    border-radius: 0;
+    border: none;
   }
 }

--- a/src/components/ui/MobileList/mobileListSection.scss
+++ b/src/components/ui/MobileList/mobileListSection.scss
@@ -1,0 +1,21 @@
+.Layer__MobileListSection {
+  display: flex;
+  flex-direction: column;
+
+  &__Heading {
+    padding-block-end: var(--spacing-xs);
+    padding-inline: var(--spacing-3xs);
+    outline: none;
+    background-color: transparent;
+    cursor: default;
+  }
+
+  &:not(:last-child) {
+    padding-block-end: var(--spacing-xs);
+  }
+
+  &:not(:first-child) {
+    padding-block-start: var(--spacing-md);
+    border-block-start: 1px solid var(--border-color);
+  }
+}

--- a/src/components/ui/MobileList/mobileListSkeleton.scss
+++ b/src/components/ui/MobileList/mobileListSkeleton.scss
@@ -8,4 +8,15 @@
     border: 1px solid var(--border-color);
     background-color: var(--color-base-0);
   }
+
+  &[data-variant='compact'] {
+    gap: 0;
+
+    .Layer__MobileListSkeleton__Item {
+      padding-inline: 0;
+      border-radius: 0;
+      border: none;
+      background-color: transparent;
+    }
+  }
 }

--- a/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerList.tsx
+++ b/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerList.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import CheckIcon from '@icons/Check'
+import type {
+  ComboBoxOption,
+  OptionsOrGroups,
+  SingleSelectComboBoxProps,
+} from '@ui/ComboBox/types'
+import { MobileList, type MobileListData } from '@ui/MobileList/MobileList'
+import { HStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+
+import './mobileSelectionDrawerList.scss'
+
+export type MobileSelectionDrawerListProps<T extends ComboBoxOption> =
+  Omit<
+    SingleSelectComboBoxProps<T>,
+    'slots' | 'aria-label' | 'aria-labelledby' | 'aria-describedby' | 'isDisabled'
+  >
+  & { ariaLabel: string }
+
+type OptionItem<T extends ComboBoxOption> = {
+  id: string
+  option: T
+}
+
+const wrap = <T extends ComboBoxOption>(option: T): OptionItem<T> => ({
+  id: option.value,
+  option,
+})
+
+const EmptyState = () => {
+  const { t } = useTranslation()
+  return <Span size='sm'>{t('common:empty.results', 'No results found')}</Span>
+}
+
+const ErrorState = () => {
+  const { t } = useTranslation()
+  return <Span size='sm'>{t('common:error.something_went_wrong', 'Something went wrong')}</Span>
+}
+
+export const MobileSelectionDrawerList = <T extends ComboBoxOption>({
+  ariaLabel,
+  selectedValue,
+  onSelectedValueChange,
+  isLoading = false,
+  isError = false,
+  ...rest
+}: MobileSelectionDrawerListProps<T>) => {
+  const source = rest as OptionsOrGroups<T>
+
+  const data = useMemo<MobileListData<OptionItem<T>> | undefined>(() => {
+    if (source.groups) {
+      return {
+        groups: source.groups.map(group => ({
+          label: group.label,
+          items: group.options.map(wrap),
+        })),
+      }
+    }
+    return source.options ? source.options.map(wrap) : undefined
+  }, [source.groups, source.options])
+
+  const renderItem = useCallback(({ option }: OptionItem<T>) => {
+    const isSelected = selectedValue?.value === option.value
+    return (
+      <HStack fluid pi='xs' align='center' justify='space-between' gap='sm'>
+        <Span size='sm'>{option.label}</Span>
+        <CheckIcon
+          size={16}
+          className='Layer__MobileSelectionDrawerList__Check'
+          data-selected={isSelected}
+        />
+      </HStack>
+    )
+  }, [selectedValue])
+
+  const onClickItem = useCallback(({ option }: OptionItem<T>) => {
+    onSelectedValueChange(option)
+  }, [onSelectedValueChange])
+
+  return (
+    <MobileList<OptionItem<T>>
+      ariaLabel={ariaLabel}
+      data={data}
+      slots={{ EmptyState, ErrorState }}
+      renderItem={renderItem}
+      onClickItem={onClickItem}
+      isLoading={isLoading}
+      isError={isError}
+      variant='compact'
+    />
+  )
+}

--- a/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
+++ b/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
@@ -40,6 +40,7 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
   ...optionOrGroups
 }: MobileSelectionDrawerWithTriggerProps<T>) => {
   const { t } = useTranslation()
+  const { options, groups } = optionOrGroups as Partial<OptionsOrGroups<T>>
 
   const [isOpen, setIsOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -54,8 +55,11 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
   const resolvedSearchPlaceholder = searchPlaceholder ?? t('common:action.search_label', 'Search')
 
   const filteredOptionsOrGroups = useMemo<OptionsOrGroups<T>>(
-    () => filterOptionsOrGroups(optionOrGroups as OptionsOrGroups<T>, searchQuery.trim().toLowerCase()),
-    [optionOrGroups, searchQuery],
+    () => filterOptionsOrGroups(
+      (groups ? { groups } : { options: options ?? [] }) as OptionsOrGroups<T>,
+      searchQuery.trim().toLowerCase(),
+    ),
+    [options, groups, searchQuery],
   )
 
   const Header = useCallback(() => (

--- a/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
+++ b/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import ChevronDown from '@icons/ChevronDown'
+import { Button } from '@ui/Button/Button'
+import type {
+  ComboBoxOption,
+  OptionsOrGroups,
+  SingleSelectComboBoxProps,
+} from '@ui/ComboBox/types'
+import { filterOptionsOrGroups } from '@ui/MobileSelectionDrawer/filterUtils'
+import { MobileSelectionDrawerList } from '@ui/MobileSelectionDrawer/MobileSelectionDrawerList'
+import { Drawer } from '@ui/Modal/Modal'
+import { ModalHeading, ModalTitleWithClose } from '@ui/Modal/ModalSlots'
+import { VStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+import { SearchField } from '@components/SearchField/SearchField'
+
+import './mobileSelectionDrawerWithTrigger.scss'
+
+export type MobileSelectionDrawerWithTriggerProps<T extends ComboBoxOption> =
+  Omit<SingleSelectComboBoxProps<T>, 'slots'>
+  & {
+    ariaLabel: string
+    heading: string
+    searchPlaceholder?: string
+  }
+
+export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
+  ariaLabel,
+  heading,
+  selectedValue,
+  onSelectedValueChange,
+  placeholder,
+  isLoading = false,
+  isError = false,
+  isDisabled = false,
+  isSearchable = false,
+  searchPlaceholder,
+  ...optionOrGroups
+}: MobileSelectionDrawerWithTriggerProps<T>) => {
+  const { t } = useTranslation()
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  useEffect(() => {
+    if (!isOpen) setSearchQuery('')
+  }, [isOpen])
+
+  const openDrawer = useCallback(() => setIsOpen(true), [])
+
+  const resolvedPlaceholder = placeholder ?? t('common:action.select_label', 'Select...')
+  const resolvedSearchPlaceholder = searchPlaceholder ?? t('common:action.search_label', 'Search')
+
+  const filteredOptionsOrGroups = useMemo<OptionsOrGroups<T>>(
+    () => filterOptionsOrGroups(optionOrGroups as OptionsOrGroups<T>, searchQuery.trim().toLowerCase()),
+    [optionOrGroups, searchQuery],
+  )
+
+  const Header = useCallback(() => (
+    <ModalTitleWithClose
+      heading={<ModalHeading size='md' weight='bold'>{heading}</ModalHeading>}
+      hideCloseButton
+      hideBottomPadding
+    />
+  ), [heading])
+
+  return (
+    <>
+      <Button onClick={openDrawer} variant='outlined' isDisabled={isDisabled}>
+        <Span size='sm' ellipsis>
+          {selectedValue?.label ?? resolvedPlaceholder}
+        </Span>
+        <ChevronDown size={16} />
+      </Button>
+
+      <Drawer
+        slots={{ Header }}
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        variant='mobile-drawer'
+        fixedHeight
+        isDismissable
+      >
+        {({ close }) => (
+          <VStack className='Layer__MobileSelectionDrawerWithTrigger' pb='md' gap='md'>
+            {isSearchable && (
+              <SearchField
+                value={searchQuery}
+                onChange={setSearchQuery}
+                label={resolvedSearchPlaceholder}
+              />
+            )}
+            <MobileSelectionDrawerList<T>
+              ariaLabel={ariaLabel}
+              {...filteredOptionsOrGroups}
+              selectedValue={selectedValue}
+              onSelectedValueChange={(value) => {
+                onSelectedValueChange(value)
+                close()
+              }}
+              isLoading={isLoading}
+              isError={isError}
+            />
+          </VStack>
+        )}
+      </Drawer>
+    </>
+  )
+}

--- a/src/components/ui/MobileSelectionDrawer/filterUtils.ts
+++ b/src/components/ui/MobileSelectionDrawer/filterUtils.ts
@@ -1,0 +1,30 @@
+import type { ComboBoxOption, OptionsOrGroups } from '@ui/ComboBox/types'
+
+const matches = (text: string, query: string) =>
+  text.toLowerCase().includes(query)
+
+const filterOptions = <T extends ComboBoxOption>(
+  options: ReadonlyArray<T>,
+  query: string,
+): ReadonlyArray<T> => options.filter(option => matches(option.label, query))
+
+export const filterOptionsOrGroups = <T extends ComboBoxOption>(
+  source: OptionsOrGroups<T>,
+  query: string,
+): OptionsOrGroups<T> => {
+  if (source.options) {
+    return { options: query ? filterOptions(source.options, query) : source.options }
+  }
+  if (source.groups) {
+    if (!query) return { groups: source.groups }
+    const filteredGroups = source.groups
+      .map(group => (
+        matches(group.label, query)
+          ? group
+          : { ...group, options: filterOptions(group.options, query) }
+      ))
+      .filter(group => group.options.length > 0)
+    return { groups: filteredGroups }
+  }
+  return { options: [] }
+}

--- a/src/components/ui/MobileSelectionDrawer/mobileSelectionDrawerList.scss
+++ b/src/components/ui/MobileSelectionDrawer/mobileSelectionDrawerList.scss
@@ -1,0 +1,9 @@
+.Layer__MobileSelectionDrawerList__Check {
+  visibility: hidden;
+  height: 1rem;
+  min-width: 1rem;
+
+  &[data-selected='true'] {
+    visibility: visible;
+  }
+}

--- a/src/components/ui/MobileSelectionDrawer/mobileSelectionDrawerWithTrigger.scss
+++ b/src/components/ui/MobileSelectionDrawer/mobileSelectionDrawerWithTrigger.scss
@@ -1,0 +1,15 @@
+.Layer__MobileSelectionDrawerWithTrigger {
+  padding-inline: var(--spacing-sm);
+
+  .Layer__SearchField {
+    inline-size: 100%;
+  }
+
+  .Layer__MobileListItem {
+    transition: background-color 120ms ease;
+
+    &[data-hovered] {
+      background-color: var(--bg-element-focus);
+    }
+  }
+}

--- a/src/styles/view.scss
+++ b/src/styles/view.scss
@@ -36,12 +36,12 @@
     display: flex;
     align-items: center;
     min-height: 44px;
-    width: 100%;
     padding: var(--spacing-md) 0;
   }
 
   .Layer__view-header__content {
     display: flex;
+    gap: var(--spacing-md);
     align-items: center;
     justify-content: space-between;
     width: 100%;


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI refactor affecting unified report navigation and header/controls rendering across breakpoints; risk is mainly regressions in mobile/desktop layout and selection interactions rather than data or security.
> 
> **Overview**
> Adds a **mobile-friendly unified report header/controls layout**: the sidebar navigation is hidden on mobile, header actions move into the `View` header, and date/group-by controls become responsive via the new `UnifiedReportControls` with compact date selectors.
> 
> Introduces a reusable `MobileSelectionDrawerWithTrigger` (searchable, grouped options) backed by enhancements to `MobileList` (grouped data + `compact` variant) and uses it to enable **mobile report switching** via `ReportsMobileSelectionDrawer`. Also factors expand/collapse-all into `ExpandableDataTableToggleButton`, updates buttons to support `icon` as a boolean for icon-only rendering, and includes assorted styling tweaks (tree navigation spacing/skeleton, unified report header sizing, categorization rules table wrapper removal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdcb0bd7071f09ed44c1449732572a1bc6a7e3d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->