### PR TITLE
fix: allow year picker to flex on unified reports

### DIFF
--- a/src/components/UnifiedReport/unifiedReportControls.scss
+++ b/src/components/UnifiedReport/unifiedReportControls.scss
@@ -17,7 +17,8 @@
   &[data-variant='small'],
   &[data-variant='medium'] {
     > *,
-    .Layer__DateGroupByComboBox__Container {
+    .Layer__DateGroupByComboBox__Container,
+    .Layer__YearPicker {
       inline-size: 100%;
       max-inline-size: none;
     }


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change scoped to unified report controls; potential impact is limited to layout/styling of the year picker in small/medium variants.
> 
> **Overview**
> Ensures the unified report controls grid lets `Layer__YearPicker` flex to full width for `data-variant='small'` and `data-variant='medium'`, aligning it with existing full-width control sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7998970084ff724da0e308b87ea5b1f79d10d5e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->