### PR TITLE
[HST/GST] integrate tax code combobox in splits

### DIFF
--- a/src/components/BankTransactionCategoryComboBox/utils.ts
+++ b/src/components/BankTransactionCategoryComboBox/utils.ts
@@ -46,6 +46,7 @@ export const convertApiCategorizationToCategoryOrSplitAsOption = (categorization
     const splits = categorization.entries.map(splitEntryEncoded => ({
       amount: splitEntryEncoded.amount || 0,
       category: splitEntryEncoded.category ? new ApiCategorizationAsOption(splitEntryEncoded.category) : null,
+      taxCode: splitEntryEncoded.tax_code ?? null,
       tags: splitEntryEncoded.tags?.map(tag => makeTagFromTransactionTag(Schema.decodeSync(TransactionTagSchema)(tag))) ?? [],
       customerVendor: splitEntryEncoded.customer
         ? decodeCustomerVendor({ ...splitEntryEncoded.customer, customerVendorType: 'CUSTOMER' })

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -118,7 +118,7 @@ export const ExpandedBankTransactionRow = ({
     getBankTransactionFirstSuggestedMatch(bankTransaction),
   )
   const [matchFormError, setMatchFormError] = useState<string | undefined>()
-  const bodyRef = useRef<HTMLSpanElement>(null)
+  const bodyRef = useRef<HTMLDivElement>(null)
 
   const {
     localSplits,
@@ -223,11 +223,11 @@ export const ExpandedBankTransactionRow = ({
     : []
 
   return (
-    <span className='Layer__expanded-bank-transaction-row'>
+    <div className='Layer__expanded-bank-transaction-row'>
       {isOpen && (
         <>
           <Separator />
-          <span className='Layer__expanded-bank-transaction-row__wrapper' ref={bodyRef}>
+          <div className='Layer__expanded-bank-transaction-row__wrapper' ref={bodyRef}>
             <VStack pis={variant === 'row' ? 'md' : undefined} pbs='sm' pbe='md'>
               {isCategorizationEnabled
                 && (
@@ -421,9 +421,9 @@ export const ExpandedBankTransactionRow = ({
                 )}
               </div>
             </VStack>
-          </span>
+          </div>
         </>
       )}
-    </span>
+    </div>
   )
 }

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -31,6 +31,7 @@ import Trash from '@icons/Trash'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Toggle, ToggleSize } from '@ui/Toggle/Toggle'
+import { Span } from '@ui/Typography/Text'
 import { BankTransactionCategoryComboBox } from '@components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox'
 import { useBankTransactionCustomerVendorVisibility } from '@components/BankTransactionCustomerVendorSelector/BankTransactionCustomerVendorVisibilityProvider'
 import { BankTransactionFormFields } from '@components/BankTransactionFormFields/BankTransactionFormFields'
@@ -38,11 +39,13 @@ import { BankTransactionReceiptsWithProvider } from '@components/BankTransaction
 import { useBankTransactionTagVisibility } from '@components/BankTransactionTagSelector/BankTransactionTagVisibilityProvider'
 import { TextButton } from '@components/Button/TextButton'
 import { CustomerVendorSelector } from '@components/CustomerVendorSelector/CustomerVendorSelector'
+import { useTaxCodeOptions } from '@components/ExpandedBankTransactionRow/useTaxCodeOptions'
 import { AmountInput } from '@components/Input/AmountInput'
 import { Input } from '@components/Input/Input'
 import { MatchForm } from '@components/MatchForm/MatchForm'
 import { Separator } from '@components/Separator/Separator'
 import { TagDimensionsGroup } from '@components/Tags/TagDimensionsGroup/TagDimensionsGroup'
+import { TaxCodeComboBox } from '@components/TaxCodeSelect/TaxCodeComboBox'
 import { ErrorText } from '@components/Typography/ErrorText'
 
 import './expandedBankTransactionRow.scss'
@@ -200,6 +203,7 @@ export const ExpandedBankTransactionRow = ({
   }
 
   const isCategorizationEnabled = useBankTransactionsIsCategorizationEnabledContext()
+  const { taxCodeOptions, hasTaxCodeOptions, getSelectedTaxCodeOption } = useTaxCodeOptions(bankTransaction)
 
   const toggleOptions = useMemo(() => [
     {
@@ -218,18 +222,12 @@ export const ExpandedBankTransactionRow = ({
     ? localSplits
     : []
 
-  const className = 'Layer__expanded-bank-transaction-row'
-
   return (
-    <span
-      className={`${className} ${className}--${
-        isOpen ? 'expanded' : 'collapsed'
-      }`}
-    >
+    <span className='Layer__expanded-bank-transaction-row'>
       {isOpen && (
         <>
           <Separator />
-          <span className={`${className}__wrapper`} ref={bodyRef}>
+          <span className='Layer__expanded-bank-transaction-row__wrapper' ref={bodyRef}>
             <VStack pis={variant === 'row' ? 'md' : undefined} pbs='sm' pbe='md'>
               {isCategorizationEnabled
                 && (
@@ -244,20 +242,19 @@ export const ExpandedBankTransactionRow = ({
                   </HStack>
                 )}
               <div
-                className={`${className}__content`}
+                className='Layer__expanded-bank-transaction-row__content'
                 id={`expanded-${bankTransaction.id}`}
               >
-                <div className={`${className}__content-panels`}>
+                <div className='Layer__expanded-bank-transaction-row__content-panels'>
                   <div
                     className={classNames(
-                      `${className}__match`,
-                      `${className}__content-panel`,
-                      purpose === Purpose.match
-                        ? `${className}__content-panel--active`
-                        : '',
+                      'Layer__expanded-bank-transaction-row__content-panel',
+                      {
+                        'Layer__expanded-bank-transaction-row__content-panel--active': purpose === Purpose.match,
+                      },
                     )}
                   >
-                    <div className={`${className}__content-panel-container`}>
+                    <div className='Layer__expanded-bank-transaction-row__content-panel-container'>
                       <MatchForm
                         bankTransaction={bankTransaction}
                         selectedMatchId={selectedMatch?.id}
@@ -276,61 +273,79 @@ export const ExpandedBankTransactionRow = ({
 
                   <div
                     className={classNames(
-                      `${className}__splits`,
-                      `${className}__content-panel`,
-                      purpose === Purpose.categorize
-                        ? `${className}__content-panel--active`
-                        : '',
+                      'Layer__expanded-bank-transaction-row__splits',
+                      'Layer__expanded-bank-transaction-row__content-panel',
+                      {
+                        'Layer__expanded-bank-transaction-row__content-panel--active': purpose === Purpose.categorize,
+                      },
                     )}
                   >
-                    <div className={`${className}__content-panel-container`}>
-                      <div className={`${className}__splits-inputs`}>
+                    <div className='Layer__expanded-bank-transaction-row__content-panel-container'>
+                      <div className='Layer__expanded-bank-transaction-row__splits-inputs'>
                         {effectiveSplits.map((split, index) => (
-                          <div
-                            className={`${className}__table-cell--split-entry`}
+                          <VStack
+                            gap='xs'
+                            pbs={asListItem && effectiveSplits.length === 1 ? 'sm' : undefined}
+                            pbe={asListItem && effectiveSplits.length > 1 ? 'sm' : undefined}
                             key={`split-${index}`}
                           >
-                            <AmountInput
-                              name={`split-${index}${asListItem ? '-li' : ''}`}
-                              disabled={
-                                index === 0 || !isCategorizationEnabled
-                              }
-                              onChange={updateSplitAmount(index)}
-                              value={getInputValueForSplitAtIndex(index, split)}
-                              onBlur={onBlurSplitAmount}
-                              className={`${className}__table-cell--split-entry__amount`}
-                              isInvalid={split.amount < 0}
-                            />
-                            <BankTransactionCategoryComboBox
-                              bankTransaction={bankTransaction}
-                              selectedValue={split.category}
-                              onSelectedValueChange={(value) => {
-                                changeCategoryForSplitAtIndex(index, value)
-                              }}
-                              isDisabled={!isCategorizationEnabled}
-                              includeSuggestedMatches={false}
-                            />
-                            {showTags && (
-                              <TagDimensionsGroup
-                                value={split.tags}
-                                onChange={tags => changeTags(index, tags)}
-                                showLabels={false}
-                                isReadOnly={!isCategorizationEnabled}
-                                className={`${className}__table-cell--split-entry__tags`}
+                            {asListItem && effectiveSplits.length > 1 && (
+                              <Span>{t('bankTransactions:action.split_number_label', 'Split #{{number}}', { number: index + 1 })}</Span>
+                            )}
+                            <div className='Layer__expanded-bank-transaction-row__table-cell--split-entry'>
+                              <AmountInput
+                                name={`split-${index}${asListItem ? '-li' : ''}`}
+                                disabled={
+                                  index === 0 || !isCategorizationEnabled
+                                }
+                                onChange={updateSplitAmount(index)}
+                                value={getInputValueForSplitAtIndex(index, split)}
+                                onBlur={onBlurSplitAmount}
+                                isInvalid={split.amount < 0}
                               />
-                            )}
-                            {showCustomerVendor && (
-                              <div className='Layer__expanded-bank-transaction-row__table-cell--split-entry__customer'>
-                                <CustomerVendorSelector
-                                  selectedCustomerVendor={split.customerVendor}
-                                  onSelectedCustomerVendorChange={customerVendor => changeCustomerVendor(index, customerVendor)}
-                                  placeholder={t('customerVendor:action.set_customer_vendor', 'Set customer or vendor')}
-                                  isReadOnly={!isCategorizationEnabled}
-                                  showLabel={false}
+                              <BankTransactionCategoryComboBox
+                                bankTransaction={bankTransaction}
+                                selectedValue={split.category}
+                                onSelectedValueChange={(value) => {
+                                  changeCategoryForSplitAtIndex(index, value)
+                                }}
+                                isDisabled={!isCategorizationEnabled}
+                                includeSuggestedMatches={false}
+                              />
+                              {hasTaxCodeOptions && (
+                                <TaxCodeComboBox
+                                  options={taxCodeOptions}
+                                  selectedValue={getSelectedTaxCodeOption(split.taxCode)}
+                                  onSelectedValueChange={(value) => {
+                                    updateSplitAtIndex(index, currentSplit => ({
+                                      ...currentSplit,
+                                      taxCode: value?.value ?? null,
+                                    }))
+                                  }}
+                                  isDisabled={!isCategorizationEnabled}
+                                  className='Layer__expanded-bank-transaction-row__table-cell--split-entry__tax-code'
                                 />
-                              </div>
-                            )}
-                            <div className='Layer__expanded-bank-transaction-row__table-cell--split-entry__button'>
+                              )}
+                              {showTags && (
+                                <TagDimensionsGroup
+                                  value={split.tags}
+                                  onChange={tags => changeTags(index, tags)}
+                                  showLabels={false}
+                                  isReadOnly={!isCategorizationEnabled}
+                                  className='Layer__expanded-bank-transaction-row__table-cell--split-entry__tags'
+                                />
+                              )}
+                              {showCustomerVendor && (
+                                <div className='Layer__expanded-bank-transaction-row__table-cell--split-entry__customer'>
+                                  <CustomerVendorSelector
+                                    selectedCustomerVendor={split.customerVendor}
+                                    onSelectedCustomerVendorChange={customerVendor => changeCustomerVendor(index, customerVendor)}
+                                    placeholder={t('customerVendor:action.set_customer_vendor', 'Set customer or vendor')}
+                                    isReadOnly={!isCategorizationEnabled}
+                                    showLabel={false}
+                                  />
+                                </div>
+                              )}
                               <Button
                                 onPress={() => removeSplit(index)}
                                 variant='outlined'
@@ -340,11 +355,16 @@ export const ExpandedBankTransactionRow = ({
                                 <Trash size={18} />
                               </Button>
                             </div>
-                          </div>
+                          </VStack>
                         ))}
                       </div>
                       {splitFormError && <HStack pb='sm'><ErrorText>{splitFormError}</ErrorText></HStack>}
-                      <div className={`${className}__total-and-btns`}>
+                      <div
+                        className={classNames(
+                          'Layer__expanded-bank-transaction-row__total-and-btns',
+                          asListItem && 'Layer__expanded-bank-transaction-row__total-and-btns--ListItem',
+                        )}
+                      >
                         {effectiveSplits.length > 1 && (
                           <Input
                             disabled={true}
@@ -355,7 +375,7 @@ export const ExpandedBankTransactionRow = ({
                         )}
                         {isCategorizationEnabled
                           ? (
-                            <div className={`${className}__splits-buttons`}>
+                            <div className='Layer__expanded-bank-transaction-row__splits-buttons'>
                               {effectiveSplits.length > 1
                                 ? (
                                   <TextButton
@@ -395,7 +415,7 @@ export const ExpandedBankTransactionRow = ({
                   <BankTransactionReceiptsWithProvider
                     bankTransaction={bankTransaction}
                     isActive={isOpen}
-                    classNamePrefix={className}
+                    classNamePrefix='Layer__expanded-bank-transaction-row'
                     floatingActions={!asListItem}
                   />
                 )}

--- a/src/components/ExpandedBankTransactionRow/expandedBankTransactionRow.scss
+++ b/src/components/ExpandedBankTransactionRow/expandedBankTransactionRow.scss
@@ -175,13 +175,13 @@
     &:has(> &__customer) {
       grid-template-areas:
         'amount category button'
-        'customer . .';
+        '. customer .';
     }
 
     &:has(> .Layer__expanded-bank-transaction-row__table-cell--split-entry__tax-code__Container) {
       grid-template-areas:
         'amount category button'
-        'tax-code . .';
+        '. tax-code .';
     }
 
     &:has(> &__tags) {

--- a/src/components/ExpandedBankTransactionRow/expandedBankTransactionRow.scss
+++ b/src/components/ExpandedBankTransactionRow/expandedBankTransactionRow.scss
@@ -8,3 +8,291 @@
     padding-inline-end: var(--spacing-md);
   }
 }
+
+.Layer__expanded-bank-transaction-row {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  background-color: var(--bg-element-focus);
+  transition:
+    background-color var(--transition-speed) ease-in-out,
+    height var(--transition-speed) ease-in-out;
+}
+
+.Layer__expanded-bank-transaction-row .Layer__expanded-bank-transaction-row__wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  overflow: hidden;
+  transition: height var(--transition-speed) ease-in-out;
+}
+
+.Layer__expanded-bank-transaction-row__content {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  min-width: 40rem;
+  max-width: 76rem;
+
+  @container (max-width: 768px) {
+    min-width: 30rem;
+  }
+}
+
+.Layer__expanded-bank-transaction-row__content-panels {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+}
+
+.Layer__expanded-bank-transaction-row__content-panel {
+  box-sizing: border-box;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  overflow: hidden;
+  height: 0;
+  max-width: 0;
+  opacity: 0;
+  transition:
+    max-width 150ms ease-out,
+    opacity 300ms ease-out;
+
+  .Layer__expanded-bank-transaction-row__content-panel-container {
+    box-sizing: border-box;
+    padding: 0 var(--spacing-md);
+  }
+
+  &.Layer__expanded-bank-transaction-row__content-panel--active {
+    height: auto;
+    max-width: 100%;
+    opacity: 1;
+  }
+
+  &:not(.Layer__expanded-bank-transaction-row__content-panel--active) {
+    .Layer__select .Layer__select__control {
+      overflow: hidden;
+      max-width: 0;
+    }
+
+    .Layer__expanded-bank-transaction-row__table-cell--split-entry {
+      overflow: hidden;
+      max-width: 0;
+    }
+
+    .Layer__expanded-bank-transaction-row__splits-buttons {
+      overflow: hidden;
+      max-width: 0;
+    }
+  }
+}
+
+@container (min-width: 701px) {
+  .Layer__expanded-bank-transaction-row__content-panel {
+    &.Layer__expanded-bank-transaction-row__content-panel--active {
+      max-width: 100%;
+      opacity: 1;
+    }
+
+    .Layer__expanded-bank-transaction-row__splits-buttons {
+      max-height: 38px;
+      white-space: nowrap;
+    }
+  }
+}
+
+.Layer__expanded-bank-transaction-row__splits {
+  display: flex;
+  gap: var(--spacing-sm);
+}
+
+.Layer__expanded-bank-transaction-row__splits-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  padding-top: 2px;
+}
+
+.Layer__expanded-bank-transaction-row__splits-buttons {
+  padding-bottom: 2px;
+}
+
+.Layer__expanded-bank-transaction-row__total-and-btns {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) 0;
+
+  &:empty {
+    display: none;
+  }
+}
+
+.Layer__expanded-bank-transaction-row__total-and-btns--ListItem {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.Layer__expanded-bank-transaction-row__file-upload {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  align-items: flex-start;
+  padding: 0 var(--spacing-md);
+}
+
+.Layer__expanded-bank-transaction-row__table-cell--split-entry {
+  display: flex;
+  gap: var(--spacing-xs);
+  align-items: flex-start;
+  min-width: 40rem;
+
+  .Layer__BankTransactionCategoryComboBox__Container {
+    grid-area: category;
+    max-width: 24.5rem;
+  }
+
+  &__customer {
+    grid-area: customer;
+    min-width: 12rem;
+  }
+
+  .Layer__Stack.Layer__expanded-bank-transaction-row__table-cell--split-entry__tax-code__Container {
+    flex: 0 0 12rem;
+    grid-area: tax-code;
+    min-width: 12rem;
+  }
+
+  @container (max-width: 768px) {
+    display: grid;
+    grid-template-areas: 'amount category button';
+    grid-template-columns: 12rem minmax(12rem, 24.5rem) 2.25rem;
+    min-width: 27.5rem;
+    max-width: min(40rem, 100%);
+
+    &:has(> &__customer) {
+      grid-template-areas:
+        'amount category button'
+        'customer . .';
+    }
+
+    &:has(> .Layer__expanded-bank-transaction-row__table-cell--split-entry__tax-code__Container) {
+      grid-template-areas:
+        'amount category button'
+        'tax-code . .';
+    }
+
+    &:has(> &__tags) {
+      grid-template-areas:
+        'amount category button'
+        'tags tags .';
+    }
+
+    &:has(> &__customer):has(> .Layer__expanded-bank-transaction-row__table-cell--split-entry__tax-code__Container) {
+      grid-template-areas:
+        'amount category button'
+        'customer tax-code .';
+    }
+
+    &:has(> &__customer):has(> &__tags) {
+      grid-template-areas:
+        'amount category button'
+        'customer tags .';
+    }
+
+    &:has(> .Layer__expanded-bank-transaction-row__table-cell--split-entry__tax-code__Container):has(> &__tags) {
+      grid-template-areas:
+        'amount category button'
+        'tax-code tags .';
+    }
+
+    &:has(> &__customer):has(> .Layer__expanded-bank-transaction-row__table-cell--split-entry__tax-code__Container):has(> &__tags) {
+      grid-template-areas:
+        'amount category button'
+        'customer tax-code .'
+        'tags tags .';
+    }
+  }
+}
+
+.Layer__expanded-bank-transaction-row__table-cell--split-entry__tags {
+  grid-area: tags;
+}
+
+@container (max-width: 600px) {
+  .Layer__expanded-bank-transaction-row__splits-inputs {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    width: 100%;
+  }
+
+  .Layer__expanded-bank-transaction-row__table-cell--split-entry {
+    width: 100%;
+
+    input {
+      width: 100%;
+    }
+
+    .Layer__input-tooltip {
+      position: relative;
+      flex: 1;
+      max-width: 42%;
+    }
+  }
+
+  .Layer__expanded-bank-transaction-row__total-and-btns {
+    box-sizing: border-box;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+
+    .Layer__input-tooltip {
+      position: relative;
+      flex: 1;
+      width: 100%;
+      max-width: 42%;
+    }
+
+    .Layer__input {
+      max-width: 100%;
+    }
+  }
+}
+
+.Layer__expanded-bank-transaction-row__splits-inputs + .Layer__text--error {
+  padding: var(--spacing-2xs) 0;
+  padding-bottom: var(--spacing-md);
+  margin: 0;
+}
+
+.Layer__expanded-bank-transaction-row__splits-inputs .Layer__input {
+  text-align: right;
+}
+
+.Layer__expanded-bank-transaction-row__total-and-btns .Layer__input {
+  max-width: 100%;
+  text-align: right;
+}
+
+@container (min-width: 401px) {
+  .Layer__expanded-bank-transaction-row__total-and-btns .Layer__input-tooltip,
+  .Layer__expanded-bank-transaction-row__table-cell--split-entry .Layer__input-tooltip {
+    flex: 1;
+    max-width: 12rem;
+
+    .Layer__input {
+      width: 100%;
+    }
+  }
+}
+
+@container (max-width: 480px) {
+  .Layer__expanded-bank-transaction-row__total-and-btns {
+    & > .Layer__input-tooltip > .Layer__input-left-text {
+      border-right-color: transparent;
+    }
+  }
+}

--- a/src/components/ExpandedBankTransactionRow/useTaxCodeOptions.ts
+++ b/src/components/ExpandedBankTransactionRow/useTaxCodeOptions.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react'
+
+import { type BankTransaction } from '@internal-types/bankTransactions'
+import { getBankTransactionTaxOptions } from '@utils/bankTransactions'
+import { TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
+
+type UseTaxCodeOptionsReturn = {
+  taxCodeOptions: TaxCodeComboBoxOption[]
+  hasTaxCodeOptions: boolean
+  getSelectedTaxCodeOption: (taxCode?: string | null) => TaxCodeComboBoxOption | null
+}
+
+export const useTaxCodeOptions = (bankTransaction: BankTransaction): UseTaxCodeOptionsReturn => {
+  const taxCodeOptions = useMemo(
+    () => getBankTransactionTaxOptions(bankTransaction).map(option => new TaxCodeComboBoxOption(option)),
+    [bankTransaction],
+  )
+
+  const hasTaxCodeOptions = taxCodeOptions.length > 0
+
+  const getSelectedTaxCodeOption = (taxCode?: string | null): TaxCodeComboBoxOption | null => {
+    if (!taxCode) {
+      return null
+    }
+
+    return taxCodeOptions.find(option => option.value === taxCode) ?? null
+  }
+
+  return { taxCodeOptions, hasTaxCodeOptions, getSelectedTaxCodeOption }
+}

--- a/src/components/ExpandedBankTransactionRow/useTaxCodeOptions.ts
+++ b/src/components/ExpandedBankTransactionRow/useTaxCodeOptions.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { getBankTransactionTaxOptions } from '@utils/bankTransactions'
@@ -18,13 +18,13 @@ export const useTaxCodeOptions = (bankTransaction: BankTransaction): UseTaxCodeO
 
   const hasTaxCodeOptions = taxCodeOptions.length > 0
 
-  const getSelectedTaxCodeOption = (taxCode?: string | null): TaxCodeComboBoxOption | null => {
+  const getSelectedTaxCodeOption = useCallback((taxCode?: string | null): TaxCodeComboBoxOption | null => {
     if (!taxCode) {
       return null
     }
 
     return taxCodeOptions.find(option => option.value === taxCode) ?? null
-  }
+  }, [taxCodeOptions])
 
   return { taxCodeOptions, hasTaxCodeOptions, getSelectedTaxCodeOption }
 }

--- a/src/components/ExpandedBankTransactionRow/utils.ts
+++ b/src/components/ExpandedBankTransactionRow/utils.ts
@@ -136,6 +136,7 @@ export const getLocalSplitStateForExpandedTransaction = (
       return {
         amount: splitEntry.amount || 0,
         category: splitEntry.category,
+        taxCode: splitEntry.taxCode ?? null,
         tags: splitEntry.tags,
         customerVendor: splitEntry.customerVendor,
       }

--- a/src/components/ExpandedBankTransactionRow/utils.ts
+++ b/src/components/ExpandedBankTransactionRow/utils.ts
@@ -59,6 +59,7 @@ export const calculateAddSplit = (
   const newSplit = {
     amount: 0,
     category: null,
+    taxCode: null,
     tags: [],
     customerVendor: null,
   }

--- a/src/components/TaxCodeSelect/TaxCodeComboBox.tsx
+++ b/src/components/TaxCodeSelect/TaxCodeComboBox.tsx
@@ -8,6 +8,7 @@ type TaxCodeComboBoxProps = TaxCodeSelectCommonProps & {
 }
 
 export const TaxCodeComboBox = ({
+  className,
   options,
   selectedValue,
   onSelectedValueChange,
@@ -22,6 +23,7 @@ export const TaxCodeComboBox = ({
 
   return (
     <ComboBox<TaxCodeComboBoxOption>
+      className={className}
       inputId={inputId}
       {...taxCodeSelectProps}
       isDisabled={isDisabled}

--- a/src/components/TaxCodeSelect/types.ts
+++ b/src/components/TaxCodeSelect/types.ts
@@ -3,5 +3,5 @@ import { type TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeCom
 
 export type TaxCodeSelectCommonProps = Pick<
   SingleSelectComboBoxProps<TaxCodeComboBoxOption>,
-  'isDisabled' | 'onSelectedValueChange' | 'selectedValue' | 'options'
+  'className' | 'isDisabled' | 'onSelectedValueChange' | 'selectedValue' | 'options'
 >

--- a/src/styles/bank_transactions.scss
+++ b/src/styles/bank_transactions.scss
@@ -159,16 +159,6 @@
   background-color: var(--bg-element-focus);
 }
 
-.Layer__expanded-bank-transaction-row {
-  position: relative;
-  display: block;
-  overflow: hidden;
-  background-color: var(--bg-element-focus);
-  transition:
-    background-color var(--transition-speed) ease-in-out,
-    height var(--transition-speed) ease-in-out;
-}
-
 .Layer__bank-transaction-row:hover,
 .Layer__bank-transaction-row:hover .Layer__table-cell,
 .Layer__bank-transaction-list-item:hover {
@@ -203,16 +193,7 @@
   }
 }
 
-.Layer__expanded-bank-transaction-row .Layer__expanded-bank-transaction-row__wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
-  overflow: hidden;
-  transition: height var(--transition-speed) ease-in-out;
-}
-
-.Layer__bank-transaction-list-item__content,
-.Layer__expanded-bank-transaction-row__content {
+.Layer__bank-transaction-list-item__content {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -223,141 +204,6 @@
   @container (max-width: 768px) {
     min-width: 30rem;
   }
-}
-
-.Layer__expanded-bank-transaction-row__content-panels {
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: row;
-}
-
-.Layer__expanded-bank-transaction-row__content-panel {
-  box-sizing: border-box;
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  gap: var(--spacing-sm);
-  overflow: hidden;
-  height: 0;
-  max-width: 0;
-  opacity: 0;
-  transition:
-    max-width 150ms ease-out,
-    opacity 300ms ease-out;
-
-  .Layer__expanded-bank-transaction-row__content-panel-container {
-    box-sizing: border-box;
-    padding: 0 var(--spacing-md);
-  }
-
-  &.Layer__expanded-bank-transaction-row__content-panel--active {
-    height: auto;
-    max-width: 100%;
-    opacity: 1;
-  }
-
-  &:not(.Layer__expanded-bank-transaction-row__content-panel--active) {
-    .Layer__select .Layer__select__control {
-      overflow: hidden;
-      max-width: 0;
-    }
-
-    .Layer__expanded-bank-transaction-row__table-cell--split-entry {
-      overflow: hidden;
-      max-width: 0;
-    }
-
-    .Layer__expanded-bank-transaction-row__splits-buttons {
-      overflow: hidden;
-      max-width: 0;
-    }
-
-    .Layer__expanded-bank-transaction-row__splits-total {
-      overflow: hidden;
-      max-width: 0;
-    }
-  }
-}
-
-.Layer__expanded-bank-transaction-row__table-cell--split-entry__right-col {
-  display: flex;
-  flex: 1;
-  gap: var(--spacing-sm);
-  align-items: center;
-}
-
-.Layer__expanded-bank-transaction-row__table-cell--split-entry__merge-btn {
-  height: 36px;
-  width: 36px;
-  padding: 0;
-}
-
-@container (min-width: 701px) {
-  .Layer__expanded-bank-transaction-row__content-panel {
-    &.Layer__expanded-bank-transaction-row__content-panel--active {
-      max-width: 100%;
-      opacity: 1;
-    }
-
-    .Layer__expanded-bank-transaction-row__splits-buttons {
-      max-height: 38px;
-      white-space: nowrap;
-    }
-
-    .Layer__expanded-bank-transaction-row__splits-total {
-      max-height: 25px;
-      white-space: nowrap;
-    }
-  }
-}
-
-.Layer__expanded-bank-transaction-row__splits {
-  display: flex;
-  gap: var(--spacing-sm);
-}
-
-.Layer__expanded-bank-transaction-row__splits-inputs {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-xs);
-  padding-top: 2px;
-}
-
-.Layer__expanded-bank-transaction-row__splits-total {
-  padding: var(--spacing-3xs);
-  color: var(--color-base-500);
-}
-
-.Layer__expanded-bank-transaction-row__splits-buttons {
-  padding-bottom: 2px;
-}
-
-.Layer__expanded-bank-transaction-row__total-and-btns {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-sm) 0;
-
-  &:empty {
-    display: none;
-  }
-}
-
-.Layer__expanded-bank-transaction-row__description {
-  padding: 0 var(--spacing-md);
-
-  & textarea {
-    height: 100px;
-    width: 100%;
-  }
-}
-
-.Layer__expanded-bank-transaction-row__file-upload {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-md);
-  align-items: flex-start;
-  padding: 0 var(--spacing-md);
 }
 
 .Layer__bank-transaction-row__actions-cell {
@@ -393,50 +239,6 @@
   gap: 8px;
   align-items: center;
   justify-content: flex-end;
-}
-
-.Layer__expanded-bank-transaction-row__table-cell--split-entry {
-  display: flex;
-  gap: var(--spacing-xs);
-  align-items: flex-start;
-  min-width: 40rem;
-
-  .Layer__BankTransactionCategoryComboBox__Container {
-    grid-area: category;
-    max-width: 24.5rem;
-  }
-
-  &__amount {
-    grid-area: amount;
-  }
-
-  &__customer {
-    grid-area: customer;
-    min-width: 12rem;
-  }
-
-  &__button {
-    grid-area: button;
-  }
-
-  @container (max-width: 768px) {
-    display: grid;
-    grid-template-areas: 'amount category button';
-    grid-template-columns: 12rem minmax(12rem, 24.5rem) 2.25rem;
-    min-width: 27.5rem;
-    max-width: min(40rem, 100%);
-
-    &:has(> .Layer__expanded-bank-transaction-row__table-cell--split-entry__customer),
-    &:has(> .Layer__expanded-bank-transaction-row__table-cell--split-entry__tags) {
-      grid-template-areas:
-        'amount category button'
-        'customer tags .';
-    }
-  }
-}
-
-.Layer__expanded-bank-transaction-row__table-cell--split-entry__tags {
-  grid-area: tags;
 }
 
 .Layer__bank-transactions__list {
@@ -839,47 +641,6 @@
   gap: var(--spacing-md);
 }
 
-@container (max-width: 600px) {
-  .Layer__expanded-bank-transaction-row__splits-inputs {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs);
-    width: 100%;
-  }
-
-  .Layer__expanded-bank-transaction-row__table-cell--split-entry {
-    width: 100%;
-
-    input {
-      width: 100%;
-    }
-
-    .Layer__input-tooltip {
-      position: relative;
-      flex: 1;
-      max-width: 42%;
-    }
-  }
-
-  .Layer__expanded-bank-transaction-row__total-and-btns {
-    box-sizing: border-box;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-
-    .Layer__input-tooltip {
-      position: relative;
-      flex: 1;
-      width: 100%;
-      max-width: 42%;
-    }
-
-    .Layer__input {
-      max-width: 100%;
-    }
-  }
-}
-
 @container (max-width: 500px) {
   .Layer__bank-transaction-list-item__expanded-row {
     input,
@@ -894,40 +655,7 @@
     .Layer__select__indicator {
       padding: var(--spacing-3xs);
     }
-
-    .Layer__expanded-bank-transaction-row__table-cell--split-entry__merge-btn {
-      height: 32px;
-      min-height: 32px;
-      width: 32px;
-
-      svg {
-        height: 14px;
-        width: 14px;
-      }
-    }
-
-    .Layer__expanded-bank-transaction-row__file-upload,
-    .Layer__expanded-bank-transaction-row__total-and-btns {
-      .Layer__btn {
-        min-height: 32px;
-      }
-
-      .Layer__btn-text {
-        font-size: var(--text-xs);
-      }
-
-      .Layer__btn-icon {
-        height: 12px;
-        width: 12px;
-      }
-    }
   }
-}
-
-.Layer__expanded-bank-transaction-row__splits-inputs + .Layer__text--error {
-  padding: var(--spacing-2xs) 0;
-  padding-bottom: var(--spacing-md);
-  margin: 0;
 }
 
 .Layer__bank-transaction-table__date-col,
@@ -940,34 +668,5 @@
   .Layer__bank-transaction-table__date-col,
   .Layer__bank-transactions__account-col {
     color: var(--color-base-1000);
-  }
-}
-
-.Layer__expanded-bank-transaction-row__splits-inputs .Layer__input {
-  text-align: right;
-}
-
-.Layer__expanded-bank-transaction-row__total-and-btns .Layer__input {
-  max-width: 100%;
-  text-align: right;
-}
-
-@container (min-width: 401px) {
-  .Layer__expanded-bank-transaction-row__total-and-btns .Layer__input-tooltip,
-  .Layer__expanded-bank-transaction-row__table-cell--split-entry .Layer__input-tooltip {
-    flex: 1;
-    max-width: 12rem;
-
-    .Layer__input {
-      width: 100%;
-    }
-  }
-}
-
-@container (max-width: 480px) {
-  .Layer__expanded-bank-transaction-row__total-and-btns {
-    & > .Layer__input-tooltip > .Layer__input-left-text {
-      border-right-color: transparent;
-    }
   }
 }

--- a/src/utils/bankTransactions.ts
+++ b/src/utils/bankTransactions.ts
@@ -132,6 +132,7 @@ export const buildCategorizeBankTransactionPayloadForSplit = (splits: Split[]): 
     ? ({
       type: 'Category',
       category: splits[0].category.classification!,
+      taxCode: splits[0].taxCode ?? null,
     })
     : ({
       type: 'Split',
@@ -139,6 +140,7 @@ export const buildCategorizeBankTransactionPayloadForSplit = (splits: Split[]): 
         // TODO: enforce upstream in the category combobox that split.category is non-null
         category: split.category!.classification!,
         amount: split.amount,
+        taxCode: split.taxCode ?? null,
         tags: split.tags.map(tag => makeTagKeyValueFromTag(tag)),
         customerId: split.customerVendor?.customerVendorType === 'CUSTOMER' ? split.customerVendor.id : undefined,
         vendorId: split.customerVendor?.customerVendorType === 'VENDOR' ? split.customerVendor.id : undefined,


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds `taxCode` into split state, UI, and categorize payloads; mistakes could send incorrect tax codes or change categorization behavior for transactions. Scope is limited to bank transaction categorization/splits and related styling.
> 
> **Overview**
> Enables selecting a **tax code per split** in the expanded bank transaction categorization UI, including loading available options from `bankTransaction.tax_options` and persisting the chosen `taxCode` into split state.
> 
> Propagates `taxCode` end-to-end: API categorization decoding now captures `tax_code`, split creation/rehydration includes `taxCode`, and `buildCategorizeBankTransactionPayloadForSplit` sends `taxCode` for both single-category and split payloads.
> 
> Refactors expanded-row markup and styling: moves expanded-row CSS from `bank_transactions.scss` into `expandedBankTransactionRow.scss`, updates class usage, and extends `TaxCodeComboBox` to accept a `className` for layout control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a43e1663ad8ed21e125b04fec89e8f4841e2a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->