### PR TITLE
[HST/GST] Show tax codes in mobile category selection

### DIFF
--- a/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsCategorizeAllModal.tsx
+++ b/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsCategorizeAllModal.tsx
@@ -122,8 +122,8 @@ export const BankTransactionsCategorizeAllModal = ({
               ? (
                 <CategorySelectDrawerWithTrigger
                   aria-labelledby={categorySelectId}
-                  value={selectedCategory}
-                  onChange={setSelectedCategory}
+                  selectedValue={selectedCategory}
+                  onSelectedValueChange={setSelectedCategory}
                   showTooltips={false}
                 />
               )

--- a/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection.tsx
+++ b/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { GridList } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
 
@@ -38,13 +38,18 @@ export const BankTransactionsMobileCategorySelection = ({
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [sessionCategories, setSessionCategories] = useState(
-    buildInitialSessionCategoriesMap(bankTransaction),
+    () => buildInitialSessionCategoriesMap(bankTransaction),
   )
+  const previousTransactionIdRef = useRef(bankTransaction.id)
 
   const { taxCodeOptions, hasTaxCodeOptions } = useTaxCodeOptions(bankTransaction)
   const { category: selectedCategory, taxCode: selectedTaxCode } = useGetBankTransactionCategorizationWithDefault(bankTransaction)
 
   useEffect(() => {
+    if (previousTransactionIdRef.current === bankTransaction.id) {
+      return
+    }
+    previousTransactionIdRef.current = bankTransaction.id
     setSessionCategories(buildInitialSessionCategoriesMap(bankTransaction))
   }, [bankTransaction])
 

--- a/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection.tsx
+++ b/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection.tsx
@@ -5,24 +5,27 @@ import { useTranslation } from 'react-i18next'
 import { VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 
-import './businessFormMobile.scss'
+import {
+  BankTransactionsMobileCategorySelectionItem,
+  type BankTransactionsMobileCategorySelectionItemOption,
+} from './BankTransactionsMobileCategorySelectionItem'
 
-import { BusinessFormMobileItem, type BusinessFormMobileItemOption } from './BusinessFormMobileItem'
+import './bankTransactionsMobileCategorySelection.scss'
 
-interface BusinessFormMobileProps {
-  options: BusinessFormMobileItemOption[]
+interface BankTransactionsMobileCategorySelectionProps {
+  options: BankTransactionsMobileCategorySelectionItemOption[]
   selectedId?: string
   showDescriptions?: boolean
-  onSelect: (option: BusinessFormMobileItemOption) => void
+  onSelect: (option: BankTransactionsMobileCategorySelectionItemOption) => void
   readOnly?: boolean
 }
 
-export const BusinessFormMobile = ({
+export const BankTransactionsMobileCategorySelection = ({
   options,
   selectedId,
   onSelect,
   readOnly,
-}: BusinessFormMobileProps) => {
+}: BankTransactionsMobileCategorySelectionProps) => {
   const { t } = useTranslation()
   const handleSelectionChange = useCallback((keys: Set<string | number> | 'all') => {
     if (readOnly) return
@@ -44,10 +47,10 @@ export const BusinessFormMobile = ({
         selectionMode='single'
         selectedKeys={selectedId ? new Set([selectedId]) : new Set()}
         onSelectionChange={handleSelectionChange}
-        className='Layer__BusinessFormMobile'
+        className='Layer__BankTransactionsMobileCategorySelection'
       >
         {options.map(option => (
-          <BusinessFormMobileItem
+          <BankTransactionsMobileCategorySelectionItem
             key={option.value.value}
             option={option}
           />

--- a/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection.tsx
+++ b/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection.tsx
@@ -1,41 +1,96 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { GridList } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
 
+import { type BankTransaction } from '@internal-types/bankTransactions'
+import { canCategoryHaveTaxCode } from '@utils/bankTransactions/taxCode'
+import { useGetBankTransactionCategorizationWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
+import { useTaxCodeOptions } from '@hooks/features/bankTransactions/useTaxCodeOptions'
+import { useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
-
-import {
-  BankTransactionsMobileCategorySelectionItem,
-  type BankTransactionsMobileCategorySelectionItemOption,
-} from './BankTransactionsMobileCategorySelectionItem'
+import { isPlaceholderAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import { CategorySelectDrawer } from '@components/CategorySelect/CategorySelectDrawer'
+import type { TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
+import { TaxCodeMobileDrawer } from '@components/TaxCodeSelect/TaxCodeMobileDrawer'
 
 import './bankTransactionsMobileCategorySelection.scss'
 
+import {
+  BankTransactionsMobileCategorySelectionItem,
+  type BankTransactionsMobileCategorySelectionOptionValue,
+} from './BankTransactionsMobileCategorySelectionItem'
+import { buildCategoryOptions, buildInitialSessionCategoriesMap } from './utils'
+
 interface BankTransactionsMobileCategorySelectionProps {
-  options: BankTransactionsMobileCategorySelectionItemOption[]
-  selectedId?: string
-  showDescriptions?: boolean
-  onSelect: (option: BankTransactionsMobileCategorySelectionItemOption) => void
-  readOnly?: boolean
+  bankTransaction: BankTransaction
+  showTooltips?: boolean
+  isSubmitting?: boolean
 }
 
 export const BankTransactionsMobileCategorySelection = ({
-  options,
-  selectedId,
-  onSelect,
-  readOnly,
+  bankTransaction,
+  showTooltips = false,
+  isSubmitting = false,
 }: BankTransactionsMobileCategorySelectionProps) => {
   const { t } = useTranslation()
-  const handleSelectionChange = useCallback((keys: Set<string | number> | 'all') => {
-    if (readOnly) return
+  const { setTransactionCategorySelection, setTransactionTaxCodeSelection } = useBankTransactionsCategorizationActions()
 
-    const selectedKey = [...keys][0]
-    const selectedOption = options.find(opt => opt.value.value === selectedKey)
-    if (selectedOption) {
-      onSelect(selectedOption)
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const [sessionCategories, setSessionCategories] = useState(
+    buildInitialSessionCategoriesMap(bankTransaction),
+  )
+
+  const { taxCodeOptions, hasTaxCodeOptions } = useTaxCodeOptions(bankTransaction)
+  const { category: selectedCategory, taxCode: selectedTaxCode } = useGetBankTransactionCategorizationWithDefault(bankTransaction)
+
+  useEffect(() => {
+    setSessionCategories(buildInitialSessionCategoriesMap(bankTransaction))
+  }, [bankTransaction])
+
+  const categoryOptions = useMemo(
+    () => buildCategoryOptions(
+      sessionCategories,
+      t('bankTransactions:action.show_all_categories', 'Show all categories'),
+    ),
+    [sessionCategories, t],
+  )
+
+  const handleCategoryGridSelect = useCallback((selectionKeys: Set<string | number> | 'all') => {
+    if (selectionKeys === 'all') return
+
+    const selectedKey = [...selectionKeys][0]
+    const selectedCategoryItem = categoryOptions.find(categoryItem => categoryItem.value.value === selectedKey)
+    if (!selectedCategoryItem) return
+
+    if (selectedCategoryItem.asLink) {
+      setIsDrawerOpen(true)
+      return
     }
-  }, [options, onSelect, readOnly])
+
+    const selectedCategoryOption = selectedCategoryItem.value
+    if (!isPlaceholderAsOption(selectedCategoryOption)) {
+      setSessionCategories(previousCategories => new Map(previousCategories).set(selectedCategoryOption.value, selectedCategoryOption))
+    }
+
+    if (selectedCategory && selectedCategory.value === selectedCategoryOption.value) {
+      setTransactionCategorySelection(bankTransaction.id, null)
+      return
+    }
+
+    setTransactionCategorySelection(bankTransaction.id, selectedCategoryOption)
+  }, [bankTransaction.id, categoryOptions, selectedCategory, setTransactionCategorySelection])
+
+  const handleCategoryDrawerSelect = useCallback((selectedDrawerCategory: BankTransactionsMobileCategorySelectionOptionValue | null) => {
+    if (!selectedDrawerCategory) return
+
+    setSessionCategories(previousCategories => new Map(previousCategories).set(selectedDrawerCategory.value, selectedDrawerCategory))
+    setTransactionCategorySelection(bankTransaction.id, selectedDrawerCategory)
+  }, [bankTransaction.id, setTransactionCategorySelection])
+
+  const handleTaxCodeSelect = useCallback((taxCode: TaxCodeComboBoxOption | null) => {
+    setTransactionTaxCodeSelection(bankTransaction.id, taxCode)
+  }, [bankTransaction.id, setTransactionTaxCodeSelection])
 
   return (
     <VStack gap='sm'>
@@ -45,17 +100,29 @@ export const BankTransactionsMobileCategorySelection = ({
       <GridList
         aria-label={t('bankTransactions:action.select_a_category', 'Select a category')}
         selectionMode='single'
-        selectedKeys={selectedId ? new Set([selectedId]) : new Set()}
-        onSelectionChange={handleSelectionChange}
+        selectedKeys={selectedCategory?.value ? new Set([selectedCategory.value]) : new Set()}
+        onSelectionChange={handleCategoryGridSelect}
         className='Layer__BankTransactionsMobileCategorySelection'
       >
-        {options.map(option => (
-          <BankTransactionsMobileCategorySelectionItem
-            key={option.value.value}
-            option={option}
-          />
+        {categoryOptions.map(categoryItem => (
+          <BankTransactionsMobileCategorySelectionItem key={categoryItem.value.value} option={categoryItem} />
         ))}
       </GridList>
+      {hasTaxCodeOptions && canCategoryHaveTaxCode(selectedCategory) && (
+        <TaxCodeMobileDrawer
+          options={taxCodeOptions}
+          selectedValue={selectedTaxCode}
+          onSelectedValueChange={handleTaxCodeSelect}
+          isDisabled={isSubmitting}
+        />
+      )}
+      <CategorySelectDrawer
+        onSelectedValueChange={handleCategoryDrawerSelect}
+        selectedValue={selectedCategory}
+        showTooltips={showTooltips}
+        isOpen={isDrawerOpen}
+        onOpenChange={setIsDrawerOpen}
+      />
     </VStack>
   )
 }

--- a/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelectionItem.tsx
+++ b/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelectionItem.tsx
@@ -6,22 +6,22 @@ import { Checkbox } from '@ui/Checkbox/Checkbox'
 import { HStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 
-import './businessFormMobileItem.scss'
+import './bankTransactionsMobileCategorySelectionItem.scss'
 
-export type BusinessFormOptionValue = BankTransactionNonSuggestedMatchOption
+export type BankTransactionsMobileCategorySelectionOptionValue = BankTransactionNonSuggestedMatchOption
 
-export interface BusinessFormMobileItemOption {
-  value: BusinessFormOptionValue
+export interface BankTransactionsMobileCategorySelectionItemOption {
+  value: BankTransactionsMobileCategorySelectionOptionValue
   asLink?: boolean
 }
 
-interface BusinessFormMobileItemProps {
-  option: BusinessFormMobileItemOption
+interface BankTransactionsMobileCategorySelectionItemProps {
+  option: BankTransactionsMobileCategorySelectionItemOption
 }
 
-export const BusinessFormMobileItem = ({
+export const BankTransactionsMobileCategorySelectionItem = ({
   option,
-}: BusinessFormMobileItemProps) => {
+}: BankTransactionsMobileCategorySelectionItemProps) => {
   const value = option.value.value
   const label = option.value.label
 
@@ -30,7 +30,7 @@ export const BusinessFormMobileItem = ({
       id={value}
       key={value}
       textValue={label}
-      className='Layer__BusinessFormMobileItem'
+      className='Layer__BankTransactionsMobileCategorySelectionItem'
     >
       <HStack gap='md' pi='md' pb='sm'>
         {!option.asLink && (
@@ -45,7 +45,7 @@ export const BusinessFormMobileItem = ({
         {option.asLink && (
           <ChevronRight
             size={16}
-            className='Layer__BusinessFormMobileItem__link-icon'
+            className='Layer__BankTransactionsMobileCategorySelectionItem__link-icon'
           />
         )}
       </HStack>

--- a/src/components/BankTransactionsMobileCategorySelection/bankTransactionsMobileCategorySelection.scss
+++ b/src/components/BankTransactionsMobileCategorySelection/bankTransactionsMobileCategorySelection.scss
@@ -1,4 +1,4 @@
-.Layer__BusinessFormMobile {
+.Layer__BankTransactionsMobileCategorySelection {
   border-radius: var(--border-radius-2xs);
   border: 1px solid var(--color-base-300);
 }

--- a/src/components/BankTransactionsMobileCategorySelection/bankTransactionsMobileCategorySelection.scss
+++ b/src/components/BankTransactionsMobileCategorySelection/bankTransactionsMobileCategorySelection.scss
@@ -1,4 +1,5 @@
 .Layer__BankTransactionsMobileCategorySelection {
+  overflow: hidden;
   border-radius: var(--border-radius-2xs);
   border: 1px solid var(--color-base-300);
 }

--- a/src/components/BankTransactionsMobileCategorySelection/bankTransactionsMobileCategorySelectionItem.scss
+++ b/src/components/BankTransactionsMobileCategorySelection/bankTransactionsMobileCategorySelectionItem.scss
@@ -1,4 +1,4 @@
-.Layer__BusinessFormMobileItem {
+.Layer__BankTransactionsMobileCategorySelectionItem {
   &[data-selected] {
     background: var(--color-base-100);
   }

--- a/src/components/BankTransactionsMobileCategorySelection/utils.ts
+++ b/src/components/BankTransactionsMobileCategorySelection/utils.ts
@@ -1,0 +1,45 @@
+import { type BankTransaction } from '@internal-types/bankTransactions'
+import { CategorizationType } from '@internal-types/categories'
+import { ApiCategorizationAsOption, PlaceholderAsOption } from '@internal-types/categorizationOption'
+import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
+import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/BankTransactionCategoryComboBox/utils'
+import { type BankTransactionsMobileCategorySelectionItemOption } from '@components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelectionItem'
+
+const SELECT_CATEGORY_VALUE = 'SELECT_CATEGORY'
+
+export const buildInitialSessionCategoriesMap = (bankTransaction: BankTransaction) => {
+  const categoriesMap = new Map<string, BankTransactionNonSuggestedMatchOption>()
+
+  if (bankTransaction.category) {
+    const existingCategory = convertApiCategorizationToCategoryOrSplitAsOption(bankTransaction.category)
+    categoriesMap.set(existingCategory.value, existingCategory)
+  }
+
+  if (bankTransaction?.categorization_flow?.type === CategorizationType.ASK_FROM_SUGGESTIONS) {
+    bankTransaction.categorization_flow.suggestions.forEach((suggestion) => {
+      const suggestionOption = new ApiCategorizationAsOption(suggestion)
+      categoriesMap.set(suggestionOption.value, suggestionOption)
+    })
+  }
+
+  return categoriesMap
+}
+
+export const buildCategoryOptions = (
+  sessionCategories: Map<string, BankTransactionNonSuggestedMatchOption>,
+  showAllCategoriesLabel: string,
+): BankTransactionsMobileCategorySelectionItemOption[] => {
+  const categoryOptionsList: BankTransactionsMobileCategorySelectionItemOption[] = Array.from(sessionCategories.values()).map(category => ({
+    value: category,
+  }))
+
+  categoryOptionsList.push({
+    value: new PlaceholderAsOption({
+      label: showAllCategoriesLabel,
+      value: SELECT_CATEGORY_VALUE,
+    }),
+    asLink: true,
+  })
+
+  return categoryOptionsList
+}

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
@@ -19,8 +19,8 @@ import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/B
 import { BankTransactionFormFields } from '@components/BankTransactionFormFields/BankTransactionFormFields'
 import { BankTransactionReceipts } from '@components/BankTransactionReceipts/BankTransactionReceipts'
 import { type BankTransactionReceiptsHandle } from '@components/BankTransactionReceipts/BankTransactionReceipts'
-import { BusinessFormMobile } from '@components/BusinessForm/BusinessFormMobile'
-import { type BusinessFormMobileItemOption, type BusinessFormOptionValue } from '@components/BusinessForm/BusinessFormMobileItem'
+import { BankTransactionsMobileCategorySelection } from '@components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection'
+import { type BankTransactionsMobileCategorySelectionItemOption, type BankTransactionsMobileCategorySelectionOptionValue } from '@components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelectionItem'
 import { CategorySelectDrawer } from '@components/CategorySelect/CategorySelectDrawer'
 import { FileInput } from '@components/Input/FileInput'
 import { ErrorText } from '@components/Typography/ErrorText'
@@ -28,12 +28,12 @@ import { ErrorText } from '@components/Typography/ErrorText'
 const SELECT_CATEGORY_VALUE = 'SELECT_CATEGORY'
 
 export const isSelectCategoryOption = (
-  value: BusinessFormOptionValue,
+  value: BankTransactionsMobileCategorySelectionOptionValue,
 ): boolean => {
   return isPlaceholderAsOption(value) && value.value === SELECT_CATEGORY_VALUE
 }
 
-type DisplayOption = BusinessFormMobileItemOption
+type DisplayOption = BankTransactionsMobileCategorySelectionItemOption
 
 interface BankTransactionsMobileListBusinessFormProps {
   bankTransaction: BankTransaction
@@ -160,7 +160,7 @@ export const BankTransactionsMobileListBusinessForm = ({
       <VStack gap='sm'>
         {showCategorization
           && (
-            <BusinessFormMobile
+            <BankTransactionsMobileCategorySelection
               options={options}
               onSelect={onCategorySelect}
               selectedId={selectedCategory?.value}

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
@@ -1,40 +1,22 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
-import { CategorizationType } from '@internal-types/categories'
-import { ApiCategorizationAsOption, PlaceholderAsOption } from '@internal-types/categorizationOption'
 import { hasReceipts, isCategorized } from '@utils/bankTransactions/shared'
+import { resolveCategoryTaxCode } from '@utils/bankTransactions/taxCode'
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
 import { useGetBankTransactionCategorizationWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
-import { useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
-import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import PaperclipIcon from '@icons/Paperclip'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
-import { isPlaceholderAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
-import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/BankTransactionCategoryComboBox/utils'
 import { BankTransactionFormFields } from '@components/BankTransactionFormFields/BankTransactionFormFields'
 import { BankTransactionReceipts } from '@components/BankTransactionReceipts/BankTransactionReceipts'
 import { type BankTransactionReceiptsHandle } from '@components/BankTransactionReceipts/BankTransactionReceipts'
 import { BankTransactionsMobileCategorySelection } from '@components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection'
-import { type BankTransactionsMobileCategorySelectionItemOption, type BankTransactionsMobileCategorySelectionOptionValue } from '@components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelectionItem'
-import { CategorySelectDrawer } from '@components/CategorySelect/CategorySelectDrawer'
 import { FileInput } from '@components/Input/FileInput'
 import { ErrorText } from '@components/Typography/ErrorText'
-
-const SELECT_CATEGORY_VALUE = 'SELECT_CATEGORY'
-
-export const isSelectCategoryOption = (
-  value: BankTransactionsMobileCategorySelectionOptionValue,
-): boolean => {
-  return isPlaceholderAsOption(value) && value.value === SELECT_CATEGORY_VALUE
-}
-
-type DisplayOption = BankTransactionsMobileCategorySelectionItemOption
-
 interface BankTransactionsMobileListBusinessFormProps {
   bankTransaction: BankTransaction
   showCategorization?: boolean
@@ -59,76 +41,16 @@ export const BankTransactionsMobileListBusinessForm = ({
     isError: isErrorCategorizing,
   } = useCategorizeBankTransactionWithCacheUpdate()
 
-  const [sessionCategories, setSessionCategories] = useState<Map<string, BankTransactionNonSuggestedMatchOption>>(() => {
-    const initialMap = new Map<string, BankTransactionNonSuggestedMatchOption>()
-
-    if (bankTransaction.category) {
-      const existingCategory = convertApiCategorizationToCategoryOrSplitAsOption(bankTransaction.category)
-      initialMap.set(existingCategory.value, existingCategory)
-    }
-
-    if (bankTransaction?.categorization_flow?.type === CategorizationType.ASK_FROM_SUGGESTIONS) {
-      bankTransaction.categorization_flow.suggestions.forEach((suggestion) => {
-        const opt = new ApiCategorizationAsOption(suggestion)
-        initialMap.set(opt.value, opt)
-      })
-    }
-
-    return initialMap
-  })
-
   const selectedCategorization = useGetBankTransactionCategorizationWithDefault(bankTransaction)
-  const { category: selectedCategory } = selectedCategorization
-
-  const { setTransactionCategorySelection } = useBankTransactionsCategorizationActions()
+  const { category: selectedCategory, taxCode: selectedTaxCode } = selectedCategorization
 
   const [showRetry, setShowRetry] = useState(false)
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
 
   useEffect(() => {
     if (isErrorCategorizing) {
       setShowRetry(true)
     }
   }, [isErrorCategorizing])
-
-  const options = useMemo((): DisplayOption[] => {
-    const options: DisplayOption[] = Array.from(sessionCategories.values()).map(category => ({
-      value: category,
-    }))
-
-    options.push({
-      value: new PlaceholderAsOption({
-        label: t('bankTransactions:action.show_all_categories', 'Show all categories'),
-        value: 'SELECT_CATEGORY',
-      }),
-      asLink: true,
-    })
-
-    return options
-  }, [t, sessionCategories])
-
-  const onCategorySelect = (category: DisplayOption) => {
-    if (isSelectCategoryOption(category.value)) {
-      setIsDrawerOpen(true)
-    }
-    else {
-      const option = category.value
-
-      if (!isPlaceholderAsOption(option)) {
-        setSessionCategories(prev => new Map(prev).set(option.value, option))
-      }
-
-      if (
-        selectedCategory
-        && option.value === selectedCategory.value
-      ) {
-        setTransactionCategorySelection(bankTransaction.id, null)
-      }
-      else {
-        setTransactionCategorySelection(bankTransaction.id, option)
-      }
-    }
-  }
 
   const save = () => {
     if (!selectedCategory) {
@@ -143,29 +65,26 @@ export const BankTransactionsMobileListBusinessForm = ({
       {
         type: 'Category',
         category: payload,
+        taxCode: resolveCategoryTaxCode(
+          bankTransaction,
+          selectedCategory,
+          selectedTaxCode,
+        ),
       },
       true,
     )
   }
 
-  const onDrawerSelect = useCallback((category: BankTransactionNonSuggestedMatchOption | null) => {
-    if (!category) return
-
-    setSessionCategories(prev => new Map(prev).set(category.value, category))
-    setTransactionCategorySelection(bankTransaction.id, category)
-  }, [bankTransaction.id, setTransactionCategorySelection])
-
   return (
     <>
       <VStack gap='sm'>
-        {showCategorization
-          && (
-            <BankTransactionsMobileCategorySelection
-              options={options}
-              onSelect={onCategorySelect}
-              selectedId={selectedCategory?.value}
-            />
-          )}
+        {showCategorization && (
+          <BankTransactionsMobileCategorySelection
+            bankTransaction={bankTransaction}
+            showTooltips={showTooltips}
+            isSubmitting={isCategorizing}
+          />
+        )}
         <BankTransactionFormFields
           bankTransaction={bankTransaction}
           showDescriptions={showDescriptions}
@@ -200,22 +119,21 @@ export const BankTransactionsMobileListBusinessForm = ({
               accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
             />
           )}
-          {showCategorization && sessionCategories.size > 0
-            && (
-              <Button
-                onClick={save}
-                fullWidth
-                isDisabled={!selectedCategory || isCategorizing}
-              >
-                {isCategorizing
-                  ? (isCategorized(bankTransaction)
-                    ? t('common:state.updating', 'Updating...')
-                    : t('common:state.confirming', 'Confirming...'))
-                  : (isCategorized(bankTransaction)
-                    ? t('common:action.update_label', 'Update')
-                    : t('common:action.confirm_label', 'Confirm'))}
-              </Button>
-            )}
+          {showCategorization && (
+            <Button
+              onClick={save}
+              fullWidth
+              isDisabled={!selectedCategory || isCategorizing}
+            >
+              {isCategorizing
+                ? (isCategorized(bankTransaction)
+                  ? t('common:state.updating', 'Updating...')
+                  : t('common:state.confirming', 'Confirming...'))
+                : (isCategorized(bankTransaction)
+                  ? t('common:action.update_label', 'Update')
+                  : t('common:action.confirm_label', 'Confirm'))}
+            </Button>
+          )}
         </HStack>
         {isErrorCategorizing && showRetry
           ? (
@@ -225,13 +143,6 @@ export const BankTransactionsMobileListBusinessForm = ({
           )
           : null}
       </VStack>
-      <CategorySelectDrawer
-        onSelect={onDrawerSelect}
-        selectedId={selectedCategory?.value}
-        showTooltips={showTooltips}
-        isOpen={isDrawerOpen}
-        onOpenChange={setIsDrawerOpen}
-      />
     </>
 
   )

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListPersonalForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListPersonalForm.tsx
@@ -94,6 +94,7 @@ export const BankTransactionsMobileListPersonalForm = ({
             ? PersonalStableName.CREDIT
             : PersonalStableName.DEBIT,
         },
+        taxCode: null,
       },
       true,
     )

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
@@ -109,8 +109,8 @@ export const BankTransactionsMobileListSplitForm = ({
                   className='Layer__BankTransactionsMobileSplitForm__SplitRow'
                 >
                   <CategorySelectDrawerWithTrigger
-                    value={split.category}
-                    onChange={handleCategoryChange(index)}
+                    selectedValue={split.category}
+                    onSelectedValueChange={handleCategoryChange(index)}
                     showTooltips={showTooltips}
                   />
                   <AmountInput

--- a/src/components/CategorySelect/CategorySelectDrawer.tsx
+++ b/src/components/CategorySelect/CategorySelectDrawer.tsx
@@ -9,7 +9,14 @@ import { Drawer } from '@ui/Modal/Modal'
 import { ModalHeading, ModalTitleWithClose } from '@ui/Modal/ModalSlots'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { ActionableList } from '@components/ActionableList/ActionableList'
-import { buildFilteredCategoryOptions, type CategoryGroup, type CategoryOption, flattenCategories, isGroup } from '@components/CategorySelect/utils'
+import {
+  buildFilteredCategoryOptions,
+  type CategoryGroup,
+  type CategoryOption,
+  flattenCategories,
+  getSelectedCategoryActionableId,
+  isGroup,
+} from '@components/CategorySelect/utils'
 import { SearchField } from '@components/SearchField/SearchField'
 
 interface CategorySelectDrawerProps {
@@ -32,6 +39,7 @@ export const CategorySelectDrawer = ({
   const [query, setQuery] = useState('')
   const [selectedGroup, setSelectedGroup] = useState<CategoryGroup | null>(null)
   const selectedId = selectedValue?.value
+  const selectedActionableId = getSelectedCategoryActionableId(selectedValue)
 
   const clearSelectedGroup = useCallback(() => {
     setSelectedGroup(null)
@@ -101,7 +109,7 @@ export const CategorySelectDrawer = ({
               onSelectedValueChange(item.value)
               close()
             }}
-            selectedId={selectedId}
+            selectedId={selectedActionableId}
             showDescriptions={showTooltips}
             className='Layer__bank-transaction-mobile-list-item__categories_list'
           />

--- a/src/components/CategorySelect/CategorySelectDrawer.tsx
+++ b/src/components/CategorySelect/CategorySelectDrawer.tsx
@@ -13,16 +13,16 @@ import { buildFilteredCategoryOptions, type CategoryGroup, type CategoryOption, 
 import { SearchField } from '@components/SearchField/SearchField'
 
 interface CategorySelectDrawerProps {
-  onSelect: (value: BankTransactionNonSuggestedMatchOption | null) => void
-  selectedId?: string
+  onSelectedValueChange: (value: BankTransactionNonSuggestedMatchOption | null) => void
+  selectedValue: BankTransactionNonSuggestedMatchOption | null
   showTooltips: boolean
   isOpen: boolean
   onOpenChange: (isOpen: boolean) => void
 }
 
 export const CategorySelectDrawer = ({
-  onSelect,
-  selectedId,
+  onSelectedValueChange,
+  selectedValue,
   showTooltips,
   isOpen,
   onOpenChange,
@@ -31,6 +31,7 @@ export const CategorySelectDrawer = ({
   const { data: categories } = useCategories()
   const [query, setQuery] = useState('')
   const [selectedGroup, setSelectedGroup] = useState<CategoryGroup | null>(null)
+  const selectedId = selectedValue?.value
 
   const clearSelectedGroup = useCallback(() => {
     setSelectedGroup(null)
@@ -97,7 +98,7 @@ export const CategorySelectDrawer = ({
                 setQuery('')
                 return
               }
-              onSelect(item.value)
+              onSelectedValueChange(item.value)
               close()
             }}
             selectedId={selectedId}

--- a/src/components/CategorySelect/CategorySelectDrawerWithTrigger.tsx
+++ b/src/components/CategorySelect/CategorySelectDrawerWithTrigger.tsx
@@ -10,14 +10,17 @@ import { CategorySelectDrawer } from '@components/CategorySelect/CategorySelectD
 
 import './categorySelectDrawerWithTrigger.scss'
 
-type Props = {
-  value: BankTransactionNonSuggestedMatchOption | null
-  onChange: (newValue: BankTransactionNonSuggestedMatchOption | null) => void
-  disabled?: boolean
+type CategorySelectDrawerWithTriggerProps = {
+  selectedValue: BankTransactionNonSuggestedMatchOption | null
+  onSelectedValueChange: (newValue: BankTransactionNonSuggestedMatchOption | null) => void
   showTooltips: boolean
 }
 
-export const CategorySelectDrawerWithTrigger = ({ value, onChange, showTooltips }: Props) => {
+export const CategorySelectDrawerWithTrigger = ({
+  selectedValue,
+  onSelectedValueChange,
+  showTooltips,
+}: CategorySelectDrawerWithTriggerProps) => {
   const { t } = useTranslation()
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
 
@@ -29,13 +32,13 @@ export const CategorySelectDrawerWithTrigger = ({ value, onChange, showTooltips 
         onClick={() => { setIsDrawerOpen(true) }}
         variant='outlined'
       >
-        <Span ellipsis>{value?.label ?? t('common:action.select_label', 'Select...')}</Span>
+        <Span ellipsis>{selectedValue?.label ?? t('common:action.select_label', 'Select...')}</Span>
         <ChevronDown size={16} />
       </Button>
 
       <CategorySelectDrawer
-        onSelect={onChange}
-        selectedId={value?.value}
+        onSelectedValueChange={onSelectedValueChange}
+        selectedValue={selectedValue}
         showTooltips={showTooltips}
         isOpen={isDrawerOpen}
         onOpenChange={setIsDrawerOpen}

--- a/src/components/CategorySelect/utils.ts
+++ b/src/components/CategorySelect/utils.ts
@@ -101,7 +101,26 @@ const isSelectedCategory = (opt: CategoryOption, selectedId: string): boolean =>
 }
 
 const toActionableListOption = (opt: CategoryOption): ActionableListOption<CategoryOption> => {
+  const baseOption = {
+    label: opt.label,
+    value: opt,
+  }
+
   return isGroup(opt)
-    ? { label: opt.label, id: opt.id, value: opt, asLink: true }
-    : { label: opt.label, id: opt.value, description: opt.original.description ?? undefined, value: opt }
+    ? { ...baseOption, id: getGroupActionableId(opt.id, opt.label), asLink: true }
+    : { ...baseOption, id: getCategoryActionableId(opt.value, opt.label), description: opt.original.description ?? undefined }
+}
+
+export const getSelectedCategoryActionableId = (selectedValue: { value: string, label: string } | null): string | undefined => {
+  if (!selectedValue) return undefined
+
+  return getCategoryActionableId(selectedValue.value, selectedValue.label)
+}
+
+const getGroupActionableId = (id: string, label: string): string => {
+  return `group:${id}|label:${label}`
+}
+
+const getCategoryActionableId = (value: string, label: string): string => {
+  return `category:${value}|label:${label}`
 }

--- a/src/components/MatchForm/matchFormMobile.scss
+++ b/src/components/MatchForm/matchFormMobile.scss
@@ -1,4 +1,5 @@
 .Layer__MatchFormMobile {
+  overflow: hidden;
   border-radius: var(--border-radius-2xs);
   border: 1px solid var(--color-base-300);
 

--- a/src/components/TaxCodeSelect/TaxCodeMobileDrawer.tsx
+++ b/src/components/TaxCodeSelect/TaxCodeMobileDrawer.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
+import ChevronRight from '@icons/ChevronRight'
 import { MobileSelectionDrawerWithTrigger } from '@ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger'
 import { type TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
 import { type TaxCodeSelectCommonProps } from '@components/TaxCodeSelect/types'
@@ -28,6 +29,11 @@ export const TaxCodeMobileDrawer = ({
       isDisabled={isDisabled}
       isSearchable
       searchPlaceholder={t('bankTransactions:action.search_tax_codes', 'Search tax codes...')}
+      slotProps={{
+        Trigger: {
+          icon: <ChevronRight size={16} />,
+        },
+      }}
     />
   )
 }

--- a/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
+++ b/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import ChevronDown from '@icons/ChevronDown'
@@ -12,7 +12,7 @@ import { filterOptionsOrGroups } from '@ui/MobileSelectionDrawer/filterUtils'
 import { MobileSelectionDrawerList } from '@ui/MobileSelectionDrawer/MobileSelectionDrawerList'
 import { Drawer } from '@ui/Modal/Modal'
 import { ModalHeading, ModalTitleWithClose } from '@ui/Modal/ModalSlots'
-import { VStack } from '@ui/Stack/Stack'
+import { HStack, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { SearchField } from '@components/SearchField/SearchField'
 
@@ -24,6 +24,11 @@ export type MobileSelectionDrawerWithTriggerProps<T extends ComboBoxOption> =
     ariaLabel: string
     heading: string
     searchPlaceholder?: string
+    slotProps?: {
+      Trigger?: {
+        icon?: ReactNode
+      }
+    }
   }
 
 export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
@@ -37,6 +42,7 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
   isDisabled = false,
   isSearchable = false,
   searchPlaceholder,
+  slotProps,
   ...optionOrGroups
 }: MobileSelectionDrawerWithTriggerProps<T>) => {
   const { t } = useTranslation()
@@ -53,6 +59,8 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
 
   const resolvedPlaceholder = placeholder ?? t('common:action.select_label', 'Select...')
   const resolvedSearchPlaceholder = searchPlaceholder ?? t('common:action.search_label', 'Search')
+
+  const triggerIcon = slotProps?.Trigger?.icon ?? <ChevronDown size={16} />
 
   const filteredOptionsOrGroups = useMemo<OptionsOrGroups<T>>(
     () => filterOptionsOrGroups(
@@ -72,11 +80,17 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
 
   return (
     <>
-      <Button onClick={openDrawer} variant='outlined' isDisabled={isDisabled}>
-        <Span size='sm' ellipsis>
-          {selectedValue?.label ?? resolvedPlaceholder}
-        </Span>
-        <ChevronDown size={16} />
+      <Button onClick={openDrawer} variant='outlined' isDisabled={isDisabled} fullWidth flex>
+        <HStack
+          fluid
+          justify='space-between'
+          className='Layer__MobileSelectionDrawerWithTrigger__Trigger'
+        >
+          <Span size='sm' ellipsis>
+            {selectedValue?.label ?? resolvedPlaceholder}
+          </Span>
+          {triggerIcon}
+        </HStack>
       </Button>
 
       <Drawer
@@ -88,7 +102,7 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
         isDismissable
       >
         {({ close }) => (
-          <VStack className='Layer__MobileSelectionDrawerWithTrigger' pi='sm' pb='xs' gap='md'>
+          <VStack className='Layer__MobileSelectionDrawerWithTrigger__Drawer' pi='sm' pb='xs' gap='md'>
             {isSearchable && (
               <SearchField
                 value={searchQuery}

--- a/src/components/ui/MobileSelectionDrawer/mobileSelectionDrawerWithTrigger.scss
+++ b/src/components/ui/MobileSelectionDrawer/mobileSelectionDrawerWithTrigger.scss
@@ -1,4 +1,8 @@
-.Layer__MobileSelectionDrawerWithTrigger {
+.Layer__MobileSelectionDrawerWithTrigger__Trigger {
+  width: 100%;
+}
+
+.Layer__MobileSelectionDrawerWithTrigger__Drawer {
   .Layer__SearchField {
     inline-size: 100%;
   }


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates mobile categorization flows to include tax code selection and to send `taxCode` in categorization payloads, which can affect transaction classification behavior. Also refactors shared category drawer selection IDs and prop names, so regressions are possible in mobile selection UIs.
> 
> **Overview**
> Adds a dedicated **mobile category selection** component for bank transactions that supports choosing a category from suggested/current options, opening the full category drawer, and (when applicable) selecting a **tax code** via `TaxCodeMobileDrawer`.
> 
> Refactors mobile business transaction categorization to use this new component and includes `taxCode` in the categorize request (resolved via `resolveCategoryTaxCode`); personal categorization now explicitly sends `taxCode: null`. Updates `CategorySelectDrawer`/`CategorySelectDrawerWithTrigger` APIs to `selectedValue`/`onSelectedValueChange` and changes selection tracking to use stable actionable IDs, and extends `MobileSelectionDrawerWithTrigger` with customizable trigger icons plus minor mobile list styling tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3fb37b4a77de583b34e50333248387b1d50da02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->