### PR TITLE
Set mobile drawer style to 100% page height + top: 15svh

### DIFF
--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -49,7 +49,6 @@ type InternalModalProps = {
   children: React.ReactNode | ((renderProps: ModalRenderProps) => React.ReactNode)
 }
 
-const MODAL_CLASS_NAME = 'Layer__Modal'
 const InternalModal = forwardRef<HTMLElementTagNameMap['div'], InternalModalProps>(
   ({ children, flexBlock, flexInline, size, variant = 'center' }, ref) => {
     const dataProperties = toDataProperties({ size, 'flex-block': flexBlock, 'flex-inline': flexInline, variant })
@@ -57,7 +56,7 @@ const InternalModal = forwardRef<HTMLElementTagNameMap['div'], InternalModalProp
     return (
       <ReactAriaModal
         {...dataProperties}
-        className={MODAL_CLASS_NAME}
+        className='Layer__Modal'
         ref={ref}
       >
         {({ isEntering, isExiting }) => {
@@ -75,8 +74,6 @@ const MobileDrawerKeyboardSpacer = () => {
 
   return <div className='Layer__Dialog__KeyboardSpacer' style={{ height: keyboardHeight }} />
 }
-
-const DIALOG_CLASS_NAME = 'Layer__Dialog'
 
 type DialogSlots = {
   Header?: React.FC<DialogRenderProps>
@@ -97,7 +94,7 @@ const Dialog = forwardRef<HTMLElement, DialogComponentProps>(
       <ReactAriaDialog
         {...dataProperties}
         {...restProps}
-        className={DIALOG_CLASS_NAME}
+        className='Layer__Dialog'
         ref={ref}
       >
         {(renderProps) => {

--- a/src/components/ui/Modal/modal.scss
+++ b/src/components/ui/Modal/modal.scss
@@ -101,11 +101,11 @@
 
   &[data-variant='mobile-drawer'] {
     position: fixed;
-    bottom: 0;
+    top: 15svh;
     overflow: hidden;
 
     block-size: auto;
-    max-block-size: 80%;
+    max-block-size: 100%;
     inline-size: 100%;
 
     padding: 0;
@@ -120,7 +120,7 @@
     }
 
     &[data-fixed] {
-      min-block-size: 80%;
+      min-block-size: 100%;
     }
   }
 


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?

<img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/98286894-4369-4488-a152-13ff6bc11b9c" />

<img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/2166d80c-8e9f-44a2-b31c-0542090118e4" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change, but it alters `mobile-drawer` positioning/sizing and could affect scrolling/keyboard behavior on some mobile browsers.
> 
> **Overview**
> Updates the `mobile-drawer` modal layout to start at `top: 15svh` and allow the drawer to extend to full height (`max-block-size`/`min-block-size` now `100%` instead of `80%`).
> 
> Minor cleanup removes unused class name constants in `Modal.tsx` by inlining the `className` strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 930c91b26438449bd454f982432453cbeb8d8c5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->