### PR TITLE
fix(accounting-overview): remove stray onClick on TransactionsToReview wrapper (4/5)

### DIFF
--- a/src/views/AccountingOverview/internal/TransactionsToReview.tsx
+++ b/src/views/AccountingOverview/internal/TransactionsToReview.tsx
@@ -113,7 +113,7 @@ export function TransactionsToReview({
       break
   }
   return (
-    <div onClick={onClick} className={CLASS_NAME}>
+    <div className={CLASS_NAME}>
       <VStack gap={verticalGap} align='start'>
         <ProfitAndLossSummariesHeading variants={variants}>
           {t('bankTransactions:label.transactions_to_review', 'Transactions to review')}


### PR DESCRIPTION
## Scope

The outer `<div>` wrapper in `TransactionsToReview` had its own `onClick={onClick}` handler in addition to the inner action button being click-bound. Clicking anywhere on the card fired the handler twice, which surfaced when a parent view bound `onTransactionsToReviewClick` to a distinct callback than another card's primary action.

Removes the wrapper-level `onClick` so the card only fires from explicit interactive elements inside it.

## Verification

- Click anywhere on the transactions-to-review card other than the explicit button: nothing fires.
- Click the button: handler runs once.
- `npx tsc --noEmit -p tsconfig.json` clean.

Root: `this`
Base: `main`
Next: None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI event-handling change limited to one component; risk is confined to click behavior/regressions in navigation from this card.
> 
> **Overview**
> Fixes `TransactionsToReview` so only the explicit `IconButton` triggers the provided `onClick` handler by removing the wrapper `<div>`’s `onClick`. This prevents accidental/double invocation when clicking elsewhere on the card.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a957d7595d16a144e55ca532a038fdb69bed280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->