### PR TITLE
fix: ensure both unified report headers have borders

### DIFF
--- a/src/components/UnifiedReport/UnifiedReportBaseHeader.tsx
+++ b/src/components/UnifiedReport/UnifiedReportBaseHeader.tsx
@@ -6,12 +6,14 @@ import { SkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
 import { UnifiedReportControls } from '@components/UnifiedReport/UnifiedReportControls'
 import { UnifiedReportHeaderButtons } from '@components/UnifiedReport/UnifiedReportHeaderButtons'
 
+import './unifiedReportBaseHeader.scss'
+
 export const UnifiedReportBaseHeader = () => {
   const { baseReport } = useBaseUnifiedReport()
   const { isDesktop } = useSizeClass()
 
   return (
-    <VStack>
+    <VStack className='Layer__UnifiedReport__BaseHeader'>
       {isDesktop && (
         <HStack pi='lg' pbs='lg' align='center' justify='space-between'>
           {baseReport

--- a/src/components/UnifiedReport/unifiedReportBaseHeader.scss
+++ b/src/components/UnifiedReport/unifiedReportBaseHeader.scss
@@ -1,0 +1,3 @@
+.Layer__UnifiedReport__BaseHeader {
+  border-bottom: 1px solid var(--border-color);
+}

--- a/src/components/UnifiedReport/unifiedReportTable.scss
+++ b/src/components/UnifiedReport/unifiedReportTable.scss
@@ -1,7 +1,7 @@
 .Layer__UI__Table__UnifiedReport {
   width: max-content;
   min-width: 100%;
-  border-block: 1px solid var(--color-base-300);
+  border-bottom: 1px solid var(--color-base-300);
 
   .Layer__UI__Table-Column,
   .Layer__UI__Table-Cell {


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only styling changes that may slightly affect layout/border rendering but do not touch data or behavior.
> 
> **Overview**
> Ensures the Unified Report header area consistently renders a bottom border by wrapping `UnifiedReportBaseHeader` with a new class and adding `unifiedReportBaseHeader.scss` to apply `border-bottom`.
> 
> Adjusts the Unified Report table styling to use only a bottom border (replacing the previous block border) to align header/table border appearance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 869c69ce7a56b4760f954ac42a7a3b60cdc690bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->