### PR TITLE
[HST/GST] Add tax code option models and reusable tax code selectors

### DIFF
--- a/src/components/TaxCodeSelect/TaxCodeComboBox.tsx
+++ b/src/components/TaxCodeSelect/TaxCodeComboBox.tsx
@@ -1,0 +1,41 @@
+import { ComboBox } from '@ui/ComboBox/ComboBox'
+import { type TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
+import { useTaxCodeSelect } from '@components/TaxCodeSelect/useTaxCodeSelect'
+
+type TaxCodeComboBoxProps = {
+  options: TaxCodeComboBoxOption[]
+  value: TaxCodeComboBoxOption | null
+  onChange: (value: TaxCodeComboBoxOption | null) => void
+  isDisabled?: boolean
+  inputId?: string
+  className?: string
+}
+
+export const TaxCodeComboBox = ({
+  options,
+  value,
+  onChange,
+  isDisabled = false,
+  inputId,
+  className,
+}: TaxCodeComboBoxProps) => {
+  const { allOptions, selectedValue, handleChange, placeholder } = useTaxCodeSelect({
+    options,
+    value,
+    onChange,
+  })
+
+  return (
+    <ComboBox<TaxCodeComboBoxOption>
+      inputId={inputId}
+      selectedValue={selectedValue}
+      onSelectedValueChange={handleChange}
+      options={allOptions}
+      isDisabled={isDisabled}
+      isSearchable
+      isClearable
+      placeholder={placeholder}
+      className={className}
+    />
+  )
+}

--- a/src/components/TaxCodeSelect/TaxCodeComboBox.tsx
+++ b/src/components/TaxCodeSelect/TaxCodeComboBox.tsx
@@ -3,8 +3,6 @@ import { type TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeCom
 import { type TaxCodeSelectCommonProps } from '@components/TaxCodeSelect/types'
 import { useTaxCodeSelect } from '@components/TaxCodeSelect/useTaxCodeSelect'
 
-const EMPTY_ARRAY: ReadonlyArray<TaxCodeComboBoxOption> = []
-
 type TaxCodeComboBoxProps = TaxCodeSelectCommonProps & {
   inputId?: string
 }
@@ -21,15 +19,11 @@ export const TaxCodeComboBox = ({
     selectedValue,
     onSelectedValueChange,
   })
-  const { options: taxCodeOptions = EMPTY_ARRAY, selectedValue: resolvedSelectedValue, onSelectedValueChange: handleChange, placeholder } = taxCodeSelectProps
 
   return (
     <ComboBox<TaxCodeComboBoxOption>
       inputId={inputId}
-      options={taxCodeOptions}
-      selectedValue={resolvedSelectedValue}
-      onSelectedValueChange={handleChange}
-      placeholder={placeholder}
+      {...taxCodeSelectProps}
       isDisabled={isDisabled}
       isSearchable
       isClearable

--- a/src/components/TaxCodeSelect/TaxCodeComboBox.tsx
+++ b/src/components/TaxCodeSelect/TaxCodeComboBox.tsx
@@ -1,41 +1,38 @@
 import { ComboBox } from '@ui/ComboBox/ComboBox'
 import { type TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
+import { type TaxCodeSelectCommonProps } from '@components/TaxCodeSelect/types'
 import { useTaxCodeSelect } from '@components/TaxCodeSelect/useTaxCodeSelect'
 
-type TaxCodeComboBoxProps = {
-  options: TaxCodeComboBoxOption[]
-  value: TaxCodeComboBoxOption | null
-  onChange: (value: TaxCodeComboBoxOption | null) => void
-  isDisabled?: boolean
+const EMPTY_ARRAY: ReadonlyArray<TaxCodeComboBoxOption> = []
+
+type TaxCodeComboBoxProps = TaxCodeSelectCommonProps & {
   inputId?: string
-  className?: string
 }
 
 export const TaxCodeComboBox = ({
   options,
-  value,
-  onChange,
+  selectedValue,
+  onSelectedValueChange,
   isDisabled = false,
   inputId,
-  className,
 }: TaxCodeComboBoxProps) => {
-  const { allOptions, selectedValue, handleChange, placeholder } = useTaxCodeSelect({
+  const taxCodeSelectProps = useTaxCodeSelect({
     options,
-    value,
-    onChange,
+    selectedValue,
+    onSelectedValueChange,
   })
+  const { options: taxCodeOptions = EMPTY_ARRAY, selectedValue: resolvedSelectedValue, onSelectedValueChange: handleChange, placeholder } = taxCodeSelectProps
 
   return (
     <ComboBox<TaxCodeComboBoxOption>
       inputId={inputId}
-      selectedValue={selectedValue}
+      options={taxCodeOptions}
+      selectedValue={resolvedSelectedValue}
       onSelectedValueChange={handleChange}
-      options={allOptions}
+      placeholder={placeholder}
       isDisabled={isDisabled}
       isSearchable
       isClearable
-      placeholder={placeholder}
-      className={className}
     />
   )
 }

--- a/src/components/TaxCodeSelect/TaxCodeMobileDrawer.tsx
+++ b/src/components/TaxCodeSelect/TaxCodeMobileDrawer.tsx
@@ -2,39 +2,32 @@ import { useTranslation } from 'react-i18next'
 
 import { MobileSelectionDrawerWithTrigger } from '@ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger'
 import { type TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
+import { type TaxCodeSelectCommonProps } from '@components/TaxCodeSelect/types'
 import { useTaxCodeSelect } from '@components/TaxCodeSelect/useTaxCodeSelect'
 
-type TaxCodeMobileDrawerProps = {
-  options: TaxCodeComboBoxOption[]
-  value: TaxCodeComboBoxOption | null
-  onChange: (value: TaxCodeComboBoxOption | null) => void
-  isDisabled?: boolean
-}
+type TaxCodeMobileDrawerProps = TaxCodeSelectCommonProps
 
 export const TaxCodeMobileDrawer = ({
   options,
-  value,
-  onChange,
+  selectedValue,
+  onSelectedValueChange,
   isDisabled = false,
 }: TaxCodeMobileDrawerProps) => {
   const { t } = useTranslation()
-  const { allOptions, selectedValue, handleChange, placeholder } = useTaxCodeSelect({
+  const taxCodeSelectProps = useTaxCodeSelect({
     options,
-    value,
-    onChange,
+    selectedValue,
+    onSelectedValueChange,
   })
 
   return (
     <MobileSelectionDrawerWithTrigger<TaxCodeComboBoxOption>
       ariaLabel={t('bankTransactions:action.select_tax_code', 'Select tax code')}
       heading={t('bankTransactions:action.select_tax_code', 'Select tax code')}
-      options={allOptions}
-      selectedValue={selectedValue}
-      onSelectedValueChange={handleChange}
+      {...taxCodeSelectProps}
       isDisabled={isDisabled}
       isSearchable
       searchPlaceholder={t('bankTransactions:action.search_tax_codes', 'Search tax codes...')}
-      placeholder={placeholder}
     />
   )
 }

--- a/src/components/TaxCodeSelect/TaxCodeMobileDrawer.tsx
+++ b/src/components/TaxCodeSelect/TaxCodeMobileDrawer.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from 'react-i18next'
+
+import { MobileSelectionDrawerWithTrigger } from '@ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger'
+import { type TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
+import { useTaxCodeSelect } from '@components/TaxCodeSelect/useTaxCodeSelect'
+
+type TaxCodeMobileDrawerProps = {
+  options: TaxCodeComboBoxOption[]
+  value: TaxCodeComboBoxOption | null
+  onChange: (value: TaxCodeComboBoxOption | null) => void
+  isDisabled?: boolean
+}
+
+export const TaxCodeMobileDrawer = ({
+  options,
+  value,
+  onChange,
+  isDisabled = false,
+}: TaxCodeMobileDrawerProps) => {
+  const { t } = useTranslation()
+  const { allOptions, selectedValue, handleChange, placeholder } = useTaxCodeSelect({
+    options,
+    value,
+    onChange,
+  })
+
+  return (
+    <MobileSelectionDrawerWithTrigger<TaxCodeComboBoxOption>
+      ariaLabel={t('bankTransactions:action.select_tax_code', 'Select tax code')}
+      heading={t('bankTransactions:action.select_tax_code', 'Select tax code')}
+      options={allOptions}
+      selectedValue={selectedValue}
+      onSelectedValueChange={handleChange}
+      isDisabled={isDisabled}
+      isSearchable
+      searchPlaceholder={t('bankTransactions:action.search_tax_codes', 'Search tax codes...')}
+      placeholder={placeholder}
+    />
+  )
+}

--- a/src/components/TaxCodeSelect/taxCodeComboBoxOption.ts
+++ b/src/components/TaxCodeSelect/taxCodeComboBoxOption.ts
@@ -1,0 +1,29 @@
+import type { BankTransactionTaxOption } from '@schemas/bankTransactions/bankTransaction'
+import { BaseComboBoxOption } from '@ui/ComboBox/baseComboBoxOption'
+
+export const NO_TAX_CODE = '__no_tax_code__'
+
+export class TaxCodeComboBoxOption extends BaseComboBoxOption<BankTransactionTaxOption> {
+  constructor(taxOption: BankTransactionTaxOption) {
+    super(taxOption)
+  }
+
+  static noTaxCode(label: string): TaxCodeComboBoxOption {
+    return new TaxCodeComboBoxOption({
+      code: NO_TAX_CODE,
+      display_name: label,
+    })
+  }
+
+  get original() {
+    return this.internalValue
+  }
+
+  get label() {
+    return this.internalValue.display_name
+  }
+
+  get value() {
+    return this.internalValue.code
+  }
+}

--- a/src/components/TaxCodeSelect/types.ts
+++ b/src/components/TaxCodeSelect/types.ts
@@ -1,0 +1,7 @@
+import { type SingleSelectComboBoxProps } from '@ui/ComboBox/types'
+import { type TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
+
+export type TaxCodeSelectCommonProps = Pick<
+  SingleSelectComboBoxProps<TaxCodeComboBoxOption>,
+  'isDisabled' | 'onSelectedValueChange' | 'selectedValue' | 'options'
+>

--- a/src/components/TaxCodeSelect/useTaxCodeSelect.ts
+++ b/src/components/TaxCodeSelect/useTaxCodeSelect.ts
@@ -3,12 +3,17 @@ import { useTranslation } from 'react-i18next'
 
 import { NO_TAX_CODE, TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
 
-import type { TaxCodeSelectCommonProps } from './types'
-
 type UseTaxCodeSelectParams = {
   options?: ReadonlyArray<TaxCodeComboBoxOption>
   selectedValue: TaxCodeComboBoxOption | null
   onSelectedValueChange: (value: TaxCodeComboBoxOption | null) => void
+}
+
+type UseTaxCodeSelectReturn = {
+  options: ReadonlyArray<TaxCodeComboBoxOption>
+  selectedValue: TaxCodeComboBoxOption
+  onSelectedValueChange: (value: TaxCodeComboBoxOption | null) => void
+  placeholder: string
 }
 
 const EMPTY_ARRAY: ReadonlyArray<TaxCodeComboBoxOption> = []
@@ -17,7 +22,7 @@ export const useTaxCodeSelect = ({
   options = EMPTY_ARRAY,
   selectedValue,
   onSelectedValueChange,
-}: UseTaxCodeSelectParams): TaxCodeSelectCommonProps => {
+}: UseTaxCodeSelectParams): UseTaxCodeSelectReturn => {
   const { t } = useTranslation()
   const noTaxCodeOption = useMemo<TaxCodeComboBoxOption>(
     () => TaxCodeComboBoxOption.noTaxCode(t('bankTransactions:action.no_tax_code', 'No tax code')),
@@ -48,7 +53,7 @@ export const useTaxCodeSelect = ({
     [t],
   )
 
-  return useMemo(() => ({
+  return useMemo<UseTaxCodeSelectReturn>(() => ({
     options: optionsWithNoTaxCode,
     selectedValue: resolvedSelectedValue,
     onSelectedValueChange: handleChange,

--- a/src/components/TaxCodeSelect/useTaxCodeSelect.ts
+++ b/src/components/TaxCodeSelect/useTaxCodeSelect.ts
@@ -3,53 +3,55 @@ import { useTranslation } from 'react-i18next'
 
 import { NO_TAX_CODE, TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
 
+import type { TaxCodeSelectCommonProps } from './types'
+
 type UseTaxCodeSelectParams = {
-  options: TaxCodeComboBoxOption[]
-  value: TaxCodeComboBoxOption | null
-  onChange: (value: TaxCodeComboBoxOption | null) => void
+  options?: ReadonlyArray<TaxCodeComboBoxOption>
+  selectedValue: TaxCodeComboBoxOption | null
+  onSelectedValueChange: (value: TaxCodeComboBoxOption | null) => void
 }
 
-type UseTaxCodeSelectReturn = {
-  allOptions: TaxCodeComboBoxOption[]
-  selectedValue: TaxCodeComboBoxOption
-  handleChange: (next: TaxCodeComboBoxOption | null) => void
-  placeholder: string
-}
+const EMPTY_ARRAY: ReadonlyArray<TaxCodeComboBoxOption> = []
 
 export const useTaxCodeSelect = ({
-  options,
-  value,
-  onChange,
-}: UseTaxCodeSelectParams): UseTaxCodeSelectReturn => {
+  options = EMPTY_ARRAY,
+  selectedValue,
+  onSelectedValueChange,
+}: UseTaxCodeSelectParams): TaxCodeSelectCommonProps => {
   const { t } = useTranslation()
   const noTaxCodeOption = useMemo<TaxCodeComboBoxOption>(
     () => TaxCodeComboBoxOption.noTaxCode(t('bankTransactions:action.no_tax_code', 'No tax code')),
     [t],
   )
 
-  const allOptions = useMemo<TaxCodeComboBoxOption[]>(
+  const optionsWithNoTaxCode = useMemo<TaxCodeComboBoxOption[]>(
     () => [noTaxCodeOption, ...options],
     [noTaxCodeOption, options],
   )
 
-  const selectedValue = useMemo<TaxCodeComboBoxOption>(
-    () => value ?? noTaxCodeOption,
-    [value, noTaxCodeOption],
+  const resolvedSelectedValue = useMemo<TaxCodeComboBoxOption>(
+    () => selectedValue ?? noTaxCodeOption,
+    [selectedValue, noTaxCodeOption],
   )
 
   const handleChange = useCallback((next: TaxCodeComboBoxOption | null) => {
     if (next === null || next.value === NO_TAX_CODE) {
-      onChange(null)
+      onSelectedValueChange(null)
       return
     }
 
-    onChange(options.find(option => option.value === next.value) ?? null)
-  }, [onChange, options])
+    onSelectedValueChange(options.find(option => option.value === next.value) ?? null)
+  }, [onSelectedValueChange, options])
 
-  return {
-    allOptions,
-    selectedValue,
-    handleChange,
-    placeholder: t('bankTransactions:action.select_tax_code', 'Select tax code'),
-  }
+  const placeholder = useMemo(
+    () => t('bankTransactions:action.select_tax_code', 'Select tax code'),
+    [t],
+  )
+
+  return useMemo(() => ({
+    options: optionsWithNoTaxCode,
+    selectedValue: resolvedSelectedValue,
+    onSelectedValueChange: handleChange,
+    placeholder,
+  }), [optionsWithNoTaxCode, resolvedSelectedValue, handleChange, placeholder])
 }

--- a/src/components/TaxCodeSelect/useTaxCodeSelect.ts
+++ b/src/components/TaxCodeSelect/useTaxCodeSelect.ts
@@ -1,0 +1,55 @@
+import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { NO_TAX_CODE, TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
+
+type UseTaxCodeSelectParams = {
+  options: TaxCodeComboBoxOption[]
+  value: TaxCodeComboBoxOption | null
+  onChange: (value: TaxCodeComboBoxOption | null) => void
+}
+
+type UseTaxCodeSelectReturn = {
+  allOptions: TaxCodeComboBoxOption[]
+  selectedValue: TaxCodeComboBoxOption
+  handleChange: (next: TaxCodeComboBoxOption | null) => void
+  placeholder: string
+}
+
+export const useTaxCodeSelect = ({
+  options,
+  value,
+  onChange,
+}: UseTaxCodeSelectParams): UseTaxCodeSelectReturn => {
+  const { t } = useTranslation()
+  const noTaxCodeOption = useMemo<TaxCodeComboBoxOption>(
+    () => TaxCodeComboBoxOption.noTaxCode(t('bankTransactions:action.no_tax_code', 'No tax code')),
+    [t],
+  )
+
+  const allOptions = useMemo<TaxCodeComboBoxOption[]>(
+    () => [noTaxCodeOption, ...options],
+    [noTaxCodeOption, options],
+  )
+
+  const selectedValue = useMemo<TaxCodeComboBoxOption>(
+    () => value ?? noTaxCodeOption,
+    [value, noTaxCodeOption],
+  )
+
+  const handleChange = useCallback((next: TaxCodeComboBoxOption | null) => {
+    if (next === null || next.value === NO_TAX_CODE) {
+      onChange(null)
+      return
+    }
+
+    onChange(options.find(option => option.value === next.value) ?? null)
+  }, [onChange, options])
+
+  return {
+    allOptions,
+    selectedValue,
+    handleChange,
+    placeholder: t('bankTransactions:action.select_tax_code', 'Select tax code'),
+  }
+}

--- a/src/schemas/bankTransactions/bankTransaction.ts
+++ b/src/schemas/bankTransactions/bankTransaction.ts
@@ -35,6 +35,7 @@ export const BankTransactionTaxOptionSchema = Schema.Struct({
     Schema.fromKey('display_name'),
   ),
 })
+export type BankTransactionTaxOption = typeof BankTransactionTaxOptionSchema.Encoded
 
 export const BankTransactionTaxOptionsSchema = Schema.Record({
   key: Schema.String,

--- a/src/utils/bankTransactions.ts
+++ b/src/utils/bankTransactions.ts
@@ -4,6 +4,7 @@ import { type BankTransaction, DisplayState, type Split, type SuggestedMatch } f
 import { type DateRange } from '@internal-types/general'
 import { Direction } from '@internal-types/general'
 import type { TagFilterInput } from '@internal-types/tags'
+import { type BankTransactionTaxOption } from '@schemas/bankTransactions/bankTransaction'
 import type { CategoryUpdate } from '@schemas/bankTransactions/categoryUpdate'
 import { makeTagKeyValueFromTag } from '@schemas/tag'
 import { CategorizedCategories, ReviewCategories } from '@components/BankTransactions/constants'
@@ -76,6 +77,14 @@ export const countTransactionsToReview = ({
 
 export const hasReceipts = (bankTransaction?: BankTransaction) =>
   bankTransaction?.document_ids && bankTransaction.document_ids.length > 0
+
+export const getBankTransactionTaxOptions = (bankTransaction?: BankTransaction): BankTransactionTaxOption[] => {
+  if (!bankTransaction?.tax_options) {
+    return []
+  }
+
+  return Object.values(bankTransaction.tax_options).flat()
+}
 
 export const isTransferMatch = (bankTransaction?: BankTransaction) => {
   return bankTransaction?.match?.details.type === 'Transfer_Match'


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk UI/data-wiring change: introduces new tax-code selection components and normalizes “no tax code” to `null`, which could affect downstream handling if consumers assume a non-null selection.
> 
> **Overview**
> Adds a reusable tax-code selection layer for bank transactions, including a desktop `TaxCodeComboBox` and mobile `TaxCodeMobileDrawer`, both backed by shared `useTaxCodeSelect` logic.
> 
> The new hook injects a translated **“No tax code”** option, provides a default selected value, and maps clearing/choosing that sentinel back to `onSelectedValueChange(null)`.
> 
> Extends the bank transaction schema with an exported `BankTransactionTaxOption` type and adds `getBankTransactionTaxOptions` to flatten `tax_options` into a single list for UI consumption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1af72967e6ddaf92e53fc5cfd018a5fa7ebe364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->