### PR TITLE
polish: demo testing feedback for reports

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,6 +1,8 @@
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { flexRender, type HeaderGroup, type Row as RowType } from '@tanstack/react-table'
+import classNames from 'classnames'
 
+import { useHorizontalOverflow } from '@hooks/utils/size/useHorizontalOverflow'
 import { useColumnPinningStyles } from '@hooks/utils/tables/useColumnPinningStyles'
 import {
   Cell,
@@ -10,7 +12,7 @@ import {
   TableBody,
   TableHeader,
 } from '@ui/Table/Table'
-import { Loader } from '@components/Loader/Loader'
+import { DataTableHeaderSkeleton, DataTableSkeleton, DEFAULT_SKELETON_COLUMNS } from '@components/DataTable/DataTableSkeleton'
 
 import './dataTable.scss'
 
@@ -51,8 +53,11 @@ export const DataTable = <TData extends object>({
   numColumns,
   withClickableRow,
 }: DataTableProps<TData>) => {
-  const nonAria = headerGroups.length > 1
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const nonAria = headerGroups.length > 1 || numColumns === 0
   const { EmptyState, ErrorState } = slots
+  const hasHorizontalOverflow = useHorizontalOverflow(scrollContainerRef, { dependencies: [data, numColumns] })
+  const showLoadingFallbackHeaders = isLoading && numColumns === 0
 
   const { headerRef, pinningStyles } = useColumnPinningStyles(headerGroups)
 
@@ -69,13 +74,7 @@ export const DataTable = <TData extends object>({
     }
 
     if (isLoading) {
-      return (
-        <Row className='Layer__DataTable__EmptyState__Row' nonAria={nonAria}>
-          <Cell className='Layer__DataTable__EmptyState__Cell' colSpan={numColumns} nonAria={nonAria}>
-            <Loader />
-          </Cell>
-        </Row>
-      )
+      return <DataTableSkeleton numColumns={numColumns} nonAria={nonAria} />
     }
 
     if (isEmptyTable) {
@@ -125,31 +124,39 @@ export const DataTable = <TData extends object>({
   }, [isError, isLoading, isEmptyTable, data, nonAria, numColumns, ErrorState, EmptyState, withClickableRow, componentName, pinningStyles])
 
   return (
-    <div className='Layer__UI__Table-ScrollContainer'>
+    <div
+      ref={scrollContainerRef}
+      className={classNames(
+        'Layer__UI__Table-ScrollContainer',
+        hasHorizontalOverflow && 'Layer__UI__Table-ScrollContainer--has-horizontal-overflow',
+      )}
+    >
       <Table aria-label={ariaLabel} className={`Layer__UI__Table__${componentName}`} nonAria={nonAria}>
         <TableHeader ref={headerRef} nonAria={nonAria}>
-          {headerGroups.map(headerGroup => (
-            <Row key={headerGroup.id} nonAria={nonAria}>
-              {headerGroup.headers.map(header => (
-                <Column
-                  key={header.id}
-                  isRowHeader={header.column.columnDef.meta?.isRowHeader}
-                  className={`Layer__UI__Table-Column__${componentName}--${header.id}`}
-                  alignment={header.column.columnDef.meta?.alignment}
-                  pinned={header.column.getIsPinned()}
-                  style={pinningStyles.get(header.column.id)}
-                  nonAria={nonAria}
-                  colSpan={header.colSpan}
-                >
-                  {header.isPlaceholder
-                    ? null
-                    : (typeof header.column.columnDef.header === 'function'
-                      ? header.column.columnDef.header(header.getContext())
-                      : header.column.columnDef.header)}
-                </Column>
-              ))}
-            </Row>
-          ))}
+          {showLoadingFallbackHeaders
+            ? <DataTableHeaderSkeleton nonAria={nonAria} numColumns={DEFAULT_SKELETON_COLUMNS} />
+            : headerGroups.map(headerGroup => (
+              <Row key={headerGroup.id} nonAria={nonAria}>
+                {headerGroup.headers.map(header => (
+                  <Column
+                    key={header.id}
+                    isRowHeader={header.column.columnDef.meta?.isRowHeader}
+                    className={`Layer__UI__Table-Column__${componentName}--${header.id}`}
+                    alignment={header.column.columnDef.meta?.alignment}
+                    pinned={header.column.getIsPinned()}
+                    style={pinningStyles.get(header.column.id)}
+                    nonAria={nonAria}
+                    colSpan={header.colSpan}
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : (typeof header.column.columnDef.header === 'function'
+                        ? header.column.columnDef.header(header.getContext())
+                        : header.column.columnDef.header)}
+                  </Column>
+                ))}
+              </Row>
+            ))}
         </TableHeader>
         <TableBody dependencies={dependencies} nonAria={nonAria}>
           {renderTableBody}

--- a/src/components/DataTable/DataTableSkeleton.tsx
+++ b/src/components/DataTable/DataTableSkeleton.tsx
@@ -1,0 +1,64 @@
+import { useMemo } from 'react'
+
+import {
+  Cell,
+  Column,
+  Row,
+} from '@ui/Table/Table'
+import { SkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
+
+import './dataTableSkeleton.scss'
+
+type DataTableSkeletonProps = {
+  nonAria: boolean
+  numColumns: number
+}
+
+type DataTableHeaderSkeletonProps = {
+  nonAria: boolean
+  numColumns?: number
+}
+
+export const DEFAULT_SKELETON_COLUMNS = 3
+
+export const DataTableHeaderSkeleton = ({ nonAria, numColumns = DEFAULT_SKELETON_COLUMNS }: DataTableHeaderSkeletonProps) => {
+  const resolvedNumColumns = numColumns > 0 ? numColumns : DEFAULT_SKELETON_COLUMNS
+
+  return (
+    <Row nonAria={nonAria}>
+      {Array.from({ length: resolvedNumColumns }).map((_, index) => (
+        <Column key={`loading-header-${index}`} nonAria={nonAria}>
+          <SkeletonLoader width={index === 0 ? '60%' : '40%'} height='12px' />
+        </Column>
+      ))}
+    </Row>
+  )
+}
+
+export const DataTableSkeleton = ({ numColumns, nonAria }: DataTableSkeletonProps) => {
+  const resolvedNumColumns = numColumns > 0 ? numColumns : DEFAULT_SKELETON_COLUMNS
+
+  const loadingColumns = useMemo(
+    () => Array.from({ length: resolvedNumColumns }, (_, index) => ({ index })),
+    [resolvedNumColumns],
+  )
+
+  return (
+    <>
+      {Array.from({ length: 6 }).map((_, rowIndex) => (
+        <Row key={`loading-${rowIndex}`} nonAria={nonAria}>
+          {loadingColumns.map((column) => {
+            const trim = column.index === 0 && rowIndex >= 3
+              ? (rowIndex - 2) * 10
+              : 0
+            return (
+              <Cell key={`loading-${rowIndex}-${column.index}`} className='Layer__skeleton-loader__row' nonAria={nonAria}>
+                <SkeletonLoader width={`${100 - trim}%`} height='20px' />
+              </Cell>
+            )
+          })}
+        </Row>
+      ))}
+    </>
+  )
+}

--- a/src/components/DataTable/DataTableSkeleton.tsx
+++ b/src/components/DataTable/DataTableSkeleton.tsx
@@ -7,8 +7,6 @@ import {
 } from '@ui/Table/Table'
 import { SkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
 
-import './dataTableSkeleton.scss'
-
 type DataTableSkeletonProps = {
   nonAria: boolean
   numColumns: number

--- a/src/components/DataTable/dataTableSkeleton.scss
+++ b/src/components/DataTable/dataTableSkeleton.scss
@@ -1,3 +1,0 @@
-.Layer__DataTable__SkeletonGroup {
-  width: 100%;
-}

--- a/src/components/DataTable/dataTableSkeleton.scss
+++ b/src/components/DataTable/dataTableSkeleton.scss
@@ -1,0 +1,3 @@
+.Layer__DataTable__SkeletonGroup {
+  width: 100%;
+}

--- a/src/components/TreeNavigation/TreeNavigation.tsx
+++ b/src/components/TreeNavigation/TreeNavigation.tsx
@@ -6,7 +6,6 @@ import {
 } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
 
-import Check from '@icons/Check'
 import ChevronRight from '@icons/ChevronRight'
 import { HStack } from '@ui/Stack/Stack'
 import { Tree, TreeItem, TreeItemContent } from '@ui/Tree/Tree'
@@ -85,10 +84,7 @@ type RenderTreeLeafArgs<TLeaf extends object> = {
 const renderTreeLeaf = <TLeaf extends object>({ leaf, leafConfig }: RenderTreeLeafArgs<TLeaf>): ReactElement => (
   <TreeItem id={leafConfig.getId(leaf)} textValue={leafConfig.getTextValue(leaf)}>
     <TreeItemContent>
-      <HStack align='center' justify='space-between'>
-        {leafConfig.renderLabel(leaf)}
-        <Check className='Layer__TreeNavigation__Check' />
-      </HStack>
+      {leafConfig.renderLabel(leaf)}
     </TreeItemContent>
   </TreeItem>
 )

--- a/src/components/TreeNavigation/treeNavigation.scss
+++ b/src/components/TreeNavigation/treeNavigation.scss
@@ -9,12 +9,6 @@
   border-bottom: 1px solid var(--color-base-300);
   cursor: pointer;
 
-  .Layer__TreeNavigation__Check {
-    visibility: hidden;
-    height: 1rem;
-    min-width: 1rem;
-  }
-
   &[aria-level='1'] {
     background-color: var(--color-base-0);
   }
@@ -28,7 +22,7 @@
   }
 
   &[data-selected] {
-    font-weight: var(--font-weight-bold);
+    background-color: var(--color-base-100);
 
     &::after {
       content: '';
@@ -38,10 +32,6 @@
       bottom: 0;
       width: 2px;
       background: black;
-    }
-
-    .Layer__TreeNavigation__Check {
-      visibility: visible;
     }
   }
 }

--- a/src/components/UnifiedReport/UnifiedReport.tsx
+++ b/src/components/UnifiedReport/UnifiedReport.tsx
@@ -30,7 +30,7 @@ const UnifiedReportContent = () => {
 
   return (
     <View title={t('reports:label.reports', 'Reports')} viewClassName='Layer__UnifiedReport' header={header}>
-      <HStack>
+      <HStack className='Layer__UnifiedReport__Body'>
         {isDesktop && (
           <VStack className='Layer__UnifiedReport__Sidebar'>
             <ReportsNavigation />

--- a/src/components/UnifiedReport/UnifiedReportTable.tsx
+++ b/src/components/UnifiedReport/UnifiedReportTable.tsx
@@ -36,8 +36,8 @@ export const UnifiedReportTable = () => {
     return (
       <DataState
         status={DataStateStatus.allDone}
-        title={t('reports:empty.no_rows_found', 'No rows found')}
-        description={t('reports:empty.report_has_no_rows', 'This report has no rows.')}
+        title={t('reports:empty.no_rows_found', 'No line items found')}
+        description={t('reports:empty.report_has_no_rows', 'This report has no line items.')}
         spacing
       />
     )

--- a/src/components/UnifiedReport/unifiedReport.scss
+++ b/src/components/UnifiedReport/unifiedReport.scss
@@ -1,5 +1,6 @@
 .Layer__view.Layer__UnifiedReport {
   overflow: hidden;
+  max-height: 100vh;
   min-width: clamp(23rem, 100%, 1406px);
 
   .Layer__view-main.Layer__view-main {
@@ -11,12 +12,18 @@
   }
 }
 
+.Layer__UnifiedReport__Body {
+  max-height: calc(100vh - 76px);
+}
+
 .Layer__UnifiedReport__Sidebar {
   flex-shrink: 0;
-  width: 15rem;
+  overflow-y: auto;
+  width: clamp(14rem, 16vw, 24rem);
   border-right: 1px solid var(--color-base-300);
 }
 
 .Layer__UnifiedReport__Content {
+  overflow-y: auto;
   min-width: 0;
 }

--- a/src/components/UnifiedReport/unifiedReportTable.scss
+++ b/src/components/UnifiedReport/unifiedReportTable.scss
@@ -1,9 +1,14 @@
 .Layer__UI__Table__UnifiedReport {
+  width: max-content;
   min-width: 100%;
 
   .Layer__UI__Table-Column,
   .Layer__UI__Table-Cell {
     display: table-cell;
     min-width: 6rem;
+  }
+
+  .Layer__UI__Table-TableBody .Layer__UI__Table-Row:last-child .Layer__UI__Table-Cell {
+    border-bottom: 1px solid var(--color-base-300);
   }
 }

--- a/src/components/UnifiedReport/unifiedReportTable.scss
+++ b/src/components/UnifiedReport/unifiedReportTable.scss
@@ -1,14 +1,11 @@
 .Layer__UI__Table__UnifiedReport {
   width: max-content;
   min-width: 100%;
+  border-block: 1px solid var(--color-base-300);
 
   .Layer__UI__Table-Column,
   .Layer__UI__Table-Cell {
     display: table-cell;
     min-width: 6rem;
-  }
-
-  .Layer__UI__Table-TableBody .Layer__UI__Table-Row:last-child .Layer__UI__Table-Cell {
-    border-bottom: 1px solid var(--color-base-300);
   }
 }

--- a/src/components/ui/Table/table.scss
+++ b/src/components/ui/Table/table.scss
@@ -101,6 +101,18 @@
   background-color: inherit;
 }
 
+.Layer__UI__Table-ScrollContainer.Layer__UI__Table-ScrollContainer--has-horizontal-overflow {
+  .Layer__UI__Table-Column[data-pinned='left'],
+  .Layer__UI__Table-Cell[data-pinned='left'] {
+    border-right: 1px solid var(--color-base-200);
+  }
+
+  .Layer__UI__Table-Column[data-pinned='right'],
+  .Layer__UI__Table-Cell[data-pinned='right'] {
+    border-left: 1px solid var(--color-base-200);
+  }
+}
+
 .Layer__UI__Table-TableHeader .Layer__UI__Table-Column[data-pinned] {
   z-index: 2;
   background-color: var(--color-base-0);

--- a/src/components/ui/Table/table.scss
+++ b/src/components/ui/Table/table.scss
@@ -5,6 +5,7 @@
 
 .Layer__UI__Table-TableHeader {
   height: 3.25rem;
+  background-color: var(--color-base-0);
 
   &:not(:last-child) .Layer__UI__Table-Column {
     border-bottom: 1px solid var(--color-base-300);
@@ -115,5 +116,4 @@
 
 .Layer__UI__Table-TableHeader .Layer__UI__Table-Column[data-pinned] {
   z-index: 2;
-  background-color: var(--color-base-0);
 }

--- a/src/hooks/utils/size/useHorizontalOverflow.ts
+++ b/src/hooks/utils/size/useHorizontalOverflow.ts
@@ -1,0 +1,40 @@
+import { type RefObject, useCallback, useEffect, useState } from 'react'
+import useResizeObserver from '@react-hook/resize-observer'
+
+type UseHorizontalOverflowOptions = {
+  dependencies?: unknown[]
+}
+
+export function useHorizontalOverflow(
+  elementRef: RefObject<HTMLElement | null>,
+  options: UseHorizontalOverflowOptions = { dependencies: [] },
+) {
+  const { dependencies = [] } = options
+  const [hasHorizontalOverflow, setHasHorizontalOverflow] = useState(false)
+
+  const updateHorizontalOverflow = useCallback(() => {
+    const element = elementRef.current
+    if (!element) return
+
+    setHasHorizontalOverflow(Math.ceil(element.scrollWidth) > Math.ceil(element.clientWidth))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elementRef, ...dependencies])
+
+  useResizeObserver(elementRef, updateHorizontalOverflow)
+  useEffect(() => {
+    const element = elementRef.current?.firstElementChild as HTMLElement | null
+    if (!element) return
+
+    const observer = new ResizeObserver(() => updateHorizontalOverflow())
+    observer.observe(element)
+
+    return () => observer.disconnect()
+  }, [elementRef, updateHorizontalOverflow])
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => updateHorizontalOverflow())
+    return () => cancelAnimationFrame(id)
+  }, [updateHorizontalOverflow])
+
+  return hasHorizontalOverflow
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,4 +1,7 @@
-.Layer__component * {
+.Layer__component *,
+.Layer__view * {
+  scrollbar-width: thin;
+
   &::-webkit-scrollbar {
     height: 6px;
     width: 6px;

--- a/src/styles/reports.scss
+++ b/src/styles/reports.scss
@@ -1,3 +1,7 @@
+.Layer__reports {
+  overflow: hidden;
+}
+
 .Layer__reports .Layer__panel__content {
   border-radius: var(--border-radius-sm);
 }


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI risk: adds a new overflow-detection hook using `ResizeObserver` and applies global scrollbar styling, which could affect table rendering/scrolling across views and browsers.
> 
> **Overview**
> Polishes report/table UX by replacing the `DataTable` loading spinner with a new skeleton-based loading state (including fallback headers when the column count is unknown).
> 
> Adds `useHorizontalOverflow` to detect horizontal overflow and conditionally style pinned columns with divider borders only when scrolling is needed, and tweaks table header background defaults.
> 
> Updates reports navigation/Unified Report layout to use scrollable sidebar/content areas with capped viewport heights, adjusts Unified Report table sizing/borders, and refines TreeNavigation selection styling (removing the check icon and using a selection indicator).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bcefa7424488f3ebd34e06dfdab4baab0cc90c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->