### PR TITLE
fix: reports css bugs

### DIFF
--- a/src/components/UnifiedReports/unifiedReportTable.scss
+++ b/src/components/UnifiedReports/unifiedReportTable.scss
@@ -7,5 +7,6 @@
   .Layer__UI__Table-Cell {
     display: table-cell;
     min-width: 6rem;
+    max-width: 16rem;
   }
 }

--- a/src/components/ui/Table/table.scss
+++ b/src/components/ui/Table/table.scss
@@ -14,6 +14,14 @@
   > tr {
     height: inherit;
   }
+
+  .Layer__UI__Table-Row {
+    background-color: var(--color-base-0);
+  }
+
+  @media (width <= 500px) {
+    height: auto;
+  }
 }
 
 .Layer__UI__Table-Row {
@@ -22,7 +30,6 @@
 
   @media (width <= 500px) {
     height: auto;
-    min-height: 3.25rem;
   }
 
   &:not(:last-child) .Layer__UI__Table-Cell {
@@ -113,18 +120,17 @@
 .Layer__UI__Table-Column[data-pinned],
 .Layer__UI__Table-Cell[data-pinned] {
   z-index: 1;
-  background-color: inherit;
 }
 
 .Layer__UI__Table-ScrollContainer.Layer__UI__Table-ScrollContainer--has-horizontal-overflow {
   .Layer__UI__Table-Column[data-pinned='left'],
   .Layer__UI__Table-Cell[data-pinned='left'] {
-    border-right: 1px solid var(--color-base-200);
+    border-right: 1px solid var(--color-base-300);
   }
 
   .Layer__UI__Table-Column[data-pinned='right'],
   .Layer__UI__Table-Cell[data-pinned='right'] {
-    border-left: 1px solid var(--color-base-200);
+    border-left: 1px solid var(--color-base-300);
   }
 }
 

--- a/src/components/ui/Typography/text.scss
+++ b/src/components/ui/Typography/text.scss
@@ -44,6 +44,9 @@
 
   &[data-ellipsis],
   &[data-with-tooltip] {
+    display: inline-block;
+    vertical-align: middle;
+
     overflow: hidden;
     max-inline-size: min(80ch, 60rem, 100%);
     white-space: nowrap;

--- a/src/components/ui/Typography/text.scss
+++ b/src/components/ui/Typography/text.scss
@@ -44,9 +44,6 @@
 
   &[data-ellipsis],
   &[data-with-tooltip] {
-    display: inline-block;
-    vertical-align: middle;
-
     overflow: hidden;
     max-inline-size: min(80ch, 60rem, 100%);
     white-space: nowrap;
@@ -99,4 +96,16 @@
    * A `label` is an inline element by default. This change allows us to apply padding.
    */
   display: inline-block;
+}
+
+.Layer__Span[data-ellipsis],
+.Layer__Span[data-with-tooltip] {
+  /*
+   * `Span` is `display: inline` by default, which ignores `overflow` and `text-overflow`
+   * — so ellipsis silently does nothing. Promote to `inline-block` so the rules above
+   * actually apply, and pin `vertical-align` so the new baseline doesn't shift the span
+   * relative to neighbouring inline content.
+   */
+  display: inline-block;
+  vertical-align: middle;
 }


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only changes; potential impact is limited to table layout (pinned column borders/backgrounds, header rows) and text truncation rendering for `Span` elements.
> 
> **Overview**
> Fixes a few UI styling issues in reports and shared table/typography components.
> 
> Unified Reports table cells/columns now have a `max-width` to prevent overly wide columns. The base `Table` styles adjust header row background/responsive height and tweak pinned-column overflow borders (and remove `background-color: inherit`) for more consistent pinned styling.
> 
> `Typography` `Span` elements using `data-ellipsis`/`data-with-tooltip` are promoted to `inline-block` with `vertical-align: middle` so CSS ellipsis (and tooltip truncation detection) reliably takes effect without baseline shifts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4eac7f9c23d946cc8a8eca9ccaad65f861e8cdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->