### PR TITLE
fix: isolate LayerProvider's SWRConfig from parent SWRConfig

### DIFF
--- a/src/providers/LayerProvider/LayerProvider.tsx
+++ b/src/providers/LayerProvider/LayerProvider.tsx
@@ -66,7 +66,7 @@ export const LayerProvider = ({
   }
 
   return (
-    <SWRConfig value={swrConfig}>
+    <SWRConfig value={() => swrConfig}>
       <LayerI18nProvider locale={locale}>
         <StaleLocaleCacheInvalidator />
         <EnvironmentInputProvider environment={environment} environmentConfigOverride={environmentConfigOverride} usePlaidSandbox={usePlaidSandbox}>


### PR DESCRIPTION
Pass `value` as a function so SWR doesn't merge the parent context.                                                           
  Without this, consumer-set keys (e.g. `isPaused`, `suspense`) leak                                                            
  into Layer's internal SWR calls — `isPaused: () => true` silently                                                             
  halts all revalidation, and `suspense: true` crashes useAuth/useBusiness. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `SWRConfig` is provided, which can affect data fetching/revalidation behavior across all Layer internal SWR hooks. Scope is small (single-line change) but impacts a core provider wrapper.
> 
> **Overview**
> Ensures `LayerProvider`’s internal SWR configuration does **not** merge with any parent `SWRConfig` by passing `value` as a function (`value={() => swrConfig}`) instead of an object.
> 
> This prevents consumer-defined SWR options (e.g. `isPaused`, `suspense`) from leaking into Layer’s internal SWR calls and altering revalidation/throwing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba771425b87b2de53aa802f7e84b031a41e8dc9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->