### PR TITLE
[HST/GST] Add Tax Codes to Mobile Split Form

### DIFF
--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
@@ -6,6 +6,7 @@ import { type BankTransaction } from '@internal-types/bankTransactions'
 import { buildCategorizeBankTransactionPayloadForSplit, hasReceipts, isCategorized } from '@utils/bankTransactions/shared'
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
 import { useSplitsForm } from '@hooks/features/bankTransactions/useSplitsForm'
+import { useTaxCodeOptions } from '@hooks/features/bankTransactions/useTaxCodeOptions'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
 import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import PaperclipIcon from '@icons/Paperclip'
@@ -19,6 +20,7 @@ import { type BankTransactionReceiptsHandle } from '@components/BankTransactionR
 import { CategorySelectDrawerWithTrigger } from '@components/CategorySelect/CategorySelectDrawerWithTrigger'
 import { AmountInput } from '@components/Input/AmountInput'
 import { FileInput } from '@components/Input/FileInput'
+import { TaxCodeMobileDrawer } from '@components/TaxCodeSelect/TaxCodeMobileDrawer'
 import { ErrorText } from '@components/Typography/ErrorText'
 import { Text, TextSize, TextWeight } from '@components/Typography/Text'
 
@@ -58,9 +60,12 @@ export const BankTransactionsMobileListSplitForm = ({
     removeSplit,
     updateSplitAmount,
     changeCategoryForSplitAtIndex,
+    updateSplitAtIndex,
     getInputValueForSplitAtIndex,
     onBlurSplitAmount,
   } = useSplitsForm({ bankTransaction })
+
+  const { taxCodeOptions, hasTaxCodeOptions, getSelectedTaxCodeOption } = useTaxCodeOptions(bankTransaction)
 
   const effectiveSplits = showCategorization
     ? localSplits
@@ -108,11 +113,6 @@ export const BankTransactionsMobileListSplitForm = ({
                   justify='space-between'
                   className='Layer__BankTransactionsMobileSplitForm__SplitRow'
                 >
-                  <CategorySelectDrawerWithTrigger
-                    selectedValue={split.category}
-                    onSelectedValueChange={handleCategoryChange(index)}
-                    showTooltips={showTooltips}
-                  />
                   <AmountInput
                     name={`split-${index}`}
                     disabled={index === 0 || !showCategorization}
@@ -122,6 +122,26 @@ export const BankTransactionsMobileListSplitForm = ({
                     isInvalid={split.amount < 0}
                     className='Layer__BankTransactionsMobileSplitForm__AmountInput'
                   />
+                  <CategorySelectDrawerWithTrigger
+                    selectedValue={split.category}
+                    onSelectedValueChange={handleCategoryChange(index)}
+                    showTooltips={showTooltips}
+                  />
+                  {hasTaxCodeOptions && (
+                    <VStack className='Layer__BankTransactionsMobileSplitForm__TaxCode'>
+                      <TaxCodeMobileDrawer
+                        options={taxCodeOptions}
+                        selectedValue={getSelectedTaxCodeOption(split.taxCode)}
+                        onSelectedValueChange={(value) => {
+                          updateSplitAtIndex(index, currentSplit => ({
+                            ...currentSplit,
+                            taxCode: value?.value ?? null,
+                          }))
+                        }}
+                        isDisabled={!showCategorization}
+                      />
+                    </VStack>
+                  )}
                   <Button
                     onClick={() => removeSplit(index)}
                     variant='outlined'

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
@@ -126,6 +126,7 @@ export const BankTransactionsMobileListSplitForm = ({
                     selectedValue={split.category}
                     onSelectedValueChange={handleCategoryChange(index)}
                     showTooltips={showTooltips}
+                    slotProps={{ Trigger: { size: 'sm' } }}
                   />
                   {hasTaxCodeOptions && (
                     <VStack className='Layer__BankTransactionsMobileSplitForm__TaxCode'>

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
@@ -14,7 +14,7 @@ import PaperclipIcon from '@icons/Paperclip'
 import Scissors from '@icons/Scissors'
 import Trash from '@icons/Trash'
 import { Button } from '@ui/Button/Button'
-import { HStack, VStack } from '@ui/Stack/Stack'
+import { HStack, Spacer, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { BankTransactionFormFields } from '@components/BankTransactionFormFields/BankTransactionFormFields'
 import { BankTransactionReceipts } from '@components/BankTransactionReceipts/BankTransactionReceipts'
@@ -25,7 +25,6 @@ import { FileInput } from '@components/Input/FileInput'
 import { Input } from '@components/Input/Input'
 import { TaxCodeMobileDrawer } from '@components/TaxCodeSelect/TaxCodeMobileDrawer'
 import { ErrorText } from '@components/Typography/ErrorText'
-import { Text, TextSize, TextWeight } from '@components/Typography/Text'
 
 import './bankTransactionsMobileListSplitForm.scss'
 
@@ -71,8 +70,6 @@ export const BankTransactionsMobileListSplitForm = ({
 
   const { taxCodeOptions, hasTaxCodeOptions, getSelectedTaxCodeOption } = useTaxCodeOptions(bankTransaction)
 
-  const addSplitButtonText = t('bankTransactions:action.split_label', 'Split')
-
   useEffect(() => {
     if (isErrorCategorizing) {
       setShowRetry(true)
@@ -96,12 +93,12 @@ export const BankTransactionsMobileListSplitForm = ({
 
   return (
     <VStack gap='sm'>
-      {showCategorization
-        && (
-          <VStack gap='sm'>
-            <Text weight={TextWeight.bold} size={TextSize.sm}>
+      {showCategorization && (
+        <VStack gap='sm'>
+          <VStack gap='3xs'>
+            <Span size='sm' weight='bold'>
               {t('bankTransactions:action.split_transaction', 'Split transaction')}
-            </Text>
+            </Span>
             <VStack gap='sm'>
               {localSplits.map((split, index) => (
                 <HStack
@@ -124,7 +121,7 @@ export const BankTransactionsMobileListSplitForm = ({
                     selectedValue={split.category}
                     onSelectedValueChange={handleCategoryChange(index)}
                     showTooltips={showTooltips}
-                    slotProps={{ Trigger: { size: 'sm' } }}
+                    slotProps={{ TriggerSpan: { size: 'sm' } }}
                   />
                   {hasTaxCodeOptions && (
                     <VStack className='Layer__BankTransactionsMobileSplitForm__TaxCode'>
@@ -153,47 +150,32 @@ export const BankTransactionsMobileListSplitForm = ({
                 </HStack>
               ))}
             </VStack>
-            {localSplits.length > 1
-              ? (
-                <VStack pbs='xs' gap='3xs'>
-                  <Span size='sm'>
-                    {t('common:label.total', 'Total')}
-                  </Span>
-                  <HStack justify='space-between'>
-                    <Input
-                      disabled={true}
-                      inputMode='numeric'
-                      value={formatCurrencyFromCents(localSplits.reduce((total, { amount }) => total + amount, 0))}
-                      className='Layer__BankTransactionsMobileSplitForm__TotalAmountInput'
-                    />
-                    <Button
-                      onClick={addSplit}
-                      variant='outlined'
-                    >
-                      <HStack align='center' gap='2xs' pis='2xs' pie='2xs'>
-                        {addSplitButtonText}
-                        <Scissors size={14} />
-                      </HStack>
-                    </Button>
-                  </HStack>
-                </VStack>
-              )
-              : (
-                <HStack justify='end'>
-                  <Button
-                    onClick={addSplit}
-                    variant='outlined'
-                  >
-                    <HStack align='center' gap='2xs' pis='2xs' pie='2xs'>
-                      {addSplitButtonText}
-                      <Scissors size={14} />
-                    </HStack>
-                  </Button>
-                </HStack>
-              )}
-            {splitFormError && <HStack pbe='sm'><ErrorText>{splitFormError}</ErrorText></HStack>}
           </VStack>
-        )}
+          <HStack align='end'>
+            {localSplits.length > 1 && (
+              <VStack pbs='xs' gap='3xs'>
+                <Span size='sm' weight='bold'>
+                  {t('common:label.total', 'Total')}
+                </Span>
+                <Input
+                  disabled={true}
+                  inputMode='numeric'
+                  value={formatCurrencyFromCents(localSplits.reduce((total, { amount }) => total + amount, 0))}
+                  className='Layer__BankTransactionsMobileSplitForm__TotalAmountInput'
+                />
+              </VStack>
+            )}
+            <Spacer />
+            <Button onClick={addSplit} variant='outlined'>
+              <HStack align='center' gap='2xs' pis='2xs' pie='2xs'>
+                {t('bankTransactions:action.split_label', 'Split')}
+                <Scissors size={14} />
+              </HStack>
+            </Button>
+          </HStack>
+          {splitFormError && <ErrorText>{splitFormError}</ErrorText>}
+        </VStack>
+      )}
       <BankTransactionFormFields
         bankTransaction={bankTransaction}
         showDescriptions={showDescriptions}

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
@@ -8,18 +8,21 @@ import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/ban
 import { useSplitsForm } from '@hooks/features/bankTransactions/useSplitsForm'
 import { useTaxCodeOptions } from '@hooks/features/bankTransactions/useTaxCodeOptions'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import PaperclipIcon from '@icons/Paperclip'
 import Scissors from '@icons/Scissors'
 import Trash from '@icons/Trash'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
 import { BankTransactionFormFields } from '@components/BankTransactionFormFields/BankTransactionFormFields'
 import { BankTransactionReceipts } from '@components/BankTransactionReceipts/BankTransactionReceipts'
 import { type BankTransactionReceiptsHandle } from '@components/BankTransactionReceipts/BankTransactionReceipts'
 import { CategorySelectDrawerWithTrigger } from '@components/CategorySelect/CategorySelectDrawerWithTrigger'
 import { AmountInput } from '@components/Input/AmountInput'
 import { FileInput } from '@components/Input/FileInput'
+import { Input } from '@components/Input/Input'
 import { TaxCodeMobileDrawer } from '@components/TaxCodeSelect/TaxCodeMobileDrawer'
 import { ErrorText } from '@components/Typography/ErrorText'
 import { Text, TextSize, TextWeight } from '@components/Typography/Text'
@@ -42,6 +45,7 @@ export const BankTransactionsMobileListSplitForm = ({
   showDescriptions,
 }: BankTransactionsMobileListSplitFormProps) => {
   const { t } = useTranslation()
+  const { formatCurrencyFromCents } = useIntlFormatter()
   const receiptsRef = useRef<BankTransactionReceiptsHandle>(null)
 
   const {
@@ -67,13 +71,7 @@ export const BankTransactionsMobileListSplitForm = ({
 
   const { taxCodeOptions, hasTaxCodeOptions, getSelectedTaxCodeOption } = useTaxCodeOptions(bankTransaction)
 
-  const effectiveSplits = showCategorization
-    ? localSplits
-    : []
-
-  const addSplitButtonText = effectiveSplits.length > 1
-    ? t('bankTransactions:action.add_new_split', 'Add new split')
-    : t('bankTransactions:action.split_label', 'Split')
+  const addSplitButtonText = t('bankTransactions:action.split_label', 'Split')
 
   useEffect(() => {
     if (isErrorCategorizing) {
@@ -155,15 +153,44 @@ export const BankTransactionsMobileListSplitForm = ({
                 </HStack>
               ))}
             </VStack>
-            <HStack justify='end'>
-              <Button
-                onClick={addSplit}
-                variant='outlined'
-              >
-                <Scissors size={14} />
-                {addSplitButtonText}
-              </Button>
-            </HStack>
+            {localSplits.length > 1
+              ? (
+                <VStack pbs='xs' gap='3xs'>
+                  <Span size='sm'>
+                    {t('common:label.total', 'Total')}
+                  </Span>
+                  <HStack justify='space-between'>
+                    <Input
+                      disabled={true}
+                      inputMode='numeric'
+                      value={formatCurrencyFromCents(localSplits.reduce((total, { amount }) => total + amount, 0))}
+                      className='Layer__BankTransactionsMobileSplitForm__TotalAmountInput'
+                    />
+                    <Button
+                      onClick={addSplit}
+                      variant='outlined'
+                    >
+                      <HStack align='center' gap='2xs' pis='2xs' pie='2xs'>
+                        {addSplitButtonText}
+                        <Scissors size={14} />
+                      </HStack>
+                    </Button>
+                  </HStack>
+                </VStack>
+              )
+              : (
+                <HStack justify='end'>
+                  <Button
+                    onClick={addSplit}
+                    variant='outlined'
+                  >
+                    <HStack align='center' gap='2xs' pis='2xs' pie='2xs'>
+                      {addSplitButtonText}
+                      <Scissors size={14} />
+                    </HStack>
+                  </Button>
+                </HStack>
+              )}
             {splitFormError && <HStack pbe='sm'><ErrorText>{splitFormError}</ErrorText></HStack>}
           </VStack>
         )}

--- a/src/components/BankTransactionsMobileList/bankTransactionsMobileListSplitForm.scss
+++ b/src/components/BankTransactionsMobileList/bankTransactionsMobileListSplitForm.scss
@@ -25,6 +25,10 @@
   inline-size: 6rem;
 }
 
+.Layer__BankTransactionsMobileSplitForm__TotalAmountInput {
+  inline-size: 6rem;
+}
+
 .Layer__BankTransactionsMobileSplitForm__TaxCode {
   grid-area: tax-code;
 }

--- a/src/components/BankTransactionsMobileList/bankTransactionsMobileListSplitForm.scss
+++ b/src/components/BankTransactionsMobileList/bankTransactionsMobileListSplitForm.scss
@@ -19,14 +19,16 @@
   }
 }
 
-.Layer__BankTransactionsMobileSplitForm__AmountInput {
+.Layer__BankTransactionsMobileSplitForm__AmountInput.Layer__input {
   flex-shrink: 0;
   grid-area: amount;
   inline-size: 6rem;
+  font-size: var(--text-md);
 }
 
-.Layer__BankTransactionsMobileSplitForm__TotalAmountInput {
+.Layer__BankTransactionsMobileSplitForm__TotalAmountInput.Layer__input {
   inline-size: 6rem;
+  font-size: var(--text-md);
 }
 
 .Layer__BankTransactionsMobileSplitForm__TaxCode {

--- a/src/components/BankTransactionsMobileList/bankTransactionsMobileListSplitForm.scss
+++ b/src/components/BankTransactionsMobileList/bankTransactionsMobileListSplitForm.scss
@@ -1,8 +1,30 @@
 .Layer__BankTransactionsMobileSplitForm__SplitRow {
+  display: grid;
+  grid-template-areas: 'amount category button';
+  grid-template-columns: 6rem minmax(0, 1fr) 2.25rem;
   max-inline-size: 100%;
+
+  &:has(> .Layer__BankTransactionsMobileSplitForm__TaxCode) {
+    grid-template-areas:
+      'amount category button'
+      '. tax-code .';
+  }
+
+  .Layer__CategorySelectDrawerWithTrigger {
+    grid-area: category;
+  }
+
+  > .Layer__UI__Button {
+    grid-area: button;
+  }
 }
 
 .Layer__BankTransactionsMobileSplitForm__AmountInput {
   flex-shrink: 0;
+  grid-area: amount;
   inline-size: 6rem;
+}
+
+.Layer__BankTransactionsMobileSplitForm__TaxCode {
+  grid-area: tax-code;
 }

--- a/src/components/CategorySelect/CategorySelectDrawerWithTrigger.tsx
+++ b/src/components/CategorySelect/CategorySelectDrawerWithTrigger.tsx
@@ -15,9 +15,7 @@ type CategorySelectDrawerWithTriggerProps = {
   onSelectedValueChange: (newValue: BankTransactionNonSuggestedMatchOption | null) => void
   showTooltips: boolean
   slotProps?: {
-    Trigger?: {
-      size?: TextStyleProps['size']
-    }
+    TriggerSpan?: TextStyleProps
   }
 }
 
@@ -38,7 +36,7 @@ export const CategorySelectDrawerWithTrigger = ({
         onClick={() => { setIsDrawerOpen(true) }}
         variant='outlined'
       >
-        <Span ellipsis size={slotProps?.Trigger?.size ?? 'md'}>{selectedValue?.label ?? t('common:action.select_label', 'Select...')}</Span>
+        <Span ellipsis size='md' {...slotProps?.TriggerSpan}>{selectedValue?.label ?? t('common:action.select_label', 'Select...')}</Span>
         <ChevronDown size={16} />
       </Button>
 

--- a/src/components/CategorySelect/CategorySelectDrawerWithTrigger.tsx
+++ b/src/components/CategorySelect/CategorySelectDrawerWithTrigger.tsx
@@ -5,7 +5,7 @@ import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTran
 import ChevronDown from '@icons/ChevronDown'
 import { Button } from '@ui/Button/Button'
 import { HStack } from '@ui/Stack/Stack'
-import { Span } from '@ui/Typography/Text'
+import { Span, type TextStyleProps } from '@ui/Typography/Text'
 import { CategorySelectDrawer } from '@components/CategorySelect/CategorySelectDrawer'
 
 import './categorySelectDrawerWithTrigger.scss'
@@ -14,12 +14,18 @@ type CategorySelectDrawerWithTriggerProps = {
   selectedValue: BankTransactionNonSuggestedMatchOption | null
   onSelectedValueChange: (newValue: BankTransactionNonSuggestedMatchOption | null) => void
   showTooltips: boolean
+  slotProps?: {
+    Trigger?: {
+      size?: TextStyleProps['size']
+    }
+  }
 }
 
 export const CategorySelectDrawerWithTrigger = ({
   selectedValue,
   onSelectedValueChange,
   showTooltips,
+  slotProps,
 }: CategorySelectDrawerWithTriggerProps) => {
   const { t } = useTranslation()
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
@@ -32,7 +38,7 @@ export const CategorySelectDrawerWithTrigger = ({
         onClick={() => { setIsDrawerOpen(true) }}
         variant='outlined'
       >
-        <Span ellipsis>{selectedValue?.label ?? t('common:action.select_label', 'Select...')}</Span>
+        <Span ellipsis size={slotProps?.Trigger?.size ?? 'md'}>{selectedValue?.label ?? t('common:action.select_label', 'Select...')}</Span>
         <ChevronDown size={16} />
       </Button>
 


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<img width="351" height="556" alt="image" src="https://github.com/user-attachments/assets/3becec26-b956-4cd4-8860-34b17854edd2" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds tax-code input to the mobile split-categorization flow and adjusts split-row layout, which can affect how split metadata is captured and submitted for tax reporting.
> 
> **Overview**
> Adds **tax code selection per split** to the mobile split form by wiring `useTaxCodeOptions` + `TaxCodeMobileDrawer` into each split row and persisting the selection via `updateSplitAtIndex`.
> 
> Updates the mobile split UI layout to a grid (with optional second row when tax codes are shown) and adds a read-only **Total** amount field computed from split amounts.
> 
> Extends `CategorySelectDrawerWithTrigger` with optional `slotProps` to allow the trigger text styling to be customized by callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d8e732ce025bf408f2949ab32c801600c2787be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->