### PR TITLE
[HST/GST] Resolve demo testing feedback

### DIFF
--- a/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsCategorizeAllModal.tsx
+++ b/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsCategorizeAllModal.tsx
@@ -96,7 +96,7 @@ export const BankTransactionsCategorizeAllModal = ({
           taxCode: resolveCategoryTaxCode(
             bankTransactionsById.get(transactionId),
             selectedCategory,
-            selectedTaxCode,
+            selectedTaxCode?.value ?? null,
           ),
         },
       })),

--- a/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsCategorizeAllModal.tsx
+++ b/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsCategorizeAllModal.tsx
@@ -66,6 +66,13 @@ export const BankTransactionsCategorizeAllModal = ({
 
   const { taxCodeOptions } = useTaxCodeOptions(firstSelectedBankTransactionWithTaxOptions)
 
+  const handleSelectedCategoryChange = useCallback((category: BankTransactionNonSuggestedMatchOption | null) => {
+    setSelectedCategory(category)
+    if (category && !canCategoryHaveTaxCode(category)) {
+      setSelectedTaxCode(null)
+    }
+  }, [])
+
   const handleCategorizeModalClose = useCallback((isOpen: boolean) => {
     onOpenChange(isOpen)
     if (!isOpen) {
@@ -123,7 +130,7 @@ export const BankTransactionsCategorizeAllModal = ({
                 <CategorySelectDrawerWithTrigger
                   aria-labelledby={categorySelectId}
                   selectedValue={selectedCategory}
-                  onSelectedValueChange={setSelectedCategory}
+                  onSelectedValueChange={handleSelectedCategoryChange}
                   showTooltips={false}
                 />
               )
@@ -131,7 +138,7 @@ export const BankTransactionsCategorizeAllModal = ({
                 <BankTransactionCategoryComboBox
                   inputId={categorySelectId}
                   selectedValue={selectedCategory}
-                  onSelectedValueChange={setSelectedCategory}
+                  onSelectedValueChange={handleSelectedCategoryChange}
                   includeSuggestedMatches={false}
                   isDisabled={isMutating}
                 />

--- a/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection.tsx
+++ b/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection.tsx
@@ -42,7 +42,7 @@ export const BankTransactionsMobileCategorySelection = ({
   )
   const previousTransactionIdRef = useRef(bankTransaction.id)
 
-  const { taxCodeOptions, hasTaxCodeOptions } = useTaxCodeOptions(bankTransaction)
+  const { taxCodeOptions, hasTaxCodeOptions, getSelectedTaxCodeOption } = useTaxCodeOptions(bankTransaction)
   const { category: selectedCategory, taxCode: selectedTaxCode } = useGetBankTransactionCategorizationWithDefault(bankTransaction)
 
   useEffect(() => {
@@ -94,7 +94,7 @@ export const BankTransactionsMobileCategorySelection = ({
   }, [bankTransaction.id, setTransactionCategorySelection])
 
   const handleTaxCodeSelect = useCallback((taxCode: TaxCodeComboBoxOption | null) => {
-    setTransactionTaxCodeSelection(bankTransaction.id, taxCode)
+    setTransactionTaxCodeSelection(bankTransaction.id, taxCode?.value ?? null)
   }, [bankTransaction.id, setTransactionTaxCodeSelection])
 
   return (
@@ -116,7 +116,7 @@ export const BankTransactionsMobileCategorySelection = ({
       {hasTaxCodeOptions && canCategoryHaveTaxCode(selectedCategory) && (
         <TaxCodeMobileDrawer
           options={taxCodeOptions}
-          selectedValue={selectedTaxCode}
+          selectedValue={getSelectedTaxCodeOption(selectedTaxCode)}
           onSelectedValueChange={handleTaxCodeSelect}
           isDisabled={isSubmitting}
         />

--- a/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection.tsx
+++ b/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection.tsx
@@ -37,21 +37,22 @@ export const BankTransactionsMobileCategorySelection = ({
   const { setTransactionCategorySelection, setTransactionTaxCodeSelection } = useBankTransactionsCategorizationActions()
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-  const [sessionCategories, setSessionCategories] = useState(
-    () => buildInitialSessionCategoriesMap(bankTransaction),
-  )
   const previousTransactionIdRef = useRef(bankTransaction.id)
 
   const { taxCodeOptions, hasTaxCodeOptions, getSelectedTaxCodeOption } = useTaxCodeOptions(bankTransaction)
   const { category: selectedCategory, taxCode: selectedTaxCode } = useGetBankTransactionCategorizationWithDefault(bankTransaction)
 
+  const [sessionCategories, setSessionCategories] = useState(
+    () => buildInitialSessionCategoriesMap(bankTransaction, selectedCategory),
+  )
+
   useEffect(() => {
-    if (previousTransactionIdRef.current === bankTransaction.id) {
-      return
-    }
+    if (previousTransactionIdRef.current === bankTransaction.id) return
+
+    setSessionCategories(buildInitialSessionCategoriesMap(bankTransaction, selectedCategory))
+
     previousTransactionIdRef.current = bankTransaction.id
-    setSessionCategories(buildInitialSessionCategoriesMap(bankTransaction))
-  }, [bankTransaction])
+  }, [bankTransaction, selectedCategory])
 
   const categoryOptions = useMemo(
     () => buildCategoryOptions(

--- a/src/components/BankTransactionsMobileCategorySelection/utils.ts
+++ b/src/components/BankTransactionsMobileCategorySelection/utils.ts
@@ -2,7 +2,7 @@ import { type BankTransaction } from '@internal-types/bankTransactions'
 import { CategorizationType } from '@internal-types/categories'
 import { ApiCategorizationAsOption, PlaceholderAsOption } from '@internal-types/categorizationOption'
 import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
-import { isPlaceholderAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
+import { isPlaceholderAsOption, isSplitAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/BankTransactionCategoryComboBox/utils'
 import { type BankTransactionsMobileCategorySelectionItemOption } from '@components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelectionItem'
 
@@ -26,9 +26,11 @@ export const buildInitialSessionCategoriesMap = (
     })
   }
 
-  if (selectedCategory && !isPlaceholderAsOption(selectedCategory)) {
-    categoriesMap.set(selectedCategory.value, selectedCategory)
-  }
+  if (!selectedCategory) return categoriesMap
+  if (isPlaceholderAsOption(selectedCategory)) return categoriesMap
+  if (isSplitAsOption(selectedCategory) && !selectedCategory.isSingleSplit) return categoriesMap
+
+  categoriesMap.set(selectedCategory.value, selectedCategory)
 
   return categoriesMap
 }

--- a/src/components/BankTransactionsMobileCategorySelection/utils.ts
+++ b/src/components/BankTransactionsMobileCategorySelection/utils.ts
@@ -2,12 +2,16 @@ import { type BankTransaction } from '@internal-types/bankTransactions'
 import { CategorizationType } from '@internal-types/categories'
 import { ApiCategorizationAsOption, PlaceholderAsOption } from '@internal-types/categorizationOption'
 import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
+import { isPlaceholderAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/BankTransactionCategoryComboBox/utils'
 import { type BankTransactionsMobileCategorySelectionItemOption } from '@components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelectionItem'
 
 const SELECT_CATEGORY_VALUE = 'SELECT_CATEGORY'
 
-export const buildInitialSessionCategoriesMap = (bankTransaction: BankTransaction) => {
+export const buildInitialSessionCategoriesMap = (
+  bankTransaction: BankTransaction,
+  selectedCategory: BankTransactionNonSuggestedMatchOption | null,
+) => {
   const categoriesMap = new Map<string, BankTransactionNonSuggestedMatchOption>()
 
   if (bankTransaction.category) {
@@ -20,6 +24,10 @@ export const buildInitialSessionCategoriesMap = (bankTransaction: BankTransactio
       const suggestionOption = new ApiCategorizationAsOption(suggestion)
       categoriesMap.set(suggestionOption.value, suggestionOption)
     })
+  }
+
+  if (selectedCategory && !isPlaceholderAsOption(selectedCategory)) {
+    categoriesMap.set(selectedCategory.value, selectedCategory)
   }
 
   return categoriesMap

--- a/src/components/BankTransactionsMobileCategorySelection/utils.ts
+++ b/src/components/BankTransactionsMobileCategorySelection/utils.ts
@@ -8,6 +8,13 @@ import { type BankTransactionsMobileCategorySelectionItemOption } from '@compone
 
 const SELECT_CATEGORY_VALUE = 'SELECT_CATEGORY'
 
+const isSingleSelectedCategory = (selectedCategory: BankTransactionNonSuggestedMatchOption | null): boolean => {
+  if (!selectedCategory) return false
+  if (isPlaceholderAsOption(selectedCategory)) return false
+  if (isSplitAsOption(selectedCategory) && !selectedCategory.isSingleSplit) return false
+  return true
+}
+
 export const buildInitialSessionCategoriesMap = (
   bankTransaction: BankTransaction,
   selectedCategory: BankTransactionNonSuggestedMatchOption | null,
@@ -16,7 +23,9 @@ export const buildInitialSessionCategoriesMap = (
 
   if (bankTransaction.category) {
     const existingCategory = convertApiCategorizationToCategoryOrSplitAsOption(bankTransaction.category)
-    categoriesMap.set(existingCategory.value, existingCategory)
+    if (isSingleSelectedCategory(existingCategory)) {
+      categoriesMap.set(existingCategory.value, existingCategory)
+    }
   }
 
   if (bankTransaction?.categorization_flow?.type === CategorizationType.ASK_FROM_SUGGESTIONS) {
@@ -26,11 +35,9 @@ export const buildInitialSessionCategoriesMap = (
     })
   }
 
-  if (!selectedCategory) return categoriesMap
-  if (isPlaceholderAsOption(selectedCategory)) return categoriesMap
-  if (isSplitAsOption(selectedCategory) && !selectedCategory.isSingleSplit) return categoriesMap
-
-  categoriesMap.set(selectedCategory.value, selectedCategory)
+  if (selectedCategory && isSingleSelectedCategory(selectedCategory)) {
+    categoriesMap.set(selectedCategory.value, selectedCategory)
+  }
 
   return categoriesMap
 }

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListItem.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListItem.tsx
@@ -6,7 +6,12 @@ import { CategorizationStatus } from '@schemas/bankTransactions/bankTransaction'
 import { convertMatchDetailsToLinkingMetadata, decodeMatchDetails } from '@schemas/bankTransactions/match'
 import { hasReceipts, isCategorized, isCredit } from '@utils/bankTransactions/shared'
 import { useDelayedRemoveBankTransaction } from '@hooks/features/bankTransactions/useDelayedRemoveBankTransaction'
+import { useGetBankTransactionCategorizationWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
 import { useDelayedVisibility } from '@hooks/utils/visibility/useDelayedVisibility'
+import {
+  type BankTransactionCategorization,
+  BankTransactionSelectionVariant,
+} from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useBulkSelectionActions, useIdIsSelected } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useBankTransactionsContext } from '@contexts/BankTransactionsContext/BankTransactionsContext'
 import { useBankTransactionsIsCategorizationEnabledContext } from '@contexts/BankTransactionsIsCategorizationEnabledContext/BankTransactionsIsCategorizationEnabledContext'
@@ -15,6 +20,7 @@ import FileIcon from '@icons/File'
 import { AnimatedPresenceElement } from '@ui/AnimatedPresenceElement/AnimatedPresenceElement'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
+import { isSplitAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { BankTransactionsAmountDate } from '@components/BankTransactions/BankTransactionsAmountDate'
 import { BankTransactionsListItemCategory } from '@components/BankTransactions/BankTransactionsListItemCategory/BankTransactionsListItemCategory'
 import { BankTransactionsProcessingInfo } from '@components/BankTransactionsList/BankTransactionsProcessingInfo'
@@ -71,6 +77,9 @@ export const BankTransactionsMobileListItem = ({
 }: BankTransactionsMobileListItemProps) => {
   const { shouldHideAfterCategorize } = useBankTransactionsContext()
   const { setTransactionIdToOpen, transactionIdToOpen, clearTransactionIdToOpen } = useContext(TransactionToOpenContext)
+
+  const selectedCategorization = useGetBankTransactionCategorizationWithDefault(bankTransaction)
+  const [purpose, setPurpose] = useState(() => getPurposeFromStore(selectedCategorization))
 
   const categorized = isCategorized(bankTransaction)
   const isCategorizationEnabled = useBankTransactionsIsCategorizationEnabledContext()
@@ -245,6 +254,8 @@ export const BankTransactionsMobileListItem = ({
           <BankTransactionsMobileListItemExpandedRow
             bankTransaction={bankTransaction}
             isOpen={open}
+            purpose={purpose}
+            setPurpose={setPurpose}
             showCategorization={isCategorizationEnabled}
             showDescriptions={showDescriptions}
             showReceiptUploads={showReceiptUploads}
@@ -254,4 +265,20 @@ export const BankTransactionsMobileListItem = ({
       </VStack>
     </AnimatedPresenceElement>
   )
+}
+
+const getPurposeFromStore = (selectedCategorization: BankTransactionCategorization): Purpose => {
+  if (selectedCategorization.variant === BankTransactionSelectionVariant.MATCH) {
+    return Purpose.more
+  }
+
+  if (selectedCategorization.category === null) {
+    return Purpose.business
+  }
+
+  if (isSplitAsOption(selectedCategorization.category)) {
+    return Purpose.more
+  }
+
+  return Purpose.business
 }

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListItem.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListItem.tsx
@@ -272,12 +272,13 @@ const getPurposeFromStore = (selectedCategorization: BankTransactionCategorizati
     return Purpose.more
   }
 
-  if (selectedCategorization.category === null) {
+  const category = selectedCategorization.category
+  if (category === null) {
     return Purpose.business
   }
 
-  if (isSplitAsOption(selectedCategorization.category)) {
-    return Purpose.more
+  if (isSplitAsOption(category)) {
+    return category.isSingleSplit ? Purpose.business : Purpose.more
   }
 
   return Purpose.business

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListItemExpandedRow.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListItemExpandedRow.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import type { Key } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
 
@@ -7,7 +7,6 @@ import { hasMatch } from '@utils/bankTransactions/shared'
 import { translationKey } from '@utils/i18n/translationKey'
 import { useGetBankTransactionCategorizationWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
 import {
-  type BankTransactionCategorization,
   BankTransactionSelectionVariant,
   useBankTransactionsCategorizationActions,
 } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
@@ -27,6 +26,10 @@ const PURPOSE_TOGGLE_CONFIG = [
 export interface BankTransactionsMobileListItemExpandedRowProps {
   bankTransaction: BankTransaction
   isOpen?: boolean
+
+  purpose: Purpose
+  setPurpose: (value: Purpose) => void
+
   showCategorization?: boolean
   showDescriptions: boolean
   showReceiptUploads: boolean
@@ -36,6 +39,8 @@ export interface BankTransactionsMobileListItemExpandedRowProps {
 export const BankTransactionsMobileListItemExpandedRow = ({
   bankTransaction,
   isOpen,
+  purpose,
+  setPurpose,
   showCategorization,
   showDescriptions,
   showReceiptUploads,
@@ -44,8 +49,6 @@ export const BankTransactionsMobileListItemExpandedRow = ({
   const { t } = useTranslation()
   const selectedCategorization = useGetBankTransactionCategorizationWithDefault(bankTransaction)
   const { setTransactionSelectionVariant } = useBankTransactionsCategorizationActions()
-
-  const [purpose, setPurpose] = useState(getPurposeFromStore(selectedCategorization))
 
   const purposeToggleOptions = useMemo(
     () => PURPOSE_TOGGLE_CONFIG.map(opt => ({
@@ -92,20 +95,4 @@ export const BankTransactionsMobileListItemExpandedRow = ({
     </VStack>
 
   )
-}
-
-const getPurposeFromStore = (selectedCategorization: BankTransactionCategorization): Purpose => {
-  if (selectedCategorization.variant === BankTransactionSelectionVariant.MATCH) {
-    return Purpose.more
-  }
-
-  if (selectedCategorization.category === null) {
-    return Purpose.business
-  }
-
-  if (isSplitAsOption(selectedCategorization.category)) {
-    return Purpose.more
-  }
-
-  return Purpose.business
 }

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
 import { buildCategorizeBankTransactionPayloadForSplit, hasReceipts, isCategorized } from '@utils/bankTransactions/shared'
+import { canCategoryHaveTaxCode } from '@utils/bankTransactions/taxCode'
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
 import { useSplitsForm } from '@hooks/features/bankTransactions/useSplitsForm'
 import { useTaxCodeOptions } from '@hooks/features/bankTransactions/useTaxCodeOptions'
@@ -134,7 +135,7 @@ export const BankTransactionsMobileListSplitForm = ({
                             taxCode: value?.value ?? null,
                           }))
                         }}
-                        isDisabled={!showCategorization}
+                        isDisabled={!showCategorization || !canCategoryHaveTaxCode(split.category)}
                       />
                     </VStack>
                   )}

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -17,6 +17,7 @@ import { type Tag } from '@schemas/tag'
 import {
   hasMatch,
 } from '@utils/bankTransactions/shared'
+import { canCategoryHaveTaxCode } from '@utils/bankTransactions/taxCode'
 import { useSetMetadataOnBankTransaction } from '@hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useSetMetadataOnBankTransaction'
 import { useRemoveTagFromBankTransaction } from '@hooks/api/businesses/[business-id]/bank-transactions/tags/useRemoveTagFromBankTransaction'
 import { useTagBankTransaction } from '@hooks/api/businesses/[business-id]/bank-transactions/tags/useTagBankTransaction'
@@ -299,7 +300,7 @@ export const ExpandedBankTransactionRow = ({
                                       taxCode: value?.value ?? null,
                                     }))
                                   }}
-                                  isDisabled={!isCategorizationEnabled}
+                                  isDisabled={!isCategorizationEnabled || !canCategoryHaveTaxCode(split.category)}
                                   className='Layer__expanded-bank-transaction-row__table-cell--split-entry__tax-code'
                                 />
                               )}

--- a/src/components/ExpandedBankTransactionRow/expandedBankTransactionRow.scss
+++ b/src/components/ExpandedBankTransactionRow/expandedBankTransactionRow.scss
@@ -230,16 +230,8 @@
   }
 
   .Layer__expanded-bank-transaction-row__table-cell--split-entry {
-    width: 100%;
-
     input {
       width: 100%;
-    }
-
-    .Layer__input-tooltip {
-      position: relative;
-      flex: 1;
-      max-width: 42%;
     }
   }
 

--- a/src/components/ExpandedBankTransactionRow/utils.ts
+++ b/src/components/ExpandedBankTransactionRow/utils.ts
@@ -12,7 +12,6 @@ import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTran
 import { isPlaceholderAsOption, isSplitAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { isApiCategorizationAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/BankTransactionCategoryComboBox/utils'
-import type { TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
 
 export enum ValidateSplitError {
   AmountsMustBeGreaterThanZero = 'AmountsMustBeGreaterThanZero',
@@ -118,7 +117,7 @@ export const getCustomerVendorForBankTransaction = (bankTransaction: BankTransac
 export const getLocalSplitStateForExpandedTransaction = (
   bankTransaction: BankTransaction,
   selectedCategory: BankTransactionNonSuggestedMatchOption | null | undefined,
-  selectedTaxCode: TaxCodeComboBoxOption | null,
+  selectedTaxCode: string | null,
 ): Split[] => {
   let coercedSelectedCategory = selectedCategory
   if (!selectedCategory || isPlaceholderAsOption(selectedCategory)) {
@@ -145,7 +144,7 @@ export const getLocalSplitStateForExpandedTransaction = (
   return [{
     amount: bankTransaction.amount,
     category: coercedSelectedCategory ?? null,
-    taxCode: selectedTaxCode?.value ?? bankTransaction.tax_code ?? null,
+    taxCode: selectedTaxCode ?? bankTransaction.tax_code ?? null,
     tags: bankTransaction.transaction_tags.map(tag => makeTagFromTransactionTag(Schema.decodeSync(TransactionTagSchema)(tag))),
     customerVendor: getCustomerVendorForBankTransaction(bankTransaction),
   }]

--- a/src/components/ExpandedBankTransactionRow/utils.ts
+++ b/src/components/ExpandedBankTransactionRow/utils.ts
@@ -12,6 +12,7 @@ import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTran
 import { isPlaceholderAsOption, isSplitAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { isApiCategorizationAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/BankTransactionCategoryComboBox/utils'
+import type { TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
 
 export enum ValidateSplitError {
   AmountsMustBeGreaterThanZero = 'AmountsMustBeGreaterThanZero',
@@ -117,6 +118,7 @@ export const getCustomerVendorForBankTransaction = (bankTransaction: BankTransac
 export const getLocalSplitStateForExpandedTransaction = (
   bankTransaction: BankTransaction,
   selectedCategory: BankTransactionNonSuggestedMatchOption | null | undefined,
+  selectedTaxCode: TaxCodeComboBoxOption | null,
 ): Split[] => {
   let coercedSelectedCategory = selectedCategory
   if (!selectedCategory || isPlaceholderAsOption(selectedCategory)) {
@@ -143,6 +145,7 @@ export const getLocalSplitStateForExpandedTransaction = (
   return [{
     amount: bankTransaction.amount,
     category: coercedSelectedCategory ?? null,
+    taxCode: selectedTaxCode?.value ?? bankTransaction.tax_code ?? null,
     tags: bankTransaction.transaction_tags.map(tag => makeTagFromTransactionTag(Schema.decodeSync(TransactionTagSchema)(tag))),
     customerVendor: getCustomerVendorForBankTransaction(bankTransaction),
   }]

--- a/src/components/TaxCodeSelect/useTaxCodeSelect.ts
+++ b/src/components/TaxCodeSelect/useTaxCodeSelect.ts
@@ -34,10 +34,16 @@ export const useTaxCodeSelect = ({
     [noTaxCodeOption, options],
   )
 
-  const resolvedSelectedValue = useMemo<TaxCodeComboBoxOption>(
-    () => selectedValue ?? noTaxCodeOption,
-    [selectedValue, noTaxCodeOption],
-  )
+  const resolvedSelectedValue = useMemo<TaxCodeComboBoxOption>(() => {
+    if (selectedValue === null) {
+      return noTaxCodeOption
+    }
+
+    const match = options.find(option => option.value === selectedValue.value)
+    if (match) return match
+
+    return selectedValue
+  }, [selectedValue, noTaxCodeOption, options])
 
   const handleChange = useCallback((next: TaxCodeComboBoxOption | null) => {
     if (next === null || next.value === NO_TAX_CODE) {

--- a/src/components/ui/ComboBox/comboBox.scss
+++ b/src/components/ui/ComboBox/comboBox.scss
@@ -20,7 +20,9 @@
   }
 
   &--disabled {
+    background-color: var(--color-base-100);
     cursor: not-allowed;
+    color: var(--color-base-800);
   }
 
   &--readonly {

--- a/src/components/ui/ComboBox/useComboBoxSubcomponents.tsx
+++ b/src/components/ui/ComboBox/useComboBoxSubcomponents.tsx
@@ -225,7 +225,7 @@ function buildCustomSingleValue<T extends ComboBoxOption, IsMulti extends boolea
     children,
     ...restProps
   }: SingleValueProps<T, IsMulti, GroupBase<T>>) {
-    const defaultRenderedSingleValue = <Span ellipsis>{children}</Span>
+    const defaultRenderedSingleValue = <Span variant='inherit' ellipsis>{children}</Span>
 
     return (
       <components.SingleValue {...restProps}>

--- a/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
+++ b/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
@@ -8,7 +8,7 @@ import type {
   OptionsOrGroups,
   SingleSelectComboBoxProps,
 } from '@ui/ComboBox/types'
-import { filterOptionsOrGroups } from '@ui/MobileSelectionDrawer/filterUtils'
+import { filterOptionsOrGroups, resolveSelectedOption } from '@ui/MobileSelectionDrawer/filterUtils'
 import { MobileSelectionDrawerList } from '@ui/MobileSelectionDrawer/MobileSelectionDrawerList'
 import { Drawer } from '@ui/Modal/Modal'
 import { ModalHeading, ModalTitleWithClose } from '@ui/Modal/ModalSlots'
@@ -70,6 +70,10 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
     [options, groups, searchQuery],
   )
 
+  const resolvedSelectedValue = useMemo(() => {
+    return resolveSelectedOption(filteredOptionsOrGroups, selectedValue)
+  }, [filteredOptionsOrGroups, selectedValue])
+
   const Header = useCallback(() => (
     <ModalTitleWithClose
       heading={<ModalHeading size='md' weight='bold'>{heading}</ModalHeading>}
@@ -87,7 +91,7 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
           className='Layer__MobileSelectionDrawerWithTrigger__Trigger'
         >
           <Span size='sm' ellipsis>
-            {selectedValue?.label ?? resolvedPlaceholder}
+            {resolvedSelectedValue?.label ?? resolvedPlaceholder}
           </Span>
           {triggerIcon}
         </HStack>
@@ -113,7 +117,7 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
             <MobileSelectionDrawerList<T>
               ariaLabel={ariaLabel}
               {...filteredOptionsOrGroups}
-              selectedValue={selectedValue}
+              selectedValue={resolvedSelectedValue}
               onSelectedValueChange={(value) => {
                 onSelectedValueChange(value)
                 close()

--- a/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
+++ b/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
@@ -93,7 +93,7 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
           <Span size='sm' ellipsis>
             {resolvedSelectedValue?.label ?? resolvedPlaceholder}
           </Span>
-          {triggerIcon}
+          {!isDisabled && triggerIcon}
         </HStack>
       </Button>
 

--- a/src/components/ui/MobileSelectionDrawer/filterUtils.ts
+++ b/src/components/ui/MobileSelectionDrawer/filterUtils.ts
@@ -28,3 +28,22 @@ export const filterOptionsOrGroups = <T extends ComboBoxOption>(
   }
   return { options: [] }
 }
+
+export const resolveSelectedOption = <T extends ComboBoxOption>(
+  source: OptionsOrGroups<T>,
+  selectedValue: T | null,
+): T | null => {
+  if (!selectedValue) return null
+
+  const options = source.options ?? []
+  const optionMatch = options.find(option => option.value === selectedValue.value)
+  if (optionMatch) return optionMatch
+
+  const groups = source.groups ?? []
+  for (const group of groups) {
+    const match = group.options.find(option => option.value === selectedValue.value)
+    if (match) return match
+  }
+
+  return selectedValue
+}

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -86,7 +86,7 @@ const buildBulkMatchOrCategorizePayload = (
       categorization: {
         type: 'Category',
         category: classification,
-        taxCode: taxCode?.value ?? null,
+        taxCode: taxCode ?? null,
       },
     }
   }

--- a/src/hooks/features/bankTransactions/useSplitsForm.ts
+++ b/src/hooks/features/bankTransactions/useSplitsForm.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useIntl } from 'react-intl'
 
@@ -46,6 +46,9 @@ export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions)
   const selectedCategorization = useGetBankTransactionCategorizationWithDefault(bankTransaction)
   const { category: selectedCategory, taxCode: selectedTaxCode } = selectedCategorization
 
+  const prevIsOpenRef = useRef<boolean | undefined>(isOpen)
+  const prevBankTransactionRef = useRef<BankTransaction>(bankTransaction)
+
   const [localSplits, setLocalSplits] = useState<Split[]>(
     getLocalSplitStateForExpandedTransaction(bankTransaction, selectedCategory, selectedTaxCode),
   )
@@ -54,7 +57,7 @@ export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions)
   const [splitFormError, setSplitFormError] = useState<string | undefined>()
   const { setTransactionCategorySelection } = useBankTransactionsCategorizationActions()
 
-  useEffect(() => {
+  const resetLocalSplits = useCallback(() => {
     setLocalSplits(getLocalSplitStateForExpandedTransaction(
       bankTransaction,
       selectedCategory,
@@ -62,7 +65,23 @@ export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions)
     ))
     setSplitFormError(undefined)
     setInputValues({})
-  }, [bankTransaction, selectedCategory, selectedTaxCode, isOpen])
+  }, [bankTransaction, selectedCategory, selectedTaxCode])
+
+  useEffect(() => {
+    if (prevBankTransactionRef.current === bankTransaction) return
+
+    resetLocalSplits()
+
+    prevBankTransactionRef.current = bankTransaction
+  }, [bankTransaction, resetLocalSplits])
+
+  useEffect(() => {
+    if (prevIsOpenRef.current === isOpen) return
+
+    resetLocalSplits()
+
+    prevIsOpenRef.current = isOpen
+  }, [isOpen, resetLocalSplits])
 
   const saveLocalSplitsToCategoryStore = useCallback((splits: Split[]) => {
     if (!isSplitsValid(splits)) {

--- a/src/hooks/features/bankTransactions/useSplitsForm.ts
+++ b/src/hooks/features/bankTransactions/useSplitsForm.ts
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl'
 
 import { type BankTransaction, type Split } from '@internal-types/bankTransactions'
 import { SplitAsOption } from '@internal-types/categorizationOption'
+import { canCategoryHaveTaxCode } from '@utils/bankTransactions/taxCode'
 import { convertCentsToDecimalString } from '@utils/format'
 import { toLocalizedNumber } from '@utils/i18n/number/input'
 import { useGetBankTransactionCategorizationWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
@@ -143,7 +144,11 @@ export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions)
     if (newCategory === null) return
 
     const newLocalSplits = [...localSplits]
-    newLocalSplits[index].category = newCategory
+    newLocalSplits[index] = {
+      ...newLocalSplits[index],
+      category: newCategory,
+      taxCode: canCategoryHaveTaxCode(newCategory) ? newLocalSplits[index].taxCode : null,
+    }
     setLocalSplits(newLocalSplits)
     setSplitFormError(undefined)
 

--- a/src/hooks/features/bankTransactions/useSplitsForm.ts
+++ b/src/hooks/features/bankTransactions/useSplitsForm.ts
@@ -44,10 +44,10 @@ export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions)
   const { t } = useTranslation()
   const intl = useIntl()
   const selectedCategorization = useGetBankTransactionCategorizationWithDefault(bankTransaction)
-  const { category: selectedCategory } = selectedCategorization
+  const { category: selectedCategory, taxCode: selectedTaxCode } = selectedCategorization
 
   const [localSplits, setLocalSplits] = useState<Split[]>(
-    getLocalSplitStateForExpandedTransaction(bankTransaction, selectedCategory),
+    getLocalSplitStateForExpandedTransaction(bankTransaction, selectedCategory, selectedTaxCode),
   )
 
   const [inputValues, setInputValues] = useState<Record<number, string>>({})
@@ -55,10 +55,14 @@ export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions)
   const { setTransactionCategorySelection } = useBankTransactionsCategorizationActions()
 
   useEffect(() => {
-    setLocalSplits(getLocalSplitStateForExpandedTransaction(bankTransaction, selectedCategory))
+    setLocalSplits(getLocalSplitStateForExpandedTransaction(
+      bankTransaction,
+      selectedCategory,
+      selectedTaxCode,
+    ))
     setSplitFormError(undefined)
     setInputValues({})
-  }, [bankTransaction, selectedCategory, isOpen])
+  }, [bankTransaction, selectedCategory, selectedTaxCode, isOpen])
 
   const saveLocalSplitsToCategoryStore = useCallback((splits: Split[]) => {
     if (!isSplitsValid(splits)) {

--- a/src/hooks/features/bankTransactions/useSplitsForm.ts
+++ b/src/hooks/features/bankTransactions/useSplitsForm.ts
@@ -55,7 +55,10 @@ export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions)
 
   const [inputValues, setInputValues] = useState<Record<number, string>>({})
   const [splitFormError, setSplitFormError] = useState<string | undefined>()
-  const { setTransactionCategorySelection } = useBankTransactionsCategorizationActions()
+  const {
+    setTransactionCategorySelection,
+    setTransactionTaxCodeSelection,
+  } = useBankTransactionsCategorizationActions()
 
   const resetLocalSplits = useCallback(() => {
     setLocalSplits(getLocalSplitStateForExpandedTransaction(
@@ -90,8 +93,12 @@ export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions)
     }
 
     setTransactionCategorySelection(bankTransaction.id, new SplitAsOption(splits))
+
+    const nextTaxCode = splits.length === 1 ? splits[0].taxCode : null
+    setTransactionTaxCodeSelection(bankTransaction.id, nextTaxCode ?? null)
+
     setSplitFormError(undefined)
-  }, [bankTransaction.id, setTransactionCategorySelection, t])
+  }, [bankTransaction.id, setTransactionCategorySelection, setTransactionTaxCodeSelection, t])
 
   const addSplit = useCallback(() => {
     const newSplits = calculateAddSplit(localSplits)

--- a/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
+++ b/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
@@ -4,7 +4,6 @@ import { createStore, useStore } from 'zustand'
 import type { SuggestedMatchAsOption } from '@internal-types/categorizationOption'
 import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import { type BankTransactionCategoryComboBoxOption, isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
-import type { TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
 
 export enum BankTransactionSelectionVariant {
   MATCH = 'MATCH',
@@ -13,7 +12,7 @@ export enum BankTransactionSelectionVariant {
 
 export type BankTransactionCategorization = {
   category: BankTransactionNonSuggestedMatchOption | null
-  taxCode: TaxCodeComboBoxOption | null
+  taxCode: string | null
 
   match: SuggestedMatchAsOption | null
 
@@ -29,7 +28,7 @@ type BankTransactionsCategorizationActions = {
 
   setTransactionCategorySelection: (id: string, category: BankTransactionNonSuggestedMatchOption | null) => void
   setTransactionMatchSelection: (id: string, match: SuggestedMatchAsOption | null) => void
-  setTransactionTaxCodeSelection: (id: string, taxCode: TaxCodeComboBoxOption | null) => void
+  setTransactionTaxCodeSelection: (id: string, taxCode: string | null) => void
   setTransactionSelectionVariant: (id: string, variant: BankTransactionSelectionVariant) => void
 
   setOnlyNewTransactionCategorizations: (categorizations: Map<string, BankTransactionCategorization>) => void

--- a/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
+++ b/src/providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider.tsx
@@ -2,6 +2,7 @@ import { createContext, type PropsWithChildren, useContext, useMemo, useState } 
 import { createStore, useStore } from 'zustand'
 
 import type { SuggestedMatchAsOption } from '@internal-types/categorizationOption'
+import { canCategoryHaveTaxCode } from '@utils/bankTransactions/taxCode'
 import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import { type BankTransactionCategoryComboBoxOption, isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 
@@ -95,7 +96,13 @@ function buildStore() {
         },
 
         setTransactionCategorySelection: (id, category) => {
-          set(({ categorizations }) => updateCategorizationProperty(categorizations, id, 'category', category))
+          set(({ categorizations }) => {
+            const { categorizations: nextCategorizations } = updateCategorizationProperty(categorizations, id, 'category', category)
+            if (category && !canCategoryHaveTaxCode(category)) {
+              return updateCategorizationProperty(nextCategorizations, id, 'taxCode', null)
+            }
+            return { categorizations: nextCategorizations }
+          })
         },
 
         setTransactionMatchSelection: (id, match) => {

--- a/src/types/categorizationOption.ts
+++ b/src/types/categorizationOption.ts
@@ -173,6 +173,10 @@ export class SplitAsOption extends BaseCategorizationOption<Split[]> {
     return CategorizationOption.Split
   }
 
+  get isSingleSplit(): boolean {
+    return this.internalValue.length === 1
+  }
+
   get label(): string {
     return this.internalValue
       .map(split => split.category?.label ?? 'Uncategorized')
@@ -180,7 +184,7 @@ export class SplitAsOption extends BaseCategorizationOption<Split[]> {
   }
 
   get value(): string {
-    if (this.internalValue.length == 1) {
+    if (this.isSingleSplit) {
       return this.internalValue[0].category?.value ?? ''
     }
     return 'split'

--- a/src/utils/bankTransactions/shared.ts
+++ b/src/utils/bankTransactions/shared.ts
@@ -8,7 +8,7 @@ import { Direction } from '@internal-types/general'
 import type { TagFilterInput } from '@internal-types/tags'
 import type { CategoryUpdate } from '@schemas/bankTransactions/categoryUpdate'
 import { makeTagKeyValueFromTag } from '@schemas/tag'
-import { getDefaultTaxCodeOptionForBankTransaction } from '@utils/bankTransactions/taxCode'
+import { getDefaultTaxCodeForBankTransaction } from '@utils/bankTransactions/taxCode'
 import { BankTransactionSelectionVariant } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
 import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/BankTransactionCategoryComboBox/utils'
@@ -179,7 +179,7 @@ export const buildCategorizeBankTransactionPayloadForSplit = (splits: Split[]): 
 export const getDefaultCategorizationForBankTransaction = (bankTransaction: BankTransaction) => {
   return {
     category: getDefaultSelectedCategoryForBankTransaction(bankTransaction),
-    taxCode: getDefaultTaxCodeOptionForBankTransaction(bankTransaction),
+    taxCode: getDefaultTaxCodeForBankTransaction(bankTransaction),
     match: getDefaultSuggestedMatchForBankTransaction(bankTransaction),
     variant: getDefaultVariantForBankTransaction(bankTransaction),
   }

--- a/src/utils/bankTransactions/taxCode.ts
+++ b/src/utils/bankTransactions/taxCode.ts
@@ -2,7 +2,6 @@ import { type BankTransaction } from '@internal-types/bankTransactions'
 import { type BankTransactionTaxOption } from '@schemas/bankTransactions/bankTransaction'
 import { isClassificationExclusion } from '@schemas/categorization'
 import { type BankTransactionCategoryComboBoxOption, isPlaceholderAsOption, isSplitAsOption, isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
-import { TaxCodeComboBoxOption } from '@components/TaxCodeSelect/taxCodeComboBoxOption'
 
 export const getBankTransactionTaxOptions = (bankTransaction?: BankTransaction): BankTransactionTaxOption[] => {
   if (!bankTransaction?.tax_options) {
@@ -12,30 +11,30 @@ export const getBankTransactionTaxOptions = (bankTransaction?: BankTransaction):
   return Object.values(bankTransaction.tax_options).flat()
 }
 
-export const getDefaultTaxCodeOptionForBankTransaction = (bankTransaction?: BankTransaction): TaxCodeComboBoxOption | null => {
+export const getDefaultTaxCodeForBankTransaction = (bankTransaction?: BankTransaction): string | null => {
   const taxCode = bankTransaction?.tax_code
   if (!taxCode) return null
 
-  const option = getBankTransactionTaxOptions(bankTransaction).find(option => option.code === taxCode)
+  const isKnown = getBankTransactionTaxOptions(bankTransaction).some(option => option.code === taxCode)
 
-  return option ? new TaxCodeComboBoxOption(option) : null
+  return isKnown ? taxCode : null
 }
 
 export const hasBankTransactionTaxCode = (
   bankTransaction: BankTransaction | undefined,
-  selectedTaxCode: TaxCodeComboBoxOption | null,
+  selectedTaxCode: string | null,
 ) => {
   if (!selectedTaxCode) return false
-  return getBankTransactionTaxOptions(bankTransaction).some(taxOption => taxOption.code === selectedTaxCode.value)
+  return getBankTransactionTaxOptions(bankTransaction).some(taxOption => taxOption.code === selectedTaxCode)
 }
 
 export const getCategoryPayloadTaxCode = (
   selectedCategory: BankTransactionCategoryComboBoxOption | null | undefined,
-  selectedTaxCode: TaxCodeComboBoxOption | null,
+  selectedTaxCode: string | null,
 ) => {
   if (!canCategoryHaveTaxCode(selectedCategory)) return null
 
-  return selectedTaxCode?.value ?? null
+  return selectedTaxCode ?? null
 }
 
 export const canCategoryHaveTaxCode = (
@@ -56,7 +55,7 @@ export const canCategoryHaveTaxCode = (
 export const resolveCategoryTaxCode = (
   bankTransaction: BankTransaction | undefined,
   selectedCategory: BankTransactionCategoryComboBoxOption | null | undefined,
-  selectedTaxCode: TaxCodeComboBoxOption | null,
+  selectedTaxCode: string | null,
 ): string | null => {
   const resolvedTaxCode = hasBankTransactionTaxCode(bankTransaction, selectedTaxCode) ? selectedTaxCode : null
 

--- a/src/utils/bankTransactions/taxCode.ts
+++ b/src/utils/bankTransactions/taxCode.ts
@@ -44,12 +44,17 @@ export const canCategoryHaveTaxCode = (
 
   if (isPlaceholderAsOption(category)) return false
   if (isSuggestedMatchAsOption(category)) return false
-  if (isSplitAsOption(category)) return false
+  if (isSplitAsOption(category)) {
+    if (category.original.length === 1) {
+      const classification = category.original[0].category?.classification
+      return !!classification && !isClassificationExclusion(classification)
+    }
 
-  if (!category.classification) return false
-  if (isClassificationExclusion(category.classification)) return false
+    return false
+  }
 
-  return true
+  const classification = category.classification
+  return !!classification && !isClassificationExclusion(classification)
 }
 
 export const resolveCategoryTaxCode = (

--- a/src/utils/bankTransactions/taxCode.ts
+++ b/src/utils/bankTransactions/taxCode.ts
@@ -45,7 +45,7 @@ export const canCategoryHaveTaxCode = (
   if (isPlaceholderAsOption(category)) return false
   if (isSuggestedMatchAsOption(category)) return false
   if (isSplitAsOption(category)) {
-    if (category.original.length === 1) {
+    if (category.isSingleSplit) {
       const classification = category.original[0].category?.classification
       return !!classification && !isClassificationExclusion(classification)
     }


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bank transaction categorization/tax-code state and payload building, which could affect how tax codes are persisted or cleared across bulk, split, and mobile flows. Scope is moderate but mostly tightens validation and type consistency.
> 
> **Overview**
> Improves **tax code selection correctness** across bank transaction categorization flows by standardizing stored tax codes to plain `string | null` and ensuring API payloads use the resolved string value.
> 
> Tax codes are now **cleared/disabled when the chosen category can’t accept a tax code**, including split scenarios (allowing tax codes only for *single-split* categories where the underlying classification permits it), and split-form state now resets more predictably when switching transactions/open state.
> 
> Polishes selection UI behavior: mobile drawers/comboboxes resolve the displayed selected option from the current filtered option set, hide dropdown icons when disabled, and improve disabled styling; `TaxCodeSelect` also guards against stale selected options not present in the latest options list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0049a63cd68f98559991dce4c9bb7c16bf52b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->