### PR TITLE
fix: handle null vehicle year

### DIFF
--- a/src/assets/locales/en-US/vehicles.json
+++ b/src/assets/locales/en-US/vehicles.json
@@ -32,6 +32,7 @@
     "enter_vin": "Enter VIN",
     "license_plate": "License plate",
     "make_model": "Make and model",
+    "unnamed_vehicle": "Unnamed Vehicle",
     "vehicle": "Vehicle",
     "vehicle_name_hidden_from_active_list": "{{vehicleName}} will be hidden from your active vehicles list. You can reactivate it at any time.",
     "vehicle_name_restored_to_active_list": "{{vehicleName}} will be restored to your active vehicles list and available for tracking trips.",

--- a/src/assets/locales/fr-CA/vehicles.json
+++ b/src/assets/locales/fr-CA/vehicles.json
@@ -32,6 +32,7 @@
     "enter_vin": "Saisissez le NIV",
     "license_plate": "Plaque d’immatriculation",
     "make_model": "Marque et modèle",
+    "unnamed_vehicle": "",
     "vehicle": "Véhicule",
     "vehicle_name_hidden_from_active_list": "{{vehicleName}} sera masqué de votre liste de véhicules actifs. Vous pourrez le réactiver en tout temps.",
     "vehicle_name_restored_to_active_list": "{{vehicleName}} sera restauré dans votre liste de véhicules actifs et pourra être utilisé pour faire le suivi de vos déplacements.",

--- a/src/components/Trips/TripsTable/TripsTable.tsx
+++ b/src/components/Trips/TripsTable/TripsTable.tsx
@@ -62,7 +62,7 @@ const getColumnConfig = (
   {
     id: TripColumns.Vehicle,
     header: t('vehicles:label.vehicle', 'Vehicle'),
-    cell: (row: TripsRowType) => <Span ellipsis withTooltip>{getVehicleDisplayName(row.original.vehicle, t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle'))}</Span>,
+    cell: (row: TripsRowType) => <Span ellipsis withTooltip>{getVehicleDisplayName(row.original.vehicle, t)}</Span>,
     isRowHeader: true,
   },
   {

--- a/src/components/Trips/TripsTable/TripsTable.tsx
+++ b/src/components/Trips/TripsTable/TripsTable.tsx
@@ -62,7 +62,7 @@ const getColumnConfig = (
   {
     id: TripColumns.Vehicle,
     header: t('vehicles:label.vehicle', 'Vehicle'),
-    cell: (row: TripsRowType) => <Span ellipsis withTooltip>{getVehicleDisplayName(row.original.vehicle)}</Span>,
+    cell: (row: TripsRowType) => <Span ellipsis withTooltip>{getVehicleDisplayName(row.original.vehicle, t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle'))}</Span>,
     isRowHeader: true,
   },
   {

--- a/src/components/VehicleManagement/VehicleArchiveConfirmationModal.tsx
+++ b/src/components/VehicleManagement/VehicleArchiveConfirmationModal.tsx
@@ -25,7 +25,7 @@ export function VehicleArchiveConfirmationModal({
     await archiveVehicle()
   }, [archiveVehicle])
 
-  const vehicleName = getVehicleDisplayName(vehicle)
+  const vehicleName = getVehicleDisplayName(vehicle, t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle'))
 
   return (
     <BaseConfirmationModal

--- a/src/components/VehicleManagement/VehicleArchiveConfirmationModal.tsx
+++ b/src/components/VehicleManagement/VehicleArchiveConfirmationModal.tsx
@@ -25,7 +25,7 @@ export function VehicleArchiveConfirmationModal({
     await archiveVehicle()
   }, [archiveVehicle])
 
-  const vehicleName = getVehicleDisplayName(vehicle, t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle'))
+  const vehicleName = getVehicleDisplayName(vehicle, t)
 
   return (
     <BaseConfirmationModal

--- a/src/components/VehicleManagement/VehicleCard.tsx
+++ b/src/components/VehicleManagement/VehicleCard.tsx
@@ -47,7 +47,7 @@ export const VehicleCard = ({ vehicle, onEdit }: VehicleCardProps) => {
     [t],
   )
 
-  const vehicleName = getVehicleDisplayName(vehicle, t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle'))
+  const vehicleName = getVehicleDisplayName(vehicle, t)
   const isArchived = vehicle.archivedAt !== null && vehicle.archivedAt !== undefined
 
   return (

--- a/src/components/VehicleManagement/VehicleCard.tsx
+++ b/src/components/VehicleManagement/VehicleCard.tsx
@@ -47,7 +47,7 @@ export const VehicleCard = ({ vehicle, onEdit }: VehicleCardProps) => {
     [t],
   )
 
-  const vehicleName = getVehicleDisplayName(vehicle)
+  const vehicleName = getVehicleDisplayName(vehicle, t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle'))
   const isArchived = vehicle.archivedAt !== null && vehicle.archivedAt !== undefined
 
   return (

--- a/src/components/VehicleManagement/VehicleDeleteConfirmationModal.tsx
+++ b/src/components/VehicleManagement/VehicleDeleteConfirmationModal.tsx
@@ -25,7 +25,7 @@ export function VehicleDeleteConfirmationModal({
     await deleteVehicle()
   }, [deleteVehicle])
 
-  const vehicleName = getVehicleDisplayName(vehicle)
+  const vehicleName = getVehicleDisplayName(vehicle, t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle'))
 
   return (
     <BaseConfirmationModal

--- a/src/components/VehicleManagement/VehicleDeleteConfirmationModal.tsx
+++ b/src/components/VehicleManagement/VehicleDeleteConfirmationModal.tsx
@@ -25,7 +25,7 @@ export function VehicleDeleteConfirmationModal({
     await deleteVehicle()
   }, [deleteVehicle])
 
-  const vehicleName = getVehicleDisplayName(vehicle, t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle'))
+  const vehicleName = getVehicleDisplayName(vehicle, t)
 
   return (
     <BaseConfirmationModal

--- a/src/components/VehicleManagement/VehicleForm/formUtils.ts
+++ b/src/components/VehicleManagement/VehicleForm/formUtils.ts
@@ -47,7 +47,7 @@ export const validateVehicleForm = ({ vehicle }: { vehicle: VehicleForm }) => {
   }
 
   const currentYear = new Date().getFullYear()
-  if (!Number.isNaN(year) && (year < 1900 || year > currentYear + 1)) {
+  if (year != null && !Number.isNaN(year) && (year < 1900 || year > currentYear + 1)) {
     errors.push({ field: 'year', reason: VehicleFormInvalidReason.YearRange })
   }
 

--- a/src/components/VehicleManagement/VehicleReactivateConfirmationModal.tsx
+++ b/src/components/VehicleManagement/VehicleReactivateConfirmationModal.tsx
@@ -25,7 +25,7 @@ export function VehicleReactivateConfirmationModal({
     await reactivateVehicle()
   }, [reactivateVehicle])
 
-  const vehicleName = getVehicleDisplayName(vehicle, t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle'))
+  const vehicleName = getVehicleDisplayName(vehicle, t)
 
   return (
     <BaseConfirmationModal

--- a/src/components/VehicleManagement/VehicleReactivateConfirmationModal.tsx
+++ b/src/components/VehicleManagement/VehicleReactivateConfirmationModal.tsx
@@ -25,7 +25,7 @@ export function VehicleReactivateConfirmationModal({
     await reactivateVehicle()
   }, [reactivateVehicle])
 
-  const vehicleName = getVehicleDisplayName(vehicle)
+  const vehicleName = getVehicleDisplayName(vehicle, t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle'))
 
   return (
     <BaseConfirmationModal

--- a/src/components/VehicleManagement/VehicleSelector/VehicleSelector.tsx
+++ b/src/components/VehicleManagement/VehicleSelector/VehicleSelector.tsx
@@ -11,14 +11,15 @@ import { P } from '@ui/Typography/Text'
 import { Label } from '@ui/Typography/Text'
 
 import './vehicleSelector.scss'
+import { TFunction } from 'i18next'
 
 class VehicleAsOption {
   private internalVehicle: Vehicle
-  private unnamedVehicleString: string
+  private t: TFunction
 
-  constructor(vehicle: Vehicle, unnamedVehicleString: string) {
+  constructor(vehicle: Vehicle, t: TFunction) {
     this.internalVehicle = vehicle
-    this.unnamedVehicleString = unnamedVehicleString
+    this.t = t
   }
 
   get original() {
@@ -26,7 +27,7 @@ class VehicleAsOption {
   }
 
   get label() {
-    return getVehicleDisplayName(this.internalVehicle, this.unnamedVehicleString)
+    return getVehicleDisplayName(this.internalVehicle, this.t)
   }
 
   get id() {
@@ -78,7 +79,7 @@ export function VehicleSelector({
   const unnamedVehicleString = t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle')
 
   const options = useMemo(() => {
-    return data?.map(vehicle => new VehicleAsOption(vehicle, unnamedVehicleString)) || []
+    return data?.map(vehicle => new VehicleAsOption(vehicle, t)) || []
   }, [data, unnamedVehicleString])
 
   const onSelectedValueChange = useCallback((option: VehicleAsOption | null) => {
@@ -91,7 +92,7 @@ export function VehicleSelector({
         return null
       }
 
-      return new VehicleAsOption(selectedVehicle, unnamedVehicleString)
+      return new VehicleAsOption(selectedVehicle, t)
     },
     [selectedVehicle, unnamedVehicleString],
   )

--- a/src/components/VehicleManagement/VehicleSelector/VehicleSelector.tsx
+++ b/src/components/VehicleManagement/VehicleSelector/VehicleSelector.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useId, useMemo } from 'react'
 import classNames from 'classnames'
+import { type TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 
 import { type Vehicle } from '@schemas/vehicle'
@@ -11,7 +12,6 @@ import { P } from '@ui/Typography/Text'
 import { Label } from '@ui/Typography/Text'
 
 import './vehicleSelector.scss'
-import { TFunction } from 'i18next'
 
 class VehicleAsOption {
   private internalVehicle: Vehicle
@@ -76,11 +76,9 @@ export function VehicleSelector({
 
   const { data, isLoading, isError } = useListVehicles()
 
-  const unnamedVehicleString = t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle')
-
   const options = useMemo(() => {
     return data?.map(vehicle => new VehicleAsOption(vehicle, t)) || []
-  }, [data, unnamedVehicleString])
+  }, [data, t])
 
   const onSelectedValueChange = useCallback((option: VehicleAsOption | null) => {
     onSelectedVehicleChange(option?.original || null)
@@ -94,7 +92,7 @@ export function VehicleSelector({
 
       return new VehicleAsOption(selectedVehicle, t)
     },
-    [selectedVehicle, unnamedVehicleString],
+    [selectedVehicle, t],
   )
 
   const EmptyMessage = useMemo(

--- a/src/components/VehicleManagement/VehicleSelector/VehicleSelector.tsx
+++ b/src/components/VehicleManagement/VehicleSelector/VehicleSelector.tsx
@@ -14,9 +14,11 @@ import './vehicleSelector.scss'
 
 class VehicleAsOption {
   private internalVehicle: Vehicle
+  private unnamedVehicleString: string
 
-  constructor(vehicle: Vehicle) {
+  constructor(vehicle: Vehicle, unnamedVehicleString: string) {
     this.internalVehicle = vehicle
+    this.unnamedVehicleString = unnamedVehicleString
   }
 
   get original() {
@@ -24,7 +26,7 @@ class VehicleAsOption {
   }
 
   get label() {
-    return getVehicleDisplayName(this.internalVehicle)
+    return getVehicleDisplayName(this.internalVehicle, this.unnamedVehicleString)
   }
 
   get id() {
@@ -73,9 +75,11 @@ export function VehicleSelector({
 
   const { data, isLoading, isError } = useListVehicles()
 
+  const unnamedVehicleString = t('vehicles:label.unnamed_vehicle', 'Unnamed Vehicle')
+
   const options = useMemo(() => {
-    return data?.map(vehicle => new VehicleAsOption(vehicle)) || []
-  }, [data])
+    return data?.map(vehicle => new VehicleAsOption(vehicle, unnamedVehicleString)) || []
+  }, [data, unnamedVehicleString])
 
   const onSelectedValueChange = useCallback((option: VehicleAsOption | null) => {
     onSelectedVehicleChange(option?.original || null)
@@ -87,9 +91,9 @@ export function VehicleSelector({
         return null
       }
 
-      return new VehicleAsOption(selectedVehicle)
+      return new VehicleAsOption(selectedVehicle, unnamedVehicleString)
     },
-    [selectedVehicle],
+    [selectedVehicle, unnamedVehicleString],
   )
 
   const EmptyMessage = useMemo(

--- a/src/schemas/vehicle.ts
+++ b/src/schemas/vehicle.ts
@@ -18,7 +18,7 @@ export const VehicleSchema = Schema.Struct({
     Schema.fromKey('make_and_model'),
   ),
 
-  year: Schema.Number,
+  year: Schema.NullishOr(Schema.Number),
 
   licensePlate: pipe(
     Schema.propertySignature(Schema.NullishOr(Schema.String)),
@@ -65,7 +65,7 @@ export type VehicleEncoded = typeof VehicleSchema.Encoded
 
 export const VehicleFormSchema = Schema.Struct({
   makeAndModel: Schema.String,
-  year: Schema.Number,
+  year: Schema.NullishOr(Schema.Number),
   licensePlate: Schema.String,
   vin: Schema.String,
   description: Schema.String,
@@ -79,7 +79,7 @@ export const UpsertVehicleSchema = Schema.Struct({
     Schema.propertySignature(Schema.String),
     Schema.fromKey('make_and_model'),
   ),
-  year: Schema.Number,
+  year: Schema.NullishOr(Schema.Number),
   licensePlate: pipe(
     Schema.propertySignature(Schema.NullishOr(Schema.String)),
     Schema.fromKey('license_plate'),

--- a/src/utils/vehicles.ts
+++ b/src/utils/vehicles.ts
@@ -1,6 +1,8 @@
-import type { Vehicle } from '@schemas/vehicle'
-import { translationKey } from './i18n/translationKey'
 import type { TFunction } from 'i18next'
+
+import type { Vehicle } from '@schemas/vehicle'
+
+import { translationKey } from './i18n/translationKey'
 
 const unnamedVehicle = translationKey('vehicles:label.unnamed_vehicle', 'Unnamed vehicle')
 

--- a/src/utils/vehicles.ts
+++ b/src/utils/vehicles.ts
@@ -1,4 +1,13 @@
 import type { Vehicle } from '@schemas/vehicle'
 
-export const getVehicleDisplayName = (vehicle: Vehicle | null | undefined): string =>
-  vehicle ? `${vehicle.year} ${vehicle.makeAndModel}` : ''
+export const getVehicleDisplayName = (vehicle: Vehicle | null | undefined, unnamedVehicleString: string): string => {
+  if (!vehicle) return ''
+
+  const makeAndModel = vehicle.makeAndModel.trim()
+
+  if (vehicle.year == null) {
+    return makeAndModel || unnamedVehicleString
+  }
+
+  return `${vehicle.year} ${makeAndModel}`.trim()
+}

--- a/src/utils/vehicles.ts
+++ b/src/utils/vehicles.ts
@@ -1,12 +1,16 @@
 import type { Vehicle } from '@schemas/vehicle'
+import { translationKey } from './i18n/translationKey'
+import type { TFunction } from 'i18next'
 
-export const getVehicleDisplayName = (vehicle: Vehicle | null | undefined, unnamedVehicleString: string): string => {
+const unnamedVehicle = translationKey('vehicles:label.unnamed_vehicle', 'Unnamed vehicle')
+
+export const getVehicleDisplayName = (vehicle: Vehicle | null | undefined, t: TFunction): string => {
   if (!vehicle) return ''
 
   const makeAndModel = vehicle.makeAndModel.trim()
 
   if (vehicle.year == null) {
-    return makeAndModel || unnamedVehicleString
+    return makeAndModel || t(unnamedVehicle.i18nKey, unnamedVehicle.defaultValue)
   }
 
   return `${vehicle.year} ${makeAndModel}`.trim()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `Vehicle`/`UpsertVehicle` schema to allow `year` to be nullish and updates multiple UI call sites to pass translation functions, which could impact validation and vehicle labeling across the app.
> 
> **Overview**
> Vehicles can now have a *null/undefined* `year` end-to-end: `VehicleSchema`, `VehicleFormSchema`, and `UpsertVehicleSchema` were updated to accept `NullishOr(Number)`, and form validation was tweaked to avoid range-checking when `year` is unset.
> 
> Vehicle name rendering was hardened and localized by updating `getVehicleDisplayName` to handle missing `year` (and empty make/model) with an `unnamed_vehicle` fallback, and updating call sites (trips table, vehicle cards, archive/delete/reactivate modals, and the vehicle selector) to pass `t`. Adds the new `vehicles:label.unnamed_vehicle` string (FR-CA currently empty).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0bf4d8ee0ac033eebd3f5d4deb66d2811f7a00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->