### PR TITLE
Solopreneur overview: unify summary cards on SummaryCard + interaction/string overrides

### DIFF
--- a/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
+++ b/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
@@ -47,6 +47,7 @@ export const ExpensesSummaryCard = ({
   return (
     <SummaryCard
       className={classNames('Layer__ExpensesSummaryCard', className)}
+      interactionProps={interactionProps}
       slots={slots}
     >
       <ProfitAndLossDetailedCharts

--- a/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
+++ b/src/components/ExpensesSummaryCard/ExpensesSummaryCard.tsx
@@ -47,7 +47,6 @@ export const ExpensesSummaryCard = ({
   return (
     <SummaryCard
       className={classNames('Layer__ExpensesSummaryCard', className)}
-      interactionProps={interactionProps}
       slots={slots}
     >
       <ProfitAndLossDetailedCharts

--- a/src/components/MileageTrackingSummary/MileageTrackingSummary.tsx
+++ b/src/components/MileageTrackingSummary/MileageTrackingSummary.tsx
@@ -5,8 +5,8 @@ import { useMileageTrackingYearlySummary } from '@hooks/features/mileage/useMile
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { HStack, Stack, VStack } from '@ui/Stack/Stack'
-import { Heading } from '@ui/Typography/Heading'
-import { Container } from '@components/Container/Container'
+import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
+import { type SummaryCardInteractionProps, type SummaryCardStringOverrides, useSummaryCardSlots } from '@ui/SummaryCard/useSummaryCardSlots'
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
 import { Loader } from '@components/Loader/Loader'
 import { MileageDeductionChart } from '@components/MileageDeductionChart/MileageDeductionChart'
@@ -15,11 +15,7 @@ import { ConditionalBlock } from '@components/utility/ConditionalBlock'
 
 import './mileageTrackingSummary.scss'
 
-export type MileageTrackingSummaryProps = {
-  header?: string
-}
-
-export const MileageTrackingSummary = ({ header: headerOverride }: MileageTrackingSummaryProps = {}) => {
+const Content = () => {
   const { t } = useTranslation()
   const { formatDate } = useIntlFormatter()
   const { data, selectedYear, selectedYearData, chartData, isLoading, isError } = useMileageTrackingYearlySummary()
@@ -27,70 +23,86 @@ export const MileageTrackingSummary = ({ header: headerOverride }: MileageTracki
   const inYearLabel = t('mileageTracking:label.in_year', 'In {{year}}', {
     year: formatDate(new Date(selectedYear, 0, 1), DateFormat.Year),
   })
-  const title = headerOverride ?? t('mileageTracking:label.mileage_tracking', 'Mileage Tracking')
 
   const statsProps = isDesktop
     ? { direction: 'column' as const }
     : isMobile ? { direction: 'column' as const } : { direction: 'row' as const }
 
   return (
-    <Container name='mileage-tracking-summary'>
-      <VStack className='Layer__MileageTrackingSummary__Header' gap='md'>
-        <Heading size={isDesktop ? 'md' : 'sm'}>{title}</Heading>
-      </VStack>
-      <ConditionalBlock
-        data={data}
-        isLoading={isLoading}
-        isError={isError}
-        Loading={(
-          <HStack className='Layer__MileageTrackingSummary__Content' gap='lg' justify='center' align='center'>
-            <Loader />
-          </HStack>
-        )}
-        Error={(
-          <DataState
-            status={DataStateStatus.failed}
-            title={t('mileageTracking:error.load_mileage_summary_data', 'Failed to load mileage summary data')}
-            spacing
-          />
-        )}
-      >
-        {() => (
-          <Stack
-            className='Layer__MileageTrackingSummary__Content'
-            direction={isDesktop ? 'row' : 'column'}
-            gap='lg'
-          >
-            <Stack {...statsProps} className='Layer__MileageTrackingSummary__Cards' gap='md'>
-              <div className='Layer__MileageTrackingSummary__StatCardSlot'>
-                <MileageTrackingStatsCard
-                  title={t('mileageTracking:label.total_deduction', 'Total Deduction')}
-                  amount={selectedYearData?.estimatedDeduction ?? 0}
-                  formatAsMoney
-                  description={inYearLabel}
-                />
-              </div>
-              <div className='Layer__MileageTrackingSummary__StatCardSlot'>
-                <MileageTrackingStatsCard
-                  title={t('mileageTracking:label.total_miles', 'Total Miles')}
-                  amount={selectedYearData?.miles ?? 0}
-                  description={inYearLabel}
-                />
-              </div>
-              <div className='Layer__MileageTrackingSummary__StatCardSlot'>
-                <MileageTrackingStatsCard
-                  title={t('trips:label.trips', 'Trips')}
-                  amount={selectedYearData?.trips ?? 0}
-                  description={inYearLabel}
-                />
-              </div>
-            </Stack>
-            <VStack className='Layer__MileageTrackingSummary__Chart' fluid justify='end'>
-              <MileageDeductionChart data={chartData} selectedYear={selectedYear} chartHeight={isDesktop ? 250 : 200} />
-            </VStack>
+    <ConditionalBlock
+      data={data}
+      isLoading={isLoading}
+      isError={isError}
+      Loading={(
+        <HStack className='Layer__MileageTrackingSummary__Content' gap='lg' justify='center' align='center'>
+          <Loader />
+        </HStack>
+      )}
+      Error={(
+        <DataState
+          status={DataStateStatus.failed}
+          title={t('mileageTracking:error.load_mileage_summary_data', 'Failed to load mileage summary data')}
+          spacing
+        />
+      )}
+    >
+      {() => (
+        <Stack
+          className='Layer__MileageTrackingSummary__Content'
+          direction={isDesktop ? 'row' : 'column'}
+          gap='lg'
+        >
+          <Stack {...statsProps} className='Layer__MileageTrackingSummary__Cards' gap='md'>
+            <div className='Layer__MileageTrackingSummary__StatCardSlot'>
+              <MileageTrackingStatsCard
+                title={t('mileageTracking:label.total_deduction', 'Total Deduction')}
+                amount={selectedYearData?.estimatedDeduction ?? 0}
+                formatAsMoney
+                description={inYearLabel}
+              />
+            </div>
+            <div className='Layer__MileageTrackingSummary__StatCardSlot'>
+              <MileageTrackingStatsCard
+                title={t('mileageTracking:label.total_miles', 'Total Miles')}
+                amount={selectedYearData?.miles ?? 0}
+                description={inYearLabel}
+              />
+            </div>
+            <div className='Layer__MileageTrackingSummary__StatCardSlot'>
+              <MileageTrackingStatsCard
+                title={t('trips:label.trips', 'Trips')}
+                amount={selectedYearData?.trips ?? 0}
+                description={inYearLabel}
+              />
+            </div>
           </Stack>
-        )}
-      </ConditionalBlock>
-    </Container>
+          <VStack className='Layer__MileageTrackingSummary__Chart' fluid justify='end'>
+            <MileageDeductionChart data={chartData} selectedYear={selectedYear} chartHeight={isDesktop ? 250 : 200} />
+          </VStack>
+        </Stack>
+      )}
+    </ConditionalBlock>
+  )
+}
+
+export type MileageTrackingSummaryProps = {
+  stringOverrides?: SummaryCardStringOverrides
+  interactionProps?: SummaryCardInteractionProps
+}
+
+export const MileageTrackingSummary = ({ stringOverrides, interactionProps }: MileageTrackingSummaryProps = {}) => {
+  const { t } = useTranslation()
+  const title = stringOverrides?.title ?? t('mileageTracking:label.mileage_tracking', 'Mileage Tracking')
+
+  const slots = useSummaryCardSlots({
+    defaultTitle: title,
+    interactionProps,
+    stringOverrides: { title },
+  })
+
+  return (
+    <SummaryCard className='Layer__MileageTrackingSummary' slots={slots} interactionProps={interactionProps}>
+      <Content />
+    </SummaryCard>
   )
 }

--- a/src/components/MileageTrackingSummary/MileageTrackingSummary.tsx
+++ b/src/components/MileageTrackingSummary/MileageTrackingSummary.tsx
@@ -101,7 +101,7 @@ export const MileageTrackingSummary = ({ stringOverrides, interactionProps }: Mi
   })
 
   return (
-    <SummaryCard className='Layer__MileageTrackingSummary' slots={slots} interactionProps={interactionProps}>
+    <SummaryCard className='Layer__MileageTrackingSummary' slots={slots}>
       <Content />
     </SummaryCard>
   )

--- a/src/components/MileageTrackingSummary/MileageTrackingSummary.tsx
+++ b/src/components/MileageTrackingSummary/MileageTrackingSummary.tsx
@@ -92,12 +92,10 @@ export type MileageTrackingSummaryProps = {
 
 export const MileageTrackingSummary = ({ stringOverrides, interactionProps }: MileageTrackingSummaryProps = {}) => {
   const { t } = useTranslation()
-  const title = stringOverrides?.title ?? t('mileageTracking:label.mileage_tracking', 'Mileage Tracking')
-
   const slots = useSummaryCardSlots({
-    defaultTitle: title,
+    defaultTitle: t('mileageTracking:label.mileage_tracking', 'Mileage Tracking'),
     interactionProps,
-    stringOverrides: { title },
+    stringOverrides,
   })
 
   return (

--- a/src/components/MileageTrackingSummary/mileageTrackingSummary.scss
+++ b/src/components/MileageTrackingSummary/mileageTrackingSummary.scss
@@ -1,9 +1,3 @@
-.Layer__MileageTrackingSummary__Header {
-  box-sizing: border-box;
-  padding: var(--spacing-lg);
-  border-bottom: 1px solid var(--color-base-300);
-}
-
 .Layer__MileageTrackingSummary__Cards {
   min-width: 12rem;
 }

--- a/src/components/MileageTrackingSummary/mileageTrackingSummary.scss
+++ b/src/components/MileageTrackingSummary/mileageTrackingSummary.scss
@@ -4,10 +4,6 @@
   border-bottom: 1px solid var(--color-base-300);
 }
 
-.Layer__MileageTrackingSummary__Content {
-  padding: var(--spacing-lg);
-}
-
 .Layer__MileageTrackingSummary__Cards {
   min-width: 12rem;
 }

--- a/src/components/Onboarding/Onboarding.tsx
+++ b/src/components/Onboarding/Onboarding.tsx
@@ -37,7 +37,7 @@ export const Onboarding = (props: OnboardingProps) => (
   </AccountConfirmationStoreProvider>
 )
 
-export const OnboardingContent = ({
+const OnboardingContent = ({
   onTransactionsToReviewClick,
   onboardingStepOverride = undefined,
 }: OnboardingProps) => {

--- a/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
+++ b/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { ProfitAndLossContext } from '@contexts/ProfitAndLossContext/ProfitAndLossContext'
-import { VStack } from '@ui/Stack/Stack'
 import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
 import {
   type SummaryCardInteractionProps,
@@ -45,13 +44,12 @@ export const ProfitAndLossSummaryCard = ({
 
   return (
     <SummaryCard
-      className={classNames('Layer__ProfitAndLossSummaryCard', className)}
+      className={classNames('Layer__ProfitAndLossSummaryCard', 'Layer__UI__Chart--focusReset', className)}
+      interactionProps={interactionProps}
       slots={slots}
     >
-      <VStack gap='sm'>
-        <ProfitAndLossChart tagFilter={tagFilter} hideLegend />
-        {!isDesktop && legend}
-      </VStack>
+      <ProfitAndLossChart tagFilter={tagFilter} hideLegend />
+      {!isDesktop && legend}
     </SummaryCard>
   )
 }

--- a/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
+++ b/src/components/ProfitAndLossSummaryCard/ProfitAndLossSummaryCard.tsx
@@ -45,7 +45,6 @@ export const ProfitAndLossSummaryCard = ({
   return (
     <SummaryCard
       className={classNames('Layer__ProfitAndLossSummaryCard', 'Layer__UI__Chart--focusReset', className)}
-      interactionProps={interactionProps}
       slots={slots}
     >
       <ProfitAndLossChart tagFilter={tagFilter} hideLegend />

--- a/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
+++ b/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
@@ -12,7 +12,6 @@
   @media (width <= 760px) {
     .Layer__chart-wrapper {
       height: unset;
-      height: 10rem;
     }
   }
 }

--- a/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
+++ b/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
@@ -1,10 +1,18 @@
 .Layer__ProfitAndLossSummaryCard {
   .Layer__chart-wrapper,
   .Layer__chart-container {
+    height: 100%;
     min-block-size: 15.625rem;
   }
 
   div.recharts-responsive-container.Layer__chart-container {
     padding-block-start: var(--spacing-xs);
+  }
+
+  @media (width <= 760px) {
+    .Layer__chart-wrapper {
+      height: unset;
+      height: 10rem;
+    }
   }
 }

--- a/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
+++ b/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
@@ -8,9 +8,9 @@ import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { HorizontalBarChart } from '@ui/HorizontalBarChart/HorizontalBarChart'
 import { LegendLayout } from '@ui/Legend/Legend'
 import { HStack, VStack } from '@ui/Stack/Stack'
-import { Heading } from '@ui/Typography/Heading'
+import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
+import { type SummaryCardInteractionProps, type SummaryCardStringOverrides, useSummaryCardSlots } from '@ui/SummaryCard/useSummaryCardSlots'
 import { Span } from '@ui/Typography/Text'
-import { Card } from '@components/Card/Card'
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
 import { DetailedChart, type DetailedChartProps } from '@components/DetailedCharts/DetailedChart'
 import { type DetailData, type SeriesData } from '@components/DetailedCharts/types'
@@ -61,10 +61,10 @@ function TaxEstimatesSummaryCardEmpty() {
   const { t } = useTranslation()
   return (
     <DataState
+      className='Layer__TaxEstimatesSummaryCard--empty'
       status={DataStateStatus.info}
       title={t('taxEstimates:empty.no_tax_estimates_summary', 'Get started with your tax estimates')}
       description={t('taxEstimates:empty.no_tax_estimates_summary_description', 'Start by importing and categorizing your bank transactions')}
-      spacing
     />
   )
 }
@@ -134,19 +134,17 @@ const PieChartContent = ({ data, commonProps, layout }: Pick<ContentProps, 'data
 
 export type TaxEstimatesSummaryCardProps = {
   mode?: TaxEstimatesSummaryCardMode
-  title?: string
-  withHeaderSeparator?: boolean
+  interactionProps?: SummaryCardInteractionProps
+  stringOverrides?: SummaryCardStringOverrides
 }
 
 export const TaxEstimatesSummaryCard = ({
   mode = TaxEstimatesSummaryCardMode.PieChart,
-  title: titleOverride,
-  withHeaderSeparator = false,
+  interactionProps,
+  stringOverrides,
 }: TaxEstimatesSummaryCardProps = {}) => {
   const { detailData, layout, title: defaultTitle, isLoading, isError } = useTaxEstimatesSummaryCard()
-  const { isDesktop } = useSizeClass()
   const isSummaryCardLayout = layout === 'summaryCard'
-  const title = titleOverride ?? defaultTitle
 
   const commonProps: CommonProps = useMemo(() => {
     const colorByKey = detailData?.data?.reduce<Record<string, string>>((acc, item) => {
@@ -160,28 +158,23 @@ export const TaxEstimatesSummaryCard = ({
     }
   }, [detailData?.data])
 
+  const slots = useSummaryCardSlots({
+    defaultTitle,
+    interactionProps,
+    stringOverrides,
+  })
+
   return (
-    <VStack className='Layer__TaxEstimatesSummaryCard__Container'>
-      <Card className={classNames('Layer__TaxEstimatesSummaryCard', isSummaryCardLayout && 'Layer__TaxEstimatesSummaryCard--summaryCard')}>
-        <VStack gap='md' className='Layer__TaxEstimatesSummaryCard__Body'>
-          <HStack
-            className={classNames(
-              'Layer__TaxEstimatesSummaryCard__Header',
-              (isSummaryCardLayout || withHeaderSeparator) && 'Layer__SummaryCard__ContainerHeader',
-            )}
-            justify='space-between'
-            align={isSummaryCardLayout ? 'center' : 'start'}
-            gap='md'
-          >
-            <Heading size={!isDesktop ? 'sm' : 'md'}>{title}</Heading>
-          </HStack>
-          <ConditionalBlock data={detailData} isLoading={isLoading} isError={isError} Loading={<LoadingState mode={mode} />} Error={<ErrorState />}>
-            {({ data }) => allTaxSectionsAreEmpty(data)
-              ? <TaxEstimatesSummaryCardEmpty />
-              : <Content data={data} mode={mode} commonProps={commonProps} layout={layout} />}
-          </ConditionalBlock>
-        </VStack>
-      </Card>
-    </VStack>
+    <SummaryCard
+      className={classNames('Layer__TaxEstimatesSummaryCard', isSummaryCardLayout && 'Layer__TaxEstimatesSummaryCard--summaryCard')}
+      interactionProps={interactionProps}
+      slots={slots}
+    >
+      <ConditionalBlock data={detailData} isLoading={isLoading} isError={isError} Loading={<LoadingState mode={mode} />} Error={<ErrorState />}>
+        {({ data }) => allTaxSectionsAreEmpty(data)
+          ? <TaxEstimatesSummaryCardEmpty />
+          : <Content data={data} mode={mode} commonProps={commonProps} layout={layout} />}
+      </ConditionalBlock>
+    </SummaryCard>
   )
 }

--- a/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
+++ b/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
@@ -168,7 +168,6 @@ export const TaxEstimatesSummaryCard = ({
   return (
     <SummaryCard
       className={classNames('Layer__TaxEstimatesSummaryCard', isSummaryCardLayout && 'Layer__TaxEstimatesSummaryCard--summaryCard')}
-      interactionProps={interactionProps}
       slots={slots}
     >
       <ConditionalBlock data={detailData} isLoading={isLoading} isError={isError} Loading={<LoadingState mode={mode} />} Error={<ErrorState />}>

--- a/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
+++ b/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
@@ -94,6 +94,7 @@ const HorizontalBarChartContent = ({ data, commonProps }: Pick<ContentProps, 'da
   const { t } = useTranslation()
   const { formatCurrencyFromCents } = useIntlFormatter()
   const { isDesktop } = useSizeClass()
+
   return (
     <VStack className='Layer__TaxEstimatesSummaryCard__Content Layer__TaxEstimatesSummaryCard__Content--horizontal' gap='md' pi='lg' pbe='lg'>
       <HStack className='Layer__TaxEstimatesSummaryCard__TotalRow' justify='space-between' align='baseline' gap='md'>

--- a/src/components/TaxEstimatesSummaryCard/taxEstimatesSummaryCard.scss
+++ b/src/components/TaxEstimatesSummaryCard/taxEstimatesSummaryCard.scss
@@ -32,7 +32,6 @@
 
   &.Layer__card {
     gap: var(--spacing-lg);
-    padding: var(--spacing-lg);
     border: 1px solid var(--color-base-200);
     box-shadow: none;
   }
@@ -78,5 +77,10 @@
     .Layer__TaxEstimatesSummaryCard__Content {
       align-items: center;
     }
+  }
+
+  &--empty {
+    height: 100%;
+    margin: 0 auto;
   }
 }

--- a/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
@@ -18,6 +18,78 @@ const CHART_BORDER_RADIUS = 8
 const Y_AXIS_CATEGORY_KEY = '__layer_hbar_category'
 const SMALL_SEGMENT_THRESHOLD = 0.25
 
+type UseHorizontalBarChartProps<T extends SeriesData> = {
+  slots?: {
+    Legend?: ReactNode
+  }
+  data: DetailData<T>
+  stylingProps: {
+    colorSelector: ColorSelector<T>
+  }
+  formatValue: (value: number) => string
+  labelMode?: LegendLayout
+}
+
+const useHorizontalBarChart = <T extends SeriesData>({ data, stylingProps, formatValue, labelMode, slots }: UseHorizontalBarChartProps<T>) => {
+  const { data: items, total } = data
+
+  const positiveItems = useMemo(
+    () => items.filter(item => item.value > 0),
+    [items],
+  )
+
+  const positiveTotal = useMemo(() => positiveItems.reduce((sum, item) => sum + item.value, 0), [positiveItems])
+  const legendDenominator = positiveTotal > 0 ? positiveTotal : total
+
+  const effectiveLabelMode = useMemo(() => {
+    if (legendDenominator <= 0) return LegendLayout.Table
+
+    const hasSmallSegment = positiveItems.some(
+      item => item.value / legendDenominator < SMALL_SEGMENT_THRESHOLD,
+    )
+
+    if (hasSmallSegment) return LegendLayout.Table
+
+    return labelMode
+  }, [labelMode, legendDenominator, positiveItems])
+
+  const chartData = useMemo(() => {
+    const stacked = positiveItems.reduce<Record<string, number | string>>(
+      (acc, item) => {
+        acc[item.name] = item.value
+        return acc
+      },
+      { [Y_AXIS_CATEGORY_KEY]: 'series' },
+    )
+    return [stacked]
+  }, [positiveItems])
+
+  const chartKey = useMemo(() => positiveItems.map(item => item.name).join('|'), [positiveItems])
+
+  const legendNode = useMemo(() => slots?.Legend !== undefined
+    ? slots.Legend
+    : (
+      <Legend<T>
+        items={positiveItems}
+        total={legendDenominator}
+        colorSelector={stylingProps.colorSelector}
+        formatValue={formatValue}
+        layout={effectiveLabelMode}
+      />
+    ), [slots?.Legend, positiveItems, legendDenominator, stylingProps.colorSelector, formatValue, effectiveLabelMode])
+
+  return {
+    chartKey,
+    legendNode,
+    chartData,
+    positiveTotal,
+    positiveItems,
+    stylingProps,
+    formatValue,
+    labelMode,
+  }
+}
+
 export type HorizontalBarChartLabelMode = LegendLayout
 
 export type HorizontalBarChartProps<T extends SeriesData> = {
@@ -41,50 +113,7 @@ export const HorizontalBarChart = <T extends SeriesData>({
   labelMode = LegendLayout.Table,
   slots,
 }: HorizontalBarChartProps<T>) => {
-  const { data: items, total } = data
-
-  const positiveItems = useMemo(
-    () => items.filter(item => item.value > 0),
-    [items],
-  )
-
-  const positiveTotal = positiveItems.reduce((sum, item) => sum + item.value, 0)
-  const legendDenominator = positiveTotal > 0 ? positiveTotal : total
-
-  const effectiveLabelMode = useMemo(() => {
-    if (labelMode === LegendLayout.Table || legendDenominator <= 0) {
-      return labelMode
-    }
-    const hasSmallSegment = positiveItems.some(
-      item => item.value / legendDenominator < SMALL_SEGMENT_THRESHOLD,
-    )
-    return hasSmallSegment ? LegendLayout.Table : labelMode
-  }, [labelMode, legendDenominator, positiveItems])
-
-  const chartData = useMemo(() => {
-    const stacked = positiveItems.reduce<Record<string, number | string>>(
-      (acc, item) => {
-        acc[item.name] = item.value
-        return acc
-      },
-      { [Y_AXIS_CATEGORY_KEY]: 'series' },
-    )
-    return [stacked]
-  }, [positiveItems])
-
-  const chartKey = positiveItems.map(item => item.name).join('|')
-
-  const legendNode = slots?.Legend !== undefined
-    ? slots.Legend
-    : (
-      <Legend<T>
-        items={positiveItems}
-        total={legendDenominator}
-        colorSelector={stylingProps.colorSelector}
-        formatValue={formatValue}
-        layout={effectiveLabelMode}
-      />
-    )
+  const { chartKey, legendNode, chartData, positiveTotal, positiveItems } = useHorizontalBarChart<T>({ data, stylingProps, formatValue, labelMode, slots })
 
   return (
     <VStack className='Layer__HorizontalBarChart Layer__UI__Chart--focusReset' gap='md' justify='center'>

--- a/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
@@ -16,6 +16,7 @@ const CHART_HEIGHT = 24
 const CHART_MARGIN = { top: 0, right: 0, bottom: 0, left: 0 }
 const CHART_BORDER_RADIUS = 8
 const Y_AXIS_CATEGORY_KEY = '__layer_hbar_category'
+const SMALL_SEGMENT_THRESHOLD = 0.25
 
 export type HorizontalBarChartLabelMode = LegendLayout
 
@@ -50,6 +51,16 @@ export const HorizontalBarChart = <T extends SeriesData>({
   const positiveTotal = positiveItems.reduce((sum, item) => sum + item.value, 0)
   const legendDenominator = positiveTotal > 0 ? positiveTotal : total
 
+  const effectiveLabelMode = useMemo(() => {
+    if (labelMode === LegendLayout.Table || legendDenominator <= 0) {
+      return labelMode
+    }
+    const hasSmallSegment = positiveItems.some(
+      item => item.value / legendDenominator < SMALL_SEGMENT_THRESHOLD,
+    )
+    return hasSmallSegment ? LegendLayout.Table : labelMode
+  }, [labelMode, legendDenominator, positiveItems])
+
   const chartData = useMemo(() => {
     const stacked = positiveItems.reduce<Record<string, number | string>>(
       (acc, item) => {
@@ -71,7 +82,7 @@ export const HorizontalBarChart = <T extends SeriesData>({
         total={legendDenominator}
         colorSelector={stylingProps.colorSelector}
         formatValue={formatValue}
-        layout={labelMode}
+        layout={effectiveLabelMode}
       />
     )
 

--- a/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
@@ -58,7 +58,7 @@ export const HorizontalBarChart = <T extends SeriesData>({
     [items],
   )
 
-  const positiveTotal = useMemo(() => positiveItems.reduce((sum, item) => sum + item.value, 0), [positiveItems])
+  const positiveTotal = positiveItems.reduce((sum, item) => sum + item.value, 0)
   const legendDenominator = positiveTotal > 0 ? positiveTotal : total
 
   const effectiveLabelMode = determineLabelMode(labelMode, positiveItems, legendDenominator)
@@ -74,9 +74,9 @@ export const HorizontalBarChart = <T extends SeriesData>({
     return [stacked]
   }, [positiveItems])
 
-  const chartKey = useMemo(() => positiveItems.map(item => item.name).join('|'), [positiveItems])
+  const chartKey = positiveItems.map(item => item.name).join('|')
 
-  const legendNode = useMemo(() => slots?.Legend !== undefined
+  const legendNode = slots?.Legend !== undefined
     ? slots.Legend
     : (
       <Legend<T>
@@ -86,7 +86,7 @@ export const HorizontalBarChart = <T extends SeriesData>({
         formatValue={formatValue}
         layout={effectiveLabelMode}
       />
-    ), [slots?.Legend, positiveItems, legendDenominator, stylingProps.colorSelector, formatValue, effectiveLabelMode])
+    )
 
   return (
     <VStack className='Layer__HorizontalBarChart Layer__UI__Chart--focusReset' gap='md' justify='center'>

--- a/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
@@ -18,19 +18,39 @@ const CHART_BORDER_RADIUS = 8
 const Y_AXIS_CATEGORY_KEY = '__layer_hbar_category'
 const SMALL_SEGMENT_THRESHOLD = 0.25
 
-type UseHorizontalBarChartProps<T extends SeriesData> = {
-  slots?: {
-    Legend?: ReactNode
-  }
+export function determineLabelMode(requestedLabelMode: LegendLayout, positiveItems: SeriesData[], legendDenominator: number): LegendLayout {
+  if (legendDenominator <= 0) return LegendLayout.Table
+
+  const hasSmallSegment = positiveItems.some(
+    item => item.value / legendDenominator < SMALL_SEGMENT_THRESHOLD,
+  )
+
+  if (hasSmallSegment) return LegendLayout.Table
+  return requestedLabelMode
+}
+export type HorizontalBarChartLabelMode = LegendLayout
+
+export type HorizontalBarChartProps<T extends SeriesData> = {
   data: DetailData<T>
   stylingProps: {
     colorSelector: ColorSelector<T>
   }
   formatValue: (value: number) => string
-  labelMode?: LegendLayout
+  showLegend?: boolean
+  labelMode?: HorizontalBarChartLabelMode
+  slots?: {
+    Legend?: ReactNode
+  }
 }
 
-const useHorizontalBarChart = <T extends SeriesData>({ data, stylingProps, formatValue, labelMode, slots }: UseHorizontalBarChartProps<T>) => {
+export const HorizontalBarChart = <T extends SeriesData>({
+  data,
+  stylingProps,
+  formatValue,
+  showLegend = true,
+  labelMode = LegendLayout.Table,
+  slots,
+}: HorizontalBarChartProps<T>) => {
   const { data: items, total } = data
 
   const positiveItems = useMemo(
@@ -41,17 +61,7 @@ const useHorizontalBarChart = <T extends SeriesData>({ data, stylingProps, forma
   const positiveTotal = useMemo(() => positiveItems.reduce((sum, item) => sum + item.value, 0), [positiveItems])
   const legendDenominator = positiveTotal > 0 ? positiveTotal : total
 
-  const effectiveLabelMode = useMemo(() => {
-    if (legendDenominator <= 0) return LegendLayout.Table
-
-    const hasSmallSegment = positiveItems.some(
-      item => item.value / legendDenominator < SMALL_SEGMENT_THRESHOLD,
-    )
-
-    if (hasSmallSegment) return LegendLayout.Table
-
-    return labelMode
-  }, [labelMode, legendDenominator, positiveItems])
+  const effectiveLabelMode = determineLabelMode(labelMode, positiveItems, legendDenominator)
 
   const chartData = useMemo(() => {
     const stacked = positiveItems.reduce<Record<string, number | string>>(
@@ -77,43 +87,6 @@ const useHorizontalBarChart = <T extends SeriesData>({ data, stylingProps, forma
         layout={effectiveLabelMode}
       />
     ), [slots?.Legend, positiveItems, legendDenominator, stylingProps.colorSelector, formatValue, effectiveLabelMode])
-
-  return {
-    chartKey,
-    legendNode,
-    chartData,
-    positiveTotal,
-    positiveItems,
-    stylingProps,
-    formatValue,
-    labelMode,
-  }
-}
-
-export type HorizontalBarChartLabelMode = LegendLayout
-
-export type HorizontalBarChartProps<T extends SeriesData> = {
-  data: DetailData<T>
-  stylingProps: {
-    colorSelector: ColorSelector<T>
-  }
-  formatValue: (value: number) => string
-  showLegend?: boolean
-  labelMode?: HorizontalBarChartLabelMode
-  slots?: {
-    Legend?: ReactNode
-  }
-}
-
-export const HorizontalBarChart = <T extends SeriesData>({
-  data,
-  stylingProps,
-  formatValue,
-  showLegend = true,
-  labelMode = LegendLayout.Table,
-  slots,
-}: HorizontalBarChartProps<T>) => {
-  const { chartKey, legendNode, chartData, positiveTotal, positiveItems } = useHorizontalBarChart<T>({ data, stylingProps, formatValue, labelMode, slots })
 
   return (
     <VStack className='Layer__HorizontalBarChart Layer__UI__Chart--focusReset' gap='md' justify='center'>

--- a/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
@@ -18,7 +18,7 @@ const CHART_BORDER_RADIUS = 8
 const Y_AXIS_CATEGORY_KEY = '__layer_hbar_category'
 const SMALL_SEGMENT_THRESHOLD = 0.25
 
-export function determineLabelMode(requestedLabelMode: LegendLayout, positiveItems: SeriesData[], legendDenominator: number): LegendLayout {
+function determineLabelMode(requestedLabelMode: LegendLayout, positiveItems: SeriesData[], legendDenominator: number): LegendLayout {
   if (legendDenominator <= 0) return LegendLayout.Table
 
   const hasSmallSegment = positiveItems.some(

--- a/src/components/ui/SummaryCard/SummaryCard.tsx
+++ b/src/components/ui/SummaryCard/SummaryCard.tsx
@@ -1,6 +1,7 @@
 import { type PropsWithChildren, type ReactNode } from 'react'
 import classNames from 'classnames'
 
+import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
 import { Span } from '@ui/Typography/Text'
@@ -16,8 +17,10 @@ type PrimaryActionProps = {
 }
 const PrimaryAction = ({ content, onClick }: PrimaryActionProps) => {
   return (
-    <div className='Layer__SummaryCard__HeaderPrimaryAction' onClick={onClick}>
-      {content}
+    <div className='Layer__SummaryCard__HeaderPrimaryAction'>
+      <Button icon variant='ghost' onClick={onClick}>
+        {content}
+      </Button>
     </div>
   )
 }

--- a/src/components/ui/SummaryCard/SummaryCard.tsx
+++ b/src/components/ui/SummaryCard/SummaryCard.tsx
@@ -2,7 +2,6 @@ import { type PropsWithChildren, type ReactNode } from 'react'
 import classNames from 'classnames'
 
 import { HStack, VStack } from '@ui/Stack/Stack'
-import { type SummaryCardInteractionProps } from '@ui/SummaryCard/useSummaryCardSlots'
 import { Heading } from '@ui/Typography/Heading'
 import { Span } from '@ui/Typography/Text'
 import { Card } from '@components/Card/Card'
@@ -18,7 +17,6 @@ type SummaryCardSlotProps = {
 
 export type SummaryCardProps = PropsWithChildren<{
   slots: SummaryCardSlotProps
-  interactionProps?: SummaryCardInteractionProps
   className?: string
 }>
 

--- a/src/components/ui/SummaryCard/SummaryCard.tsx
+++ b/src/components/ui/SummaryCard/SummaryCard.tsx
@@ -8,6 +8,20 @@ import { Card } from '@components/Card/Card'
 
 import './summaryCard.scss'
 
+import { type SummaryCardInteractionProps } from './useSummaryCardSlots'
+
+type PrimaryActionProps = {
+  content: ReactNode
+  onClick: () => void
+}
+const PrimaryAction = ({ content, onClick }: PrimaryActionProps) => {
+  return (
+    <div className='Layer__SummaryCard__HeaderPrimaryAction' onClick={onClick}>
+      {content}
+    </div>
+  )
+}
+
 export type SummaryCardProps = PropsWithChildren<{
   slots: {
     title: ReactNode
@@ -15,11 +29,13 @@ export type SummaryCardProps = PropsWithChildren<{
     legend?: ReactNode
     primaryAction?: ReactNode
   }
+  interactionProps?: SummaryCardInteractionProps
   className?: string
 }>
 
 export const SummaryCard = ({
   slots,
+  interactionProps,
   children,
   className,
 }: SummaryCardProps) => {
@@ -59,10 +75,8 @@ export const SummaryCard = ({
                   {legend}
                 </div>
               )}
-              {primaryAction && (
-                <div className='Layer__SummaryCard__HeaderPrimaryAction'>
-                  {primaryAction}
-                </div>
+              {(primaryAction && interactionProps?.onClickExpand) && (
+                <PrimaryAction content={primaryAction} onClick={interactionProps.onClickExpand} />
               )}
             </HStack>
           )}

--- a/src/components/ui/SummaryCard/SummaryCard.tsx
+++ b/src/components/ui/SummaryCard/SummaryCard.tsx
@@ -1,44 +1,29 @@
 import { type PropsWithChildren, type ReactNode } from 'react'
 import classNames from 'classnames'
 
-import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
+import { type SummaryCardInteractionProps } from '@ui/SummaryCard/useSummaryCardSlots'
 import { Heading } from '@ui/Typography/Heading'
 import { Span } from '@ui/Typography/Text'
 import { Card } from '@components/Card/Card'
 
 import './summaryCard.scss'
 
-import { type SummaryCardInteractionProps } from './useSummaryCardSlots'
-
-type PrimaryActionProps = {
-  content: ReactNode
-  onClick: () => void
-}
-const PrimaryAction = ({ content, onClick }: PrimaryActionProps) => {
-  return (
-    <div className='Layer__SummaryCard__HeaderPrimaryAction'>
-      <Button icon variant='ghost' onClick={onClick}>
-        {content}
-      </Button>
-    </div>
-  )
+type SummaryCardSlotProps = {
+  title: ReactNode
+  subtitle?: ReactNode
+  legend?: ReactNode
+  primaryAction?: ReactNode
 }
 
 export type SummaryCardProps = PropsWithChildren<{
-  slots: {
-    title: ReactNode
-    subtitle?: ReactNode
-    legend?: ReactNode
-    primaryAction?: ReactNode
-  }
+  slots: SummaryCardSlotProps
   interactionProps?: SummaryCardInteractionProps
   className?: string
 }>
 
 export const SummaryCard = ({
   slots,
-  interactionProps,
   children,
   className,
 }: SummaryCardProps) => {
@@ -78,9 +63,7 @@ export const SummaryCard = ({
                   {legend}
                 </div>
               )}
-              {(primaryAction && interactionProps?.onClickExpand) && (
-                <PrimaryAction content={primaryAction} onClick={interactionProps.onClickExpand} />
-              )}
+              {primaryAction}
             </HStack>
           )}
         </HStack>

--- a/src/components/ui/SummaryCard/summaryCard.scss
+++ b/src/components/ui/SummaryCard/summaryCard.scss
@@ -30,11 +30,6 @@
     min-inline-size: 0;
   }
 
-  &__HeaderPrimaryAction {
-    flex-shrink: 0;
-    min-inline-size: 0;
-  }
-
   &__Content {
     box-sizing: border-box;
     flex: 1 1 auto;

--- a/src/views/SolopreneurOverview/SolopreneurOverview.tsx
+++ b/src/views/SolopreneurOverview/SolopreneurOverview.tsx
@@ -1,9 +1,8 @@
-import { type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { type OnboardingStep } from '@internal-types/layerContext'
 import type { Variants } from '@utils/styleUtils/sizeVariants'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import { type SummaryCardInteractionProps, type SummaryCardStringOverrides } from '@ui/SummaryCard/useSummaryCardSlots'
 import { ExpensesSummaryCard } from '@components/ExpensesSummaryCard/ExpensesSummaryCard'
 import { GlobalMonthPicker } from '@components/GlobalMonthPicker/GlobalMonthPicker'
 import { Header } from '@components/Header/Header'
@@ -22,34 +21,36 @@ import {
   TaxEstimatesSummaryCardMode,
 } from '@components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard'
 import { View } from '@components/View/View'
-import { type TagOption } from '@views/ProjectProfitability/ProjectProfitability'
 
 import './solopreneurOverview.scss'
-
-type CardStringOverrides = {
-  header?: string
-}
 
 interface SolopreneurOverviewStringOverrides {
   title?: string
   profitAndLossSummaries?: ProfitAndLossSummariesStringOverrides
-  cards?: {
-    profitAndLoss?: CardStringOverrides
-    expenses?: CardStringOverrides
-    taxEstimates?: CardStringOverrides
-    mileageTracking?: CardStringOverrides
+  summaryCards?: {
+    profitAndLoss?: SummaryCardStringOverrides
+    expenses?: SummaryCardStringOverrides
+    taxEstimates?: SummaryCardStringOverrides
+    mileageTracking?: SummaryCardStringOverrides
+  }
+}
+
+interface SolopreneurOverviewInteractionProps {
+  common?: {
+    onTransactionsToReviewClick?: () => void
+  }
+  summaryCards?: {
+    profitAndLoss?: SummaryCardInteractionProps
+    expenses?: SummaryCardInteractionProps
+    taxEstimates?: SummaryCardInteractionProps
+    mileageTracking?: SummaryCardInteractionProps
   }
 }
 
 export interface SolopreneurOverviewProps {
-  showTitle?: boolean
-  enableOnboarding?: boolean
-  onboardingStepOverride?: OnboardingStep
-  onTransactionsToReviewClick?: () => void
-  middleBanner?: ReactNode
   chartColorsList?: string[]
   stringOverrides?: SolopreneurOverviewStringOverrides
-  tagFilter?: TagOption
+  interactionProps?: SolopreneurOverviewInteractionProps
   slotProps?: {
     profitAndLoss?: {
       summaries?: {
@@ -60,14 +61,9 @@ export interface SolopreneurOverviewProps {
 }
 
 export const SolopreneurOverview = ({
-  showTitle = true,
-  enableOnboarding = false,
-  onboardingStepOverride = undefined,
-  onTransactionsToReviewClick,
-  middleBanner,
+  interactionProps,
   chartColorsList,
   stringOverrides,
-  tagFilter = undefined,
   slotProps,
 }: SolopreneurOverviewProps) => {
   const { t } = useTranslation()
@@ -77,17 +73,10 @@ export const SolopreneurOverview = ({
     slotProps?.profitAndLoss?.summaries?.variants
 
   return (
-    <ProfitAndLoss
-      asContainer={false}
-      tagFilter={
-        tagFilter
-          ? { key: tagFilter.tagKey, values: tagFilter.tagValues }
-          : undefined
-      }
-    >
+    <ProfitAndLoss asContainer={false}>
       <View
         title={stringOverrides?.title || t('common:label.overview', 'Overview')}
-        showHeader={showTitle}
+        showHeader
         header={(
           <Header>
             <HeaderRow>
@@ -98,33 +87,32 @@ export const SolopreneurOverview = ({
           </Header>
         )}
       >
-        {enableOnboarding && (
-          <Onboarding
-            onTransactionsToReviewClick={onTransactionsToReviewClick}
-            onboardingStepOverride={onboardingStepOverride}
-          />
-        )}
+        <Onboarding onTransactionsToReviewClick={interactionProps?.common?.onTransactionsToReviewClick} />
         <ProfitAndLossSummaries
           stringOverrides={stringOverrides?.profitAndLossSummaries}
           chartColorsList={chartColorsList}
-          onTransactionsToReviewClick={onTransactionsToReviewClick}
+          onTransactionsToReviewClick={interactionProps?.common?.onTransactionsToReviewClick}
           variants={profitAndLossSummariesVariants}
         />
-        {middleBanner}
         <div className='Layer__SolopreneurOverview__Grid'>
           <ProfitAndLossSummaryCard
-            stringOverrides={{ title: stringOverrides?.cards?.profitAndLoss?.header }}
+            stringOverrides={stringOverrides?.summaryCards?.profitAndLoss}
+            interactionProps={interactionProps?.summaryCards?.profitAndLoss}
           />
           <ExpensesSummaryCard
             stylingProps={{ chartColorsList }}
-            stringOverrides={{ title: stringOverrides?.cards?.expenses?.header }}
+            stringOverrides={stringOverrides?.summaryCards?.expenses}
+            interactionProps={interactionProps?.summaryCards?.expenses}
           />
           <TaxEstimatesSummaryCard
             mode={TaxEstimatesSummaryCardMode.HorizontalBarChart}
-            withHeaderSeparator
-            title={stringOverrides?.cards?.taxEstimates?.header}
+            stringOverrides={stringOverrides?.summaryCards?.taxEstimates}
+            interactionProps={interactionProps?.summaryCards?.taxEstimates}
           />
-          <MileageTrackingSummary {...stringOverrides?.cards?.mileageTracking} />
+          <MileageTrackingSummary
+            interactionProps={interactionProps?.summaryCards?.mileageTracking}
+            stringOverrides={stringOverrides?.summaryCards?.mileageTracking}
+          />
         </div>
       </View>
     </ProfitAndLoss>

--- a/src/views/SolopreneurOverview/SolopreneurOverview.tsx
+++ b/src/views/SolopreneurOverview/SolopreneurOverview.tsx
@@ -8,7 +8,6 @@ import { Header } from '@components/Header/Header'
 import { HeaderCol } from '@components/Header/HeaderCol'
 import { HeaderRow } from '@components/Header/HeaderRow'
 import { MileageTrackingSummary } from '@components/MileageTrackingSummary/MileageTrackingSummary'
-import { Onboarding } from '@components/Onboarding/Onboarding'
 import { ProfitAndLoss } from '@components/ProfitAndLoss/ProfitAndLoss'
 import {
   ProfitAndLossSummaries,
@@ -35,7 +34,7 @@ interface SolopreneurOverviewStringOverrides {
 }
 
 interface SolopreneurOverviewInteractionProps {
-  common?: {
+  profitAndLossSummaries?: {
     onTransactionsToReviewClick?: () => void
   }
   summaryCards?: {
@@ -75,11 +74,10 @@ export const SolopreneurOverview = ({
           </Header>
         )}
       >
-        <Onboarding onTransactionsToReviewClick={interactionProps?.common?.onTransactionsToReviewClick} />
         <ProfitAndLossSummaries
           stringOverrides={stringOverrides?.profitAndLossSummaries}
           chartColorsList={chartColorsList}
-          onTransactionsToReviewClick={interactionProps?.common?.onTransactionsToReviewClick}
+          onTransactionsToReviewClick={interactionProps?.profitAndLossSummaries?.onTransactionsToReviewClick}
         />
         <div className='Layer__SolopreneurOverview__Grid'>
           <ProfitAndLossSummaryCard

--- a/src/views/SolopreneurOverview/SolopreneurOverview.tsx
+++ b/src/views/SolopreneurOverview/SolopreneurOverview.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next'
 
-import type { Variants } from '@utils/styleUtils/sizeVariants'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { type SummaryCardInteractionProps, type SummaryCardStringOverrides } from '@ui/SummaryCard/useSummaryCardSlots'
 import { ExpensesSummaryCard } from '@components/ExpensesSummaryCard/ExpensesSummaryCard'
@@ -51,26 +50,15 @@ export interface SolopreneurOverviewProps {
   chartColorsList?: string[]
   stringOverrides?: SolopreneurOverviewStringOverrides
   interactionProps?: SolopreneurOverviewInteractionProps
-  slotProps?: {
-    profitAndLoss?: {
-      summaries?: {
-        variants?: Variants
-      }
-    }
-  }
 }
 
 export const SolopreneurOverview = ({
   interactionProps,
   chartColorsList,
   stringOverrides,
-  slotProps,
 }: SolopreneurOverviewProps) => {
   const { t } = useTranslation()
   const { value: sizeClass } = useSizeClass()
-
-  const profitAndLossSummariesVariants =
-    slotProps?.profitAndLoss?.summaries?.variants
 
   return (
     <ProfitAndLoss asContainer={false}>
@@ -92,7 +80,6 @@ export const SolopreneurOverview = ({
           stringOverrides={stringOverrides?.profitAndLossSummaries}
           chartColorsList={chartColorsList}
           onTransactionsToReviewClick={interactionProps?.common?.onTransactionsToReviewClick}
-          variants={profitAndLossSummariesVariants}
         />
         <div className='Layer__SolopreneurOverview__Grid'>
           <ProfitAndLossSummaryCard


### PR DESCRIPTION
## Summary
- Migrate `MileageTrackingSummary` and `TaxEstimatesSummaryCard` onto the shared `SummaryCard` + `useSummaryCardSlots` pattern (matching `ProfitAndLoss`/`Expenses` cards).
- Normalize `SolopreneurOverview` props: `stringOverrides.cards` → `stringOverrides.summaryCards` (typed as `SummaryCardStringOverrides`), and group callbacks under `interactionProps.{common,summaryCards}`. Removes deprecated top-level props (`showTitle`, `enableOnboarding`, `onboardingStepOverride`, `onTransactionsToReviewClick`, `middleBanner`, `tagFilter`).
- Plumb `interactionProps` through `ExpensesSummaryCard`, `ProfitAndLossSummaryCard`, `TaxEstimatesSummaryCard`, `MileageTrackingSummary` so the expand affordance renders consistently from a single source.
- `SummaryCard` now gates the primary-action slot on `interactionProps.onClickExpand` and wires the click on a header wrapper.
- `ProfitAndLossSummaryCard` adds `Layer__UI__Chart--focusReset` and a mobile chart height clamp (`10rem` under 760px) plus `height: 100%` on the chart wrapper so the card fills its grid cell.
- `HorizontalBarChart`: auto-fallback to `LegendLayout.Table` when any positive segment is `< 25%` of the denominator, to avoid cramped inline labels (used by the tax estimates horizontal bar mode).
- Minor: drop unused `padding`/spacing rules from mileage + tax SCSS now that `SummaryCard` owns the chrome; un-export `OnboardingContent`.

## Test plan
- [ ] Visual: Solopreneur Overview grid at desktop / tablet / mobile — all four cards align, headers + expand buttons render consistently.
- [ ] PnL summary card: chart fills card on desktop; clamps to ~10rem on mobile; legend renders below chart on mobile.
- [ ] Tax estimates (horizontal bar mode): when one slice is `< 25%`, legend renders in Table layout; otherwise honors the passed `labelMode`.
- [ ] Empty tax estimates state fills the grid cell.
- [ ] Mileage card: header, stats, and chart match peer cards' padding.
- [ ] Expand callbacks fire for each card when `interactionProps.summaryCards.<name>.onClickExpand` is supplied.
- [ ] Type check passes; no consumers reference removed Overview props.

## Screenshots

Desktop

<img width="1684" height="1113" alt="image" src="https://github.com/user-attachments/assets/8f209fbc-e81a-4cbd-9aa4-bdb8354c4966" />

Mobile 1

<img width="397" height="893" alt="image" src="https://github.com/user-attachments/assets/75307c46-65ac-48d4-a875-e916754c98af" />

Mobile 2 

<img width="389" height="911" alt="Screenshot 2026-05-11 at 12 37 47 PM" src="https://github.com/user-attachments/assets/c22d2d50-4566-437e-984a-def68b19c0aa" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `SolopreneurOverview`’s public props and rewires multiple dashboard cards to a new `SummaryCard`/slots API, which could break consumers and subtly affect layout/interaction behavior.
> 
> **Overview**
> Unifies Solopreneur Overview’s summary tiles onto the shared `SummaryCard` + `useSummaryCardSlots` pattern by migrating `MileageTrackingSummary` and `TaxEstimatesSummaryCard` (and adjusting styling now that `SummaryCard` owns the header/padding).
> 
> Reshapes `SolopreneurOverview`’s API: replaces `stringOverrides.cards` with `stringOverrides.summaryCards` (typed as `SummaryCardStringOverrides`) and routes callbacks through a new `interactionProps` object; removes several previously supported top-level props (e.g. onboarding/banner/tag filter hooks).
> 
> Improves chart card presentation/robustness: `ProfitAndLossSummaryCard` updates structure/CSS to better fill its grid cell and reset chart focus styling, and `HorizontalBarChart` automatically falls back to `LegendLayout.Table` when any segment is too small to label inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 728142510f94533f045d9af20ea454883ef70300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->