### PR TITLE
fix: css tweaks on mobile drawer

### DIFF
--- a/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
+++ b/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
@@ -88,7 +88,7 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
         isDismissable
       >
         {({ close }) => (
-          <VStack className='Layer__MobileSelectionDrawerWithTrigger' pb='md' gap='md'>
+          <VStack className='Layer__MobileSelectionDrawerWithTrigger' pi='sm' pb='xs' gap='md'>
             {isSearchable && (
               <SearchField
                 value={searchQuery}

--- a/src/components/ui/MobileSelectionDrawer/mobileSelectionDrawerWithTrigger.scss
+++ b/src/components/ui/MobileSelectionDrawer/mobileSelectionDrawerWithTrigger.scss
@@ -1,6 +1,4 @@
 .Layer__MobileSelectionDrawerWithTrigger {
-  padding-inline: var(--spacing-sm);
-
   .Layer__SearchField {
     inline-size: 100%;
   }


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated UI spacing changes limited to the mobile drawer layout with no logic or data-flow impact.
> 
> **Overview**
> Adjusts spacing in `MobileSelectionDrawerWithTrigger` by adding `pi='sm'` and changing bottom padding to `pb='xs'` on the root `VStack` inside the drawer.
> 
> Removes the now-redundant `padding-inline` rule from `mobileSelectionDrawerWithTrigger.scss`, leaving layout to be controlled via the stack component props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 927b8614deb5bfc72386a36d7a69c9c090f3a10a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->