### PR TITLE
Undoing card layout flip booking vs booked

### DIFF
--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -38,38 +38,19 @@ const BookkeepingOverviewTasksContent = ({
   onBookCall,
   onClickReconnectAccounts,
 }: BookkeepingOverviewTasksContentProps) => {
-  const callBookingEmptyPromptFirst =
-    showCallBookingCard && callBooking == null
-
-  if (callBookingEmptyPromptFirst) {
-    return (
-      <>
-        <CallBooking
-          callBooking={callBooking}
-          onBookCall={onBookCall}
-        />
-        <Tasks
-          mobile={tasksMobile}
-          stringOverrides={tasksStringOverrides}
-          onClickReconnectAccounts={onClickReconnectAccounts}
-        />
-      </>
-    )
-  }
-
   return (
     <>
-      <Tasks
-        mobile={tasksMobile}
-        stringOverrides={tasksStringOverrides}
-        onClickReconnectAccounts={onClickReconnectAccounts}
-      />
       {showCallBookingCard && (
         <CallBooking
           callBooking={callBooking}
           onBookCall={onBookCall}
         />
       )}
+      <Tasks
+        mobile={tasksMobile}
+        stringOverrides={tasksStringOverrides}
+        onClickReconnectAccounts={onClickReconnectAccounts}
+      />
     </>
   )
 }


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->
<img width="1502" height="757" alt="Screenshot 2026-05-01 at 11 05 32 AM" src="https://github.com/user-attachments/assets/9028e73e-bed9-4d8c-8024-1beb28e64a6d" />

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout change that reorders `CallBooking` and `Tasks` rendering; no data or auth logic impacted.
> 
> **Overview**
> Restores the `BookkeepingOverview` tasks panel layout to always render the `CallBooking` card *above* `Tasks` whenever `showCallBookingCard` is true.
> 
> This removes the prior conditional that flipped the order depending on whether `callBooking` was present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71943449ac0dfc651e20225069a437c7009afe6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->