### PR TITLE
chore: release v0.1.129-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.129-alpha",
+  "version": "0.1.129-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.129-alpha",
+      "version": "0.1.129-alpha.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.129-alpha",
+  "version": "0.1.129-alpha.1",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.129-alpha.1`.

- Mode: **alpha**
- Tag (post-merge): `v0.1.129-alpha.1`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates package metadata (version fields) with no runtime code changes.
> 
> **Overview**
> Updates `@layerfi/components` release metadata by bumping the version from `0.1.129-alpha` to `0.1.129-alpha.1` in `package.json` and `package-lock.json` (and normalizes the trailing newline in `package.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c732355f087054acb3d1ea5a9f3b2ea2912ecb7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->