### PR TITLE
[HST/GST] Refactor category provider store to contain both category/match

### DIFF
--- a/src/components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox.tsx
+++ b/src/components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox.tsx
@@ -5,6 +5,7 @@ import type { GroupBase } from 'react-select'
 import type { BankTransaction } from '@internal-types/bankTransactions'
 import { convertMatchDetailsToLinkingMetadata, decodeMatchDetails } from '@schemas/bankTransactions/match'
 import { useCategories } from '@hooks/api/businesses/[business-id]/categories/useCategories'
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import { useInAppLinkContext } from '@contexts/InAppLinkContext'
 import { ComboBox } from '@ui/ComboBox/ComboBox'
 import { LoadingSpinner } from '@ui/Loading/LoadingSpinner'
@@ -75,15 +76,27 @@ const BankTransactionCategoryComboBoxGroupHeading = ({ group, fallback }: BankTr
   )
 }
 
-type BankTransactionCategoryComboBoxProps = {
+type BankTransactionCategoryComboBoxBaseProps = {
   bankTransaction?: BankTransaction
-  selectedValue: BankTransactionCategoryComboBoxOption | null
-  onSelectedValueChange: (value: BankTransactionCategoryComboBoxOption | null) => void
-  includeSuggestedMatches?: boolean
   isDisabled?: boolean
   isLoading?: boolean
   inputId?: string
 }
+
+type BankTransactionCategoryComboBoxWithMatchesProps = {
+  selectedValue: BankTransactionCategoryComboBoxOption | null
+  onSelectedValueChange: (value: BankTransactionCategoryComboBoxOption | null) => void
+  includeSuggestedMatches?: true
+}
+
+type BankTransactionCategoryComboBoxWithoutMatchesProps = {
+  selectedValue: BankTransactionNonSuggestedMatchOption | null
+  onSelectedValueChange: (value: BankTransactionNonSuggestedMatchOption | null) => void
+  includeSuggestedMatches: false
+}
+
+type BankTransactionCategoryComboBoxProps = BankTransactionCategoryComboBoxBaseProps
+  & (BankTransactionCategoryComboBoxWithMatchesProps | BankTransactionCategoryComboBoxWithoutMatchesProps)
 
 export const BankTransactionCategoryComboBox = ({
   bankTransaction,
@@ -139,12 +152,24 @@ export const BankTransactionCategoryComboBox = ({
     return <BankTransactionsUncategorizedSelectedValue selectedValue={selectedValue} />
   }, [selectedValue])
 
+  const handleSelectedValueChange = useCallback((value: BankTransactionCategoryComboBoxOption | null) => {
+    if (!includeSuggestedMatches) {
+      if (value !== null && isSuggestedMatchAsOption(value)) return
+      const onSelectedValueChangeWithoutMatches = onSelectedValueChange as (nextValue: BankTransactionNonSuggestedMatchOption | null) => void
+      onSelectedValueChangeWithoutMatches(value)
+      return
+    }
+
+    const onSelectedValueChangeWithMatches = onSelectedValueChange as (nextValue: BankTransactionCategoryComboBoxOption | null) => void
+    onSelectedValueChangeWithMatches(value)
+  }, [includeSuggestedMatches, onSelectedValueChange])
+
   return (
     <ComboBox<BankTransactionCategoryComboBoxOption>
       className='Layer__BankTransactionCategoryComboBox'
       inputId={inputId}
       groups={groups}
-      onSelectedValueChange={onSelectedValueChange}
+      onSelectedValueChange={handleSelectedValueChange}
       selectedValue={selectedValue}
       placeholder={placeholder}
       slots={{

--- a/src/components/BankTransactionCategoryComboBox/utils.ts
+++ b/src/components/BankTransactionCategoryComboBox/utils.ts
@@ -10,7 +10,7 @@ import { decodeCustomerVendor } from '@schemas/customerVendor'
 import { TransactionTagSchema } from '@schemas/tag'
 import { makeTagFromTransactionTag } from '@schemas/tag'
 import { translationKey } from '@utils/i18n/translationKey'
-import { type BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 
 export enum BankTransactionCategoryComboBoxGroup {
   TRANSFER = 'TRANSFER',
@@ -41,7 +41,7 @@ export const getGroupDisplayLabel = (label: string | undefined, t: TFunction): s
 export const isBoldGroupLabel = (label: string | undefined): boolean =>
   label !== undefined && BOLD_GROUP_LABELS.has(label as BankTransactionCategoryComboBoxGroup)
 
-export const convertApiCategorizationToCategoryOrSplitAsOption = (categorization: CategorizationEncoded): BankTransactionCategoryComboBoxOption => {
+export const convertApiCategorizationToCategoryOrSplitAsOption = (categorization: CategorizationEncoded): BankTransactionNonSuggestedMatchOption => {
   if (isSplitCategorizationEncoded(categorization)) {
     const splits = categorization.entries.map(splitEntryEncoded => ({
       amount: splitEntryEncoded.amount || 0,
@@ -116,25 +116,6 @@ export const getSuggestedCategoriesGroup = (bankTransaction: BankTransaction, t:
       label: BankTransactionCategoryComboBoxGroup.SUGGESTIONS,
       options: categorizationFlow.suggestions.map(suggestion => convertApiCategorizationToCategoryOrSplitAsOption(suggestion)),
     }
-  }
-
-  return null
-}
-
-export const getDefaultSelectedCategoryForBankTransaction = (
-  bankTransaction: BankTransaction,
-  ignoreSuggestedMatches = false,
-): BankTransactionCategoryComboBoxOption | null => {
-  if (bankTransaction.category) {
-    return convertApiCategorizationToCategoryOrSplitAsOption(bankTransaction.category)
-  }
-
-  if (!ignoreSuggestedMatches && bankTransaction.suggested_matches?.[0]) {
-    return new SuggestedMatchAsOption(bankTransaction.suggested_matches[0])
-  }
-
-  if (hasSuggestions(bankTransaction.categorization_flow)) {
-    return convertApiCategorizationToCategoryOrSplitAsOption(bankTransaction.categorization_flow.suggestions[0])
   }
 
   return null

--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -9,7 +9,7 @@ import { useDelayedRemoveBankTransaction } from '@hooks/features/bankTransaction
 import { useSaveBankTransactionRow } from '@hooks/features/bankTransactions/useSaveBankTransactionRow'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useDelayedVisibility } from '@hooks/utils/visibility/useDelayedVisibility'
-import { useBankTransactionsCategorizationActions, useGetBankTransactionCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useBankTransactionsCategorizationActions, useGetBankTransactionMatchOrCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useBulkSelectionActions, useCountSelectedIds, useIdIsSelected } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useBankTransactionsIsCategorizationEnabledContext } from '@contexts/BankTransactionsIsCategorizationEnabledContext/BankTransactionsIsCategorizationEnabledContext'
 import AlertCircle from '@icons/AlertCircle'
@@ -80,7 +80,7 @@ export const BankTransactionRow = ({
   const { count: bulkSelectionCount } = useCountSelectedIds()
   const isBulkSelectionActive = bulkSelectionCount > 0
   const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
-  const { selectedCategory } = useGetBankTransactionCategoryByTransactionId(bankTransaction.id)
+  const selectedOption = useGetBankTransactionMatchOrCategoryByTransactionId(bankTransaction.id)
   const { saveBankTransactionRow, isProcessing, isError } = useSaveBankTransactionRow()
 
   const { isBeingRemoved } = useDelayedRemoveBankTransaction({ bankTransaction })
@@ -89,14 +89,14 @@ export const BankTransactionRow = ({
 
   const save = useCallback(async () => {
     if (open && !isExpandedRowValid) return
-    if (!selectedCategory) return
+    if (!selectedOption) return
 
-    await saveBankTransactionRow(selectedCategory, bankTransaction)
+    await saveBankTransactionRow(selectedOption, bankTransaction)
 
     // Remove from bulk selection store
     deselect(bankTransaction.id)
     setOpen(false)
-  }, [bankTransaction, deselect, isExpandedRowValid, open, saveBankTransactionRow, selectedCategory])
+  }, [bankTransaction, deselect, selectedOption, isExpandedRowValid, open, saveBankTransactionRow])
 
   const submitButton = useMemo(() => (
     <SubmitButton
@@ -108,7 +108,7 @@ export const BankTransactionRow = ({
       className={isError ? 'Layer__bank-transaction__retry-btn' : 'Layer__bank-transaction__submit-btn'}
       processing={isProcessing}
       active={open}
-      disabled={selectedCategory === null || isBulkSelectionActive}
+      disabled={selectedOption === null || isBulkSelectionActive}
       action={displayAsCategorized ? SubmitAction.SAVE : SubmitAction.UPDATE}
       withRetry
       error={isError ? t('bankTransactions:error.approval_failed_check_connection', 'Approval failed. Check connection and retry in a few seconds.') : undefined}
@@ -126,7 +126,7 @@ export const BankTransactionRow = ({
     isProcessing,
     open,
     save,
-    selectedCategory,
+    selectedOption,
     stringOverrides?.approveButtonText,
     stringOverrides?.updateButtonText,
     t,
@@ -279,9 +279,9 @@ export const BankTransactionRow = ({
                 {isCategorizationEnabled && !displayAsCategorized && (
                   <BankTransactionCategoryComboBox
                     bankTransaction={bankTransaction}
-                    selectedValue={selectedCategory ?? null}
+                    selectedValue={selectedOption}
                     onSelectedValueChange={(selectedCategory: BankTransactionCategoryComboBoxOption | null) => {
-                      setTransactionCategorization(bankTransaction.id, { category: selectedCategory })
+                      setTransactionCategorization(bankTransaction.id, selectedCategory)
                     }}
                     isDisabled={isProcessing}
                   />

--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -6,10 +6,11 @@ import { type BankTransaction } from '@internal-types/bankTransactions'
 import { isCategorized, isCredit } from '@utils/bankTransactions/shared'
 import { toDataProperties } from '@utils/styleUtils/toDataProperties'
 import { useDelayedRemoveBankTransaction } from '@hooks/features/bankTransactions/useDelayedRemoveBankTransaction'
+import { useGetBankTransactionMatchOrCategoryWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
 import { useSaveBankTransactionRow } from '@hooks/features/bankTransactions/useSaveBankTransactionRow'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useDelayedVisibility } from '@hooks/utils/visibility/useDelayedVisibility'
-import { useBankTransactionsCategorizationActions, useGetBankTransactionMatchOrCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useBulkSelectionActions, useCountSelectedIds, useIdIsSelected } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useBankTransactionsIsCategorizationEnabledContext } from '@contexts/BankTransactionsIsCategorizationEnabledContext/BankTransactionsIsCategorizationEnabledContext'
 import AlertCircle from '@icons/AlertCircle'
@@ -80,7 +81,7 @@ export const BankTransactionRow = ({
   const { count: bulkSelectionCount } = useCountSelectedIds()
   const isBulkSelectionActive = bulkSelectionCount > 0
   const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
-  const selectedOption = useGetBankTransactionMatchOrCategoryByTransactionId(bankTransaction.id)
+  const selectedOption = useGetBankTransactionMatchOrCategoryWithDefault(bankTransaction)
   const { saveBankTransactionRow, isProcessing, isError } = useSaveBankTransactionRow()
 
   const { isBeingRemoved } = useDelayedRemoveBankTransaction({ bankTransaction })

--- a/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsCategorizeAllModal.tsx
+++ b/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsCategorizeAllModal.tsx
@@ -6,13 +6,14 @@ import { tPlural } from '@utils/i18n/plural'
 import { useBulkCategorize } from '@hooks/api/businesses/[business-id]/bank-transactions/bulk-categorize/useBulkCategorize'
 import { useTaxCodeOptions } from '@hooks/features/bankTransactions/useTaxCodeOptions'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import { useBulkSelectionActions, useCountSelectedIds, useSelectedIds } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useBankTransactionsContext } from '@contexts/BankTransactionsContext/BankTransactionsContext'
 import { VStack } from '@ui/Stack/Stack'
 import { Label, Span } from '@ui/Typography/Text'
 import { BaseConfirmationModal } from '@blocks/BaseConfirmationModal/BaseConfirmationModal'
 import { BankTransactionCategoryComboBox } from '@components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox'
-import { type BankTransactionCategoryComboBoxOption, isApiCategorizationAsOption, isCategoryAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import { isApiCategorizationAsOption, isCategoryAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { getBankTransactionsById, getFirstBankTransactionWithTaxOptions, getSelectedBankTransactions } from '@components/BankTransactions/BankTransactionsBulkActions/utils'
 import { CategorySelectDrawerWithTrigger } from '@components/CategorySelect/CategorySelectDrawerWithTrigger'
 import type { TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
@@ -42,7 +43,9 @@ export const BankTransactionsCategorizeAllModal = ({
   const { selectedIds } = useSelectedIds()
   const { clearSelection } = useBulkSelectionActions()
   const { data: bankTransactions } = useBankTransactionsContext()
-  const [selectedCategory, setSelectedCategory] = useState<BankTransactionCategoryComboBoxOption | null>(null)
+
+  const [selectedCategory, setSelectedCategory] = useState<BankTransactionNonSuggestedMatchOption | null>(null)
+
   const [selectedTaxCode, setSelectedTaxCode] = useState<TaxCodeComboBoxOption | null>(null)
   const { trigger, isMutating } = useBulkCategorize()
 

--- a/src/components/BankTransactions/BankTransactionsListItemCategory/BankTransactionsListItemCategory.tsx
+++ b/src/components/BankTransactions/BankTransactionsListItemCategory/BankTransactionsListItemCategory.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { isCategorized } from '@utils/bankTransactions/shared'
-import { useGetBankTransactionCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useGetBankTransactionMatchOrCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { BankTransactionsBaseSelectedValue } from '@components/BankTransactionsSelectedValue/BankTransactionsBaseSelectedValue'
 import { BankTransactionsCategorizedSelectedValue } from '@components/BankTransactionsSelectedValue/BankTransactionsCategorizedSelectedValue'
 import { BankTransactionsUncategorizedSelectedValue } from '@components/BankTransactionsSelectedValue/BankTransactionsUncategorizedSelectedValue'
@@ -23,7 +23,7 @@ export const BankTransactionsListItemCategory = ({
     ? 'Layer__bankTransactionsListItemCategory__Mobile'
     : 'Layer__bankTransactionsListItemCategory__List'
   const categorized = isCategorized(bankTransaction)
-  const { selectedCategory } = useGetBankTransactionCategoryByTransactionId(bankTransaction.id)
+  const selectedOption = useGetBankTransactionMatchOrCategoryByTransactionId(bankTransaction.id)
 
   if (categorized) {
     return (
@@ -37,10 +37,10 @@ export const BankTransactionsListItemCategory = ({
   }
 
   return (
-    selectedCategory
+    selectedOption
       ? (
         <BankTransactionsUncategorizedSelectedValue
-          selectedValue={selectedCategory ?? null}
+          selectedValue={selectedOption}
           className={className}
           slotProps={{ Label: { size: 'sm' } }}
           showCategoryBadge={mobile}

--- a/src/components/BankTransactions/BankTransactionsListItemCategory/BankTransactionsListItemCategory.tsx
+++ b/src/components/BankTransactions/BankTransactionsListItemCategory/BankTransactionsListItemCategory.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { isCategorized } from '@utils/bankTransactions/shared'
-import { useGetBankTransactionMatchOrCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useGetBankTransactionMatchOrCategoryWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
 import { BankTransactionsBaseSelectedValue } from '@components/BankTransactionsSelectedValue/BankTransactionsBaseSelectedValue'
 import { BankTransactionsCategorizedSelectedValue } from '@components/BankTransactionsSelectedValue/BankTransactionsCategorizedSelectedValue'
 import { BankTransactionsUncategorizedSelectedValue } from '@components/BankTransactionsSelectedValue/BankTransactionsUncategorizedSelectedValue'
@@ -23,7 +23,7 @@ export const BankTransactionsListItemCategory = ({
     ? 'Layer__bankTransactionsListItemCategory__Mobile'
     : 'Layer__bankTransactionsListItemCategory__List'
   const categorized = isCategorized(bankTransaction)
-  const selectedOption = useGetBankTransactionMatchOrCategoryByTransactionId(bankTransaction.id)
+  const selectedOption = useGetBankTransactionMatchOrCategoryWithDefault(bankTransaction)
 
   if (categorized) {
     return (

--- a/src/components/BankTransactionsList/BankTransactionsListItem.tsx
+++ b/src/components/BankTransactionsList/BankTransactionsListItem.tsx
@@ -9,11 +9,12 @@ import {
   isCredit,
 } from '@utils/bankTransactions/shared'
 import { useDelayedRemoveBankTransaction } from '@hooks/features/bankTransactions/useDelayedRemoveBankTransaction'
+import { useGetBankTransactionMatchOrCategoryWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
 import { useSaveBankTransactionRow } from '@hooks/features/bankTransactions/useSaveBankTransactionRow'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { useDelayedVisibility } from '@hooks/utils/visibility/useDelayedVisibility'
-import { useBankTransactionsCategorizationActions, useGetBankTransactionMatchOrCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useBulkSelectionActions, useIdIsSelected } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useBankTransactionsIsCategorizationEnabledContext } from '@contexts/BankTransactionsIsCategorizationEnabledContext/BankTransactionsIsCategorizationEnabledContext'
 import ChevronDownFill from '@icons/ChevronDownFill'
@@ -79,7 +80,7 @@ export const BankTransactionsListItem = ({
   const isSelected = useIdIsSelected()
   const isTransactionSelected = isSelected(bankTransaction.id)
   const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
-  const selectedOption = useGetBankTransactionMatchOrCategoryByTransactionId(bankTransaction.id)
+  const selectedOption = useGetBankTransactionMatchOrCategoryWithDefault(bankTransaction)
 
   const save = useCallback(async () => {
     if (openExpandedRow && !isExpandedRowValid) return

--- a/src/components/BankTransactionsList/BankTransactionsListItem.tsx
+++ b/src/components/BankTransactionsList/BankTransactionsListItem.tsx
@@ -13,7 +13,7 @@ import { useSaveBankTransactionRow } from '@hooks/features/bankTransactions/useS
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { useDelayedVisibility } from '@hooks/utils/visibility/useDelayedVisibility'
-import { useBankTransactionsCategorizationActions, useGetBankTransactionCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useBankTransactionsCategorizationActions, useGetBankTransactionMatchOrCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useBulkSelectionActions, useIdIsSelected } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useBankTransactionsIsCategorizationEnabledContext } from '@contexts/BankTransactionsIsCategorizationEnabledContext/BankTransactionsIsCategorizationEnabledContext'
 import ChevronDownFill from '@icons/ChevronDownFill'
@@ -79,18 +79,18 @@ export const BankTransactionsListItem = ({
   const isSelected = useIdIsSelected()
   const isTransactionSelected = isSelected(bankTransaction.id)
   const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
-  const { selectedCategory } = useGetBankTransactionCategoryByTransactionId(bankTransaction.id)
+  const selectedOption = useGetBankTransactionMatchOrCategoryByTransactionId(bankTransaction.id)
 
   const save = useCallback(async () => {
     if (openExpandedRow && !isExpandedRowValid) return
-    if (!selectedCategory) return
+    if (!selectedOption) return
 
-    await saveBankTransactionRow(selectedCategory, bankTransaction)
+    await saveBankTransactionRow(selectedOption, bankTransaction)
 
     // Remove from bulk selection store
     deselect(bankTransaction.id)
     setOpenExpandedRow(false)
-  }, [bankTransaction, deselect, isExpandedRowValid, openExpandedRow, saveBankTransactionRow, selectedCategory])
+  }, [bankTransaction, deselect, selectedOption, isExpandedRowValid, openExpandedRow, saveBankTransactionRow])
 
   const preventRowExpansion = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -196,9 +196,9 @@ export const BankTransactionsListItem = ({
             {!openExpandedRow && (
               <BankTransactionCategoryComboBox
                 bankTransaction={bankTransaction}
-                selectedValue={selectedCategory ?? null}
+                selectedValue={selectedOption}
                 onSelectedValueChange={(selectedCategory: BankTransactionCategoryComboBoxOption | null) => {
-                  setTransactionCategorization(bankTransaction.id, { category: selectedCategory })
+                  setTransactionCategorization(bankTransaction.id, selectedCategory)
                 }}
                 isDisabled={isProcessing}
               />

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
@@ -7,8 +7,9 @@ import { CategorizationType } from '@internal-types/categories'
 import { ApiCategorizationAsOption, PlaceholderAsOption } from '@internal-types/categorizationOption'
 import { hasReceipts, isCategorized } from '@utils/bankTransactions/shared'
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
+import { useGetBankTransactionCategorizationWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
-import { useBankTransactionsCategorizationActions, useGetBankTransactionCategorizationByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import PaperclipIcon from '@icons/Paperclip'
 import { Button } from '@ui/Button/Button'
@@ -76,8 +77,8 @@ export const BankTransactionsMobileListBusinessForm = ({
     return initialMap
   })
 
-  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
-  const { category: selectedCategory } = selectedCategorization ?? {}
+  const selectedCategorization = useGetBankTransactionCategorizationWithDefault(bankTransaction)
+  const { category: selectedCategory } = selectedCategorization
 
   const { setTransactionCategorySelection } = useBankTransactionsCategorizationActions()
 

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
@@ -8,11 +8,12 @@ import { ApiCategorizationAsOption, PlaceholderAsOption } from '@internal-types/
 import { hasReceipts, isCategorized } from '@utils/bankTransactions/shared'
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
-import { useBankTransactionsCategorizationActions, useGetBankTransactionCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useBankTransactionsCategorizationActions, useGetBankTransactionCategorizationByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import PaperclipIcon from '@icons/Paperclip'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
-import { type BankTransactionCategoryComboBoxOption, isPlaceholderAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import { isPlaceholderAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/BankTransactionCategoryComboBox/utils'
 import { BankTransactionFormFields } from '@components/BankTransactionFormFields/BankTransactionFormFields'
 import { BankTransactionReceipts } from '@components/BankTransactionReceipts/BankTransactionReceipts'
@@ -57,8 +58,8 @@ export const BankTransactionsMobileListBusinessForm = ({
     isError: isErrorCategorizing,
   } = useCategorizeBankTransactionWithCacheUpdate()
 
-  const [sessionCategories, setSessionCategories] = useState<Map<string, BankTransactionCategoryComboBoxOption>>(() => {
-    const initialMap = new Map<string, BankTransactionCategoryComboBoxOption>()
+  const [sessionCategories, setSessionCategories] = useState<Map<string, BankTransactionNonSuggestedMatchOption>>(() => {
+    const initialMap = new Map<string, BankTransactionNonSuggestedMatchOption>()
 
     if (bankTransaction.category) {
       const existingCategory = convertApiCategorizationToCategoryOrSplitAsOption(bankTransaction.category)
@@ -75,8 +76,10 @@ export const BankTransactionsMobileListBusinessForm = ({
     return initialMap
   })
 
-  const { selectedCategory } = useGetBankTransactionCategoryByTransactionId(bankTransaction.id)
-  const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
+  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
+  const { category: selectedCategory } = selectedCategorization ?? {}
+
+  const { setTransactionCategorySelection } = useBankTransactionsCategorizationActions()
 
   const [showRetry, setShowRetry] = useState(false)
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
@@ -118,10 +121,10 @@ export const BankTransactionsMobileListBusinessForm = ({
         selectedCategory
         && option.value === selectedCategory.value
       ) {
-        setTransactionCategorization(bankTransaction.id, { category: null })
+        setTransactionCategorySelection(bankTransaction.id, null)
       }
       else {
-        setTransactionCategorization(bankTransaction.id, { category: option })
+        setTransactionCategorySelection(bankTransaction.id, option)
       }
     }
   }
@@ -144,12 +147,12 @@ export const BankTransactionsMobileListBusinessForm = ({
     )
   }
 
-  const onDrawerSelect = useCallback((category: BankTransactionCategoryComboBoxOption | null) => {
+  const onDrawerSelect = useCallback((category: BankTransactionNonSuggestedMatchOption | null) => {
     if (!category) return
 
     setSessionCategories(prev => new Map(prev).set(category.value, category))
-    setTransactionCategorization(bankTransaction.id, { category })
-  }, [bankTransaction.id, setTransactionCategorization])
+    setTransactionCategorySelection(bankTransaction.id, category)
+  }, [bankTransaction.id, setTransactionCategorySelection])
 
   return (
     <>

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListItemExpandedRow.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListItemExpandedRow.tsx
@@ -3,15 +3,21 @@ import type { Key } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
-import { CategorizationStatus } from '@schemas/bankTransactions/bankTransaction'
 import { hasMatch } from '@utils/bankTransactions/shared'
 import { translationKey } from '@utils/i18n/translationKey'
+import type { BankTransactionCategorization } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import {
+  BankTransactionSelectionVariant,
+  DEFAULT_CATEGORIZATION,
+  useBankTransactionsCategorizationActions,
+  useGetBankTransactionCategorizationByTransactionId,
+} from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { VStack } from '@ui/Stack/Stack'
 import { Toggle } from '@ui/Toggle/Toggle'
+import { isSplitAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { BankTransactionsMobileForms } from '@components/BankTransactionsMobileList/BankTransactionsMobileForms'
 
 import { Purpose } from './BankTransactionsMobileListItem'
-import { PersonalStableName } from './constants'
 
 const PURPOSE_TOGGLE_CONFIG = [
   { value: 'business' as const, ...translationKey('common:label.business', 'Business'), style: { minWidth: 84 } },
@@ -37,7 +43,10 @@ export const BankTransactionsMobileListItemExpandedRow = ({
   showTooltips,
 }: BankTransactionsMobileListItemExpandedRowProps) => {
   const { t } = useTranslation()
-  const [purpose, setPurpose] = useState<Purpose>(getInitialPurpose(bankTransaction))
+  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
+  const { setTransactionSelectionVariant } = useBankTransactionsCategorizationActions()
+
+  const [purpose, setPurpose] = useState(getPurposeFromStore(selectedCategorization))
 
   const purposeToggleOptions = useMemo(
     () => PURPOSE_TOGGLE_CONFIG.map(opt => ({
@@ -47,8 +56,19 @@ export const BankTransactionsMobileListItemExpandedRow = ({
     [t],
   )
 
-  const onChangePurpose = (key: Key) =>
-    setPurpose(key as Purpose)
+  const onChangePurpose = (key: Key) => {
+    const nextPurpose = key as Purpose
+    const isCurrentlySplit = !!selectedCategorization?.category && isSplitAsOption(selectedCategorization.category)
+
+    const nextVariant = nextPurpose === Purpose.more
+      && hasMatch(bankTransaction)
+      && !isCurrentlySplit
+      ? BankTransactionSelectionVariant.MATCH
+      : BankTransactionSelectionVariant.CATEGORY
+
+    setTransactionSelectionVariant(bankTransaction.id, nextVariant)
+    setPurpose(nextPurpose)
+  }
 
   return (
     <VStack pi='md' gap='md' pbe='md'>
@@ -75,35 +95,20 @@ export const BankTransactionsMobileListItemExpandedRow = ({
   )
 }
 
-const isPersonalCategory = (category: BankTransaction['category']): boolean => {
-  if (!category) {
-    return false
+const getPurposeFromStore = (selectedCategorization: BankTransactionCategorization | undefined): Purpose => {
+  const effectiveCategorization = selectedCategorization ?? DEFAULT_CATEGORIZATION
+
+  if (effectiveCategorization.variant === BankTransactionSelectionVariant.MATCH) {
+    return Purpose.more
   }
 
-  if (category.type === 'Account' && 'stable_name' in category) {
-    const stableName = category.stable_name
-    if (stableName === PersonalStableName.CREDIT || stableName === PersonalStableName.DEBIT) {
-      return true
-    }
-  }
-
-  if (category.type === 'Exclusion') {
-    return true
-  }
-
-  return false
-}
-
-const getInitialPurpose = (bankTransaction: BankTransaction): Purpose => {
-  if (bankTransaction.category) {
-    if (isPersonalCategory(bankTransaction.category)) {
-      return Purpose.personal
-    }
-    if (bankTransaction.categorization_status === CategorizationStatus.SPLIT) {
-      return Purpose.more
-    }
+  if (effectiveCategorization.category === null) {
     return Purpose.business
   }
 
-  return hasMatch(bankTransaction) ? Purpose.more : Purpose.business
+  if (isSplitAsOption(effectiveCategorization.category)) {
+    return Purpose.more
+  }
+
+  return Purpose.business
 }

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListItemExpandedRow.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListItemExpandedRow.tsx
@@ -5,12 +5,11 @@ import { useTranslation } from 'react-i18next'
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { hasMatch } from '@utils/bankTransactions/shared'
 import { translationKey } from '@utils/i18n/translationKey'
-import type { BankTransactionCategorization } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useGetBankTransactionCategorizationWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
 import {
+  type BankTransactionCategorization,
   BankTransactionSelectionVariant,
-  DEFAULT_CATEGORIZATION,
   useBankTransactionsCategorizationActions,
-  useGetBankTransactionCategorizationByTransactionId,
 } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { VStack } from '@ui/Stack/Stack'
 import { Toggle } from '@ui/Toggle/Toggle'
@@ -43,7 +42,7 @@ export const BankTransactionsMobileListItemExpandedRow = ({
   showTooltips,
 }: BankTransactionsMobileListItemExpandedRowProps) => {
   const { t } = useTranslation()
-  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
+  const selectedCategorization = useGetBankTransactionCategorizationWithDefault(bankTransaction)
   const { setTransactionSelectionVariant } = useBankTransactionsCategorizationActions()
 
   const [purpose, setPurpose] = useState(getPurposeFromStore(selectedCategorization))
@@ -95,18 +94,16 @@ export const BankTransactionsMobileListItemExpandedRow = ({
   )
 }
 
-const getPurposeFromStore = (selectedCategorization: BankTransactionCategorization | undefined): Purpose => {
-  const effectiveCategorization = selectedCategorization ?? DEFAULT_CATEGORIZATION
-
-  if (effectiveCategorization.variant === BankTransactionSelectionVariant.MATCH) {
+const getPurposeFromStore = (selectedCategorization: BankTransactionCategorization): Purpose => {
+  if (selectedCategorization.variant === BankTransactionSelectionVariant.MATCH) {
     return Purpose.more
   }
 
-  if (effectiveCategorization.category === null) {
+  if (selectedCategorization.category === null) {
     return Purpose.business
   }
 
-  if (isSplitAsOption(effectiveCategorization.category)) {
+  if (isSplitAsOption(selectedCategorization.category)) {
     return Purpose.more
   }
 

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm.tsx
@@ -6,11 +6,11 @@ import { SuggestedMatchAsOption } from '@internal-types/categorizationOption'
 import {
   getBankTransactionMatchAsSuggestedMatch,
 } from '@utils/bankTransactions/shared'
+import { useGetBankTransactionCategorizationWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
 import { useMatchBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useMatchBankTransactionWithCacheUpdate'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
 import {
   useBankTransactionsCategorizationActions,
-  useGetBankTransactionCategorizationByTransactionId,
 } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import PaperclipIcon from '@icons/Paperclip'
 import { Button } from '@ui/Button/Button'
@@ -45,8 +45,8 @@ export const BankTransactionsMobileListMatchForm = ({
     isError: isErrorMatching,
   } = useMatchBankTransactionWithCacheUpdate()
   const { setTransactionMatchSelection } = useBankTransactionsCategorizationActions()
-  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
-  const { match: selectedMatch } = selectedCategorization ?? {}
+  const selectedCategorization = useGetBankTransactionCategorizationWithDefault(bankTransaction)
+  const { match: selectedMatch } = selectedCategorization
   const selectedMatchId = selectedMatch?.original.id
 
   const [formError, setFormError] = useState<string | undefined>()

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm.tsx
@@ -1,13 +1,17 @@
-import { useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { type BankTransaction, type SuggestedMatch } from '@internal-types/bankTransactions'
+import { type BankTransaction } from '@internal-types/bankTransactions'
+import { SuggestedMatchAsOption } from '@internal-types/categorizationOption'
 import {
-  getBankTransactionFirstSuggestedMatch,
   getBankTransactionMatchAsSuggestedMatch,
 } from '@utils/bankTransactions/shared'
 import { useMatchBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useMatchBankTransactionWithCacheUpdate'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
+import {
+  useBankTransactionsCategorizationActions,
+  useGetBankTransactionCategorizationByTransactionId,
+} from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import PaperclipIcon from '@icons/Paperclip'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
@@ -40,40 +44,29 @@ export const BankTransactionsMobileListMatchForm = ({
     isMutating: isMatching,
     isError: isErrorMatching,
   } = useMatchBankTransactionWithCacheUpdate()
+  const { setTransactionMatchSelection } = useBankTransactionsCategorizationActions()
+  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
+  const { match: selectedMatch } = selectedCategorization ?? {}
+  const selectedMatchId = selectedMatch?.original.id
 
-  const [selectedMatch, setSelectedMatch] = useState<SuggestedMatch | undefined>(
-    getBankTransactionFirstSuggestedMatch(bankTransaction),
-  )
   const [formError, setFormError] = useState<string | undefined>()
 
-  const onMatchSubmit = async (matchId: string) => {
-    const foundMatch = bankTransaction.suggested_matches?.find(
-      x => x.id === matchId,
-    )
-    if (!foundMatch) {
-      return
-    }
+  const onMatchSubmit = useCallback(async (matchId: string) => {
+    await matchBankTransaction(bankTransaction, matchId, true)
+  }, [matchBankTransaction, bankTransaction])
 
-    await matchBankTransaction(bankTransaction, foundMatch.id, true)
-  }
+  const save = useCallback(() => {
+    if (!showCategorization) return
 
-  const save = () => {
-    if (!showCategorization) {
-      return
-    }
-
-    if (!selectedMatch) {
+    if (!selectedMatchId) {
       setFormError(t('bankTransactions:error.select_option_match_transaction', 'Select an option to match the transaction'))
+      return
     }
 
-    if (
-      selectedMatch
-      && selectedMatch.id !== getBankTransactionMatchAsSuggestedMatch(bankTransaction)?.id
-    ) {
-      void onMatchSubmit(selectedMatch.id)
+    if (selectedMatchId !== getBankTransactionMatchAsSuggestedMatch(bankTransaction)?.id) {
+      void onMatchSubmit(selectedMatchId)
     }
-    return
-  }
+  }, [showCategorization, selectedMatchId, bankTransaction, t, onMatchSubmit])
 
   return (
     <VStack gap='sm'>
@@ -83,10 +76,13 @@ export const BankTransactionsMobileListMatchForm = ({
       <MatchFormMobile
         readOnly={!showCategorization}
         bankTransaction={bankTransaction}
-        selectedMatchId={selectedMatch?.id}
+        selectedMatchId={selectedMatchId}
         setSelectedMatch={(suggestedMatch) => {
           setFormError(undefined)
-          setSelectedMatch(suggestedMatch)
+          setTransactionMatchSelection(
+            bankTransaction.id,
+            suggestedMatch ? new SuggestedMatchAsOption(suggestedMatch) : null,
+          )
         }}
       />
       <BankTransactionFormFields
@@ -118,9 +114,9 @@ export const BankTransactionsMobileListMatchForm = ({
           <Button
             fullWidth
             isDisabled={
-              !selectedMatch
+              !selectedMatchId
               || isMatching
-              || selectedMatch.id === getBankTransactionMatchAsSuggestedMatch(bankTransaction)?.id
+              || selectedMatchId === getBankTransactionMatchAsSuggestedMatch(bankTransaction)?.id
             }
             onClick={save}
           >

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitAndMatchForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitAndMatchForm.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { hasMatch } from '@utils/bankTransactions/shared'
+import { BankTransactionSelectionVariant, useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useGetBankTransactionCategorizationByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { BankTransactionsMobileListMatchForm } from '@components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm'
 import { BankTransactionsMobileListSplitForm } from '@components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm'
 import { TextButton } from '@components/Button/TextButton'
@@ -15,11 +16,6 @@ interface BankTransactionsMobileListSplitAndMatchFormProps {
   showDescriptions?: boolean
 }
 
-enum Purpose {
-  categorize = 'categorize',
-  match = 'match',
-}
-
 export const BankTransactionsMobileListSplitAndMatchForm = ({
   bankTransaction,
   showTooltips,
@@ -29,17 +25,14 @@ export const BankTransactionsMobileListSplitAndMatchForm = ({
 }: BankTransactionsMobileListSplitAndMatchFormProps) => {
   const { t } = useTranslation()
   const anyMatch = hasMatch(bankTransaction)
-  const [formType, setFormType] = useState(
-    bankTransaction.category
-      ? Purpose.categorize
-      : anyMatch
-        ? Purpose.match
-        : Purpose.categorize,
-  )
+
+  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
+  const { variant } = selectedCategorization ?? {}
+  const { setTransactionSelectionVariant } = useBankTransactionsCategorizationActions()
 
   return (
     <>
-      {formType === Purpose.categorize && (
+      {variant === BankTransactionSelectionVariant.CATEGORY && (
         <BankTransactionsMobileListSplitForm
           bankTransaction={bankTransaction}
           showTooltips={showTooltips}
@@ -48,7 +41,7 @@ export const BankTransactionsMobileListSplitAndMatchForm = ({
           showCategorization={showCategorization}
         />
       )}
-      {formType === Purpose.match && (
+      {variant === BankTransactionSelectionVariant.MATCH && (
         <BankTransactionsMobileListMatchForm
           bankTransaction={bankTransaction}
           showReceiptUploads={showReceiptUploads}
@@ -57,14 +50,14 @@ export const BankTransactionsMobileListSplitAndMatchForm = ({
         />
       )}
       {showCategorization && anyMatch && (
-        formType === Purpose.match
+        variant === BankTransactionSelectionVariant.MATCH
           ? (
-            <TextButton onClick={() => setFormType(Purpose.categorize)}>
+            <TextButton onClick={() => setTransactionSelectionVariant(bankTransaction.id, BankTransactionSelectionVariant.CATEGORY)}>
               {t('bankTransactions:action.or_split_transaction', 'or split transaction')}
             </TextButton>
           )
           : (
-            <TextButton onClick={() => setFormType(Purpose.match)}>
+            <TextButton onClick={() => setTransactionSelectionVariant(bankTransaction.id, BankTransactionSelectionVariant.MATCH)}>
               {t('bankTransactions:action.or_find_match', 'or find match')}
             </TextButton>
           )

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitAndMatchForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitAndMatchForm.tsx
@@ -2,8 +2,8 @@ import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { hasMatch } from '@utils/bankTransactions/shared'
+import { useGetBankTransactionCategorizationWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
 import { BankTransactionSelectionVariant, useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
-import { useGetBankTransactionCategorizationByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { BankTransactionsMobileListMatchForm } from '@components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm'
 import { BankTransactionsMobileListSplitForm } from '@components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm'
 import { TextButton } from '@components/Button/TextButton'
@@ -26,8 +26,8 @@ export const BankTransactionsMobileListSplitAndMatchForm = ({
   const { t } = useTranslation()
   const anyMatch = hasMatch(bankTransaction)
 
-  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
-  const { variant } = selectedCategorization ?? {}
+  const selectedCategorization = useGetBankTransactionCategorizationWithDefault(bankTransaction)
+  const { variant } = selectedCategorization
   const { setTransactionSelectionVariant } = useBankTransactionsCategorizationActions()
 
   return (

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
@@ -7,13 +7,12 @@ import { buildCategorizeBankTransactionPayloadForSplit, hasReceipts, isCategoriz
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
 import { useSplitsForm } from '@hooks/features/bankTransactions/useSplitsForm'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
-import { useGetBankTransactionCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import PaperclipIcon from '@icons/Paperclip'
 import Scissors from '@icons/Scissors'
 import Trash from '@icons/Trash'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
-import { type BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { BankTransactionFormFields } from '@components/BankTransactionFormFields/BankTransactionFormFields'
 import { BankTransactionReceipts } from '@components/BankTransactionReceipts/BankTransactionReceipts'
 import { type BankTransactionReceiptsHandle } from '@components/BankTransactionReceipts/BankTransactionReceipts'
@@ -49,7 +48,6 @@ export const BankTransactionsMobileListSplitForm = ({
     isError: isErrorCategorizing,
   } = useCategorizeBankTransactionWithCacheUpdate()
 
-  const { selectedCategory } = useGetBankTransactionCategoryByTransactionId(bankTransaction.id)
   const [showRetry, setShowRetry] = useState(false)
 
   const {
@@ -62,10 +60,7 @@ export const BankTransactionsMobileListSplitForm = ({
     changeCategoryForSplitAtIndex,
     getInputValueForSplitAtIndex,
     onBlurSplitAmount,
-  } = useSplitsForm({
-    bankTransaction,
-    selectedCategory,
-  })
+  } = useSplitsForm({ bankTransaction })
 
   const effectiveSplits = showCategorization
     ? localSplits
@@ -92,7 +87,7 @@ export const BankTransactionsMobileListSplitForm = ({
     )
   }
 
-  const handleCategoryChange = useCallback((index: number) => (value: BankTransactionCategoryComboBoxOption | null) => {
+  const handleCategoryChange = useCallback((index: number) => (value: BankTransactionNonSuggestedMatchOption | null) => {
     changeCategoryForSplitAtIndex(index, value)
   }, [changeCategoryForSplitAtIndex])
 

--- a/src/components/BusinessForm/BusinessFormMobileItem.tsx
+++ b/src/components/BusinessForm/BusinessFormMobileItem.tsx
@@ -1,14 +1,14 @@
 import { GridListItem } from 'react-aria-components'
 
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import ChevronRight from '@icons/ChevronRight'
 import { Checkbox } from '@ui/Checkbox/Checkbox'
 import { HStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
-import { type BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 
 import './businessFormMobileItem.scss'
 
-export type BusinessFormOptionValue = BankTransactionCategoryComboBoxOption
+export type BusinessFormOptionValue = BankTransactionNonSuggestedMatchOption
 
 export interface BusinessFormMobileItemOption {
   value: BusinessFormOptionValue

--- a/src/components/CategorySelect/CategorySelectDrawer.tsx
+++ b/src/components/CategorySelect/CategorySelectDrawer.tsx
@@ -2,18 +2,18 @@ import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useCategories } from '@hooks/api/businesses/[business-id]/categories/useCategories'
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import ChevronLeft from '@icons/ChevronLeft'
 import { Button } from '@ui/Button/Button'
 import { Drawer } from '@ui/Modal/Modal'
 import { ModalHeading, ModalTitleWithClose } from '@ui/Modal/ModalSlots'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { ActionableList } from '@components/ActionableList/ActionableList'
-import type { BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { buildFilteredCategoryOptions, type CategoryGroup, type CategoryOption, flattenCategories, isGroup } from '@components/CategorySelect/utils'
 import { SearchField } from '@components/SearchField/SearchField'
 
 interface CategorySelectDrawerProps {
-  onSelect: (value: BankTransactionCategoryComboBoxOption | null) => void
+  onSelect: (value: BankTransactionNonSuggestedMatchOption | null) => void
   selectedId?: string
   showTooltips: boolean
   isOpen: boolean

--- a/src/components/CategorySelect/CategorySelectDrawerWithTrigger.tsx
+++ b/src/components/CategorySelect/CategorySelectDrawerWithTrigger.tsx
@@ -1,18 +1,18 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import ChevronDown from '@icons/ChevronDown'
 import { Button } from '@ui/Button/Button'
 import { HStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
-import type { BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { CategorySelectDrawer } from '@components/CategorySelect/CategorySelectDrawer'
 
 import './categorySelectDrawerWithTrigger.scss'
 
 type Props = {
-  value: BankTransactionCategoryComboBoxOption | null
-  onChange: (newValue: BankTransactionCategoryComboBoxOption | null) => void
+  value: BankTransactionNonSuggestedMatchOption | null
+  onChange: (newValue: BankTransactionNonSuggestedMatchOption | null) => void
   disabled?: boolean
   showTooltips: boolean
 }

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -9,14 +9,12 @@ import { useTranslation } from 'react-i18next'
 
 import {
   type BankTransaction,
-  type SuggestedMatch,
 } from '@internal-types/bankTransactions'
 import { type Split } from '@internal-types/bankTransactions'
-import { SplitAsOption, SuggestedMatchAsOption } from '@internal-types/categorizationOption'
+import { SuggestedMatchAsOption } from '@internal-types/categorizationOption'
 import { type CustomerVendorSchema } from '@schemas/customerVendor'
 import { type Tag } from '@schemas/tag'
 import {
-  getBankTransactionFirstSuggestedMatch,
   hasMatch,
 } from '@utils/bankTransactions/shared'
 import { useSetMetadataOnBankTransaction } from '@hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useSetMetadataOnBankTransaction'
@@ -25,7 +23,7 @@ import { useTagBankTransaction } from '@hooks/api/businesses/[business-id]/bank-
 import { useSplitsForm } from '@hooks/features/bankTransactions/useSplitsForm'
 import { useTaxCodeOptions } from '@hooks/features/bankTransactions/useTaxCodeOptions'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
-import { useBankTransactionsCategorizationActions, useGetBankTransactionCategoryByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { BankTransactionSelectionVariant, useBankTransactionsCategorizationActions, useGetBankTransactionCategorizationByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useBankTransactionsIsCategorizationEnabledContext } from '@contexts/BankTransactionsIsCategorizationEnabledContext/BankTransactionsIsCategorizationEnabledContext'
 import Scissors from '@icons/ScissorsFullOpen'
 import Trash from '@icons/Trash'
@@ -54,11 +52,6 @@ export type ExpandedRowState = {
   splits: Split[]
   description: string
   file: unknown
-}
-
-enum Purpose {
-  categorize = 'categorize',
-  match = 'match',
 }
 
 export interface DocumentWithStatus {
@@ -96,8 +89,10 @@ export const ExpandedBankTransactionRow = ({
 }: ExpandedBankTransactionRowProps) => {
   const { t } = useTranslation()
   const { formatCurrencyFromCents } = useIntlFormatter()
-  const { selectedCategory } = useGetBankTransactionCategoryByTransactionId(bankTransaction.id)
-  const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
+  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
+  const { match: selectedMatch, variant: purpose } = selectedCategorization ?? {}
+
+  const { setTransactionMatchSelection, setTransactionSelectionVariant } = useBankTransactionsCategorizationActions()
   // Hooks for auto-saving tags and customer/vendor in unsplit state
   const { trigger: tagBankTransaction } = useTagBankTransaction({ bankTransactionId: bankTransaction.id })
   const { trigger: removeTagFromBankTransaction } = useRemoveTagFromBankTransaction({ bankTransactionId: bankTransaction.id })
@@ -107,16 +102,6 @@ export const ExpandedBankTransactionRow = ({
   const { showTags } = useBankTransactionTagVisibility()
   const { showCustomerVendor } = useBankTransactionCustomerVendorVisibility()
 
-  const [purpose, setPurpose] = useState<Purpose>(
-    bankTransaction.category
-      ? Purpose.categorize
-      : hasMatch(bankTransaction)
-        ? Purpose.match
-        : Purpose.categorize,
-  )
-  const [selectedMatch, setSelectedMatch] = useState<SuggestedMatch | undefined>(
-    getBankTransactionFirstSuggestedMatch(bankTransaction),
-  )
   const [matchFormError, setMatchFormError] = useState<string | undefined>()
   const bodyRef = useRef<HTMLDivElement>(null)
 
@@ -132,10 +117,10 @@ export const ExpandedBankTransactionRow = ({
     onBlurSplitAmount,
     getInputValueForSplitAtIndex,
     setSplitFormError,
-  } = useSplitsForm({ bankTransaction, selectedCategory, isOpen })
+  } = useSplitsForm({ bankTransaction, isOpen })
 
   useEffect(() => {
-    const isValid = purpose === Purpose.match
+    const isValid = purpose === BankTransactionSelectionVariant.MATCH
       ? !!selectedMatch
       : isSplitsValid
 
@@ -143,18 +128,11 @@ export const ExpandedBankTransactionRow = ({
   }, [isSplitsValid, onValidityChange, purpose, selectedMatch])
 
   const onChangePurpose = (key: React.Key) => {
-    const newPurpose = key === 'match'
-      ? Purpose.match
-      : Purpose.categorize
-    setPurpose(newPurpose)
+    const newPurpose = key === BankTransactionSelectionVariant.MATCH
+      ? BankTransactionSelectionVariant.MATCH
+      : BankTransactionSelectionVariant.CATEGORY
 
-    if (newPurpose === Purpose.match) {
-      setTransactionCategorization(bankTransaction.id, { category: selectedMatch ? new SuggestedMatchAsOption(selectedMatch) : null })
-    }
-
-    else if (newPurpose === Purpose.categorize && isSplitsValid) {
-      setTransactionCategorization(bankTransaction.id, { category: new SplitAsOption(localSplits) })
-    }
+    setTransactionSelectionVariant(bankTransaction.id, newPurpose)
 
     setSplitFormError(undefined)
     setMatchFormError(undefined)
@@ -207,11 +185,11 @@ export const ExpandedBankTransactionRow = ({
 
   const toggleOptions = useMemo(() => [
     {
-      value: 'categorize',
+      value: BankTransactionSelectionVariant.CATEGORY,
       label: t('common:action.categorize', 'Categorize'),
     },
     {
-      value: 'match',
+      value: BankTransactionSelectionVariant.MATCH,
       label: t('bankTransactions:label.match', 'Match'),
       disabled: !hasMatch(bankTransaction),
       disabledMessage: t('bankTransactions:error.matching_transactions_not_found', 'We could not find matching transactions'),
@@ -250,21 +228,18 @@ export const ExpandedBankTransactionRow = ({
                     className={classNames(
                       'Layer__expanded-bank-transaction-row__content-panel',
                       {
-                        'Layer__expanded-bank-transaction-row__content-panel--active': purpose === Purpose.match,
+                        'Layer__expanded-bank-transaction-row__content-panel--active': purpose === BankTransactionSelectionVariant.MATCH,
                       },
                     )}
                   >
                     <div className='Layer__expanded-bank-transaction-row__content-panel-container'>
                       <MatchForm
                         bankTransaction={bankTransaction}
-                        selectedMatchId={selectedMatch?.id}
+                        selectedMatchId={selectedMatch?.original.id}
                         readOnly={!isCategorizationEnabled}
                         setSelectedMatch={(suggestedMatch) => {
-                          setSelectedMatch(suggestedMatch)
+                          setTransactionMatchSelection(bankTransaction.id, suggestedMatch ? new SuggestedMatchAsOption(suggestedMatch) : null)
                           setMatchFormError(!suggestedMatch ? t('bankTransactions:error.select_option_match_transaction', 'Select an option to match the transaction') : undefined)
-                          setTransactionCategorization(bankTransaction.id, {
-                            category: suggestedMatch ? new SuggestedMatchAsOption(suggestedMatch) : null,
-                          })
                         }}
                         matchFormError={matchFormError}
                       />
@@ -276,7 +251,7 @@ export const ExpandedBankTransactionRow = ({
                       'Layer__expanded-bank-transaction-row__splits',
                       'Layer__expanded-bank-transaction-row__content-panel',
                       {
-                        'Layer__expanded-bank-transaction-row__content-panel--active': purpose === Purpose.categorize,
+                        'Layer__expanded-bank-transaction-row__content-panel--active': purpose === BankTransactionSelectionVariant.CATEGORY,
                       },
                     )}
                   >
@@ -406,8 +381,8 @@ export const ExpandedBankTransactionRow = ({
                   <BankTransactionFormFields
                     bankTransaction={bankTransaction}
                     showDescriptions={showDescriptions}
-                    hideTags={purpose === Purpose.categorize}
-                    hideCustomerVendor={purpose === Purpose.categorize}
+                    hideTags={purpose === BankTransactionSelectionVariant.CATEGORY}
+                    hideCustomerVendor={purpose === BankTransactionSelectionVariant.CATEGORY}
                   />
                 </VStack>
 

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -20,10 +20,14 @@ import {
 import { useSetMetadataOnBankTransaction } from '@hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useSetMetadataOnBankTransaction'
 import { useRemoveTagFromBankTransaction } from '@hooks/api/businesses/[business-id]/bank-transactions/tags/useRemoveTagFromBankTransaction'
 import { useTagBankTransaction } from '@hooks/api/businesses/[business-id]/bank-transactions/tags/useTagBankTransaction'
+import { useGetBankTransactionCategorizationWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
 import { useSplitsForm } from '@hooks/features/bankTransactions/useSplitsForm'
 import { useTaxCodeOptions } from '@hooks/features/bankTransactions/useTaxCodeOptions'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
-import { BankTransactionSelectionVariant, useBankTransactionsCategorizationActions, useGetBankTransactionCategorizationByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import {
+  BankTransactionSelectionVariant,
+  useBankTransactionsCategorizationActions,
+} from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useBankTransactionsIsCategorizationEnabledContext } from '@contexts/BankTransactionsIsCategorizationEnabledContext/BankTransactionsIsCategorizationEnabledContext'
 import Scissors from '@icons/ScissorsFullOpen'
 import Trash from '@icons/Trash'
@@ -89,8 +93,8 @@ export const ExpandedBankTransactionRow = ({
 }: ExpandedBankTransactionRowProps) => {
   const { t } = useTranslation()
   const { formatCurrencyFromCents } = useIntlFormatter()
-  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
-  const { match: selectedMatch, variant: purpose } = selectedCategorization ?? {}
+  const selectedCategorization = useGetBankTransactionCategorizationWithDefault(bankTransaction)
+  const { match: selectedMatch, variant: purpose } = selectedCategorization
 
   const { setTransactionMatchSelection, setTransactionSelectionVariant } = useBankTransactionsCategorizationActions()
   // Hooks for auto-saving tags and customer/vendor in unsplit state
@@ -162,9 +166,7 @@ export const ExpandedBankTransactionRow = ({
       })
 
       removedTags.forEach((tag) => {
-        void removeTagFromBankTransaction({
-          tagId: tag.id,
-        })
+        void removeTagFromBankTransaction({ tagId: tag.id })
       })
     }
   }

--- a/src/components/ExpandedBankTransactionRow/utils.ts
+++ b/src/components/ExpandedBankTransactionRow/utils.ts
@@ -8,10 +8,10 @@ import { isSplitCategorizationEncoded } from '@schemas/categorization'
 import { decodeCustomerVendor } from '@schemas/customerVendor'
 import { makeTagFromTransactionTag, TransactionTagSchema } from '@schemas/tag'
 import { toLocalizedCents } from '@utils/i18n/number/input'
-import { type BankTransactionCategoryComboBoxOption, isPlaceholderAsOption, isSplitAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
-import { isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
+import { isPlaceholderAsOption, isSplitAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { isApiCategorizationAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
-import { convertApiCategorizationToCategoryOrSplitAsOption, getDefaultSelectedCategoryForBankTransaction } from '@components/BankTransactionCategoryComboBox/utils'
+import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/BankTransactionCategoryComboBox/utils'
 
 export enum ValidateSplitError {
   AmountsMustBeGreaterThanZero = 'AmountsMustBeGreaterThanZero',
@@ -116,15 +116,11 @@ export const getCustomerVendorForBankTransaction = (bankTransaction: BankTransac
 
 export const getLocalSplitStateForExpandedTransaction = (
   bankTransaction: BankTransaction,
-  selectedCategory: BankTransactionCategoryComboBoxOption | null | undefined,
+  selectedCategory: BankTransactionNonSuggestedMatchOption | null | undefined,
 ): Split[] => {
   let coercedSelectedCategory = selectedCategory
   if (!selectedCategory || isPlaceholderAsOption(selectedCategory)) {
     coercedSelectedCategory = null
-  }
-
-  else if (isSuggestedMatchAsOption(selectedCategory)) {
-    coercedSelectedCategory = getDefaultSelectedCategoryForBankTransaction(bankTransaction, true)
   }
 
   else if (isApiCategorizationAsOption(selectedCategory) && isSplitCategorizationEncoded(selectedCategory.original)) {
@@ -144,12 +140,10 @@ export const getLocalSplitStateForExpandedTransaction = (
     })
   }
   // Single category
-  return [
-    {
-      amount: bankTransaction.amount,
-      category: coercedSelectedCategory ?? null,
-      tags: bankTransaction.transaction_tags.map(tag => makeTagFromTransactionTag(Schema.decodeSync(TransactionTagSchema)(tag))),
-      customerVendor: getCustomerVendorForBankTransaction(bankTransaction),
-    },
-  ]
+  return [{
+    amount: bankTransaction.amount,
+    category: coercedSelectedCategory ?? null,
+    tags: bankTransaction.transaction_tags.map(tag => makeTagFromTransactionTag(Schema.decodeSync(TransactionTagSchema)(tag))),
+    customerVendor: getCustomerVendorForBankTransaction(bankTransaction),
+  }]
 }

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -47,10 +47,6 @@ const buildBulkMatchOrCategorizePayload = (
   for (const transactionId of selectedIds) {
     const { category, match, taxCode, variant } = categorizations.get(transactionId) ?? DEFAULT_CATEGORIZATION
 
-    if (!category || isPlaceholderAsOption(category)) {
-      continue
-    }
-
     if (variant === BankTransactionSelectionVariant.MATCH) {
       if (!match) continue
 
@@ -58,6 +54,10 @@ const buildBulkMatchOrCategorizePayload = (
         type: 'match',
         suggestedMatchId: match.original.id,
       }
+      continue
+    }
+
+    if (!category || isPlaceholderAsOption(category)) {
       continue
     }
 

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -9,10 +9,10 @@ import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
 import { useAuth } from '@hooks/utils/auth/useAuth'
-import { type BankTransactionCategorization, DEFAULT_CATEGORIZATION, useGetAllBankTransactionsCategorizations } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { type BankTransactionCategorization, BankTransactionSelectionVariant, DEFAULT_CATEGORIZATION, useGetAllBankTransactionsCategorizations } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useSelectedIds } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
-import { type BankTransactionCategoryComboBoxOption, isApiCategorizationAsOption, isCategoryAsOption, isPlaceholderAsOption, isSplitAsOption, isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import { type BankTransactionCategoryComboBoxOption, isApiCategorizationAsOption, isCategoryAsOption, isPlaceholderAsOption, isSplitAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 
 const BULK_MATCH_OR_CATEGORIZE_TAG = '#bulk-match-or-categorize'
 
@@ -45,16 +45,18 @@ const buildBulkMatchOrCategorizePayload = (
   const transactions: Record<string, MatchOrCategorizeTransaction> = {}
 
   for (const transactionId of selectedIds) {
-    const { category, taxCode } = categorizations.get(transactionId) ?? DEFAULT_CATEGORIZATION
+    const { category, match, taxCode, variant } = categorizations.get(transactionId) ?? DEFAULT_CATEGORIZATION
 
     if (!category || isPlaceholderAsOption(category)) {
       continue
     }
 
-    if (isSuggestedMatchAsOption(category)) {
+    if (variant === BankTransactionSelectionVariant.MATCH) {
+      if (!match) continue
+
       transactions[transactionId] = {
         type: 'match',
-        suggestedMatchId: category.value,
+        suggestedMatchId: match.original.id,
       }
       continue
     }
@@ -84,7 +86,7 @@ const buildBulkMatchOrCategorizePayload = (
       categorization: {
         type: 'Category',
         category: classification,
-        taxCode,
+        taxCode: taxCode?.value ?? null,
       },
     }
   }

--- a/src/hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault.ts
+++ b/src/hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { getDefaultCategorizationForBankTransaction } from '@utils/bankTransactions/shared'
 import {
@@ -9,8 +11,12 @@ import { type BankTransactionCategoryComboBoxOption } from '@components/BankTran
 
 export const useGetBankTransactionCategorizationWithDefault = (bankTransaction: BankTransaction): BankTransactionCategorization => {
   const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
+  const defaultCategorization = useMemo(
+    () => getDefaultCategorizationForBankTransaction(bankTransaction),
+    [bankTransaction],
+  )
 
-  return selectedCategorization ?? getDefaultCategorizationForBankTransaction(bankTransaction)
+  return selectedCategorization ?? defaultCategorization
 }
 
 export const useGetBankTransactionMatchOrCategoryWithDefault = (bankTransaction: BankTransaction): BankTransactionCategoryComboBoxOption | null => {

--- a/src/hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault.ts
+++ b/src/hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault.ts
@@ -1,0 +1,24 @@
+import { type BankTransaction } from '@internal-types/bankTransactions'
+import { getDefaultCategorizationForBankTransaction } from '@utils/bankTransactions/shared'
+import {
+  type BankTransactionCategorization,
+  BankTransactionSelectionVariant,
+  useGetBankTransactionCategorizationByTransactionId,
+} from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { type BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+
+export const useGetBankTransactionCategorizationWithDefault = (bankTransaction: BankTransaction): BankTransactionCategorization => {
+  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
+
+  return selectedCategorization ?? getDefaultCategorizationForBankTransaction(bankTransaction)
+}
+
+export const useGetBankTransactionMatchOrCategoryWithDefault = (bankTransaction: BankTransaction): BankTransactionCategoryComboBoxOption | null => {
+  const selectedCategorization = useGetBankTransactionCategorizationWithDefault(bankTransaction)
+
+  if (selectedCategorization.variant === BankTransactionSelectionVariant.CATEGORY) {
+    return selectedCategorization.category
+  }
+
+  return selectedCategorization.match
+}

--- a/src/hooks/features/bankTransactions/useSplitsForm.ts
+++ b/src/hooks/features/bankTransactions/useSplitsForm.ts
@@ -6,8 +6,8 @@ import { type BankTransaction, type Split } from '@internal-types/bankTransactio
 import { SplitAsOption } from '@internal-types/categorizationOption'
 import { convertCentsToDecimalString } from '@utils/format'
 import { toLocalizedNumber } from '@utils/i18n/number/input'
-import { useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
-import { type BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import { useBankTransactionsCategorizationActions, useGetBankTransactionCategorizationByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import {
   calculateAddSplit,
   calculateRemoveSplit,
@@ -19,7 +19,6 @@ import {
 
 interface UseSplitsFormOptions {
   bankTransaction: BankTransaction
-  selectedCategory: BankTransactionCategoryComboBoxOption | null | undefined
   isOpen?: boolean
 }
 
@@ -31,7 +30,7 @@ export interface UseSplitsFormReturn {
   addSplit: () => void
   removeSplit: (index: number) => void
   updateSplitAmount: (index: number) => (value?: string) => void
-  changeCategoryForSplitAtIndex: (index: number, category: BankTransactionCategoryComboBoxOption | null) => void
+  changeCategoryForSplitAtIndex: (index: number, category: BankTransactionNonSuggestedMatchOption | null) => void
   updateSplitAtIndex: (index: number, updater: (split: Split) => Split) => void
   onBlurSplitAmount: () => void
   setSplitFormError: (error: string | undefined) => void
@@ -40,20 +39,19 @@ export interface UseSplitsFormReturn {
   saveLocalSplitsToCategoryStore: (splits: Split[]) => void
 }
 
-export const useSplitsForm = ({
-  bankTransaction,
-  selectedCategory,
-  isOpen,
-}: UseSplitsFormOptions): UseSplitsFormReturn => {
+export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions): UseSplitsFormReturn => {
   const { t } = useTranslation()
   const intl = useIntl()
+  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
+  const { category: selectedCategory } = selectedCategorization ?? {}
 
   const [localSplits, setLocalSplits] = useState<Split[]>(
     getLocalSplitStateForExpandedTransaction(bankTransaction, selectedCategory),
   )
+
   const [inputValues, setInputValues] = useState<Record<number, string>>({})
   const [splitFormError, setSplitFormError] = useState<string | undefined>()
-  const { setTransactionCategorization } = useBankTransactionsCategorizationActions()
+  const { setTransactionCategorySelection } = useBankTransactionsCategorizationActions()
 
   useEffect(() => {
     setLocalSplits(getLocalSplitStateForExpandedTransaction(bankTransaction, selectedCategory))
@@ -67,9 +65,9 @@ export const useSplitsForm = ({
       return
     }
 
-    setTransactionCategorization(bankTransaction.id, { category: new SplitAsOption(splits) })
+    setTransactionCategorySelection(bankTransaction.id, new SplitAsOption(splits))
     setSplitFormError(undefined)
-  }, [bankTransaction.id, setTransactionCategorization, t])
+  }, [bankTransaction.id, setTransactionCategorySelection, t])
 
   const addSplit = useCallback(() => {
     const newSplits = calculateAddSplit(localSplits)
@@ -110,7 +108,7 @@ export const useSplitsForm = ({
     saveLocalSplitsToCategoryStore(newLocalSplits)
   }, [localSplits, bankTransaction.amount, intl.locale, saveLocalSplitsToCategoryStore])
 
-  const changeCategoryForSplitAtIndex = useCallback((index: number, newCategory: BankTransactionCategoryComboBoxOption | null) => {
+  const changeCategoryForSplitAtIndex = useCallback((index: number, newCategory: BankTransactionNonSuggestedMatchOption | null) => {
     if (newCategory === null) return
 
     const newLocalSplits = [...localSplits]

--- a/src/hooks/features/bankTransactions/useSplitsForm.ts
+++ b/src/hooks/features/bankTransactions/useSplitsForm.ts
@@ -6,7 +6,8 @@ import { type BankTransaction, type Split } from '@internal-types/bankTransactio
 import { SplitAsOption } from '@internal-types/categorizationOption'
 import { convertCentsToDecimalString } from '@utils/format'
 import { toLocalizedNumber } from '@utils/i18n/number/input'
-import { useBankTransactionsCategorizationActions, useGetBankTransactionCategorizationByTransactionId } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useGetBankTransactionCategorizationWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
+import { useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import {
   calculateAddSplit,
@@ -42,8 +43,8 @@ export interface UseSplitsFormReturn {
 export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions): UseSplitsFormReturn => {
   const { t } = useTranslation()
   const intl = useIntl()
-  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(bankTransaction.id)
-  const { category: selectedCategory } = selectedCategorization ?? {}
+  const selectedCategorization = useGetBankTransactionCategorizationWithDefault(bankTransaction)
+  const { category: selectedCategory } = selectedCategorization
 
   const [localSplits, setLocalSplits] = useState<Split[]>(
     getLocalSplitStateForExpandedTransaction(bankTransaction, selectedCategory),

--- a/src/hooks/features/bankTransactions/useUpsertBankTransactionsDefaultCategories.tsx
+++ b/src/hooks/features/bankTransactions/useUpsertBankTransactionsDefaultCategories.tsx
@@ -1,18 +1,32 @@
 import { useEffect } from 'react'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
+import {
+  getDefaultSelectedCategoryForBankTransaction,
+  getDefaultSuggestedMatchForBankTransaction,
+  getVariantForBankTransaction,
+} from '@utils/bankTransactions/shared'
+import { getDefaultTaxCodeOptionForBankTransaction } from '@utils/bankTransactions/taxCode'
 import { type BankTransactionCategorization, useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
-import { getDefaultSelectedCategoryForBankTransaction } from '@components/BankTransactionCategoryComboBox/utils'
+
+const getDefaultCategorizationForBankTransaction = (bankTransaction: BankTransaction) => {
+  return {
+    category: getDefaultSelectedCategoryForBankTransaction(bankTransaction),
+    taxCode: getDefaultTaxCodeOptionForBankTransaction(bankTransaction),
+    match: getDefaultSuggestedMatchForBankTransaction(bankTransaction),
+    variant: getVariantForBankTransaction(bankTransaction),
+  }
+}
 
 export const useUpsertBankTransactionsDefaultCategories = (bankTransactions: BankTransaction[] | undefined) => {
   const { setOnlyNewTransactionCategorizations } = useBankTransactionsCategorizationActions()
   useEffect(() => {
     if (!bankTransactions) return
 
-    const defaultCategories = new Map<string, Partial<BankTransactionCategorization>>(
+    const defaultCategories = new Map<string, BankTransactionCategorization>(
       bankTransactions.map(transaction => [
         transaction.id,
-        { category: getDefaultSelectedCategoryForBankTransaction(transaction) },
+        getDefaultCategorizationForBankTransaction(transaction),
       ]),
     )
 

--- a/src/hooks/features/bankTransactions/useUpsertBankTransactionsDefaultCategories.tsx
+++ b/src/hooks/features/bankTransactions/useUpsertBankTransactionsDefaultCategories.tsx
@@ -1,22 +1,8 @@
 import { useEffect } from 'react'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
-import {
-  getDefaultSelectedCategoryForBankTransaction,
-  getDefaultSuggestedMatchForBankTransaction,
-  getVariantForBankTransaction,
-} from '@utils/bankTransactions/shared'
-import { getDefaultTaxCodeOptionForBankTransaction } from '@utils/bankTransactions/taxCode'
+import { getDefaultCategorizationForBankTransaction } from '@utils/bankTransactions/shared'
 import { type BankTransactionCategorization, useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
-
-const getDefaultCategorizationForBankTransaction = (bankTransaction: BankTransaction) => {
-  return {
-    category: getDefaultSelectedCategoryForBankTransaction(bankTransaction),
-    taxCode: getDefaultTaxCodeOptionForBankTransaction(bankTransaction),
-    match: getDefaultSuggestedMatchForBankTransaction(bankTransaction),
-    variant: getVariantForBankTransaction(bankTransaction),
-  }
-}
 
 export const useUpsertBankTransactionsDefaultCategories = (bankTransactions: BankTransaction[] | undefined) => {
   const { setOnlyNewTransactionCategorizations } = useBankTransactionsCategorizationActions()

--- a/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
+++ b/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
@@ -84,11 +84,15 @@ function buildStore() {
       actions: {
         setTransactionCategorization: (id, update) => {
           set(({ categorizations }) => {
-            if (!update) return { categorizations }
+            if (!update) {
+              const { categorizations: categorizationsWithoutMatch } = updateCategorizationProperty(categorizations, id, 'match', null)
+              const { categorizations: categorizationsWithoutSelection } = updateCategorizationProperty(categorizationsWithoutMatch, id, 'category', null)
+              return updateCategorizationProperty(categorizationsWithoutSelection, id, 'variant', BankTransactionSelectionVariant.CATEGORY)
+            }
 
             const isSuggestedMatch = isSuggestedMatchAsOption(update)
-            const { categorizations: updatedCategorizations } = updateCategorizationProperty(categorizations, id, isSuggestedMatch ? 'match' : 'category', update)
-            return updateCategorizationProperty(updatedCategorizations, id, 'variant', isSuggestedMatch ? BankTransactionSelectionVariant.MATCH : BankTransactionSelectionVariant.CATEGORY)
+            const { categorizations: nextCategorizations } = updateCategorizationProperty(categorizations, id, isSuggestedMatch ? 'match' : 'category', update)
+            return updateCategorizationProperty(nextCategorizations, id, 'variant', isSuggestedMatch ? BankTransactionSelectionVariant.MATCH : BankTransactionSelectionVariant.CATEGORY)
           })
         },
 

--- a/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
+++ b/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
@@ -34,7 +34,6 @@ type BankTransactionsCategorizationActions = {
 
   setOnlyNewTransactionCategorizations: (categorizations: Map<string, BankTransactionCategorization>) => void
   clearTransactionCategorizations: (ids: string[]) => void
-  clearAllTransactionCategorizations: () => void
 }
 
 type BankTransactionsCategorizationStore = BankTransactionsCategorizationState & {
@@ -163,9 +162,6 @@ function buildStore() {
           })
         },
 
-        clearAllTransactionCategorizations: () => {
-          set({ categorizations: new Map() })
-        },
       },
     }
   })

--- a/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
+++ b/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
@@ -1,13 +1,23 @@
 import { createContext, type PropsWithChildren, useContext, useMemo, useState } from 'react'
 import { createStore, useStore } from 'zustand'
 
-import type { BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import type { SuggestedMatchAsOption } from '@internal-types/categorizationOption'
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
+import { type BankTransactionCategoryComboBoxOption, isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import type { TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
 
-export type TaxCodeComboboxOption = string
+export enum BankTransactionSelectionVariant {
+  MATCH = 'MATCH',
+  CATEGORY = 'CATEGORY',
+}
 
 export type BankTransactionCategorization = {
-  category: BankTransactionCategoryComboBoxOption | null
-  taxCode: TaxCodeComboboxOption | null
+  category: BankTransactionNonSuggestedMatchOption | null
+  taxCode: TaxCodeComboBoxOption | null
+
+  match: SuggestedMatchAsOption | null
+
+  variant: BankTransactionSelectionVariant
 }
 
 export type BankTransactionsCategorizationState = {
@@ -15,8 +25,14 @@ export type BankTransactionsCategorizationState = {
 }
 
 type BankTransactionsCategorizationActions = {
-  setTransactionCategorization: (id: string, update: Partial<BankTransactionCategorization>) => void
-  setOnlyNewTransactionCategorizations: (categorizations: Map<string, Partial<BankTransactionCategorization>>) => void
+  setTransactionCategorization: (id: string, update: BankTransactionCategoryComboBoxOption | null) => void
+
+  setTransactionCategorySelection: (id: string, category: BankTransactionNonSuggestedMatchOption | null) => void
+  setTransactionMatchSelection: (id: string, match: SuggestedMatchAsOption | null) => void
+  setTransactionTaxCodeSelection: (id: string, taxCode: TaxCodeComboBoxOption | null) => void
+  setTransactionSelectionVariant: (id: string, variant: BankTransactionSelectionVariant) => void
+
+  setOnlyNewTransactionCategorizations: (categorizations: Map<string, BankTransactionCategorization>) => void
   clearTransactionCategorizations: (ids: string[]) => void
   clearAllTransactionCategorizations: () => void
 }
@@ -28,6 +44,10 @@ type BankTransactionsCategorizationStore = BankTransactionsCategorizationState &
 export const DEFAULT_CATEGORIZATION: BankTransactionCategorization = {
   category: null,
   taxCode: null,
+
+  match: null,
+
+  variant: BankTransactionSelectionVariant.CATEGORY,
 }
 
 const mergeCategorization = (
@@ -36,7 +56,26 @@ const mergeCategorization = (
 ): BankTransactionCategorization => ({
   category: next.category === undefined ? current.category : next.category,
   taxCode: next.taxCode === undefined ? current.taxCode : next.taxCode,
+  match: next.match === undefined ? current.match : next.match,
+  variant: next.variant === undefined ? current.variant : next.variant,
 })
+
+const updateCategorizationProperty = <K extends keyof BankTransactionCategorization>(
+  categorizations: Map<string, BankTransactionCategorization>,
+  id: string,
+  key: K,
+  value: BankTransactionCategorization[K],
+) => {
+  const current = categorizations.get(id) ?? DEFAULT_CATEGORIZATION
+  const merged = { ...current, [key]: value } as BankTransactionCategorization
+  const shouldWrite = current[key] !== merged[key]
+
+  if (!shouldWrite) return { categorizations }
+
+  const newMap = new Map(categorizations)
+  newMap.set(id, merged)
+  return { categorizations: newMap }
+}
 
 function buildStore() {
   return createStore<BankTransactionsCategorizationStore>((set) => {
@@ -45,18 +84,28 @@ function buildStore() {
       actions: {
         setTransactionCategorization: (id, update) => {
           set(({ categorizations }) => {
-            const newMap = new Map(categorizations)
-            const current = categorizations.get(id) ?? DEFAULT_CATEGORIZATION
-            const merged = mergeCategorization(current, update)
+            if (!update) return { categorizations }
 
-            const shouldWrite = !categorizations.has(id)
-              || current.category !== merged.category
-              || current.taxCode !== merged.taxCode
-
-            if (!shouldWrite) return { categorizations }
-            newMap.set(id, merged)
-            return { categorizations: newMap }
+            const isSuggestedMatch = isSuggestedMatchAsOption(update)
+            const { categorizations: updatedCategorizations } = updateCategorizationProperty(categorizations, id, isSuggestedMatch ? 'match' : 'category', update)
+            return updateCategorizationProperty(updatedCategorizations, id, 'variant', isSuggestedMatch ? BankTransactionSelectionVariant.MATCH : BankTransactionSelectionVariant.CATEGORY)
           })
+        },
+
+        setTransactionCategorySelection: (id, category) => {
+          set(({ categorizations }) => updateCategorizationProperty(categorizations, id, 'category', category))
+        },
+
+        setTransactionMatchSelection: (id, match) => {
+          set(({ categorizations }) => updateCategorizationProperty(categorizations, id, 'match', match))
+        },
+
+        setTransactionTaxCodeSelection: (id, taxCode) => {
+          set(({ categorizations }) => updateCategorizationProperty(categorizations, id, 'taxCode', taxCode))
+        },
+
+        setTransactionSelectionVariant: (id, variant) => {
+          set(({ categorizations }) => updateCategorizationProperty(categorizations, id, 'variant', variant))
         },
 
         setOnlyNewTransactionCategorizations: (newCategorizations) => {
@@ -66,19 +115,36 @@ function buildStore() {
             const newMap = new Map(categorizations)
 
             newCategorizations.forEach((next, id) => {
-              const isNewTransaction = !categorizations.has(id)
+              const current = categorizations.get(id)
 
-              const current = categorizations.get(id) ?? DEFAULT_CATEGORIZATION
-              const merged = mergeCategorization(current, next)
+              if (!current) {
+                const merged = mergeCategorization(DEFAULT_CATEGORIZATION, next)
 
-              const shouldWrite = isNewTransaction
-                || (current.category === null && merged.category !== null)
-                || (current.taxCode === null && merged.taxCode !== null)
-
-              if (shouldWrite) {
                 newMap.set(id, merged)
                 hasChanges = true
+
+                return
               }
+
+              const nextUpdates: Partial<BankTransactionCategorization> = {}
+
+              if (current.category === null && next.category) {
+                nextUpdates.category = next.category
+              }
+
+              if (current.match === null && next.match) {
+                nextUpdates.match = next.match
+              }
+
+              if (current.taxCode === null && next.taxCode !== null) {
+                nextUpdates.taxCode = next.taxCode
+              }
+
+              if (Object.keys(nextUpdates).length === 0) return
+
+              const merged = mergeCategorization(current, nextUpdates)
+              newMap.set(id, merged)
+              hasChanges = true
             })
 
             return hasChanges ? { categorizations: newMap } : state
@@ -118,18 +184,24 @@ export function useBankTransactionsCategorizationActions(): BankTransactionsCate
 
 export function useGetBankTransactionCategorizationByTransactionId(
   transactionId: string,
-): { selectedCategorization: BankTransactionCategorization | undefined } {
+): BankTransactionCategorization | undefined {
   const store = useBankTransactionsCategorizationStore()
   const selectedCategorization = useStore(store, state => state.categorizations.get(transactionId))
-  return { selectedCategorization }
+
+  return selectedCategorization
 }
 
-export function useGetBankTransactionCategoryByTransactionId(
+export function useGetBankTransactionMatchOrCategoryByTransactionId(
   transactionId: string,
-): { selectedCategory: BankTransactionCategoryComboBoxOption | null | undefined } {
-  const store = useBankTransactionsCategorizationStore()
-  const selectedCategory = useStore(store, state => state.categorizations.get(transactionId)?.category)
-  return { selectedCategory }
+): BankTransactionCategoryComboBoxOption | null {
+  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(transactionId)
+  if (!selectedCategorization) return null
+
+  if (selectedCategorization.variant === BankTransactionSelectionVariant.CATEGORY) {
+    return selectedCategorization.category
+  }
+
+  return selectedCategorization.match
 }
 
 export function useGetAllBankTransactionsCategorizations(): { categorizations: ReadonlyMap<string, BankTransactionCategorization> } {

--- a/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
+++ b/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
@@ -191,19 +191,6 @@ export function useGetBankTransactionCategorizationByTransactionId(
   return selectedCategorization
 }
 
-export function useGetBankTransactionMatchOrCategoryByTransactionId(
-  transactionId: string,
-): BankTransactionCategoryComboBoxOption | null {
-  const selectedCategorization = useGetBankTransactionCategorizationByTransactionId(transactionId)
-  if (!selectedCategorization) return null
-
-  if (selectedCategorization.variant === BankTransactionSelectionVariant.CATEGORY) {
-    return selectedCategorization.category
-  }
-
-  return selectedCategorization.match
-}
-
 export function useGetAllBankTransactionsCategorizations(): { categorizations: ReadonlyMap<string, BankTransactionCategorization> } {
   const store = useBankTransactionsCategorizationStore()
   const categorizations = useStore(store, state => state.categorizations)

--- a/src/providers/BankTransactionsCategorizationStore/utils.ts
+++ b/src/providers/BankTransactionsCategorizationStore/utils.ts
@@ -1,0 +1,7 @@
+import type { SuggestedMatchAsOption } from '@internal-types/categorizationOption'
+import type { BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+
+export type BankTransactionNonSuggestedMatchOption = Exclude<
+  BankTransactionCategoryComboBoxOption,
+  SuggestedMatchAsOption
+>

--- a/src/types/bankTransactions.ts
+++ b/src/types/bankTransactions.ts
@@ -11,7 +11,7 @@ import type { CustomerSchema } from '@schemas/customer'
 import type { CustomerVendorSchema } from '@schemas/customerVendor'
 import type { Tag, TransactionTagEncoded } from '@schemas/tag'
 import type { VendorSchema } from '@schemas/vendor'
-import type { BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 
 export enum BankTransactionMatchType {
   CONFIRM_MATCH = 'Confirm_Match',
@@ -92,7 +92,7 @@ export interface DocumentS3Urls {
 
 export type Split = {
   amount: number
-  category: BankTransactionCategoryComboBoxOption | null
+  category: BankTransactionNonSuggestedMatchOption | null
   taxCode?: string | null
   tags: readonly Tag[]
   customerVendor: typeof CustomerVendorSchema.Type | null

--- a/src/utils/bankTransactions/shared.ts
+++ b/src/utils/bankTransactions/shared.ts
@@ -1,11 +1,16 @@
 import { isWithinInterval, parseISO } from 'date-fns'
 
 import { type BankTransaction, DisplayState, type Split, type SuggestedMatch } from '@internal-types/bankTransactions'
+import { hasSuggestions } from '@internal-types/categories'
+import { SuggestedMatchAsOption } from '@internal-types/categorizationOption'
 import { type DateRange } from '@internal-types/general'
 import { Direction } from '@internal-types/general'
 import type { TagFilterInput } from '@internal-types/tags'
 import type { CategoryUpdate } from '@schemas/bankTransactions/categoryUpdate'
 import { makeTagKeyValueFromTag } from '@schemas/tag'
+import { BankTransactionSelectionVariant } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
+import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/BankTransactionCategoryComboBox/utils'
 import { CategorizedCategories, ReviewCategories } from '@components/BankTransactions/constants'
 
 export const filterVisibility = (
@@ -29,6 +34,11 @@ export const filterVisibility = (
 export interface NumericRangeFilter {
   min?: number
   max?: number
+}
+
+export enum BankTransactionsDateFilterMode {
+  MonthlyView = 'MonthlyView',
+  GlobalDateRange = 'GlobalDateRange',
 }
 
 export const hasMatch = (bankTransaction?: BankTransaction) => {
@@ -100,14 +110,38 @@ export const getBankTransactionMatchAsSuggestedMatch = (bankTransaction?: BankTr
   return undefined
 }
 
-export const getBankTransactionFirstSuggestedMatch = (bankTransaction?: BankTransaction): SuggestedMatch | undefined => {
+export const getSuggestedMatchForBankTransaction = (bankTransaction?: BankTransaction): SuggestedMatch | undefined => {
   return getBankTransactionMatchAsSuggestedMatch(bankTransaction) ?? bankTransaction?.suggested_matches?.[0]
 }
 
-export enum BankTransactionsDateFilterMode {
-  MonthlyView = 'MonthlyView',
-  GlobalDateRange = 'GlobalDateRange',
+export const getBankTransactionFirstSuggestedMatch = (bankTransaction?: BankTransaction): SuggestedMatch | undefined => {
+  return getSuggestedMatchForBankTransaction(bankTransaction)
 }
+
+export const getDefaultSuggestedMatchForBankTransaction = (bankTransaction?: BankTransaction): SuggestedMatchAsOption | null => {
+  const suggestedMatch = getSuggestedMatchForBankTransaction(bankTransaction)
+
+  return suggestedMatch ? new SuggestedMatchAsOption(suggestedMatch) : null
+}
+
+export const getDefaultSelectedCategoryForBankTransaction = (
+  bankTransaction: BankTransaction,
+): BankTransactionNonSuggestedMatchOption | null => {
+  if (bankTransaction.category) {
+    return convertApiCategorizationToCategoryOrSplitAsOption(bankTransaction.category)
+  }
+
+  if (hasSuggestions(bankTransaction.categorization_flow)) {
+    return convertApiCategorizationToCategoryOrSplitAsOption(bankTransaction.categorization_flow.suggestions[0])
+  }
+
+  return null
+}
+
+export const getVariantForBankTransaction = (bankTransaction?: BankTransaction): BankTransactionSelectionVariant => {
+  return getSuggestedMatchForBankTransaction(bankTransaction) ? BankTransactionSelectionVariant.MATCH : BankTransactionSelectionVariant.CATEGORY
+}
+
 export type BankTransactionFilters = {
   amount?: NumericRangeFilter
   account?: string[]

--- a/src/utils/bankTransactions/shared.ts
+++ b/src/utils/bankTransactions/shared.ts
@@ -8,6 +8,7 @@ import { Direction } from '@internal-types/general'
 import type { TagFilterInput } from '@internal-types/tags'
 import type { CategoryUpdate } from '@schemas/bankTransactions/categoryUpdate'
 import { makeTagKeyValueFromTag } from '@schemas/tag'
+import { getDefaultTaxCodeOptionForBankTransaction } from '@utils/bankTransactions/taxCode'
 import { BankTransactionSelectionVariant } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/BankTransactionCategoryComboBox/utils'
@@ -138,7 +139,7 @@ export const getDefaultSelectedCategoryForBankTransaction = (
   return null
 }
 
-export const getVariantForBankTransaction = (bankTransaction?: BankTransaction): BankTransactionSelectionVariant => {
+export const getDefaultVariantForBankTransaction = (bankTransaction?: BankTransaction): BankTransactionSelectionVariant => {
   return getSuggestedMatchForBankTransaction(bankTransaction) ? BankTransactionSelectionVariant.MATCH : BankTransactionSelectionVariant.CATEGORY
 }
 
@@ -170,4 +171,13 @@ export const buildCategorizeBankTransactionPayloadForSplit = (splits: Split[]): 
         vendorId: split.customerVendor?.customerVendorType === 'VENDOR' ? split.customerVendor.id : undefined,
       })),
     })
+}
+
+export const getDefaultCategorizationForBankTransaction = (bankTransaction: BankTransaction) => {
+  return {
+    category: getDefaultSelectedCategoryForBankTransaction(bankTransaction),
+    taxCode: getDefaultTaxCodeOptionForBankTransaction(bankTransaction),
+    match: getDefaultSuggestedMatchForBankTransaction(bankTransaction),
+    variant: getDefaultVariantForBankTransaction(bankTransaction),
+  }
 }

--- a/src/utils/bankTransactions/shared.ts
+++ b/src/utils/bankTransactions/shared.ts
@@ -139,7 +139,10 @@ export const getDefaultSelectedCategoryForBankTransaction = (
   return null
 }
 
-export const getDefaultVariantForBankTransaction = (bankTransaction?: BankTransaction): BankTransactionSelectionVariant => {
+export const getDefaultVariantForBankTransaction = (bankTransaction: BankTransaction): BankTransactionSelectionVariant => {
+  if (bankTransaction.match) return BankTransactionSelectionVariant.MATCH
+  if (bankTransaction.category) return BankTransactionSelectionVariant.CATEGORY
+
   return getSuggestedMatchForBankTransaction(bankTransaction) ? BankTransactionSelectionVariant.MATCH : BankTransactionSelectionVariant.CATEGORY
 }
 

--- a/src/utils/bankTransactions/taxCode.ts
+++ b/src/utils/bankTransactions/taxCode.ts
@@ -2,7 +2,7 @@ import { type BankTransaction } from '@internal-types/bankTransactions'
 import { type BankTransactionTaxOption } from '@schemas/bankTransactions/bankTransaction'
 import { isClassificationExclusion } from '@schemas/categorization'
 import { type BankTransactionCategoryComboBoxOption, isPlaceholderAsOption, isSplitAsOption, isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
-import type { TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
+import { TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
 
 export const getBankTransactionTaxOptions = (bankTransaction?: BankTransaction): BankTransactionTaxOption[] => {
   if (!bankTransaction?.tax_options) {
@@ -10,6 +10,15 @@ export const getBankTransactionTaxOptions = (bankTransaction?: BankTransaction):
   }
 
   return Object.values(bankTransaction.tax_options).flat()
+}
+
+export const getDefaultTaxCodeOptionForBankTransaction = (bankTransaction?: BankTransaction): TaxCodeComboBoxOption | null => {
+  const taxCode = bankTransaction?.tax_code
+  if (!taxCode) return null
+
+  const option = getBankTransactionTaxOptions(bankTransaction).find(option => option.code === taxCode)
+
+  return option ? new TaxCodeComboBoxOption(option) : null
 }
 
 export const hasBankTransactionTaxCode = (


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core bank-transaction categorization state and bulk submit payloads to support both matches and categories, which could affect approval/matching flows if the new variant/selection syncing is incorrect.
> 
> **Overview**
> Unifies bank-transaction selection state so the categorization store tracks **both** `category` and `match` plus an explicit `variant` (`MATCH` vs `CATEGORY`), and updates UI flows to read/write this combined state.
> 
> Updates list/row/expanded and mobile forms to use new selectors (`useGetBankTransactionCategorizationWithDefault` / `useGetBankTransactionMatchOrCategoryWithDefault`) and new store actions (`setTransactionMatchSelection`, `setTransactionCategorySelection`, `setTransactionSelectionVariant`) instead of the old category-only accessors.
> 
> Adjusts bulk match-or-categorize to build requests based on the stored `variant` (sending match requests from `match.original.id`, otherwise category/split requests) and introduces shared “default categorization” helpers (including default tax code option) for initial store population and UI defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87df97f164c91c324c654a2334cd52256f121ce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->