### PR TITLE
chore: release v0.1.132-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.132-alpha.1",
+  "version": "0.1.132-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.132-alpha.1",
+      "version": "0.1.132-alpha.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.132-alpha.1",
+  "version": "0.1.132-alpha.2",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.132-alpha.2`.

- Mode: **alpha**
- Tag (post-merge): `v0.1.132-alpha.2`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a release/version bump only, with no functional code changes.
> 
> **Overview**
> Updates the package version from `0.1.132-alpha.1` to `0.1.132-alpha.2` in `package.json` and `package-lock.json` to publish the next alpha release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dede35000ab5bfe660ed880a230a6ae108cc5d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->