### PR TITLE
Removing auto open

### DIFF
--- a/src/assets/locales/en-US/callBookings.json
+++ b/src/assets/locales/en-US/callBookings.json
@@ -1,13 +1,13 @@
 {
   "action": {
     "add_calendar": "Add to Calendar",
-    "book_call": "Book a call",
+    "book_call": "Schedule Call",
     "download_ics_file": "Download .ics file",
     "join_call": "Join call"
   },
   "label": {
     "ad_hoc_call": "Ad hoc call",
-    "book_call_with_bookkeeper": "Book a call with your bookkeeper",
+    "book_call_with_bookkeeper": "Schedule an onboarding call with your bookkeeper",
     "google_calendar": "Google Calendar",
     "meet_bookkeeping_team": "Meet with our bookkeeping team",
     "on_this_call_well": "On this call, we'll",

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -46,10 +46,10 @@ const EmptyState = ({ onBookCall }: { onBookCall?: () => void }) => {
         {t('callBookings:prompt.ready_to_get_started', 'Ready to get started?')}
       </Heading>
       <Span variant='subtle' align='center'>
-        {t('callBookings:label.book_call_with_bookkeeper', 'Book a call with your bookkeeper')}
+        {t('callBookings:label.book_call_with_bookkeeper', 'Schedule an onboarding call with your bookkeeper')}
       </Span>
       <Button variant='solid' onClick={onBookCall}>
-        {t('callBookings:action.book_call', 'Book a call')}
+        {t('callBookings:action.book_call', 'Schedule Call')}
       </Button>
     </VStack>
   )

--- a/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
+++ b/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback } from 'react'
 
 import { type CallBooking, CallBookingPurpose, CallBookingType } from '@schemas/callBooking'
 import { useBookkeepingStatus, useBookkeepingStatusGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus'
@@ -22,9 +22,6 @@ export const useBookkeepingOnboardingCallBooking = () => {
   const { forceReloadBookkeepingStatus } = useBookkeepingStatusGlobalCacheActions()
   const { trigger: createCallBooking } = useCreateCallBooking()
   const { data: callBookings, isError, isLoading } = useCallBookings({ limit: 1 })
-
-  const [embedDismissed, setEmbedDismissed] = useState(false)
-  const [hasScheduledCallInSession, setHasScheduledCallInSession] = useState(false)
 
   const onboardingCallUrl = bookkeepingStatus?.showEmbeddedOnboarding
     ? bookkeepingStatus.onboardingCallUrl
@@ -50,7 +47,6 @@ export const useBookkeepingOnboardingCallBooking = () => {
         purpose: CallBookingPurpose.BOOKKEEPING_ONBOARDING,
         call_type: CallBookingType.GOOGLE_MEET,
       })
-      setHasScheduledCallInSession(true)
       void forceReloadBookkeepingStatus()
     }
     catch (error: unknown) {
@@ -58,24 +54,13 @@ export const useBookkeepingOnboardingCallBooking = () => {
     }
   }, [createCallBooking, forceReloadBookkeepingStatus])
 
-  const handleCalendlyClose = useCallback(() => {
-    setEmbedDismissed(true)
-  }, [])
-
   const { isCalendlyVisible, calendlyLink, calendlyRef, openCalendly, closeCalendly } = useCalendly({
     onEventScheduled: recordCalendlyScheduled,
-    onClose: handleCalendlyClose,
   })
 
   const callBooking: CallBooking | null = callBookings?.[0]?.data[0] ?? null
   const hasResolvedCallBooking = !isLoading && !isError
 
-  const shouldOfferOnboarding = hasResolvedCallBooking
-    && callBooking == null
-    && onboardingCallUrl != null
-    && !hasScheduledCallInSession
-
-  const shouldAutoOpenEmbed = shouldOfferOnboarding && !embedDismissed
   const showScheduledCallBooking = hasResolvedCallBooking && callBooking != null
   const showEmptyCallBooking =
     bookkeepingStatus?.showEmbeddedOnboarding === true
@@ -87,14 +72,6 @@ export const useBookkeepingOnboardingCallBooking = () => {
       openCalendly(onboardingCallUrl)
     }
   }, [onboardingCallUrl, openCalendly])
-
-  useEffect(() => {
-    if (!shouldAutoOpenEmbed || onboardingCallUrl == null) {
-      return
-    }
-
-    openCalendly(onboardingCallUrl)
-  }, [shouldAutoOpenEmbed, onboardingCallUrl, openCalendly])
 
   return {
     callBooking: callBooking ?? undefined,


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavioral change to the onboarding scheduling flow (removes auto-open), which could impact user conversion and support expectations, but does not touch auth, payments, or sensitive data.
> 
> **Overview**
> Stops automatically opening the embedded Calendly scheduler for bookkeeping onboarding calls by removing the session/dismissal state and the `useEffect`-based auto-open behavior in `useBookkeepingOnboardingCallBooking` (Calendly now only opens via the explicit “Schedule Call” action).
> 
> Updates call-booking copy in `callBookings.json` and the `CallBooking` empty state to use “Schedule Call” and clarify that the booking is an onboarding call with the bookkeeper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7df8fd2c5b04014ae43b4cd90a2993776c1806b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->