### PR TITLE
Add handling for new duration type cell for unified reports

### DIFF
--- a/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
+++ b/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
@@ -10,6 +10,7 @@ import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useTimeEntriesDeleteModal, useTimeEntriesDrawer } from '@providers/TimeEntriesStore/TimeEntriesStoreProvider'
 import { Button } from '@ui/Button/Button'
 import { HStack } from '@ui/Stack/Stack'
+import { DurationSpan } from '@ui/Typography/DurationSpan'
 import { Span } from '@ui/Typography/Text'
 import { Container } from '@components/Container/Container'
 import type { NestedColumnConfig } from '@components/DataTable/columnUtils'
@@ -36,12 +37,7 @@ const TimeEntryDateCell = memo(function TimeEntryDateCell({ date }: { date: Time
 })
 
 const TimeEntryDurationCell = memo(function TimeEntryDurationCell({ durationMinutes }: { durationMinutes: TimeEntry['durationMinutes'] }) {
-  const { t } = useTranslation()
-  const { formatMinutesAsDuration } = useIntlFormatter()
-  if (durationMinutes === 0) {
-    return <Span>{t('timeTracking:label.less_than_one_minute', '< 1 min')}</Span>
-  }
-  return <Span>{formatMinutesAsDuration(durationMinutes)}</Span>
+  return <DurationSpan durationMinutes={durationMinutes} />
 })
 
 const TimeEntryActionsCell = memo(function TimeEntryActionsCell({ entry }: { entry: TimeEntry }) {

--- a/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
+++ b/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
@@ -37,7 +37,7 @@ const TimeEntryDateCell = memo(function TimeEntryDateCell({ date }: { date: Time
 })
 
 const TimeEntryDurationCell = memo(function TimeEntryDurationCell({ durationMinutes }: { durationMinutes: TimeEntry['durationMinutes'] }) {
-  return <DurationSpan durationMinutes={durationMinutes} />
+  return <DurationSpan durationMinutes={durationMinutes} zeroValueDisplay={false} />
 })
 
 const TimeEntryActionsCell = memo(function TimeEntryActionsCell({ entry }: { entry: TimeEntry }) {

--- a/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
+++ b/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTable.tsx
@@ -37,7 +37,7 @@ const TimeEntryDateCell = memo(function TimeEntryDateCell({ date }: { date: Time
 })
 
 const TimeEntryDurationCell = memo(function TimeEntryDurationCell({ durationMinutes }: { durationMinutes: TimeEntry['durationMinutes'] }) {
-  return <DurationSpan durationMinutes={durationMinutes} zeroValueDisplay={false} />
+  return <DurationSpan durationMinutes={durationMinutes} showLessThanOneMinuteForZero />
 })
 
 const TimeEntryActionsCell = memo(function TimeEntryActionsCell({ entry }: { entry: TimeEntry }) {

--- a/src/components/TimeTrackingStats/TimeTrackingStats.tsx
+++ b/src/components/TimeTrackingStats/TimeTrackingStats.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_CHART_COLORS } from '@utils/chartColors'
 import { type TimeTrackingSummaryFilterParams, useTimeTrackingSummary } from '@hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { HStack, VStack } from '@ui/Stack/Stack'
+import { DurationSpan } from '@ui/Typography/DurationSpan'
 import { Heading } from '@ui/Typography/Heading'
 import { Span } from '@ui/Typography/Text'
 import { Container } from '@components/Container/Container'
@@ -73,7 +74,7 @@ const TimeTrackingStatsLegendSwatch = ({ color }: { color: string }) => (
 )
 
 const TimeTrackingStatsBreakdown = memo(function TimeTrackingStatsBreakdown({ entries }: { entries: TimeTrackingServiceBreakdown[] }) {
-  const { formatMinutesAsDuration, formatPercent } = useIntlFormatter()
+  const { formatPercent } = useIntlFormatter()
   const chartData = useMemo(() => buildStackedChartData(entries), [entries])
   const chartTotalMinutes = useMemo(
     () => entries.reduce((total, entry) => total + entry.totalMinutes, 0),
@@ -126,9 +127,7 @@ const TimeTrackingStatsBreakdown = memo(function TimeTrackingStatsBreakdown({ en
               <Span size='md' ellipsis withTooltip>{serviceName}</Span>
             </HStack>
             <HStack className='Layer__TimeTrackingStats__LegendMeta' gap='2xs' align='baseline'>
-              <Span className='Layer__TimeTrackingStats__LegendDuration' size='sm'>
-                {formatMinutesAsDuration(totalMinutes)}
-              </Span>
+              <DurationSpan className='Layer__TimeTrackingStats__LegendDuration' size='sm' durationMinutes={totalMinutes} />
               <Span className='Layer__TimeTrackingStats__LegendPercentage' size='sm' variant='subtle'>
                 {formatPercent(percentage, { maximumFractionDigits: 0 })}
               </Span>
@@ -142,16 +141,11 @@ const TimeTrackingStatsBreakdown = memo(function TimeTrackingStatsBreakdown({ en
 
 function TimeTrackingStatsContent({ summary }: { summary: TimeEntrySummary }) {
   const { t } = useTranslation()
-  const { formatMinutesAsDuration } = useIntlFormatter()
 
   const serviceBreakdown = useMemo(
     () => buildServiceBreakdown(summary.byService, t('timeTracking:label.other', 'Other')),
     [summary.byService, t],
   )
-
-  const totalDurationDisplay = summary.totalMinutes > 0
-    ? formatMinutesAsDuration(summary.totalMinutes)
-    : t('timeTracking:label.zero_minutes', '0 min')
 
   return (
     <VStack className='Layer__TimeTrackingStats__Content' gap='lg' pb='md' pi='md'>
@@ -163,9 +157,13 @@ function TimeTrackingStatsContent({ summary }: { summary: TimeEntrySummary }) {
           </VStack>
           <VStack className='Layer__TimeTrackingStats__Summary' gap='3xs' pi='md'>
             <Span size='sm' variant='subtle'>{t('common:label.this_period', 'This Period')}</Span>
-            <Span className='Layer__TimeTrackingStats__SummaryValue' weight='bold'>
-              {totalDurationDisplay}
-            </Span>
+            {summary.totalMinutes > 0
+              ? <DurationSpan className='Layer__TimeTrackingStats__SummaryValue' weight='bold' durationMinutes={summary.totalMinutes} />
+              : (
+                <Span className='Layer__TimeTrackingStats__SummaryValue' weight='bold'>
+                  {t('timeTracking:label.zero_minutes', '0 min')}
+                </Span>
+              )}
           </VStack>
         </HStack>
       </HStack>

--- a/src/components/TimeTrackingStats/TimeTrackingStats.tsx
+++ b/src/components/TimeTrackingStats/TimeTrackingStats.tsx
@@ -157,13 +157,12 @@ function TimeTrackingStatsContent({ summary }: { summary: TimeEntrySummary }) {
           </VStack>
           <VStack className='Layer__TimeTrackingStats__Summary' gap='3xs' pi='md'>
             <Span size='sm' variant='subtle'>{t('common:label.this_period', 'This Period')}</Span>
-            {summary.totalMinutes > 0
-              ? <DurationSpan className='Layer__TimeTrackingStats__SummaryValue' weight='bold' durationMinutes={summary.totalMinutes} />
-              : (
-                <Span className='Layer__TimeTrackingStats__SummaryValue' weight='bold'>
-                  {t('timeTracking:label.zero_minutes', '0 min')}
-                </Span>
-              )}
+            <DurationSpan
+              className='Layer__TimeTrackingStats__SummaryValue'
+              weight='bold'
+              durationMinutes={summary.totalMinutes}
+              zeroValueDisplay='zeroMinutes'
+            />
           </VStack>
         </HStack>
       </HStack>

--- a/src/components/TimeTrackingStats/TimeTrackingStats.tsx
+++ b/src/components/TimeTrackingStats/TimeTrackingStats.tsx
@@ -161,7 +161,6 @@ function TimeTrackingStatsContent({ summary }: { summary: TimeEntrySummary }) {
               className='Layer__TimeTrackingStats__SummaryValue'
               weight='bold'
               durationMinutes={summary.totalMinutes}
-              zeroValueDisplay='zeroMinutes'
             />
           </VStack>
         </HStack>

--- a/src/components/UnifiedReport/UnifiedReportTableCellContent.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTableCellContent.tsx
@@ -43,7 +43,15 @@ export const UnifiedReportTableCellContent = ({ cell, column, breadcrumb }: Unif
     content = <Span ellipsis weight={weight} variant={variant}>{formatNumber(cellValue.value)}</Span>
   }
   else if (isDurationCellValue(cellValue)) {
-    content = <DurationSpan ellipsis weight={weight} variant={variant} durationMinutes={cellValue.value} />
+    content = (
+      <DurationSpan
+        ellipsis
+        weight={weight}
+        variant={variant}
+        durationMinutes={cellValue.value}
+        zeroValueDisplay={false}
+      />
+    )
   }
   else if (isEmptyCellValue(cellValue)) {
     return null

--- a/src/components/UnifiedReport/UnifiedReportTableCellContent.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTableCellContent.tsx
@@ -1,8 +1,11 @@
+import { useTranslation } from 'react-i18next'
+
 import type { ReportConfig } from '@schemas/reports/reportConfig'
 import {
   isCurrencyCellValue,
   isDateCellValue,
   isDecimalCellValue,
+  isDurationCellValue,
   isEmptyCellValue,
   type UnifiedReportCell,
   type UnifiedReportColumn,
@@ -20,7 +23,8 @@ type UnifiedReportTableCellContentProps = {
 }
 
 export const UnifiedReportTableCellContent = ({ cell, column, breadcrumb }: UnifiedReportTableCellContentProps) => {
-  const { formatDate, formatNumber } = useIntlFormatter()
+  const { t } = useTranslation()
+  const { formatDate, formatMinutesAsDuration, formatNumber } = useIntlFormatter()
   const openDetailReport = useOpenDetailReport()
 
   if (!cell) return
@@ -39,6 +43,12 @@ export const UnifiedReportTableCellContent = ({ cell, column, breadcrumb }: Unif
   }
   else if (isDecimalCellValue(cellValue)) {
     content = <Span ellipsis weight={weight} variant={variant}>{formatNumber(cellValue.value)}</Span>
+  }
+  else if (isDurationCellValue(cellValue)) {
+    const value = cellValue.value === 0
+      ? t('timeTracking:label.less_than_one_minute', '< 1 min')
+      : formatMinutesAsDuration(cellValue.value)
+    content = <Span ellipsis weight={weight} variant={variant}>{value}</Span>
   }
   else if (isEmptyCellValue(cellValue)) {
     return null

--- a/src/components/UnifiedReport/UnifiedReportTableCellContent.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTableCellContent.tsx
@@ -49,7 +49,7 @@ export const UnifiedReportTableCellContent = ({ cell, column, breadcrumb }: Unif
         weight={weight}
         variant={variant}
         durationMinutes={cellValue.value}
-        zeroValueDisplay={false}
+        showLessThanOneMinuteForZero
       />
     )
   }

--- a/src/components/UnifiedReport/UnifiedReportTableCellContent.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTableCellContent.tsx
@@ -1,5 +1,3 @@
-import { useTranslation } from 'react-i18next'
-
 import type { ReportConfig } from '@schemas/reports/reportConfig'
 import {
   isCurrencyCellValue,
@@ -13,6 +11,7 @@ import {
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useOpenDetailReport } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { Button } from '@ui/Button/Button'
+import { DurationSpan } from '@ui/Typography/DurationSpan'
 import { MoneySpan } from '@ui/Typography/MoneySpan'
 import { Span } from '@ui/Typography/Text'
 
@@ -23,8 +22,7 @@ type UnifiedReportTableCellContentProps = {
 }
 
 export const UnifiedReportTableCellContent = ({ cell, column, breadcrumb }: UnifiedReportTableCellContentProps) => {
-  const { t } = useTranslation()
-  const { formatDate, formatMinutesAsDuration, formatNumber } = useIntlFormatter()
+  const { formatDate, formatNumber } = useIntlFormatter()
   const openDetailReport = useOpenDetailReport()
 
   if (!cell) return
@@ -45,10 +43,7 @@ export const UnifiedReportTableCellContent = ({ cell, column, breadcrumb }: Unif
     content = <Span ellipsis weight={weight} variant={variant}>{formatNumber(cellValue.value)}</Span>
   }
   else if (isDurationCellValue(cellValue)) {
-    const value = cellValue.value === 0
-      ? t('timeTracking:label.less_than_one_minute', '< 1 min')
-      : formatMinutesAsDuration(cellValue.value)
-    content = <Span ellipsis weight={weight} variant={variant}>{value}</Span>
+    content = <DurationSpan ellipsis weight={weight} variant={variant} durationMinutes={cellValue.value} />
   }
   else if (isEmptyCellValue(cellValue)) {
     return null

--- a/src/components/ui/Typography/DurationSpan.tsx
+++ b/src/components/ui/Typography/DurationSpan.tsx
@@ -6,16 +6,16 @@ import { Span, type TextStyleProps } from '@ui/Typography/Text'
 
 type DurationSpanProps = {
   durationMinutes: number
-  zeroValueDisplay?: 'lessThanOneMinute' | 'zeroMinutes'
+  zeroValueDisplay?: boolean
 } & TextStyleProps & Pick<ComponentPropsWithoutRef<'span'>, 'slot'>
 
 const DurationSpan = forwardRef<HTMLSpanElement, DurationSpanProps>(
-  ({ durationMinutes, className, zeroValueDisplay = 'lessThanOneMinute', ...restProps }, ref) => {
+  ({ durationMinutes, className, zeroValueDisplay = true, ...restProps }, ref) => {
     const { t } = useTranslation()
     const { formatMinutesAsDuration } = useIntlFormatter()
     const formattedDuration = durationMinutes !== 0
       ? formatMinutesAsDuration(durationMinutes)
-      : zeroValueDisplay === 'zeroMinutes'
+      : zeroValueDisplay
         ? t('timeTracking:label.zero_minutes', '0 min')
         : t('timeTracking:label.less_than_one_minute', '< 1 min')
 

--- a/src/components/ui/Typography/DurationSpan.tsx
+++ b/src/components/ui/Typography/DurationSpan.tsx
@@ -1,0 +1,28 @@
+import { type ComponentPropsWithoutRef, forwardRef } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { Span, type TextStyleProps } from '@ui/Typography/Text'
+
+type DurationSpanProps = {
+  durationMinutes: number
+} & TextStyleProps & Pick<ComponentPropsWithoutRef<'span'>, 'slot'>
+
+const DurationSpan = forwardRef<HTMLSpanElement, DurationSpanProps>(
+  ({ durationMinutes, className, ...restProps }, ref) => {
+    const { t } = useTranslation()
+    const { formatMinutesAsDuration } = useIntlFormatter()
+    const formattedDuration = durationMinutes === 0
+      ? t('timeTracking:label.less_than_one_minute', '< 1 min')
+      : formatMinutesAsDuration(durationMinutes)
+
+    return (
+      <Span {...restProps} className={className} ref={ref}>
+        {formattedDuration}
+      </Span>
+    )
+  },
+)
+DurationSpan.displayName = 'DurationSpan'
+
+export { DurationSpan }

--- a/src/components/ui/Typography/DurationSpan.tsx
+++ b/src/components/ui/Typography/DurationSpan.tsx
@@ -6,18 +6,18 @@ import { Span, type TextStyleProps } from '@ui/Typography/Text'
 
 type DurationSpanProps = {
   durationMinutes: number
-  zeroValueDisplay?: boolean
+  showLessThanOneMinuteForZero?: boolean
 } & TextStyleProps & Pick<ComponentPropsWithoutRef<'span'>, 'slot'>
 
 const DurationSpan = forwardRef<HTMLSpanElement, DurationSpanProps>(
-  ({ durationMinutes, className, zeroValueDisplay = true, ...restProps }, ref) => {
+  ({ durationMinutes, className, showLessThanOneMinuteForZero = false, ...restProps }, ref) => {
     const { t } = useTranslation()
     const { formatMinutesAsDuration } = useIntlFormatter()
     const formattedDuration = durationMinutes !== 0
       ? formatMinutesAsDuration(durationMinutes)
-      : zeroValueDisplay
-        ? t('timeTracking:label.zero_minutes', '0 min')
-        : t('timeTracking:label.less_than_one_minute', '< 1 min')
+      : showLessThanOneMinuteForZero
+        ? t('timeTracking:label.less_than_one_minute', '< 1 min')
+        : t('timeTracking:label.zero_minutes', '0 min')
 
     return (
       <Span {...restProps} className={className} ref={ref}>

--- a/src/components/ui/Typography/DurationSpan.tsx
+++ b/src/components/ui/Typography/DurationSpan.tsx
@@ -6,15 +6,18 @@ import { Span, type TextStyleProps } from '@ui/Typography/Text'
 
 type DurationSpanProps = {
   durationMinutes: number
+  zeroValueDisplay?: 'lessThanOneMinute' | 'zeroMinutes'
 } & TextStyleProps & Pick<ComponentPropsWithoutRef<'span'>, 'slot'>
 
 const DurationSpan = forwardRef<HTMLSpanElement, DurationSpanProps>(
-  ({ durationMinutes, className, ...restProps }, ref) => {
+  ({ durationMinutes, className, zeroValueDisplay = 'lessThanOneMinute', ...restProps }, ref) => {
     const { t } = useTranslation()
     const { formatMinutesAsDuration } = useIntlFormatter()
-    const formattedDuration = durationMinutes === 0
-      ? t('timeTracking:label.less_than_one_minute', '< 1 min')
-      : formatMinutesAsDuration(durationMinutes)
+    const formattedDuration = durationMinutes !== 0
+      ? formatMinutesAsDuration(durationMinutes)
+      : zeroValueDisplay === 'zeroMinutes'
+        ? t('timeTracking:label.zero_minutes', '0 min')
+        : t('timeTracking:label.less_than_one_minute', '< 1 min')
 
     return (
       <Span {...restProps} className={className} ref={ref}>

--- a/src/schemas/reports/unifiedReport.ts
+++ b/src/schemas/reports/unifiedReport.ts
@@ -112,6 +112,11 @@ const UnifiedCellValueDecimalSchema = Schema.Struct({
   value: Schema.Number,
 })
 
+const UnifiedCellValueDurationSchema = Schema.Struct({
+  type: Schema.Literal('Duration'),
+  value: Schema.Number,
+})
+
 const UnifiedCellValueEmptySchema = Schema.Struct({
   type: Schema.Literal('Empty'),
 })
@@ -125,6 +130,7 @@ const UnifiedCellValueSchema = Schema.Union(
   UnifiedCellValueCurrencySchema,
   UnifiedCellValueDateSchema,
   UnifiedCellValueDecimalSchema,
+  UnifiedCellValueDurationSchema,
   UnifiedCellValueEmptySchema,
   UnifiedCellValueUnknownSchema,
 )
@@ -133,6 +139,7 @@ export type UnifiedCellValue = typeof UnifiedCellValueSchema.Type
 export type UnifiedCellValueCurrency = typeof UnifiedCellValueCurrencySchema.Type
 export type UnifiedCellValueDate = typeof UnifiedCellValueDateSchema.Type
 export type UnifiedCellValueDecimal = typeof UnifiedCellValueDecimalSchema.Type
+export type UnifiedCellValueDuration = typeof UnifiedCellValueDurationSchema.Type
 export type UnifiedCellValueEmpty = typeof UnifiedCellValueEmptySchema.Type
 export type UnifiedCellValueUnknown = typeof UnifiedCellValueUnknownSchema.Type
 
@@ -144,6 +151,9 @@ export const isDateCellValue = (value: UnifiedCellValue): value is UnifiedCellVa
 
 export const isDecimalCellValue = (value: UnifiedCellValue): value is UnifiedCellValueDecimal =>
   value.type === 'Decimal'
+
+export const isDurationCellValue = (value: UnifiedCellValue): value is UnifiedCellValueDuration =>
+  value.type === 'Duration'
 
 export const isEmptyCellValue = (value: UnifiedCellValue): value is UnifiedCellValueEmpty =>
   value.type === 'Empty'


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it expands the unified report cell-value schema and changes how duration values are rendered across multiple screens; mismatches with backend-provided types/units could cause incorrect display.
> 
> **Overview**
> Adds first-class support for a new unified report cell value type `Duration` (minutes) and renders it in `UnifiedReportTableCellContent` via a new shared `DurationSpan` component.
> 
> Introduces `DurationSpan` to centralize minute-to-duration formatting (including configurable zero-minute display) and replaces duplicated duration formatting logic in `TimeEntriesTable` and `TimeTrackingStats` with this component for consistent output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9bce015395d61c6bec4cc2e5d54fe77991e0ed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->