### PR TITLE
feat(solopreneur): ProfitAndLossSummaryCard + ExpensesSummaryCard (1/5)

### DIFF
--- a/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
+++ b/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
@@ -1,0 +1,64 @@
+import { type ReactNode } from 'react'
+import classNames from 'classnames'
+import { useTranslation } from 'react-i18next'
+
+import { useGlobalMonthSubtitle } from '@hooks/utils/i18n/useGlobalMonthSubtitle'
+import { type HeadingSize } from '@ui/Typography/Heading'
+import { ProfitAndLossDetailedCharts, type ProfitAndLossDetailedChartsStringOverrides } from '@components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts'
+import { ExpandSummaryCardButton } from '@ui/SummaryCard/ExpandSummaryCardButton'
+import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
+
+import './expensesSummaryCard.scss'
+
+export interface ExpensesSummaryCardInteractionProps {
+  onExpandClick?: () => void
+}
+
+export type ExpensesSummaryCardProps = {
+  title?: string
+  headerSize?: HeadingSize
+  chartColorsList?: string[]
+  stringOverrides?: ProfitAndLossDetailedChartsStringOverrides
+  legend?: ReactNode
+  interactionProps?: ExpensesSummaryCardInteractionProps
+  className?: string
+}
+
+export const ExpensesSummaryCard = ({
+  title,
+  headerSize,
+  chartColorsList,
+  stringOverrides,
+  legend,
+  interactionProps,
+  className,
+}: ExpensesSummaryCardProps) => {
+  const { t } = useTranslation()
+  const subtitle = useGlobalMonthSubtitle()
+
+  const { onExpandClick } = interactionProps ?? {}
+
+  const resolvedPrimaryAction = onExpandClick
+    ? <ExpandSummaryCardButton callback={onExpandClick} ariaLabel={t('common:label.view_details', 'View details')} />
+    : undefined
+
+  return (
+    <SummaryCard
+      className={classNames('Layer__ExpensesSummaryCard', className)}
+      title={title ?? t('common:label.expenses', 'Expenses')}
+      subtitle={subtitle}
+      headerSize={headerSize}
+      legend={legend}
+      primaryAction={resolvedPrimaryAction}
+    >
+      <ProfitAndLossDetailedCharts
+        scope='expenses'
+        hideClose
+        hideHeader
+        chartColorsList={chartColorsList}
+        stringOverrides={stringOverrides}
+        slotProps={{ detailedTable: { showTypeColumn: false } }}
+      />
+    </SummaryCard>
+  )
+}

--- a/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
+++ b/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
@@ -2,71 +2,25 @@ import { useMemo } from 'react'
 import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 
-import { useGlobalMonthSubtitle } from '@hooks/utils/i18n/useGlobalMonthSubtitle'
-import { ExpandSummaryCardButton } from '@ui/SummaryCard/ExpandSummaryCardButton'
-import { SummaryCard, type SummaryCardProps } from '@ui/SummaryCard/SummaryCard'
+import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
+import {
+  useSummaryCardSlots,
+  type SummaryCardInteractionProps,
+  type SummaryCardStringOverrides,
+} from '@ui/SummaryCard/useSummaryCardSlots'
 import { ProfitAndLossDetailedCharts, type ProfitAndLossDetailedChartsStringOverrides } from '@components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts'
 
 import './expensesSummaryCard.scss'
-
-type InteractionProps = {
-  onClickExpand?: () => void
-}
 
 type StylingProps = {
   chartColorsList?: string[]
 }
 
-type StringOverrides = {
-  title?: string
-}
-
 export type ExpensesSummaryCardProps = {
   stylingProps?: StylingProps
-  interactionProps?: InteractionProps
-  stringOverrides?: StringOverrides
+  interactionProps?: SummaryCardInteractionProps
+  stringOverrides?: SummaryCardStringOverrides
   className?: string
-}
-
-const useExpensesSummaryCard = ({ stylingProps, interactionProps, stringOverrides }: UseExpensesSummaryCardParams) => {
-  const { t } = useTranslation()
-  const subtitle = useGlobalMonthSubtitle()
-  const { chartColorsList } = stylingProps ?? {}
-
-  const { onClickExpand } = interactionProps ?? {}
-
-  const resolvedSlots: SummaryCardProps['slots'] = useMemo(() => {
-    const resolvedPrimaryAction = onClickExpand
-      ? <ExpandSummaryCardButton callback={onClickExpand} ariaLabel={t('common:label.view_label', 'View')} />
-      : undefined
-
-    return {
-      title: stringOverrides?.title ?? t('common:label.expenses', 'Expenses'),
-      subtitle: subtitle,
-      legend: undefined,
-      primaryAction: resolvedPrimaryAction,
-    }
-  }, [stringOverrides?.title, subtitle, t, onClickExpand])
-
-  const resolvedStringOverrides: ProfitAndLossDetailedChartsStringOverrides = useMemo(() => {
-    return {
-      detailedChartStringOverrides: {
-        expenseChartHeader: stringOverrides?.title ?? t('common:label.expenses', 'Expenses'),
-      },
-    }
-  }, [stringOverrides?.title, t])
-
-  return {
-    resolvedSlots,
-    resolvedStringOverrides,
-    chartColorsList,
-  }
-}
-
-type UseExpensesSummaryCardParams = {
-  stylingProps?: StylingProps
-  interactionProps?: InteractionProps
-  stringOverrides?: StringOverrides
 }
 
 export const ExpensesSummaryCard = ({
@@ -75,11 +29,25 @@ export const ExpensesSummaryCard = ({
   stringOverrides,
   className,
 }: ExpensesSummaryCardProps) => {
-  const { resolvedSlots, resolvedStringOverrides, chartColorsList } = useExpensesSummaryCard({ stylingProps, interactionProps, stringOverrides })
+  const { t } = useTranslation()
+  const { chartColorsList } = stylingProps ?? {}
+
+  const slots = useSummaryCardSlots({
+    defaultTitle: t('common:label.expenses', 'Expenses'),
+    interactionProps,
+    stringOverrides,
+  })
+
+  const resolvedStringOverrides: ProfitAndLossDetailedChartsStringOverrides = useMemo(() => ({
+    detailedChartStringOverrides: {
+      expenseChartHeader: stringOverrides?.title ?? t('common:label.expenses', 'Expenses'),
+    },
+  }), [stringOverrides?.title, t])
+
   return (
     <SummaryCard
       className={classNames('Layer__ExpensesSummaryCard', className)}
-      slots={resolvedSlots}
+      slots={slots}
     >
       <ProfitAndLossDetailedCharts
         scope='expenses'

--- a/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
+++ b/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
@@ -1,62 +1,92 @@
-import { type ReactNode } from 'react'
+import { useMemo } from 'react'
 import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 
 import { useGlobalMonthSubtitle } from '@hooks/utils/i18n/useGlobalMonthSubtitle'
-import { type HeadingSize } from '@ui/Typography/Heading'
-import { ProfitAndLossDetailedCharts, type ProfitAndLossDetailedChartsStringOverrides } from '@components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts'
 import { ExpandSummaryCardButton } from '@ui/SummaryCard/ExpandSummaryCardButton'
-import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
+import { SummaryCard, type SummaryCardProps } from '@ui/SummaryCard/SummaryCard'
+import { ProfitAndLossDetailedCharts, type ProfitAndLossDetailedChartsStringOverrides } from '@components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts'
 
 import './expensesSummaryCard.scss'
 
-export interface ExpensesSummaryCardInteractionProps {
+type InteractionProps = {
   onExpandClick?: () => void
 }
 
-export type ExpensesSummaryCardProps = {
-  title?: string
-  headerSize?: HeadingSize
+type StylingProps = {
   chartColorsList?: string[]
-  stringOverrides?: ProfitAndLossDetailedChartsStringOverrides
-  legend?: ReactNode
-  interactionProps?: ExpensesSummaryCardInteractionProps
+}
+
+type StringOverrides = {
+  title?: string
+}
+
+export type ExpensesSummaryCardProps = {
+  stylingProps?: StylingProps
+  interactionProps?: InteractionProps
+  stringOverrides?: StringOverrides
   className?: string
 }
 
-export const ExpensesSummaryCard = ({
-  title,
-  headerSize,
-  chartColorsList,
-  stringOverrides,
-  legend,
-  interactionProps,
-  className,
-}: ExpensesSummaryCardProps) => {
+const useExpensesSummaryCard = ({ stylingProps, interactionProps, stringOverrides }: UseExpensesSummaryCardParams) => {
   const { t } = useTranslation()
   const subtitle = useGlobalMonthSubtitle()
+  const { chartColorsList } = stylingProps ?? {}
 
   const { onExpandClick } = interactionProps ?? {}
 
-  const resolvedPrimaryAction = onExpandClick
-    ? <ExpandSummaryCardButton callback={onExpandClick} ariaLabel={t('common:label.view_details', 'View details')} />
-    : undefined
+  const resolvedSlots: SummaryCardProps['slots'] = useMemo(() => {
+    const resolvedPrimaryAction = onExpandClick
+      ? <ExpandSummaryCardButton callback={onExpandClick} ariaLabel={t('common:label.view_details', 'View details')} />
+      : undefined
 
+    return {
+      title: stringOverrides?.title ?? t('common:label.expenses', 'Expenses'),
+      subtitle: subtitle,
+      legend: <></>,
+      primaryAction: resolvedPrimaryAction,
+    }
+  }, [stringOverrides?.title, subtitle, t, onExpandClick])
+
+  const resolvedStringOverrides: ProfitAndLossDetailedChartsStringOverrides = useMemo(() => {
+    return {
+      detailedChartStringOverrides: {
+        expenseChartHeader: stringOverrides?.title ?? t('common:label.expenses', 'Expenses'),
+      },
+    }
+  }, [stringOverrides?.title, t])
+
+  return {
+    resolvedSlots,
+    resolvedStringOverrides,
+    chartColorsList,
+  }
+}
+
+type UseExpensesSummaryCardParams = {
+  stylingProps?: StylingProps
+  interactionProps?: InteractionProps
+  stringOverrides?: StringOverrides
+}
+
+export const ExpensesSummaryCard = ({
+  stylingProps,
+  interactionProps,
+  stringOverrides,
+  className,
+}: ExpensesSummaryCardProps) => {
+  const { resolvedSlots, resolvedStringOverrides, chartColorsList } = useExpensesSummaryCard({ stylingProps, interactionProps, stringOverrides })
   return (
     <SummaryCard
       className={classNames('Layer__ExpensesSummaryCard', className)}
-      title={title ?? t('common:label.expenses', 'Expenses')}
-      subtitle={subtitle}
-      headerSize={headerSize}
-      legend={legend}
-      primaryAction={resolvedPrimaryAction}
+      slots={resolvedSlots}
     >
       <ProfitAndLossDetailedCharts
         scope='expenses'
         hideClose
         hideHeader
         chartColorsList={chartColorsList}
-        stringOverrides={stringOverrides}
+        stringOverrides={resolvedStringOverrides}
         slotProps={{ detailedTable: { showTypeColumn: false } }}
       />
     </SummaryCard>

--- a/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
+++ b/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
@@ -4,9 +4,9 @@ import { useTranslation } from 'react-i18next'
 
 import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
 import {
-  useSummaryCardSlots,
   type SummaryCardInteractionProps,
   type SummaryCardStringOverrides,
+  useSummaryCardSlots,
 } from '@ui/SummaryCard/useSummaryCardSlots'
 import { ProfitAndLossDetailedCharts, type ProfitAndLossDetailedChartsStringOverrides } from '@components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts'
 

--- a/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
+++ b/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
@@ -10,7 +10,7 @@ import { ProfitAndLossDetailedCharts, type ProfitAndLossDetailedChartsStringOver
 import './expensesSummaryCard.scss'
 
 type InteractionProps = {
-  onExpandClick?: () => void
+  onClickExpand?: () => void
 }
 
 type StylingProps = {
@@ -33,11 +33,11 @@ const useExpensesSummaryCard = ({ stylingProps, interactionProps, stringOverride
   const subtitle = useGlobalMonthSubtitle()
   const { chartColorsList } = stylingProps ?? {}
 
-  const { onExpandClick } = interactionProps ?? {}
+  const { onClickExpand } = interactionProps ?? {}
 
   const resolvedSlots: SummaryCardProps['slots'] = useMemo(() => {
-    const resolvedPrimaryAction = onExpandClick
-      ? <ExpandSummaryCardButton callback={onExpandClick} ariaLabel={t('common:label.view_details', 'View details')} />
+    const resolvedPrimaryAction = onClickExpand
+      ? <ExpandSummaryCardButton callback={onClickExpand} ariaLabel={t('common:label.view_details', 'View details')} />
       : undefined
 
     return {
@@ -46,7 +46,7 @@ const useExpensesSummaryCard = ({ stylingProps, interactionProps, stringOverride
       legend: <></>,
       primaryAction: resolvedPrimaryAction,
     }
-  }, [stringOverrides?.title, subtitle, t, onExpandClick])
+  }, [stringOverrides?.title, subtitle, t, onClickExpand])
 
   const resolvedStringOverrides: ProfitAndLossDetailedChartsStringOverrides = useMemo(() => {
     return {

--- a/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
+++ b/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
@@ -37,13 +37,13 @@ const useExpensesSummaryCard = ({ stylingProps, interactionProps, stringOverride
 
   const resolvedSlots: SummaryCardProps['slots'] = useMemo(() => {
     const resolvedPrimaryAction = onClickExpand
-      ? <ExpandSummaryCardButton callback={onClickExpand} ariaLabel={t('common:label.view_details', 'View details')} />
+      ? <ExpandSummaryCardButton callback={onClickExpand} ariaLabel={t('common:label.view_label', 'View')} />
       : undefined
 
     return {
       title: stringOverrides?.title ?? t('common:label.expenses', 'Expenses'),
       subtitle: subtitle,
-      legend: <></>,
+      legend: undefined,
       primaryAction: resolvedPrimaryAction,
     }
   }, [stringOverrides?.title, subtitle, t, onClickExpand])

--- a/src/components/ExpensesSummaryCard/expensesSummaryCard.scss
+++ b/src/components/ExpensesSummaryCard/expensesSummaryCard.scss
@@ -1,0 +1,63 @@
+.Layer__ExpensesSummaryCard {
+  .Layer__SummaryCard__Content {
+    overflow: hidden;
+    block-size: 100%;
+  }
+
+  .Layer__profit-and-loss-detailed-charts,
+  .Layer__profit-and-loss-detailed-charts__content {
+    gap: var(--spacing-md);
+    block-size: 100%;
+    min-block-size: 0;
+  }
+
+  .Layer__profit-and-loss-detailed-charts__content {
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    justify-content: space-between;
+    overflow: hidden;
+  }
+
+  .Layer__profit-and-loss-detailed-charts__content > .Layer__DetailedChart {
+    flex: 0 0 auto;
+    inline-size: auto;
+    min-inline-size: 14rem;
+    max-inline-size: 18rem;
+  }
+
+  .Layer__profit-and-loss-detailed-charts__content > .Layer__DetailedTable {
+    flex: 1 1 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    min-block-size: 0;
+    min-inline-size: 0;
+  }
+
+  .Layer__DetailedTable table {
+    border-collapse: separate;
+    border-spacing: 0;
+  }
+
+  .Layer__DetailedTable thead th {
+    position: sticky;
+    z-index: 1;
+    box-shadow: inset 0 -1px 0 var(--color-base-300);
+    background: var(--color-base-0);
+    inset-block-start: 0;
+    border-block-end: 0;
+  }
+
+  .Layer__profit-and-loss-detailed-charts .Layer__DetailedChart__container {
+    padding-right: var(--spacing-xs);
+    padding-left: var(--spacing-xs);
+  }
+
+  .Layer__DetailedTable {
+    min-inline-size: 10rem;
+  }
+
+  .Layer__DetailedTable__container {
+    padding-inline: 0;
+  }
+}

--- a/src/components/ExpensesSummaryCard/expensesSummaryCard.scss
+++ b/src/components/ExpensesSummaryCard/expensesSummaryCard.scss
@@ -49,8 +49,8 @@
   }
 
   .Layer__profit-and-loss-detailed-charts .Layer__DetailedChart__container {
-    padding-right: var(--spacing-xs);
-    padding-left: var(--spacing-xs);
+    padding-inline-start: var(--spacing-xs);
+    padding-inline-end: var(--spacing-xs);
   }
 
   .Layer__DetailedTable {

--- a/src/components/ProfitAndLossSummaryCard/PnlLegend.tsx
+++ b/src/components/ProfitAndLossSummaryCard/PnlLegend.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next'
+
+import { HStack, Stack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+
+import './pnlLegend.scss'
+
+const Swatch = ({ className }: { className: string }) => (
+  <span className={`Layer__PnlLegend__Swatch ${className}`} aria-hidden />
+)
+
+export type PnlLegendProps = {
+  direction?: 'row' | 'column'
+}
+
+export const PnlLegend = ({ direction = 'row' }: PnlLegendProps) => {
+  const { t } = useTranslation()
+  return (
+    <Stack className='Layer__PnlLegend' direction={direction} gap={direction === 'row' ? 'md' : '2xs'} pis={direction === 'column' ? 'md' : undefined} pbe={direction === 'column' ? 'md' : undefined}>
+      <HStack gap='2xs' align='center'>
+        <Swatch className='Layer__PnlLegend__Swatch--income' />
+        <Span size='sm'>{t('common:label.revenue', 'Revenue')}</Span>
+      </HStack>
+      <HStack gap='2xs' align='center'>
+        <Swatch className='Layer__PnlLegend__Swatch--expenses' />
+        <Span size='sm'>{t('common:label.expenses', 'Expenses')}</Span>
+      </HStack>
+      <HStack gap='2xs' align='center'>
+        <Swatch className='Layer__PnlLegend__Swatch--uncategorized' />
+        <Span size='sm'>{t('common:label.uncategorized', 'Uncategorized')}</Span>
+      </HStack>
+    </Stack>
+  )
+}

--- a/src/components/ProfitAndLossSummaryCard/PnlLegend.tsx
+++ b/src/components/ProfitAndLossSummaryCard/PnlLegend.tsx
@@ -16,7 +16,14 @@ export type PnlLegendProps = {
 export const PnlLegend = ({ direction = 'row' }: PnlLegendProps) => {
   const { t } = useTranslation()
   return (
-    <Stack className='Layer__PnlLegend' direction={direction} gap={direction === 'row' ? 'md' : '2xs'} pis={direction === 'column' ? 'md' : undefined} pbe={direction === 'column' ? 'md' : undefined}>
+    <Stack
+      className='Layer__PnlLegend'
+      direction={direction}
+      align='start'
+      gap={direction === 'row' ? 'md' : '2xs'}
+      pis={direction === 'column' ? 'md' : undefined}
+      pbe={direction === 'column' ? 'md' : undefined}
+    >
       <HStack gap='2xs' align='center'>
         <Swatch className='Layer__PnlLegend__Swatch--income' />
         <Span size='sm'>{t('common:label.revenue', 'Revenue')}</Span>

--- a/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
+++ b/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
@@ -1,0 +1,63 @@
+import { type ReactNode, useContext } from 'react'
+import classNames from 'classnames'
+import { useTranslation } from 'react-i18next'
+
+import { useGlobalMonthSubtitle } from '@hooks/utils/i18n/useGlobalMonthSubtitle'
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import { ProfitAndLossContext } from '@contexts/ProfitAndLossContext/ProfitAndLossContext'
+import { VStack } from '@ui/Stack/Stack'
+import { type HeadingSize } from '@ui/Typography/Heading'
+import { ProfitAndLossChart } from '@components/ProfitAndLossChart/ProfitAndLossChart'
+import { PnlLegend } from '@components/ProfitAndLossSummaryCard/PnlLegend'
+import { ExpandSummaryCardButton } from '@ui/SummaryCard/ExpandSummaryCardButton'
+import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
+
+import './profitAndLossSummaryCard.scss'
+
+export interface ProfitAndLossSummaryCardInteractionProps {
+  onExpandClick?: () => void
+}
+
+export type ProfitAndLossSummaryCardProps = {
+  title?: string
+  headerSize?: HeadingSize
+  className?: string
+  legend?: ReactNode
+  interactionProps?: ProfitAndLossSummaryCardInteractionProps
+}
+
+export const ProfitAndLossSummaryCard = ({
+  title,
+  headerSize,
+  legend,
+  interactionProps,
+  className,
+}: ProfitAndLossSummaryCardProps) => {
+  const { t } = useTranslation()
+  const { isDesktop } = useSizeClass()
+  const subtitle = useGlobalMonthSubtitle()
+  const { tagFilter } = useContext(ProfitAndLossContext)
+
+  const { onExpandClick } = interactionProps ?? {}
+
+  const resolvedLegend = legend ?? <PnlLegend direction={isDesktop ? 'row' : 'column'} />
+  const resolvedPrimaryAction = onExpandClick
+    ? <ExpandSummaryCardButton callback={onExpandClick} ariaLabel={t('common:label.view_details', 'View details')} />
+    : undefined
+
+  return (
+    <SummaryCard
+      className={classNames('Layer__ProfitAndLossSummaryCard', className)}
+      title={title ?? t('common:label.profit_loss', 'Profit & Loss')}
+      subtitle={subtitle}
+      headerSize={headerSize}
+      legend={isDesktop ? resolvedLegend : undefined}
+      primaryAction={resolvedPrimaryAction}
+    >
+      <VStack gap='sm'>
+        <ProfitAndLossChart tagFilter={tagFilter} hideLegend />
+        {!isDesktop && resolvedLegend}
+      </VStack>
+    </SummaryCard>
+  )
+}

--- a/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
+++ b/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
@@ -14,7 +14,7 @@ import { PnlLegend } from '@components/ProfitAndLossSummaryCard/PnlLegend'
 import './profitAndLossSummaryCard.scss'
 
 type InteractionProps = {
-  onExpandClick?: () => void
+  onClickExpand?: () => void
 }
 
 type StringOverrides = {
@@ -37,7 +37,7 @@ const useProfitAndLossSummaryCard = ({ interactionProps, stringOverrides }: UseP
   const { isDesktop } = useSizeClass()
   const subtitle = useGlobalMonthSubtitle()
 
-  const { onExpandClick } = interactionProps ?? {}
+  const { onClickExpand } = interactionProps ?? {}
 
   const legend = useMemo(
     () => <PnlLegend direction={isDesktop ? 'row' : 'column'} />,
@@ -45,8 +45,8 @@ const useProfitAndLossSummaryCard = ({ interactionProps, stringOverrides }: UseP
   )
 
   const resolvedSlots: SummaryCardProps['slots'] = useMemo(() => {
-    const resolvedPrimaryAction = onExpandClick
-      ? <ExpandSummaryCardButton callback={onExpandClick} ariaLabel={t('common:label.view_details', 'View details')} />
+    const resolvedPrimaryAction = onClickExpand
+      ? <ExpandSummaryCardButton callback={onClickExpand} ariaLabel={t('common:label.view_details', 'View details')} />
       : undefined
 
     return {
@@ -55,7 +55,7 @@ const useProfitAndLossSummaryCard = ({ interactionProps, stringOverrides }: UseP
       legend: isDesktop ? legend : undefined,
       primaryAction: resolvedPrimaryAction,
     }
-  }, [stringOverrides?.title, subtitle, t, onExpandClick, isDesktop, legend])
+  }, [stringOverrides?.title, subtitle, t, onClickExpand, isDesktop, legend])
 
   return {
     resolvedSlots,

--- a/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
+++ b/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
@@ -1,18 +1,18 @@
 import { useContext, useMemo } from 'react'
 import classNames from 'classnames'
+import { useTranslation } from 'react-i18next'
 
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { ProfitAndLossContext } from '@contexts/ProfitAndLossContext/ProfitAndLossContext'
 import { VStack } from '@ui/Stack/Stack'
 import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
 import {
-  useSummaryCardSlots,
   type SummaryCardInteractionProps,
   type SummaryCardStringOverrides,
+  useSummaryCardSlots,
 } from '@ui/SummaryCard/useSummaryCardSlots'
 import { ProfitAndLossChart } from '@components/ProfitAndLossChart/ProfitAndLossChart'
 import { PnlLegend } from '@components/ProfitAndLossSummaryCard/PnlLegend'
-import { useTranslation } from 'react-i18next'
 
 import './profitAndLossSummaryCard.scss'
 

--- a/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
+++ b/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
@@ -46,7 +46,7 @@ const useProfitAndLossSummaryCard = ({ interactionProps, stringOverrides }: UseP
 
   const resolvedSlots: SummaryCardProps['slots'] = useMemo(() => {
     const resolvedPrimaryAction = onClickExpand
-      ? <ExpandSummaryCardButton callback={onClickExpand} ariaLabel={t('common:label.view_details', 'View details')} />
+      ? <ExpandSummaryCardButton callback={onClickExpand} ariaLabel={t('common:label.view_label', 'View')} />
       : undefined
 
     return {

--- a/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
+++ b/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
@@ -1,67 +1,25 @@
 import { useContext, useMemo } from 'react'
 import classNames from 'classnames'
-import { useTranslation } from 'react-i18next'
 
-import { useGlobalMonthSubtitle } from '@hooks/utils/i18n/useGlobalMonthSubtitle'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { ProfitAndLossContext } from '@contexts/ProfitAndLossContext/ProfitAndLossContext'
 import { VStack } from '@ui/Stack/Stack'
-import { ExpandSummaryCardButton } from '@ui/SummaryCard/ExpandSummaryCardButton'
-import { SummaryCard, type SummaryCardProps } from '@ui/SummaryCard/SummaryCard'
+import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
+import {
+  useSummaryCardSlots,
+  type SummaryCardInteractionProps,
+  type SummaryCardStringOverrides,
+} from '@ui/SummaryCard/useSummaryCardSlots'
 import { ProfitAndLossChart } from '@components/ProfitAndLossChart/ProfitAndLossChart'
 import { PnlLegend } from '@components/ProfitAndLossSummaryCard/PnlLegend'
+import { useTranslation } from 'react-i18next'
 
 import './profitAndLossSummaryCard.scss'
 
-type InteractionProps = {
-  onClickExpand?: () => void
-}
-
-type StringOverrides = {
-  title?: string
-}
-
 export type ProfitAndLossSummaryCardProps = {
-  interactionProps?: InteractionProps
-  stringOverrides?: StringOverrides
+  interactionProps?: SummaryCardInteractionProps
+  stringOverrides?: SummaryCardStringOverrides
   className?: string
-}
-
-type UseProfitAndLossSummaryCardParams = {
-  interactionProps?: InteractionProps
-  stringOverrides?: StringOverrides
-}
-
-const useProfitAndLossSummaryCard = ({ interactionProps, stringOverrides }: UseProfitAndLossSummaryCardParams) => {
-  const { t } = useTranslation()
-  const { isDesktop } = useSizeClass()
-  const subtitle = useGlobalMonthSubtitle()
-
-  const { onClickExpand } = interactionProps ?? {}
-
-  const legend = useMemo(
-    () => <PnlLegend direction={isDesktop ? 'row' : 'column'} />,
-    [isDesktop],
-  )
-
-  const resolvedSlots: SummaryCardProps['slots'] = useMemo(() => {
-    const resolvedPrimaryAction = onClickExpand
-      ? <ExpandSummaryCardButton callback={onClickExpand} ariaLabel={t('common:label.view_label', 'View')} />
-      : undefined
-
-    return {
-      title: stringOverrides?.title ?? t('common:label.profit_loss', 'Profit & Loss'),
-      subtitle,
-      legend: isDesktop ? legend : undefined,
-      primaryAction: resolvedPrimaryAction,
-    }
-  }, [stringOverrides?.title, subtitle, t, onClickExpand, isDesktop, legend])
-
-  return {
-    resolvedSlots,
-    legend,
-    isDesktop,
-  }
 }
 
 export const ProfitAndLossSummaryCard = ({
@@ -69,13 +27,26 @@ export const ProfitAndLossSummaryCard = ({
   stringOverrides,
   className,
 }: ProfitAndLossSummaryCardProps) => {
+  const { t } = useTranslation()
+  const { isDesktop } = useSizeClass()
   const { tagFilter } = useContext(ProfitAndLossContext)
-  const { resolvedSlots, legend, isDesktop } = useProfitAndLossSummaryCard({ interactionProps, stringOverrides })
+
+  const legend = useMemo(
+    () => <PnlLegend direction={isDesktop ? 'row' : 'column'} />,
+    [isDesktop],
+  )
+
+  const slots = useSummaryCardSlots({
+    defaultTitle: t('common:label.profit_loss', 'Profit & Loss'),
+    legend: isDesktop ? legend : undefined,
+    interactionProps,
+    stringOverrides,
+  })
 
   return (
     <SummaryCard
       className={classNames('Layer__ProfitAndLossSummaryCard', className)}
-      slots={resolvedSlots}
+      slots={slots}
     >
       <VStack gap='sm'>
         <ProfitAndLossChart tagFilter={tagFilter} hideLegend />

--- a/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
+++ b/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useContext } from 'react'
+import { useContext, useMemo } from 'react'
 import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 
@@ -6,57 +6,80 @@ import { useGlobalMonthSubtitle } from '@hooks/utils/i18n/useGlobalMonthSubtitle
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { ProfitAndLossContext } from '@contexts/ProfitAndLossContext/ProfitAndLossContext'
 import { VStack } from '@ui/Stack/Stack'
-import { type HeadingSize } from '@ui/Typography/Heading'
+import { ExpandSummaryCardButton } from '@ui/SummaryCard/ExpandSummaryCardButton'
+import { SummaryCard, type SummaryCardProps } from '@ui/SummaryCard/SummaryCard'
 import { ProfitAndLossChart } from '@components/ProfitAndLossChart/ProfitAndLossChart'
 import { PnlLegend } from '@components/ProfitAndLossSummaryCard/PnlLegend'
-import { ExpandSummaryCardButton } from '@ui/SummaryCard/ExpandSummaryCardButton'
-import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
 
 import './profitAndLossSummaryCard.scss'
 
-export interface ProfitAndLossSummaryCardInteractionProps {
+type InteractionProps = {
   onExpandClick?: () => void
 }
 
-export type ProfitAndLossSummaryCardProps = {
+type StringOverrides = {
   title?: string
-  headerSize?: HeadingSize
-  className?: string
-  legend?: ReactNode
-  interactionProps?: ProfitAndLossSummaryCardInteractionProps
 }
 
-export const ProfitAndLossSummaryCard = ({
-  title,
-  headerSize,
-  legend,
-  interactionProps,
-  className,
-}: ProfitAndLossSummaryCardProps) => {
+export type ProfitAndLossSummaryCardProps = {
+  interactionProps?: InteractionProps
+  stringOverrides?: StringOverrides
+  className?: string
+}
+
+type UseProfitAndLossSummaryCardParams = {
+  interactionProps?: InteractionProps
+  stringOverrides?: StringOverrides
+}
+
+const useProfitAndLossSummaryCard = ({ interactionProps, stringOverrides }: UseProfitAndLossSummaryCardParams) => {
   const { t } = useTranslation()
   const { isDesktop } = useSizeClass()
   const subtitle = useGlobalMonthSubtitle()
-  const { tagFilter } = useContext(ProfitAndLossContext)
 
   const { onExpandClick } = interactionProps ?? {}
 
-  const resolvedLegend = legend ?? <PnlLegend direction={isDesktop ? 'row' : 'column'} />
-  const resolvedPrimaryAction = onExpandClick
-    ? <ExpandSummaryCardButton callback={onExpandClick} ariaLabel={t('common:label.view_details', 'View details')} />
-    : undefined
+  const legend = useMemo(
+    () => <PnlLegend direction={isDesktop ? 'row' : 'column'} />,
+    [isDesktop],
+  )
+
+  const resolvedSlots: SummaryCardProps['slots'] = useMemo(() => {
+    const resolvedPrimaryAction = onExpandClick
+      ? <ExpandSummaryCardButton callback={onExpandClick} ariaLabel={t('common:label.view_details', 'View details')} />
+      : undefined
+
+    return {
+      title: stringOverrides?.title ?? t('common:label.profit_loss', 'Profit & Loss'),
+      subtitle,
+      legend: isDesktop ? legend : undefined,
+      primaryAction: resolvedPrimaryAction,
+    }
+  }, [stringOverrides?.title, subtitle, t, onExpandClick, isDesktop, legend])
+
+  return {
+    resolvedSlots,
+    legend,
+    isDesktop,
+  }
+}
+
+export const ProfitAndLossSummaryCard = ({
+  interactionProps,
+  stringOverrides,
+  className,
+}: ProfitAndLossSummaryCardProps) => {
+  const { tagFilter } = useContext(ProfitAndLossContext)
+  const { resolvedSlots, legend, isDesktop } = useProfitAndLossSummaryCard({ interactionProps, stringOverrides })
 
   return (
     <SummaryCard
       className={classNames('Layer__ProfitAndLossSummaryCard', className)}
-      title={title ?? t('common:label.profit_loss', 'Profit & Loss')}
-      subtitle={subtitle}
-      headerSize={headerSize}
-      legend={isDesktop ? resolvedLegend : undefined}
-      primaryAction={resolvedPrimaryAction}
+      slots={resolvedSlots}
     >
       <VStack gap='sm'>
         <ProfitAndLossChart tagFilter={tagFilter} hideLegend />
-        {!isDesktop && resolvedLegend}
+        {!isDesktop && legend}
       </VStack>
     </SummaryCard>
   )

--- a/src/components/ProfitAndLossSummaryCard/pnlLegend.scss
+++ b/src/components/ProfitAndLossSummaryCard/pnlLegend.scss
@@ -1,0 +1,34 @@
+.Layer__PnlLegend {
+  align-items: flex-start;
+}
+
+.Layer__PnlLegend__Swatch {
+  display: inline-block;
+  flex-shrink: 0;
+  block-size: 0.625rem;
+  inline-size: 0.625rem;
+  border-radius: 50%;
+}
+
+.Layer__PnlLegend__Swatch--income {
+  background-color: var(--bar-color-income);
+}
+
+.Layer__PnlLegend__Swatch--expenses {
+  background-color: var(--bar-color-expenses);
+}
+
+.Layer__PnlLegend__Swatch--uncategorized {
+  background-image:
+    linear-gradient(
+      45deg,
+      var(--color-base-500) 25%,
+      transparent 25%,
+      transparent 50%,
+      var(--color-base-500) 50%,
+      var(--color-base-500) 75%,
+      transparent 75%,
+      transparent
+    );
+  background-size: 4px 4px;
+}

--- a/src/components/ProfitAndLossSummaryCard/pnlLegend.scss
+++ b/src/components/ProfitAndLossSummaryCard/pnlLegend.scss
@@ -1,7 +1,3 @@
-.Layer__PnlLegend {
-  align-items: flex-start;
-}
-
 .Layer__PnlLegend__Swatch {
   display: inline-block;
   flex-shrink: 0;

--- a/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
+++ b/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
@@ -1,12 +1,7 @@
 .Layer__ProfitAndLossSummaryCard {
   .Layer__chart-wrapper,
   .Layer__chart-container {
-    min-height: 250px;
-  }
-
-  .Layer__DetailedChart__container {
-    height: unset;
-    min-height: 250px;
+    min-block-size: 15.625rem;
   }
 
   div.recharts-responsive-container.Layer__chart-container {

--- a/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
+++ b/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
@@ -1,0 +1,15 @@
+.Layer__ProfitAndLossSummaryCard {
+  .Layer__chart-wrapper,
+  .Layer__chart-container {
+    min-height: 250px;
+  }
+
+  .Layer__DetailedChart__container {
+    height: unset;
+    min-height: 250px;
+  }
+
+  div.recharts-responsive-container.Layer__chart-container {
+    padding-top: var(--spacing-xs);
+  }
+}

--- a/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
+++ b/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
@@ -5,6 +5,6 @@
   }
 
   div.recharts-responsive-container.Layer__chart-container {
-    padding-top: var(--spacing-xs);
+    padding-block-start: var(--spacing-xs);
   }
 }

--- a/src/components/ui/SummaryCard/SummaryCard.tsx
+++ b/src/components/ui/SummaryCard/SummaryCard.tsx
@@ -2,15 +2,12 @@ import { type PropsWithChildren, type ReactNode } from 'react'
 import classNames from 'classnames'
 
 import { HStack, VStack } from '@ui/Stack/Stack'
-import { Heading, type HeadingSize } from '@ui/Typography/Heading'
+import { Heading } from '@ui/Typography/Heading'
 import { Span } from '@ui/Typography/Text'
 import { Card } from '@components/Card/Card'
 
 import './summaryCard.scss'
 
-type HeadingProps = {
-  size?: HeadingSize
-}
 export type SummaryCardProps = PropsWithChildren<{
   slots: {
     title: ReactNode
@@ -18,24 +15,18 @@ export type SummaryCardProps = PropsWithChildren<{
     legend?: ReactNode
     primaryAction?: ReactNode
   }
-  slotProps?: {
-    heading?: HeadingProps
-  }
   className?: string
 }>
 
 export const SummaryCard = ({
   slots,
-  slotProps,
   children,
   className,
 }: SummaryCardProps) => {
   const { title, subtitle, legend, primaryAction } = slots
-  const { heading: headingProps } = slotProps ?? {}
-  const { size = 'md' } = headingProps ?? {}
 
   const titleNode = typeof title === 'string'
-    ? <Heading size={size}>{title}</Heading>
+    ? <Heading size='md'>{title}</Heading>
     : title
 
   const subtitleNode = typeof subtitle === 'string'

--- a/src/components/ui/SummaryCard/useSummaryCardSlots.tsx
+++ b/src/components/ui/SummaryCard/useSummaryCardSlots.tsx
@@ -1,0 +1,45 @@
+import { type ReactNode, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useGlobalMonthSubtitle } from '@hooks/utils/i18n/useGlobalMonthSubtitle'
+import { ExpandSummaryCardButton } from '@ui/SummaryCard/ExpandSummaryCardButton'
+import { type SummaryCardProps } from '@ui/SummaryCard/SummaryCard'
+
+export type SummaryCardInteractionProps = {
+  onClickExpand?: () => void
+}
+
+export type SummaryCardStringOverrides = {
+  title?: string
+}
+
+type UseSummaryCardSlotsParams = {
+  defaultTitle: string
+  legend?: ReactNode
+  interactionProps?: SummaryCardInteractionProps
+  stringOverrides?: SummaryCardStringOverrides
+}
+
+export const useSummaryCardSlots = ({
+  defaultTitle,
+  legend,
+  interactionProps,
+  stringOverrides,
+}: UseSummaryCardSlotsParams): SummaryCardProps['slots'] => {
+  const { t } = useTranslation()
+  const subtitle = useGlobalMonthSubtitle()
+  const { onClickExpand } = interactionProps ?? {}
+
+  return useMemo(() => {
+    const primaryAction = onClickExpand
+      ? <ExpandSummaryCardButton callback={onClickExpand} ariaLabel={t('common:label.view_label', 'View')} />
+      : undefined
+
+    return {
+      title: stringOverrides?.title ?? defaultTitle,
+      subtitle,
+      legend,
+      primaryAction,
+    }
+  }, [stringOverrides?.title, defaultTitle, subtitle, legend, onClickExpand, t])
+}

--- a/src/hooks/utils/i18n/useGlobalMonthSubtitle.ts
+++ b/src/hooks/utils/i18n/useGlobalMonthSubtitle.ts
@@ -1,0 +1,9 @@
+import { useGlobalDate } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
+import { MonthYearPattern } from '@utils/i18n/date/patterns'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+
+export const useGlobalMonthSubtitle = () => {
+  const { formatDate } = useIntlFormatter()
+  const { date } = useGlobalDate({ dateSelectionMode: 'month' })
+  return formatDate(date, MonthYearPattern.MonthYear)
+}

--- a/src/hooks/utils/i18n/useGlobalMonthSubtitle.ts
+++ b/src/hooks/utils/i18n/useGlobalMonthSubtitle.ts
@@ -1,6 +1,6 @@
-import { useGlobalDate } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 import { MonthYearPattern } from '@utils/i18n/date/patterns'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { useGlobalDate } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 
 export const useGlobalMonthSubtitle = () => {
   const { formatDate } = useIntlFormatter()


### PR DESCRIPTION
## Scope

- `ProfitAndLossSummaryCard` wraps `SummaryCard` around `<ProfitAndLossChart>`. Reads `tagFilter` from `ProfitAndLossContext` (no prop). Defaults the legend slot to `<PnlLegend />`, which moves out of the header into the content area below the chart on tablet/mobile. Optional `interactionProps.onExpandClick` renders an `ExpandSummaryCardButton`.
- `ExpensesSummaryCard` wraps `SummaryCard` around `<ProfitAndLossDetailedCharts scope='expenses' hideHeader hideClose slotProps={{ detailedTable: { showTypeColumn: false } }} />`. Forces horizontal chart/table layout with sticky table header and independent table scrolling regardless of breakpoint.
- New `PnlLegend` component (income / expenses / uncategorized) with `direction` prop for row/column orientation.
- New shared `useGlobalMonthSubtitle()` hook formatting the global date as `MonthYearPattern.MonthYear` (e.g. `January 2026`); both cards use it for the subtitle line.

## Verification

- `npx tsc --noEmit -p tsconfig.json` clean
- Mount each card under a `<ProfitAndLoss>` provider; both render with the current month as subtitle
- `PnlLegend` wraps to a vertical column under the chart at `width <= 760px` on the PnL card
- Expense card table scrolls under a fixed chart with the table header sticky
- `interactionProps.onExpandClick` only fires on the explicit arrow button (not on body clicks)

Root: #1333
Base: #1334
Next: #1337

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily UI composition/styling changes, but it also changes `SummaryCard`’s public props by removing `slotProps.heading`, which could break any external consumers relying on custom heading sizing.
> 
> **Overview**
> Introduces two new dashboard-style cards: `ProfitAndLossSummaryCard` (wraps `ProfitAndLossChart` in `SummaryCard` with a responsive `PnlLegend`) and `ExpensesSummaryCard` (wraps `ProfitAndLossDetailedCharts` in `SummaryCard` with forced horizontal chart/table layout, sticky table header, and independent table scrolling).
> 
> Adds `useSummaryCardSlots` and `useGlobalMonthSubtitle()` to standardize card titles/subtitles (global month) and optional expand action via `ExpandSummaryCardButton`.
> 
> Simplifies `SummaryCard` by removing `slotProps.heading` customization and always rendering string titles with `Heading size='md'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c810183e5b1c58eb6d4a0f356eb8f199b54e87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

