### PR TITLE
fix: tax profile back button no longer available if you haven't been onboarded yet

### DIFF
--- a/src/views/TaxEstimates/TaxProfile.tsx
+++ b/src/views/TaxEstimates/TaxProfile.tsx
@@ -14,10 +14,13 @@ export const TaxProfile = () => {
   const { t } = useTranslation()
   const navigate = useTaxEstimatesNavigation()
   const { data: taxProfile } = useTaxProfile()
+  const hasSavedTaxProfile = taxProfile?.userHasSavedTaxProfile === true
 
   const handleGoBack = useCallback(() => {
-    navigate.toEstimates()
-  }, [navigate])
+    if (hasSavedTaxProfile) {
+      navigate.toEstimates()
+    }
+  }, [navigate, hasSavedTaxProfile])
 
   const TaxProfileHeader = useCallback(() => {
     return <Heading size='md'>{t('taxEstimates:label.tax_profile', 'Tax Profile')}</Heading>
@@ -27,7 +30,7 @@ export const TaxProfile = () => {
     <BaseDetailView
       slots={{ Header: TaxProfileHeader, BackIcon: BackArrow }}
       name='TaxProfile'
-      onGoBack={handleGoBack}
+      onGoBack={hasSavedTaxProfile ? handleGoBack : undefined}
     >
       <TaxProfileForm taxProfile={taxProfile} />
     </BaseDetailView>


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

This button, which leads to the estimates page, NOOPs when you are not yet onboarded.

This PR removes the button when not onboarded.

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<img width="1238" height="824" alt="image" src="https://github.com/user-attachments/assets/26a701a7-e196-4e70-bccd-66e4b6069c92" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change that only affects navigation from the Tax Profile screen; no data or auth logic is modified.
> 
> **Overview**
> Prevents users who haven’t completed/saved their tax profile from seeing/using the back button on the Tax Profile view.
> 
> `TaxProfile` now gates `onGoBack` (and the `navigate.toEstimates()` action) behind `taxProfile.userHasSavedTaxProfile`, so the back button is omitted rather than doing nothing when onboarding isn’t complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2ceb1a1996baa487c8ed9e8332e87db07bce29a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->