### PR TITLE
fix: fix mobile responsive design for bookkeeping tasks

### DIFF
--- a/src/components/Tabs/tabs.scss
+++ b/src/components/Tabs/tabs.scss
@@ -106,15 +106,3 @@
       width 150ms ease;
   }
 }
-
-@container (width <= 400px) {
-  .Layer__tabs-option {
-    .Layer__tasks__badge .Layer__tasks__badge__label {
-      display: none;
-    }
-
-    .Layer__tasks__badge .Layer__tasks__badge__label-short {
-      display: flex;
-    }
-  }
-}

--- a/src/components/Tasks/TaskMonthTile.tsx
+++ b/src/components/Tasks/TaskMonthTile.tsx
@@ -7,10 +7,11 @@ export type TaskMonthTileProps = {
   data: MonthData
   active?: boolean
   disabled?: boolean
+  isMobile: boolean
   onClick: (date: Date) => void
 }
 
-export const TaskMonthTile = ({ data, onClick, active, disabled }: TaskMonthTileProps) => {
+export const TaskMonthTile = ({ data, onClick, active, disabled, isMobile }: TaskMonthTileProps) => {
   const dataProperties = toDataProperties({ active, disabled })
 
   return (
@@ -23,7 +24,7 @@ export const TaskMonthTile = ({ data, onClick, active, disabled }: TaskMonthTile
         {data.monthStr}
       </Text>
       {data.status && (
-        <TaskStatusBadge status={data.status} tasksCount={data.total - data.completed} />
+        <TaskStatusBadge status={data.status} tasksCount={data.total - data.completed} isMobile={isMobile} />
       )}
     </div>
   )

--- a/src/components/Tasks/TaskStatusBadge.tsx
+++ b/src/components/Tasks/TaskStatusBadge.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react'
+import type { TFunction } from 'i18next'
+import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { tPlural } from '@utils/i18n/plural'
@@ -18,61 +19,56 @@ type TaskStatusBadgeProps = {
   tasksCount?: number
 }
 
-const useBadgeConfig = (
+type BadgeColor = 'info' | 'warning' | 'success'
+
+type BadgeConfig = {
+  color: BadgeColor
+  icon: ReactNode
+  label?: string
+  labelShort?: string
+}
+
+const buildLongLabel = (
+  t: TFunction,
+  formatNumber: (n: number) => string,
+  tasksCount: number,
+) =>
+  tPlural(t, 'bookkeeping:label.count_tasks', {
+    count: tasksCount,
+    displayCount: formatNumber(tasksCount),
+    one: '{{displayCount}} task',
+    other: '{{displayCount}} tasks',
+  })
+
+const getBadgeConfig = (
   status: TaskStatusBadgeProps['status'],
   tasksCount: TaskStatusBadgeProps['tasksCount'],
-) => {
-  const { t } = useTranslation()
-  const { formatNumber } = useIntlFormatter()
-  const { isMobile } = useSizeClass()
-
-  const label = useMemo(() => {
-    if (!tasksCount) {
-      return undefined
-    }
-
-    if (isMobile) {
-      return formatNumber(tasksCount)
-    }
-
-    return tPlural(t, 'bookkeeping:label.count_tasks', {
-      count: tasksCount,
-      displayCount: formatNumber(tasksCount),
-      one: '{{displayCount}} task',
-      other: '{{displayCount}} tasks',
-    })
-  }, [tasksCount, t, formatNumber, isMobile])
-
+  t: TFunction,
+  formatNumber: (n: number) => string,
+): BadgeConfig | undefined => {
   switch (status) {
     case BookkeepingPeriodStatus.IN_PROGRESS_AWAITING_BOOKKEEPER:
     case BookkeepingPeriodStatus.NOT_STARTED:
     case BookkeepingPeriodStatus.CLOSING_IN_REVIEW: {
       return {
-        color: 'info' as const,
+        color: 'info',
         icon: <Clock size={12} />,
-        label,
+        label: tasksCount ? buildLongLabel(t, formatNumber, tasksCount) : undefined,
         labelShort: tasksCount ? formatNumber(tasksCount) : undefined,
       }
     }
     case BookkeepingPeriodStatus.IN_PROGRESS_AWAITING_CUSTOMER:
     case BookkeepingPeriodStatus.CLOSED_OPEN_TASKS: {
       return {
-        color: 'warning' as const,
-        label: tasksCount
-          ? tPlural(t, 'bookkeeping:label.count_tasks', {
-            count: tasksCount,
-            displayCount: formatNumber(tasksCount),
-            one: '{{displayCount}} task',
-            other: '{{displayCount}} tasks',
-          })
-          : undefined,
-        labelShort: tasksCount ? formatNumber(tasksCount) : undefined,
+        color: 'warning',
         icon: <AlertCircle size={12} />,
+        label: tasksCount ? buildLongLabel(t, formatNumber, tasksCount) : undefined,
+        labelShort: tasksCount ? formatNumber(tasksCount) : undefined,
       }
     }
     case BookkeepingPeriodStatus.CLOSED_COMPLETE: {
       return {
-        color: 'success' as const,
+        color: 'success',
         icon: <CheckCircle size={12} />,
       }
     }
@@ -89,28 +85,48 @@ const useBadgeConfig = (
   }
 }
 
-export const TaskStatusBadge = ({ status, tasksCount }: TaskStatusBadgeProps) => {
-  const badgeConfig = useBadgeConfig(status, tasksCount)
-  const { isMobile } = useSizeClass()
-  if (!badgeConfig) {
-    return
-  }
-  const dataProperties = toDataProperties({ status: badgeConfig.color, icononly: !badgeConfig.label })
+type BadgeContentProps = {
+  color: BadgeColor
+  icon: ReactNode
+  display?: string
+}
+
+const BadgeContent = ({ color, icon, display }: BadgeContentProps) => {
+  const dataProperties = toDataProperties({ status: color, icononly: !display })
 
   return (
     <HStack className='Layer__TasksBadge' {...dataProperties}>
-      <HStack align='center' justify='center' className='Layer__TasksBadge__Icon' data-status={badgeConfig.color}>
-        {badgeConfig.icon}
+      <HStack align='center' justify='center' className='Layer__TasksBadge__Icon' data-status={color}>
+        {icon}
       </HStack>
-      <Text
-        className='Layer__TasksBadge__Label'
-        size={TextSize.sm}
-        status={badgeConfig.color}
-        invertColor={badgeConfig.color === 'warning'}
-        weight={TextWeight.bold}
-      >
-        {isMobile ? badgeConfig.labelShort : badgeConfig.label}
-      </Text>
+      {display
+        ? (
+          <Text
+            className='Layer__TasksBadge__Label'
+            size={TextSize.sm}
+            status={color}
+            invertColor={color === 'warning'}
+            weight={TextWeight.bold}
+          >
+            {display}
+          </Text>
+        )
+        : null}
     </HStack>
   )
+}
+
+export const TaskStatusBadge = ({ status, tasksCount }: TaskStatusBadgeProps) => {
+  const { t } = useTranslation()
+  const { formatNumber } = useIntlFormatter()
+  const { isMobile } = useSizeClass()
+
+  const badgeConfig = getBadgeConfig(status, tasksCount, t, formatNumber)
+  if (!badgeConfig) {
+    return
+  }
+
+  const display = isMobile ? badgeConfig.labelShort : badgeConfig.label
+
+  return <BadgeContent color={badgeConfig.color} icon={badgeConfig.icon} display={display} />
 }

--- a/src/components/Tasks/TaskStatusBadge.tsx
+++ b/src/components/Tasks/TaskStatusBadge.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { tPlural } from '@utils/i18n/plural'
@@ -5,9 +6,11 @@ import { toDataProperties } from '@utils/styleUtils/toDataProperties'
 import { safeAssertUnreachable } from '@utils/switch/assertUnreachable'
 import { type BookkeepingPeriod, BookkeepingPeriodStatus } from '@hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import AlertCircle from '@icons/AlertCircle'
 import CheckCircle from '@icons/CheckCircle'
 import Clock from '@icons/Clock'
+import { HStack } from '@ui/Stack/Stack'
 import { Text, TextSize, TextWeight } from '@components/Typography/Text'
 
 type TaskStatusBadgeProps = {
@@ -21,6 +24,24 @@ const useBadgeConfig = (
 ) => {
   const { t } = useTranslation()
   const { formatNumber } = useIntlFormatter()
+  const { isMobile } = useSizeClass()
+
+  const label = useMemo(() => {
+    if (!tasksCount) {
+      return undefined
+    }
+
+    if (isMobile) {
+      return formatNumber(tasksCount)
+    }
+
+    return tPlural(t, 'bookkeeping:label.count_tasks', {
+      count: tasksCount,
+      displayCount: formatNumber(tasksCount),
+      one: '{{displayCount}} task',
+      other: '{{displayCount}} tasks',
+    })
+  }, [tasksCount, t, formatNumber, isMobile])
 
   switch (status) {
     case BookkeepingPeriodStatus.IN_PROGRESS_AWAITING_BOOKKEEPER:
@@ -29,14 +50,7 @@ const useBadgeConfig = (
       return {
         color: 'info' as const,
         icon: <Clock size={12} />,
-        label: tasksCount
-          ? tPlural(t, 'bookkeeping:label.count_tasks', {
-            count: tasksCount,
-            displayCount: formatNumber(tasksCount),
-            one: '{{displayCount}} task',
-            other: '{{displayCount}} tasks',
-          })
-          : undefined,
+        label,
         labelShort: tasksCount ? formatNumber(tasksCount) : undefined,
       }
     }
@@ -77,45 +91,26 @@ const useBadgeConfig = (
 
 export const TaskStatusBadge = ({ status, tasksCount }: TaskStatusBadgeProps) => {
   const badgeConfig = useBadgeConfig(status, tasksCount)
-
+  const { isMobile } = useSizeClass()
   if (!badgeConfig) {
     return
   }
-
   const dataProperties = toDataProperties({ status: badgeConfig.color, icononly: !badgeConfig.label })
 
   return (
-    <span className='Layer__tasks__badge' {...dataProperties}>
-      <span className='Layer__tasks__badge__icon-wrapper' data-status={badgeConfig.color}>
+    <HStack className='Layer__TasksBadge' {...dataProperties}>
+      <HStack align='center' justify='center' className='Layer__TasksBadge__Icon' data-status={badgeConfig.color}>
         {badgeConfig.icon}
-      </span>
-      {
-        /*
-         * The labels are both rendered, BUT only one is visible at a time (controlled by container query)
-         */
-      }
-      {badgeConfig.label && (
-        <Text
-          className='Layer__tasks__badge__label'
-          size={TextSize.sm}
-          status={badgeConfig.color}
-          invertColor={badgeConfig.color === 'warning'}
-          weight={TextWeight.bold}
-        >
-          {badgeConfig.label}
-        </Text>
-      )}
-      {badgeConfig.labelShort && (
-        <Text
-          className='Layer__tasks__badge__label-short'
-          size={TextSize.sm}
-          status={badgeConfig.color}
-          invertColor={badgeConfig.color === 'warning'}
-          weight={TextWeight.bold}
-        >
-          {badgeConfig.labelShort}
-        </Text>
-      )}
-    </span>
+      </HStack>
+      <Text
+        className='Layer__TasksBadge__Label'
+        size={TextSize.sm}
+        status={badgeConfig.color}
+        invertColor={badgeConfig.color === 'warning'}
+        weight={TextWeight.bold}
+      >
+        {isMobile ? badgeConfig.labelShort : badgeConfig.label}
+      </Text>
+    </HStack>
   )
 }

--- a/src/components/Tasks/TaskStatusBadge.tsx
+++ b/src/components/Tasks/TaskStatusBadge.tsx
@@ -7,7 +7,6 @@ import { toDataProperties } from '@utils/styleUtils/toDataProperties'
 import { safeAssertUnreachable } from '@utils/switch/assertUnreachable'
 import { type BookkeepingPeriod, BookkeepingPeriodStatus } from '@hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
-import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import AlertCircle from '@icons/AlertCircle'
 import CheckCircle from '@icons/CheckCircle'
 import Clock from '@icons/Clock'
@@ -17,6 +16,7 @@ import { Text, TextSize, TextWeight } from '@components/Typography/Text'
 type TaskStatusBadgeProps = {
   status: BookkeepingPeriod['status']
   tasksCount?: number
+  isMobile: boolean
 }
 
 type BadgeColor = 'info' | 'warning' | 'success'
@@ -116,10 +116,9 @@ const BadgeContent = ({ color, icon, display }: BadgeContentProps) => {
   )
 }
 
-export const TaskStatusBadge = ({ status, tasksCount }: TaskStatusBadgeProps) => {
+export const TaskStatusBadge = ({ status, tasksCount, isMobile }: TaskStatusBadgeProps) => {
   const { t } = useTranslation()
   const { formatNumber } = useIntlFormatter()
-  const { isMobile } = useSizeClass()
 
   const badgeConfig = getBadgeConfig(status, tasksCount, t, formatNumber)
   if (!badgeConfig) {

--- a/src/components/Tasks/Tasks.tsx
+++ b/src/components/Tasks/Tasks.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { useBookkeepingPeriods } from '@hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods'
 import { CallBookingPurpose, useCallBookings } from '@hooks/api/businesses/[business-id]/call-bookings/useCallBookings'
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { VStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
 import { P, Span } from '@ui/Typography/Text'
@@ -51,6 +52,7 @@ export function Tasks({
   const { t } = useTranslation()
   const { data, isLoading } = useBookkeepingPeriods()
   const { data: callBookings, isLoading: isLoadingCallBookings } = useCallBookings()
+  const { isMobile } = useSizeClass()
 
   const tasksState: TasksState = useMemo(() => {
     if (isLoading || isLoadingCallBookings) {
@@ -106,8 +108,8 @@ export function Tasks({
           >
             {() => (
               <>
-                <TasksYearsTabs />
-                <TasksMonthSelector />
+                <TasksYearsTabs isMobile={isMobile} />
+                <TasksMonthSelector isMobile={isMobile} />
                 <TasksPending />
                 <TasksList mobile={mobile} />
               </>

--- a/src/components/Tasks/TasksMonthSelector.tsx
+++ b/src/components/Tasks/TasksMonthSelector.tsx
@@ -22,7 +22,11 @@ function useActiveYearBookkeepingPeriods() {
   return { periodsInActiveYear }
 }
 
-function TasksMonthSelector() {
+type TasksMonthSelectorProps = {
+  isMobile: boolean
+}
+
+function TasksMonthSelector({ isMobile }: TasksMonthSelectorProps) {
   const { date } = useGlobalDate()
   const { formatDate } = useIntlFormatter()
   const { setMonthByPeriod } = useGlobalDatePeriodAlignedActions()
@@ -78,6 +82,7 @@ function TasksMonthSelector() {
             data={monthData}
             active={monthData.month === activeMonthNumber}
             disabled={monthData.disabled}
+            isMobile={isMobile}
           />
         )
       })}

--- a/src/components/Tasks/TasksYearsTabs.tsx
+++ b/src/components/Tasks/TasksYearsTabs.tsx
@@ -9,7 +9,11 @@ import { useGlobalDate, useGlobalDatePeriodAlignedActions } from '@providers/Glo
 import { Tabs } from '@components/Tabs/Tabs'
 import { TaskStatusBadge } from '@components/Tasks/TaskStatusBadge'
 
-export const TasksYearsTabs = () => {
+type TasksYearsTabsProps = {
+  isMobile: boolean
+}
+
+export const TasksYearsTabs = ({ isMobile }: TasksYearsTabsProps) => {
   const { date } = useGlobalDate()
   const { setMonthByPeriod } = useGlobalDatePeriodAlignedActions()
   const { formatDate } = useIntlFormatter()
@@ -38,13 +42,14 @@ export const TasksYearsTabs = () => {
               <TaskStatusBadge
                 status={y.unresolvedTasks ? BookkeepingPeriodStatus.IN_PROGRESS_AWAITING_CUSTOMER : BookkeepingPeriodStatus.CLOSED_COMPLETE}
                 tasksCount={y.unresolvedTasks}
+                isMobile={isMobile}
               />
             )
             : null,
 
         }
       })
-  }, [formatDate, yearStatuses])
+  }, [formatDate, yearStatuses, isMobile])
 
   return (
     <Tabs

--- a/src/styles/tasks.scss
+++ b/src/styles/tasks.scss
@@ -310,7 +310,7 @@
   }
 }
 
-.Layer__tasks__badge {
+.Layer__TasksBadge {
   display: flex;
   gap: var(--spacing-3xs);
   align-items: center;
@@ -320,20 +320,6 @@
   font-size: var(--text-xs);
   color: var(--color-info-warning-bg);
   white-space: nowrap;
-
-  .Layer__tasks__badge__label-short {
-    display: none;
-  }
-
-  @container (width <= 130px) {
-    .Layer__tasks__badge__label {
-      display: none;
-    }
-
-    .Layer__tasks__badge__label-short {
-      display: flex;
-    }
-  }
 
   &[data-icononly] {
     gap: 0;
@@ -347,10 +333,7 @@
     line-height: 10px;
   }
 
-  .Layer__tasks__badge__icon-wrapper {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  .Layer__TasksBadge__Icon {
     height: 16px;
     width: 16px;
     border-radius: 50%;
@@ -387,14 +370,6 @@
 
   @container (min-width: 680px) {
     grid-template-columns: repeat(4, 1fr);
-  }
-
-  @container (max-width: 400px) {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  @container (max-width: 340px) {
-    grid-template-columns: repeat(1, 1fr);
   }
 }
 


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

Mobile design for bookkeeping tasks is too long.

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

Before:
<img width="359" height="1169" alt="image" src="https://github.com/user-attachments/assets/92490972-c007-470c-98af-6847ac3eb7d0" />


After:
<img width="380" height="660" alt="image" src="https://github.com/user-attachments/assets/53677a40-c1d2-4624-92b7-56fec95b9826" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `TaskStatusBadge`/month selector/tabs component APIs to require an `isMobile` prop; any external usage not updated will break. UI-only behavior changes but could regress badge display/spacing across breakpoints.
> 
> **Overview**
> Improves mobile responsiveness for the bookkeeping Tasks UI by switching status badges to *explicitly* render a short vs long label based on an `isMobile` flag, rather than relying on container-query CSS that rendered both labels.
> 
> Wires `isMobile` from `useSizeClass()` through `Tasks` into `TasksYearsTabs`, `TasksMonthSelector`, and `TaskMonthTile`, and refactors `TaskStatusBadge` markup/styles (new `Layer__TasksBadge` class) while removing several container-query rules for badges and month-grid layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef62a0c47f46e9ce7ae016bcada74278e146fe55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->