### PR TITLE
fix: column headers overlap pinned columns

### DIFF
--- a/src/components/ui/Table/table.scss
+++ b/src/components/ui/Table/table.scss
@@ -124,4 +124,5 @@
 
 .Layer__UI__Table-TableHeader .Layer__UI__Table-Column[data-pinned] {
   z-index: 2;
+  background-color: var(--color-base-0);
 }


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that adjusts table header styling for pinned columns; potential impact is limited to table header appearance in edge layouts.
> 
> **Overview**
> Fixes a visual bug where pinned header cells could overlap/bleed over adjacent content by giving `.Layer__UI__Table-TableHeader .Layer__UI__Table-Column[data-pinned]` an explicit `background-color` to match the header (`--color-base-0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c12fa17507f9bf09625111046c146bacb46136d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->