### PR TITLE
[HST/GST] Implement changes to the store provider to track tax codes

### DIFF
--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -12,7 +12,7 @@ import { useDelayedRemoveBankTransaction } from '@hooks/features/bankTransaction
 import { useSaveBankTransactionRow } from '@hooks/features/bankTransactions/useSaveBankTransactionRow'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useDelayedVisibility } from '@hooks/utils/visibility/useDelayedVisibility'
-import { useBankTransactionsCategoryActions, useGetBankTransactionCategory } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { useBankTransactionsCategorizationActions, useGetBankTransactionCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useBulkSelectionActions, useCountSelectedIds, useIdIsSelected } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useBankTransactionsIsCategorizationEnabledContext } from '@contexts/BankTransactionsIsCategorizationEnabledContext/BankTransactionsIsCategorizationEnabledContext'
 import AlertCircle from '@icons/AlertCircle'
@@ -82,8 +82,8 @@ export const BankTransactionRow = ({
   const isTransactionSelected = isSelected(bankTransaction.id)
   const { count: bulkSelectionCount } = useCountSelectedIds()
   const isBulkSelectionActive = bulkSelectionCount > 0
-  const { setTransactionCategory } = useBankTransactionsCategoryActions()
-  const { selectedCategory } = useGetBankTransactionCategory(bankTransaction.id)
+  const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
+  const { selectedCategory } = useGetBankTransactionCategoryByTransactionId(bankTransaction.id)
   const { saveBankTransactionRow, isProcessing, isError } = useSaveBankTransactionRow()
 
   const { isBeingRemoved } = useDelayedRemoveBankTransaction({ bankTransaction })
@@ -284,7 +284,7 @@ export const BankTransactionRow = ({
                     bankTransaction={bankTransaction}
                     selectedValue={selectedCategory ?? null}
                     onSelectedValueChange={(selectedCategory: BankTransactionCategoryComboBoxOption | null) => {
-                      setTransactionCategory(bankTransaction.id, selectedCategory)
+                      setTransactionCategorization(bankTransaction.id, { category: selectedCategory })
                     }}
                     isDisabled={isProcessing}
                   />

--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -16,7 +16,7 @@ import { usePreloadVendors } from '@hooks/api/businesses/[business-id]/vendors/u
 import { useLinkedAccounts } from '@hooks/legacy/useLinkedAccounts'
 import { useElementSize } from '@hooks/utils/size/useElementSize'
 import { useIsVisible } from '@hooks/utils/visibility/useIsVisible'
-import { BankTransactionsCategoryStoreProvider } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { BankTransactionsCategorizationStoreProvider } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { BankTransactionsProvider } from '@providers/BankTransactionsProvider/BankTransactionsProvider'
 import { BankTransactionsRoute, BankTransactionsRouteStoreProvider, useBankTransactionsRouteState, useCurrentBankTransactionsPage } from '@providers/BankTransactionsRouteStore/BankTransactionsRouteStoreProvider'
 import { BulkSelectionStoreProvider } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
@@ -134,9 +134,9 @@ export const BankTransactions = ({
                   <BankTransactionCustomerVendorVisibilityProvider showCustomerVendor={showCustomerVendor}>
                     <InAppLinkProvider renderInAppLink={renderInAppLink}>
                       <BulkSelectionStoreProvider>
-                        <BankTransactionsCategoryStoreProvider>
+                        <BankTransactionsCategorizationStoreProvider>
                           <BankTransactionsContent {...restProps} />
-                        </BankTransactionsCategoryStoreProvider>
+                        </BankTransactionsCategorizationStoreProvider>
                       </BulkSelectionStoreProvider>
                     </InAppLinkProvider>
                   </BankTransactionCustomerVendorVisibilityProvider>

--- a/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsUncategorizeAllModal.tsx
+++ b/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsUncategorizeAllModal.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { tPlural } from '@utils/i18n/plural'
 import { useBulkUncategorize } from '@hooks/api/businesses/[business-id]/bank-transactions/bulk-uncategorize/useBulkUncategorize'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
-import { useBankTransactionsCategoryActions } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useBulkSelectionActions, useCountSelectedIds, useSelectedIds } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { Span } from '@ui/Typography/Text'
 import { BaseConfirmationModal } from '@blocks/BaseConfirmationModal/BaseConfirmationModal'
@@ -22,15 +22,15 @@ export const BankTransactionsUncategorizeAllModal = ({ isOpen, onOpenChange, isM
   const { selectedIds } = useSelectedIds()
   const { clearSelection } = useBulkSelectionActions()
   const { trigger } = useBulkUncategorize()
-  const { clearMultipleTransactionCategories } = useBankTransactionsCategoryActions()
+  const { clearTransactionCategorizations } = useBankTransactionsCategorizationActions()
 
   const handleConfirm = useCallback(async () => {
     const transactionIds = Array.from(selectedIds)
 
     await trigger({ transactionIds })
-    clearMultipleTransactionCategories(transactionIds)
+    clearTransactionCategorizations(transactionIds)
     clearSelection()
-  }, [selectedIds, trigger, clearSelection, clearMultipleTransactionCategories])
+  }, [selectedIds, trigger, clearSelection, clearTransactionCategorizations])
 
   return (
     <BaseConfirmationModal

--- a/src/components/BankTransactions/BankTransactionsListItemCategory/BankTransactionsListItemCategory.tsx
+++ b/src/components/BankTransactions/BankTransactionsListItemCategory/BankTransactionsListItemCategory.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { isCategorized } from '@utils/bankTransactions'
-import { useGetBankTransactionCategory } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { useGetBankTransactionCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { BankTransactionsBaseSelectedValue } from '@components/BankTransactionsSelectedValue/BankTransactionsBaseSelectedValue'
 import { BankTransactionsCategorizedSelectedValue } from '@components/BankTransactionsSelectedValue/BankTransactionsCategorizedSelectedValue'
 import { BankTransactionsUncategorizedSelectedValue } from '@components/BankTransactionsSelectedValue/BankTransactionsUncategorizedSelectedValue'
@@ -23,7 +23,7 @@ export const BankTransactionsListItemCategory = ({
     ? 'Layer__bankTransactionsListItemCategory__Mobile'
     : 'Layer__bankTransactionsListItemCategory__List'
   const categorized = isCategorized(bankTransaction)
-  const { selectedCategory } = useGetBankTransactionCategory(bankTransaction.id)
+  const { selectedCategory } = useGetBankTransactionCategoryByTransactionId(bankTransaction.id)
 
   if (categorized) {
     return (

--- a/src/components/BankTransactionsList/BankTransactionsListItem.tsx
+++ b/src/components/BankTransactionsList/BankTransactionsListItem.tsx
@@ -13,7 +13,7 @@ import { useSaveBankTransactionRow } from '@hooks/features/bankTransactions/useS
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { useDelayedVisibility } from '@hooks/utils/visibility/useDelayedVisibility'
-import { useBankTransactionsCategoryActions, useGetBankTransactionCategory } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { useBankTransactionsCategorizationActions, useGetBankTransactionCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useBulkSelectionActions, useIdIsSelected } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useBankTransactionsIsCategorizationEnabledContext } from '@contexts/BankTransactionsIsCategorizationEnabledContext/BankTransactionsIsCategorizationEnabledContext'
 import ChevronDownFill from '@icons/ChevronDownFill'
@@ -78,8 +78,8 @@ export const BankTransactionsListItem = ({
   const { select, deselect } = useBulkSelectionActions()
   const isSelected = useIdIsSelected()
   const isTransactionSelected = isSelected(bankTransaction.id)
-  const { setTransactionCategory } = useBankTransactionsCategoryActions()
-  const { selectedCategory } = useGetBankTransactionCategory(bankTransaction.id)
+  const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
+  const { selectedCategory } = useGetBankTransactionCategoryByTransactionId(bankTransaction.id)
 
   const save = useCallback(async () => {
     if (openExpandedRow && !isExpandedRowValid) return
@@ -198,7 +198,7 @@ export const BankTransactionsListItem = ({
                 bankTransaction={bankTransaction}
                 selectedValue={selectedCategory ?? null}
                 onSelectedValueChange={(selectedCategory: BankTransactionCategoryComboBoxOption | null) => {
-                  setTransactionCategory(bankTransaction.id, selectedCategory)
+                  setTransactionCategorization(bankTransaction.id, { category: selectedCategory })
                 }}
                 isDisabled={isProcessing}
               />

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
@@ -9,7 +9,7 @@ import { hasReceipts } from '@utils/bankTransactions'
 import { isCategorized } from '@utils/bankTransactions'
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
-import { useBankTransactionsCategoryActions, useGetBankTransactionCategory } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { useBankTransactionsCategorizationActions, useGetBankTransactionCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import PaperclipIcon from '@icons/Paperclip'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
@@ -76,8 +76,8 @@ export const BankTransactionsMobileListBusinessForm = ({
     return initialMap
   })
 
-  const { selectedCategory } = useGetBankTransactionCategory(bankTransaction.id)
-  const { setTransactionCategory } = useBankTransactionsCategoryActions()
+  const { selectedCategory } = useGetBankTransactionCategoryByTransactionId(bankTransaction.id)
+  const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
 
   const [showRetry, setShowRetry] = useState(false)
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
@@ -119,10 +119,10 @@ export const BankTransactionsMobileListBusinessForm = ({
         selectedCategory
         && option.value === selectedCategory.value
       ) {
-        setTransactionCategory(bankTransaction.id, null)
+        setTransactionCategorization(bankTransaction.id, { category: null })
       }
       else {
-        setTransactionCategory(bankTransaction.id, option)
+        setTransactionCategorization(bankTransaction.id, { category: option })
       }
     }
   }
@@ -149,8 +149,8 @@ export const BankTransactionsMobileListBusinessForm = ({
     if (!category) return
 
     setSessionCategories(prev => new Map(prev).set(category.value, category))
-    setTransactionCategory(bankTransaction.id, category)
-  }, [bankTransaction.id, setTransactionCategory])
+    setTransactionCategorization(bankTransaction.id, { category })
+  }, [bankTransaction.id, setTransactionCategorization])
 
   return (
     <>

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
@@ -9,7 +9,7 @@ import { isCategorized } from '@utils/bankTransactions'
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
 import { useSplitsForm } from '@hooks/features/bankTransactions/useSplitsForm'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
-import { useGetBankTransactionCategory } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { useGetBankTransactionCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import PaperclipIcon from '@icons/Paperclip'
 import Scissors from '@icons/Scissors'
 import Trash from '@icons/Trash'
@@ -51,7 +51,7 @@ export const BankTransactionsMobileListSplitForm = ({
     isError: isErrorCategorizing,
   } = useCategorizeBankTransactionWithCacheUpdate()
 
-  const { selectedCategory } = useGetBankTransactionCategory(bankTransaction.id)
+  const { selectedCategory } = useGetBankTransactionCategoryByTransactionId(bankTransaction.id)
   const [showRetry, setShowRetry] = useState(false)
 
   const {

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -24,7 +24,7 @@ import { useRemoveTagFromBankTransaction } from '@hooks/api/businesses/[business
 import { useTagBankTransaction } from '@hooks/api/businesses/[business-id]/bank-transactions/tags/useTagBankTransaction'
 import { useSplitsForm } from '@hooks/features/bankTransactions/useSplitsForm'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
-import { useBankTransactionsCategoryActions, useGetBankTransactionCategory } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { useBankTransactionsCategorizationActions, useGetBankTransactionCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useBankTransactionsIsCategorizationEnabledContext } from '@contexts/BankTransactionsIsCategorizationEnabledContext/BankTransactionsIsCategorizationEnabledContext'
 import Scissors from '@icons/ScissorsFullOpen'
 import Trash from '@icons/Trash'
@@ -93,8 +93,8 @@ export const ExpandedBankTransactionRow = ({
 }: ExpandedBankTransactionRowProps) => {
   const { t } = useTranslation()
   const { formatCurrencyFromCents } = useIntlFormatter()
-  const { selectedCategory } = useGetBankTransactionCategory(bankTransaction.id)
-  const { setTransactionCategory } = useBankTransactionsCategoryActions()
+  const { selectedCategory } = useGetBankTransactionCategoryByTransactionId(bankTransaction.id)
+  const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
   // Hooks for auto-saving tags and customer/vendor in unsplit state
   const { trigger: tagBankTransaction } = useTagBankTransaction({ bankTransactionId: bankTransaction.id })
   const { trigger: removeTagFromBankTransaction } = useRemoveTagFromBankTransaction({ bankTransactionId: bankTransaction.id })
@@ -146,11 +146,11 @@ export const ExpandedBankTransactionRow = ({
     setPurpose(newPurpose)
 
     if (newPurpose === Purpose.match) {
-      setTransactionCategory(bankTransaction.id, selectedMatch ? new SuggestedMatchAsOption(selectedMatch) : null)
+      setTransactionCategorization(bankTransaction.id, { category: selectedMatch ? new SuggestedMatchAsOption(selectedMatch) : null })
     }
 
     else if (newPurpose === Purpose.categorize && isSplitsValid) {
-      setTransactionCategory(bankTransaction.id, new SplitAsOption(localSplits))
+      setTransactionCategorization(bankTransaction.id, { category: new SplitAsOption(localSplits) })
     }
 
     setSplitFormError(undefined)
@@ -265,10 +265,9 @@ export const ExpandedBankTransactionRow = ({
                         setSelectedMatch={(suggestedMatch) => {
                           setSelectedMatch(suggestedMatch)
                           setMatchFormError(!suggestedMatch ? t('bankTransactions:error.select_option_match_transaction', 'Select an option to match the transaction') : undefined)
-                          setTransactionCategory(
-                            bankTransaction.id,
-                            suggestedMatch ? new SuggestedMatchAsOption(suggestedMatch) : null,
-                          )
+                          setTransactionCategorization(bankTransaction.id, {
+                            category: suggestedMatch ? new SuggestedMatchAsOption(suggestedMatch) : null,
+                          })
                         }}
                         matchFormError={matchFormError}
                       />

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -2,13 +2,14 @@ import { useCallback } from 'react'
 import { pipe, Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
+import { type Split } from '@internal-types/bankTransactions'
 import { CategoryUpdateSchema } from '@schemas/bankTransactions/categoryUpdate'
 import { post } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
 import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useGetAllBankTransactionsCategories } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { type BankTransactionCategorization, DEFAULT_CATEGORIZATION, useGetAllBankTransactionsCategorizations } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useSelectedIds } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { type BankTransactionCategoryComboBoxOption, isApiCategorizationAsOption, isCategoryAsOption, isPlaceholderAsOption, isSplitAsOption, isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
@@ -17,44 +18,50 @@ const BULK_MATCH_OR_CATEGORIZE_TAG = '#bulk-match-or-categorize'
 
 type MatchOrCategorizeTransaction = typeof MatchOrCategorizeTransactionRequestSchema.Type
 
+const getClassification = (category: BankTransactionCategoryComboBoxOption | null) => {
+  if (!category || !(isCategoryAsOption(category) || isApiCategorizationAsOption(category))) {
+    return null
+  }
+  return category.classification
+}
+
+const toSplitEntry = (split: Split) => {
+  const classification = getClassification(split.category)
+  if (!classification) return null
+  return {
+    amount: split.amount,
+    category: classification,
+    taxCode: split.taxCode,
+    tags: split.tags,
+    customerId: split.customerVendor?.customerVendorType === 'CUSTOMER' ? split.customerVendor.id : undefined,
+    vendorId: split.customerVendor?.customerVendorType === 'VENDOR' ? split.customerVendor.id : undefined,
+  }
+}
+
 const buildBulkMatchOrCategorizePayload = (
   selectedIds: Iterable<string>,
-  transactionCategories: Map<string, BankTransactionCategoryComboBoxOption | null>,
+  categorizations: Map<string, BankTransactionCategorization>,
 ): Record<string, MatchOrCategorizeTransaction> => {
   const transactions: Record<string, MatchOrCategorizeTransaction> = {}
 
   for (const transactionId of selectedIds) {
-    const transactionCategory = transactionCategories.get(transactionId) ?? null
+    const { category, taxCode } = categorizations.get(transactionId) ?? DEFAULT_CATEGORIZATION
 
-    if (!transactionCategory || isPlaceholderAsOption(transactionCategory)) {
+    if (!category || isPlaceholderAsOption(category)) {
       continue
     }
 
-    if (isSuggestedMatchAsOption(transactionCategory)) {
+    if (isSuggestedMatchAsOption(category)) {
       transactions[transactionId] = {
         type: 'match',
-        suggestedMatchId: transactionCategory.value,
+        suggestedMatchId: category.value,
       }
+      continue
     }
 
-    else if (isSplitAsOption(transactionCategory)) {
-      const splitEntries = transactionCategory.original
-        .map((split) => {
-          if (!split.category || !(isCategoryAsOption(split.category) || isApiCategorizationAsOption(split.category))) {
-            return null
-          }
-          const classification = split.category.classification
-          if (!classification) {
-            return null
-          }
-          return {
-            amount: split.amount,
-            category: classification,
-            tags: split.tags,
-            customerId: split.customerVendor?.customerVendorType === 'CUSTOMER' ? split.customerVendor.id : undefined,
-            vendorId: split.customerVendor?.customerVendorType === 'VENDOR' ? split.customerVendor.id : undefined,
-          }
-        })
+    if (isSplitAsOption(category)) {
+      const splitEntries = category.original
+        .map(toSplitEntry)
         .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
 
       if (splitEntries.length > 0) {
@@ -66,19 +73,19 @@ const buildBulkMatchOrCategorizePayload = (
           },
         }
       }
+      continue
     }
 
-    else if (isCategoryAsOption(transactionCategory) || isApiCategorizationAsOption(transactionCategory)) {
-      const classification = transactionCategory.classification
-      if (classification) {
-        transactions[transactionId] = {
-          type: 'categorize',
-          categorization: {
-            type: 'Category',
-            category: classification,
-          },
-        }
-      }
+    const classification = getClassification(category)
+    if (!classification) continue
+
+    transactions[transactionId] = {
+      type: 'categorize',
+      categorization: {
+        type: 'Category',
+        category: classification,
+        taxCode,
+      },
     }
   }
 
@@ -153,15 +160,15 @@ export const useBulkMatchOrCategorize = () => {
   const { data } = useAuth()
   const { businessId, eventCallbacks } = useLayerContext()
   const { selectedIds } = useSelectedIds()
-  const { transactionCategories } = useGetAllBankTransactionsCategories()
+  const { categorizations } = useGetAllBankTransactionsCategorizations()
 
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
 
   const buildTransactionsPayload: () => BulkMatchOrCategorizeRequest = useCallback(() => {
-    const transactions = buildBulkMatchOrCategorizePayload(selectedIds, transactionCategories)
+    const transactions = buildBulkMatchOrCategorizePayload(selectedIds, categorizations)
     return { transactions }
-  }, [selectedIds, transactionCategories])
+  }, [selectedIds, categorizations])
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -40,7 +40,7 @@ const toSplitEntry = (split: Split) => {
 
 const buildBulkMatchOrCategorizePayload = (
   selectedIds: Iterable<string>,
-  categorizations: Map<string, BankTransactionCategorization>,
+  categorizations: ReadonlyMap<string, BankTransactionCategorization>,
 ): Record<string, MatchOrCategorizeTransaction> => {
   const transactions: Record<string, MatchOrCategorizeTransaction> = {}
 

--- a/src/hooks/features/bankTransactions/useSplitsForm.ts
+++ b/src/hooks/features/bankTransactions/useSplitsForm.ts
@@ -6,7 +6,7 @@ import { type BankTransaction, type Split } from '@internal-types/bankTransactio
 import { SplitAsOption } from '@internal-types/categorizationOption'
 import { convertCentsToDecimalString } from '@utils/format'
 import { toLocalizedNumber } from '@utils/i18n/number/input'
-import { useBankTransactionsCategoryActions } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { type BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import {
   calculateAddSplit,
@@ -53,7 +53,7 @@ export const useSplitsForm = ({
   )
   const [inputValues, setInputValues] = useState<Record<number, string>>({})
   const [splitFormError, setSplitFormError] = useState<string | undefined>()
-  const { setTransactionCategory } = useBankTransactionsCategoryActions()
+  const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
 
   useEffect(() => {
     setLocalSplits(getLocalSplitStateForExpandedTransaction(bankTransaction, selectedCategory))
@@ -67,9 +67,9 @@ export const useSplitsForm = ({
       return
     }
 
-    setTransactionCategory(bankTransaction.id, new SplitAsOption(splits))
+    setTransactionCategorization(bankTransaction.id, { category: new SplitAsOption(splits) })
     setSplitFormError(undefined)
-  }, [bankTransaction.id, setTransactionCategory, t])
+  }, [bankTransaction.id, setTransactionCategorization, t])
 
   const addSplit = useCallback(() => {
     const newSplits = calculateAddSplit(localSplits)

--- a/src/hooks/features/bankTransactions/useUpsertBankTransactionsDefaultCategories.tsx
+++ b/src/hooks/features/bankTransactions/useUpsertBankTransactionsDefaultCategories.tsx
@@ -1,19 +1,21 @@
 import { useEffect } from 'react'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
-import { useBankTransactionsCategoryActions } from '@providers/BankTransactionsCategoryStore/BankTransactionsCategoryStoreProvider'
+import { type BankTransactionCategorization, useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { getDefaultSelectedCategoryForBankTransaction } from '@components/BankTransactionCategoryComboBox/utils'
 
 export const useUpsertBankTransactionsDefaultCategories = (bankTransactions: BankTransaction[] | undefined) => {
-  const { setOnlyNewTransactionCategories } = useBankTransactionsCategoryActions()
+  const { setOnlyNewTransactionCategorizations } = useBankTransactionsCategorizationActions()
   useEffect(() => {
     if (!bankTransactions) return
 
-    const defaultCategories = bankTransactions.map(transaction => ({
-      id: transaction.id,
-      category: getDefaultSelectedCategoryForBankTransaction(transaction),
-    }))
+    const defaultCategories = new Map<string, Partial<BankTransactionCategorization>>(
+      bankTransactions.map(transaction => [
+        transaction.id,
+        { category: getDefaultSelectedCategoryForBankTransaction(transaction) },
+      ]),
+    )
 
-    setOnlyNewTransactionCategories(defaultCategories)
-  }, [bankTransactions, setOnlyNewTransactionCategories])
+    setOnlyNewTransactionCategorizations(defaultCategories)
+  }, [bankTransactions, setOnlyNewTransactionCategorizations])
 }

--- a/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
+++ b/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
@@ -135,8 +135,8 @@ export function useGetBankTransactionCategoryByTransactionId(
 export function useGetAllBankTransactionsCategorizations(): { categorizations: ReadonlyMap<string, BankTransactionCategorization> } {
   const store = useBankTransactionsCategorizationStore()
   const categorizations = useStore(store, state => state.categorizations)
-  const categorizationsSnapshot = useMemo(() => new Map(categorizations), [categorizations])
-  return { categorizations: categorizationsSnapshot }
+
+  return useMemo(() => ({ categorizations: new Map(categorizations) }), [categorizations])
 }
 
 type BankTransactionsCategorizationStoreProviderProps = PropsWithChildren

--- a/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
+++ b/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
@@ -40,35 +40,37 @@ const mergeCategorization = (
 
 function buildStore() {
   return createStore<BankTransactionsCategorizationStore>((set) => {
-    const setTransactionCategorization = (id: string, update: Partial<BankTransactionCategorization>) => {
-      set(({ categorizations }) => {
-        const newMap = new Map(categorizations)
-        const current = categorizations.get(id) ?? DEFAULT_CATEGORIZATION
-        const merged = mergeCategorization(current, update)
-        const shouldWrite = !categorizations.has(id)
-          || current.category !== merged.category
-          || current.taxCode !== merged.taxCode
-
-        if (!shouldWrite) return { categorizations }
-        newMap.set(id, merged)
-        return { categorizations: newMap }
-      })
-    }
-
     return {
       categorizations: new Map(),
       actions: {
-        setTransactionCategorization,
+        setTransactionCategorization: (id, update) => {
+          set(({ categorizations }) => {
+            const newMap = new Map(categorizations)
+            const current = categorizations.get(id) ?? DEFAULT_CATEGORIZATION
+            const merged = mergeCategorization(current, update)
 
-        setOnlyNewTransactionCategorizations: (categorizations) => {
+            const shouldWrite = !categorizations.has(id)
+              || current.category !== merged.category
+              || current.taxCode !== merged.taxCode
+
+            if (!shouldWrite) return { categorizations }
+            newMap.set(id, merged)
+            return { categorizations: newMap }
+          })
+        },
+
+        setOnlyNewTransactionCategorizations: (newCategorizations) => {
           set((state) => {
-            const newMap = new Map(state.categorizations)
             let hasChanges = false
+            const categorizations = state.categorizations
+            const newMap = new Map(categorizations)
 
-            categorizations.forEach((next, id) => {
-              const isNewTransaction = !newMap.has(id)
-              const current = newMap.get(id) ?? DEFAULT_CATEGORIZATION
+            newCategorizations.forEach((next, id) => {
+              const isNewTransaction = !categorizations.has(id)
+
+              const current = categorizations.get(id) ?? DEFAULT_CATEGORIZATION
               const merged = mergeCategorization(current, next)
+
               const shouldWrite = isNewTransaction
                 || (current.category === null && merged.category !== null)
                 || (current.taxCode === null && merged.taxCode !== null)

--- a/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
+++ b/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
@@ -82,7 +82,7 @@ function useBankTransactionsCategoryStore(): ReturnType<typeof buildStore> {
   const store = useContext(BankTransactionsCategoryStoreContext)
 
   if (!store) {
-    throw new Error('useBankTransactionsCategoryStore must be used within BankTransactionsCategoryStoreProvider')
+    throw new Error('useBankTransactionsCategoryStore must be used within BankTransactionsCategorizationStoreProvider')
   }
 
   return store
@@ -110,11 +110,11 @@ export function useGetAllBankTransactionsCategories(): { transactionCategories: 
   return { transactionCategories }
 }
 
-type BankTransactionsCategoryStoreProviderProps = PropsWithChildren
+type BankTransactionsCategorizationStoreProviderProps = PropsWithChildren
 
-export function BankTransactionsCategoryStoreProvider({
+export function BankTransactionsCategorizationStoreProvider({
   children,
-}: BankTransactionsCategoryStoreProviderProps): JSX.Element {
+}: BankTransactionsCategorizationStoreProviderProps): JSX.Element {
   const [store] = useState(() => buildStore())
   return (
     <BankTransactionsCategoryStoreContext.Provider value={store}>

--- a/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
+++ b/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
@@ -3,111 +3,139 @@ import { createStore, useStore } from 'zustand'
 
 import type { BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 
-export type BankTransactionsCategoryState = {
-  transactionCategories: Map<string, BankTransactionCategoryComboBoxOption | null>
+export type TaxCodeComboboxOption = string
+
+export type BankTransactionCategorization = {
+  category: BankTransactionCategoryComboBoxOption | null
+  taxCode: TaxCodeComboboxOption | null
 }
 
-type BankTransactionsCategoryActions = {
-  actions: {
-    setTransactionCategory: (id: string, category: BankTransactionCategoryComboBoxOption | null) => void
-    setOnlyNewTransactionCategories: (transactionCategories: Array<{ id: string, category: BankTransactionCategoryComboBoxOption | null }>) => void
-
-    clearTransactionCategory: (id: string) => void
-    clearMultipleTransactionCategories: (ids: string[]) => void
-    clearAllTransactionCategories: () => void
-  }
+export type BankTransactionsCategorizationState = {
+  categorizations: Map<string, BankTransactionCategorization>
 }
 
-type BankTransactionsCategoryStore = BankTransactionsCategoryState & BankTransactionsCategoryActions
+type BankTransactionsCategorizationActions = {
+  setTransactionCategory: (id: string, category: BankTransactionCategoryComboBoxOption | null) => void
+  setTransactionCategorization: (id: string, update: Partial<BankTransactionCategorization>) => void
+  setOnlyNewTransactionCategorizations: (categorizations: Map<string, Partial<BankTransactionCategorization>>) => void
+  clearTransactionCategorizations: (ids: string[]) => void
+  clearAllTransactionCategorizations: () => void
+}
+
+type BankTransactionsCategorizationStore = BankTransactionsCategorizationState & {
+  actions: BankTransactionsCategorizationActions
+}
+
+export const DEFAULT_CATEGORIZATION: BankTransactionCategorization = {
+  category: null,
+  taxCode: null,
+}
+
+const mergeCategorization = (
+  current: BankTransactionCategorization,
+  next: Partial<BankTransactionCategorization>,
+): BankTransactionCategorization => ({
+  category: next.category ?? current.category,
+  taxCode: next.taxCode ?? current.taxCode,
+})
 
 function buildStore() {
-  return createStore<BankTransactionsCategoryStore>(set => ({
-    transactionCategories: new Map<string, BankTransactionCategoryComboBoxOption | null>(),
-    actions: {
-      setTransactionCategory: (id: string, category: BankTransactionCategoryComboBoxOption | null): void => {
-        set((state) => {
-          const newMap = new Map(state.transactionCategories)
-          newMap.set(id, category)
-          return { transactionCategories: newMap }
-        })
-      },
+  return createStore<BankTransactionsCategorizationStore>((set) => {
+    const setTransactionCategorization = (id: string, update: Partial<BankTransactionCategorization>) => {
+      set(({ categorizations }) => {
+        const newMap = new Map(categorizations)
+        const current = categorizations.get(id) ?? DEFAULT_CATEGORIZATION
+        const merged = mergeCategorization(current, update)
+        const shouldWrite = !categorizations.has(id)
+          || current.category !== merged.category
+          || current.taxCode !== merged.taxCode
 
-      setOnlyNewTransactionCategories: (transactionCategories: Array<{ id: string, category: BankTransactionCategoryComboBoxOption | null }>): void => {
-        set((state) => {
-          const newMap = new Map(state.transactionCategories)
-          let hasChanges = false
+        if (!shouldWrite) return { categorizations }
+        newMap.set(id, merged)
+        return { categorizations: newMap }
+      })
+    }
 
-          transactionCategories.forEach(({ id, category }) => {
-            const isNewTransaction = !newMap.has(id)
+    return {
+      categorizations: new Map(),
+      actions: {
+        setTransactionCategory: (id, category) => setTransactionCategorization(id, { category }),
+        setTransactionCategorization,
 
-            const currentValue = newMap.get(id)
-            const hasNewSuggestionForUnselectedCategory = currentValue === null && category !== null
+        setOnlyNewTransactionCategorizations: (categorizations) => {
+          set((state) => {
+            const newMap = new Map(state.categorizations)
+            let hasChanges = false
 
-            if (isNewTransaction || hasNewSuggestionForUnselectedCategory) {
-              newMap.set(id, category)
-              hasChanges = true
-            }
+            categorizations.forEach((next, id) => {
+              const isNewTransaction = !newMap.has(id)
+              const current = newMap.get(id) ?? DEFAULT_CATEGORIZATION
+              const merged = mergeCategorization(current, next)
+              const shouldWrite = isNewTransaction
+                || (current.category === null && merged.category !== null)
+                || (current.taxCode === null && merged.taxCode !== null)
+
+              if (shouldWrite) {
+                newMap.set(id, merged)
+                hasChanges = true
+              }
+            })
+
+            return hasChanges ? { categorizations: newMap } : state
           })
-          return hasChanges ? { transactionCategories: newMap } : state
-        })
-      },
+        },
 
-      clearTransactionCategory: (id: string): void => {
-        set((state) => {
-          const newMap = new Map(state.transactionCategories)
-          newMap.delete(id)
-          return { transactionCategories: newMap }
-        })
-      },
+        clearTransactionCategorizations: (ids) => {
+          set((state) => {
+            const newMap = new Map(state.categorizations)
+            ids.forEach(id => newMap.delete(id))
+            return { categorizations: newMap }
+          })
+        },
 
-      clearMultipleTransactionCategories: (ids: string[]): void => {
-        set((state) => {
-          const newMap = new Map(state.transactionCategories)
-          ids.forEach(id => newMap.delete(id))
-          return { transactionCategories: newMap }
-        })
+        clearAllTransactionCategorizations: () => {
+          set({ categorizations: new Map() })
+        },
       },
-
-      clearAllTransactionCategories: () => {
-        set({ transactionCategories: new Map<string, BankTransactionCategoryComboBoxOption>() })
-      },
-
-    },
-  }))
+    }
+  })
 }
 
-const BankTransactionsCategoryStoreContext = createContext<ReturnType<typeof buildStore> | null>(null)
+const BankTransactionsCategorizationStoreContext = createContext<ReturnType<typeof buildStore> | null>(null)
 
-function useBankTransactionsCategoryStore(): ReturnType<typeof buildStore> {
-  const store = useContext(BankTransactionsCategoryStoreContext)
-
+function useBankTransactionsCategorizationStore() {
+  const store = useContext(BankTransactionsCategorizationStoreContext)
   if (!store) {
-    throw new Error('useBankTransactionsCategoryStore must be used within BankTransactionsCategorizationStoreProvider')
+    throw new Error('useBankTransactionsCategorizationStore must be used within BankTransactionsCategorizationStoreProvider')
   }
-
   return store
 }
 
-export function useBankTransactionsCategoryActions(): BankTransactionsCategoryActions['actions'] {
-  const store = useBankTransactionsCategoryStore()
-
+export function useBankTransactionsCategorizationActions(): BankTransactionsCategorizationActions {
+  const store = useBankTransactionsCategorizationStore()
   return useStore(store, state => state.actions)
 }
 
-export function useGetBankTransactionCategory(transactionId: string): { selectedCategory: BankTransactionCategoryComboBoxOption | null | undefined } {
-  const store = useBankTransactionsCategoryStore()
+export function useGetBankTransactionCategorizationByTransactionId(
+  transactionId: string,
+): { selectedCategorization: BankTransactionCategorization | undefined } {
+  const store = useBankTransactionsCategorizationStore()
+  const selectedCategorization = useStore(store, state => state.categorizations.get(transactionId))
+  return { selectedCategorization }
+}
 
-  const selectedCategory = useStore(store, state => state.transactionCategories.get(transactionId))
-
+export function useGetBankTransactionCategoryByTransactionId(
+  transactionId: string,
+): { selectedCategory: BankTransactionCategoryComboBoxOption | null | undefined } {
+  const store = useBankTransactionsCategorizationStore()
+  const selectedCategory = useStore(store, state => state.categorizations.get(transactionId)?.category)
   return { selectedCategory }
 }
 
-export function useGetAllBankTransactionsCategories(): { transactionCategories: Map<string, BankTransactionCategoryComboBoxOption | null> } {
-  const store = useBankTransactionsCategoryStore()
-
-  const transactionCategories = useStore(store, state => state.transactionCategories)
-
-  return { transactionCategories }
+export function useGetAllBankTransactionsCategorizations(): { categorizations: Map<string, BankTransactionCategorization> } {
+  const store = useBankTransactionsCategorizationStore()
+  const categorizations = useStore(store, state => state.categorizations)
+  return { categorizations }
 }
 
 type BankTransactionsCategorizationStoreProviderProps = PropsWithChildren
@@ -117,8 +145,8 @@ export function BankTransactionsCategorizationStoreProvider({
 }: BankTransactionsCategorizationStoreProviderProps): JSX.Element {
   const [store] = useState(() => buildStore())
   return (
-    <BankTransactionsCategoryStoreContext.Provider value={store}>
+    <BankTransactionsCategorizationStoreContext.Provider value={store}>
       {children}
-    </BankTransactionsCategoryStoreContext.Provider>
+    </BankTransactionsCategorizationStoreContext.Provider>
   )
 }

--- a/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
+++ b/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, type PropsWithChildren, useContext, useState } from 'react'
+import { createContext, type PropsWithChildren, useContext, useMemo, useState } from 'react'
 import { createStore, useStore } from 'zustand'
 
 import type { BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
@@ -15,7 +15,6 @@ export type BankTransactionsCategorizationState = {
 }
 
 type BankTransactionsCategorizationActions = {
-  setTransactionCategory: (id: string, category: BankTransactionCategoryComboBoxOption | null) => void
   setTransactionCategorization: (id: string, update: Partial<BankTransactionCategorization>) => void
   setOnlyNewTransactionCategorizations: (categorizations: Map<string, Partial<BankTransactionCategorization>>) => void
   clearTransactionCategorizations: (ids: string[]) => void
@@ -35,8 +34,8 @@ const mergeCategorization = (
   current: BankTransactionCategorization,
   next: Partial<BankTransactionCategorization>,
 ): BankTransactionCategorization => ({
-  category: next.category ?? current.category,
-  taxCode: next.taxCode ?? current.taxCode,
+  category: next.category === undefined ? current.category : next.category,
+  taxCode: next.taxCode === undefined ? current.taxCode : next.taxCode,
 })
 
 function buildStore() {
@@ -59,7 +58,6 @@ function buildStore() {
     return {
       categorizations: new Map(),
       actions: {
-        setTransactionCategory: (id, category) => setTransactionCategorization(id, { category }),
         setTransactionCategorization,
 
         setOnlyNewTransactionCategorizations: (categorizations) => {
@@ -132,10 +130,11 @@ export function useGetBankTransactionCategoryByTransactionId(
   return { selectedCategory }
 }
 
-export function useGetAllBankTransactionsCategorizations(): { categorizations: Map<string, BankTransactionCategorization> } {
+export function useGetAllBankTransactionsCategorizations(): { categorizations: ReadonlyMap<string, BankTransactionCategorization> } {
   const store = useBankTransactionsCategorizationStore()
   const categorizations = useStore(store, state => state.categorizations)
-  return { categorizations }
+  const categorizationsSnapshot = useMemo(() => new Map(categorizations), [categorizations])
+  return { categorizations: categorizationsSnapshot }
 }
 
 type BankTransactionsCategorizationStoreProviderProps = PropsWithChildren


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces the client-side store shape used across multiple bank-transaction UIs and updates bulk categorize payloads to include `taxCode`, which could cause regressions in selection/clearing and request formatting.
> 
> **Overview**
> **Replaces the per-transaction category store with a new `BankTransactionsCategorizationStore`** that tracks both `category` and `taxCode`, and updates all bank-transaction views (table rows, list items, expanded row, mobile forms, and uncategorize modal) to read/write categorizations via `setTransactionCategorization`.
> 
> **Bulk match/categorize now builds requests from the new categorization map** and includes `taxCode` in `Category` categorization payloads; split payload construction is refactored into helpers and also passes through per-split `taxCode`.
> 
> **Default category upsert logic is updated** to seed the new store via a `Map` of partial categorizations, and the old `BankTransactionsCategoryStoreProvider` is removed in favor of the new provider wrapping `BankTransactionsContent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1df1158b313ff9a6bfc85a04cb20704bd01d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->