### PR TITLE
Rename Amount to Currency, support new unified cell type Decimal

### DIFF
--- a/src/components/UnifiedReport/UnifiedReportTableCellContent.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTableCellContent.tsx
@@ -1,5 +1,12 @@
 import type { ReportConfig } from '@schemas/reports/reportConfig'
-import { isAmountCellValue, isDateCellValue, isEmptyCellValue, type UnifiedReportCell, type UnifiedReportColumn } from '@schemas/reports/unifiedReport'
+import {
+  isCurrencyCellValue,
+  isDateCellValue,
+  isDecimalCellValue,
+  isEmptyCellValue,
+  type UnifiedReportCell,
+  type UnifiedReportColumn,
+} from '@schemas/reports/unifiedReport'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useOpenDetailReport } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { Button } from '@ui/Button/Button'
@@ -13,7 +20,7 @@ type UnifiedReportTableCellContentProps = {
 }
 
 export const UnifiedReportTableCellContent = ({ cell, column, breadcrumb }: UnifiedReportTableCellContentProps) => {
-  const { formatDate } = useIntlFormatter()
+  const { formatDate, formatNumber } = useIntlFormatter()
   const openDetailReport = useOpenDetailReport()
 
   if (!cell) return
@@ -24,11 +31,14 @@ export const UnifiedReportTableCellContent = ({ cell, column, breadcrumb }: Unif
   const variant = isBold ? undefined : 'placeholder'
 
   let content
-  if (isAmountCellValue(cellValue)) {
+  if (isCurrencyCellValue(cellValue)) {
     content = <MoneySpan ellipsis weight={weight} variant={variant} amount={cellValue.value} />
   }
   else if (isDateCellValue(cellValue)) {
     content = <Span ellipsis weight={weight} variant={variant}>{formatDate(cellValue.value)}</Span>
+  }
+  else if (isDecimalCellValue(cellValue)) {
+    content = <Span ellipsis weight={weight} variant={variant}>{formatNumber(cellValue.value)}</Span>
   }
   else if (isEmptyCellValue(cellValue)) {
     return null

--- a/src/schemas/reports/unifiedReport.ts
+++ b/src/schemas/reports/unifiedReport.ts
@@ -97,14 +97,19 @@ export const UnifiedReportColumnSchema = Schema.Struct({
   ),
 })
 
-const UnifiedCellValueAmountSchema = Schema.Struct({
-  type: Schema.Literal('Amount'),
+const UnifiedCellValueCurrencySchema = Schema.Struct({
+  type: Schema.Literal('Currency'),
   value: Schema.Number,
 })
 
 const UnifiedCellValueDateSchema = Schema.Struct({
   type: Schema.Literal('Date'),
   value: Schema.Date,
+})
+
+const UnifiedCellValueDecimalSchema = Schema.Struct({
+  type: Schema.Literal('Decimal'),
+  value: Schema.Number,
 })
 
 const UnifiedCellValueEmptySchema = Schema.Struct({
@@ -117,23 +122,28 @@ const UnifiedCellValueUnknownSchema = Schema.Struct({
 })
 
 const UnifiedCellValueSchema = Schema.Union(
-  UnifiedCellValueAmountSchema,
+  UnifiedCellValueCurrencySchema,
   UnifiedCellValueDateSchema,
+  UnifiedCellValueDecimalSchema,
   UnifiedCellValueEmptySchema,
   UnifiedCellValueUnknownSchema,
 )
 
 export type UnifiedCellValue = typeof UnifiedCellValueSchema.Type
-export type UnifiedCellValueAmount = typeof UnifiedCellValueAmountSchema.Type
+export type UnifiedCellValueCurrency = typeof UnifiedCellValueCurrencySchema.Type
 export type UnifiedCellValueDate = typeof UnifiedCellValueDateSchema.Type
+export type UnifiedCellValueDecimal = typeof UnifiedCellValueDecimalSchema.Type
 export type UnifiedCellValueEmpty = typeof UnifiedCellValueEmptySchema.Type
 export type UnifiedCellValueUnknown = typeof UnifiedCellValueUnknownSchema.Type
 
-export const isAmountCellValue = (value: UnifiedCellValue): value is UnifiedCellValueAmount =>
-  value.type === 'Amount'
+export const isCurrencyCellValue = (value: UnifiedCellValue): value is UnifiedCellValueCurrency =>
+  value.type === 'Currency'
 
 export const isDateCellValue = (value: UnifiedCellValue): value is UnifiedCellValueDate =>
   value.type === 'Date'
+
+export const isDecimalCellValue = (value: UnifiedCellValue): value is UnifiedCellValueDecimal =>
+  value.type === 'Decimal'
 
 export const isEmptyCellValue = (value: UnifiedCellValue): value is UnifiedCellValueEmpty =>
   value.type === 'Empty'


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the unified report data contract (`'Amount'`  `'Currency'` plus new `'Decimal'`), so any producers/consumers expecting the old type string may break. UI formatting changes are otherwise localized to report table cell rendering.
> 
> **Overview**
> Unified report cells now use a `Currency` value type (renamed from `Amount`) and add a new `Decimal` value type in `unifiedReport` schema/type guards.
> 
> `UnifiedReportTableCellContent` is updated to render `Currency` via `MoneySpan`, render `Decimal` via localized `formatNumber`, and to import/use the new type guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 156cf1081bf42640735132a064f57581188a0828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->