### PR TITLE
fix: isolate task mutation state per task to prevent concurrent submission bugs

### DIFF
--- a/src/components/Tasks/TasksListItem.tsx
+++ b/src/components/Tasks/TasksListItem.tsx
@@ -29,10 +29,10 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
   const [userResponse, setUserResponse] = useState(task.user_response ?? '')
   const [selectedFiles, setSelectedFiles] = useState<File[]>()
 
-  const { trigger: handleSubmitUserResponseForTask } = useSubmitUserResponseForTask()
-  const { trigger: handleUploadDocumentsForTask } = useUploadDocumentsForTask()
-  const { trigger: handleDeleteUploadsOnTask } = useDeleteUploadsOnTask()
-  const { trigger: handleUpdateTaskUploadDescription } = useUpdateTaskUploadDescription()
+  const { trigger: handleSubmitUserResponseForTask, isMutating: isSubmittingResponse } = useSubmitUserResponseForTask(task.id)
+  const { trigger: handleUploadDocumentsForTask, isMutating: isUploadingDocuments } = useUploadDocumentsForTask(task.id)
+  const { trigger: handleDeleteUploadsOnTask } = useDeleteUploadsOnTask(task.id)
+  const { trigger: handleUpdateTaskUploadDescription } = useUpdateTaskUploadDescription(task.id)
 
   const taskBodyClassName = classNames(
     'Layer__tasks-list-item__body',
@@ -62,7 +62,6 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
     }
 
     await handleUploadDocumentsForTask({
-      taskId: task.id,
       files: selectedFiles,
       description: userResponse,
     })
@@ -102,6 +101,7 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
               <Button
                 variant={ButtonVariant.primary}
                 onClick={() => void submit()}
+                disabled={isUploadingDocuments}
               >
                 {t('common:action.submit_label', 'Submit')}
               </Button>
@@ -116,7 +116,6 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
               variant={ButtonVariant.secondary}
               onClick={() => {
                 void handleUpdateTaskUploadDescription({
-                  taskId: task.id,
                   description: userResponse,
                 })
               }}
@@ -130,9 +129,7 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
             <Button
               variant={ButtonVariant.secondary}
               onClick={() => {
-                void handleDeleteUploadsOnTask({
-                  taskId: task.id,
-                })
+                void handleDeleteUploadsOnTask()
               }}
             >
               {t('bookkeeping:action.delete_uploads', 'Delete Uploads')}
@@ -143,7 +140,7 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
       else { return null }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [t, task, selectedFiles, userResponse])
+  }, [t, task, selectedFiles, userResponse, isUploadingDocuments])
 
   return (
     <div className='Layer__tasks-list-item-wrapper' ref={ref}>
@@ -204,12 +201,13 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
                 : (
                   <Button
                     disabled={
-                      userResponse.length === 0
+                      isSubmittingResponse
+                      || userResponse.length === 0
                       || userResponse === task.user_response
                     }
                     variant={ButtonVariant.secondary}
                     onClick={() => {
-                      void handleSubmitUserResponseForTask({ taskId: task.id, userResponse })
+                      void handleSubmitUserResponseForTask({ userResponse })
                         .then(() => {
                           setIsOpen(false)
                         })

--- a/src/components/Tasks/TasksListMobile.tsx
+++ b/src/components/Tasks/TasksListMobile.tsx
@@ -38,7 +38,7 @@ export const TasksListMobile = ({
     <div className='Layer__tasks-list'>
       {unresolvedTasks.map((task, index) => (
         <TasksListItem
-          key={index}
+          key={task.id}
           task={task}
           defaultOpen={index === indexFirstIncomplete}
         />
@@ -69,7 +69,7 @@ export const TasksListMobile = ({
             <div className='Layer__tasks-list'>
               {sortedTasks.map((task, index) => (
                 <TasksListItem
-                  key={index}
+                  key={task.id}
                   task={task}
                   defaultOpen={index === indexFirstIncomplete}
                 />

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/delete/useDeleteUploadsOnTask.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/delete/useDeleteUploadsOnTask.ts
@@ -26,26 +26,25 @@ function buildKey({
   access_token: accessToken,
   apiUrl,
   businessId,
+  taskId,
 }: {
   access_token?: string
   apiUrl?: string
   businessId: string
+  taskId: string
 }) {
   if (accessToken && apiUrl) {
     return {
       accessToken,
       apiUrl,
       businessId,
+      taskId,
       tags: ['#delete-uploads-on-task'],
     } as const
   }
 }
 
-type UseDeleteUploadsOnTaskArg = {
-  taskId: string
-}
-
-export function useDeleteUploadsOnTask() {
+export function useDeleteUploadsOnTask(taskId: string) {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
@@ -55,10 +54,10 @@ export function useDeleteUploadsOnTask() {
     () => withLocale(buildKey({
       ...auth,
       businessId,
+      taskId,
     })),
     (
       { accessToken, apiUrl, businessId },
-      { arg: { taskId } }: { arg: UseDeleteUploadsOnTaskArg },
     ) => deleteUploadsOnTask(
       apiUrl,
       accessToken,

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/useUpdateTaskUploadDescription.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/useUpdateTaskUploadDescription.ts
@@ -31,27 +31,29 @@ function buildKey({
   access_token: accessToken,
   apiUrl,
   businessId,
+  taskId,
 }: {
   access_token?: string
   apiUrl?: string
   businessId: string
+  taskId: string
 }) {
   if (accessToken && apiUrl) {
     return {
       accessToken,
       apiUrl,
       businessId,
+      taskId,
       tags: ['#update-task-upload-description'],
     } as const
   }
 }
 
 type UseUpdateTaskUploadDescriptionArg = {
-  taskId: string
   description: string
 }
 
-export function useUpdateTaskUploadDescription() {
+export function useUpdateTaskUploadDescription(taskId: string) {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
@@ -61,10 +63,11 @@ export function useUpdateTaskUploadDescription() {
     () => withLocale(buildKey({
       ...auth,
       businessId,
+      taskId,
     })),
     (
       { accessToken, apiUrl, businessId },
-      { arg: { taskId, description } }: { arg: UseUpdateTaskUploadDescriptionArg },
+      { arg: { description } }: { arg: UseUpdateTaskUploadDescriptionArg },
     ) => updateTaskUploadsDescription(
       apiUrl,
       accessToken,

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/useUploadDocumentsForTask.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/useUploadDocumentsForTask.ts
@@ -44,28 +44,30 @@ function buildKey({
   access_token: accessToken,
   apiUrl,
   businessId,
+  taskId,
 }: {
   access_token?: string
   apiUrl?: string
   businessId: string
+  taskId: string
 }) {
   if (accessToken && apiUrl) {
     return {
       accessToken,
       apiUrl,
       businessId,
+      taskId,
       tags: ['#use-upload-documents-for-task'],
     } as const
   }
 }
 
 type UseUploadDocumentsForTaskArg = {
-  taskId: string
   files: ReadonlyArray<File>
   description?: string
 }
 
-export function useUploadDocumentsForTask() {
+export function useUploadDocumentsForTask(taskId: string) {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
@@ -75,10 +77,11 @@ export function useUploadDocumentsForTask() {
     () => withLocale(buildKey({
       ...auth,
       businessId,
+      taskId,
     })),
     (
       { accessToken, apiUrl, businessId },
-      { arg: { taskId, files, description } }: { arg: UseUploadDocumentsForTaskArg },
+      { arg: { files, description } }: { arg: UseUploadDocumentsForTaskArg },
     ) => completeTaskWithUpload(
       apiUrl,
       accessToken,

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/user-response/useSubmitResponseForTask.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/user-response/useSubmitResponseForTask.ts
@@ -30,27 +30,29 @@ function buildKey({
   access_token: accessToken,
   apiUrl,
   businessId,
+  taskId,
 }: {
   access_token?: string
   apiUrl?: string
   businessId: string
+  taskId: string
 }) {
   if (accessToken && apiUrl) {
     return {
       accessToken,
       apiUrl,
       businessId,
+      taskId,
       tags: ['#submit-user-response-for-task'],
     } as const
   }
 }
 
 type UseSubmitUserResponseForTaskArg = {
-  taskId: string
   userResponse: string
 }
 
-export function useSubmitUserResponseForTask() {
+export function useSubmitUserResponseForTask(taskId: string) {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
@@ -60,10 +62,11 @@ export function useSubmitUserResponseForTask() {
     () => withLocale(buildKey({
       ...auth,
       businessId,
+      taskId,
     })),
     (
       { accessToken, apiUrl, businessId },
-      { arg: { taskId, userResponse } }: { arg: UseSubmitUserResponseForTaskArg },
+      { arg: { userResponse } }: { arg: UseSubmitUserResponseForTaskArg },
     ) => submitUserResponseForTask(
       apiUrl,
       accessToken,


### PR DESCRIPTION
## Summary

- **Root cause (primary):** All four task mutation hooks (`useSubmitUserResponseForTask`, `useUploadDocumentsForTask`, `useDeleteUploadsOnTask`, `useUpdateTaskUploadDescription`) built their SWR key from `{ businessId, apiUrl, accessToken }` — without `taskId`. Every `TasksListItem` on the page therefore shared the same SWR mutation state slot. When two tasks were submitted in quick succession, SWR's concurrent mutation handling on a shared key could fire both HTTP requests while producing unpredictable client-side state — the rare "two tasks submitted at the same time" bug.
- **Fix:** `taskId` is now a parameter to each hook and is included in `buildKey`, giving every task item its own isolated mutation state.
- **`isMutating` guards:** With per-task keys in place, `isMutating` now accurately reflects only that task's in-flight state. Submit buttons are disabled for the duration of a request, preventing rapid re-clicks.
- **Mobile index keys:** `TasksListMobile` used `key={index}` on both task lists. After submitting task A (which re-sorts to "completed"), React reused the component instance at index 0 for task B while it still held task A's local `userResponse` state. Fixed by using `key={task.id}`.

## Files changed

- `src/hooks/api/businesses/[business-id]/tasks/[task-id]/user-response/useSubmitResponseForTask.ts`
- `src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/useUploadDocumentsForTask.ts`
- `src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/delete/useDeleteUploadsOnTask.ts`
- `src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/useUpdateTaskUploadDescription.ts`
- `src/components/Tasks/TasksListItem.tsx`
- `src/components/Tasks/TasksListMobile.tsx`

## Test plan

- [ ] Submit a free-response task — confirm single submission, panel closes, task moves to completed
- [ ] Submit a document-upload task — confirm single submission, files shown, task moves to completed
- [ ] Submit two different tasks back-to-back quickly — confirm only one server call per task, no duplicate submissions
- [ ] Verify submit button is disabled while a request is in-flight (can't double-click
- [ ] On mobile: submit the first task in the list, confirm the second task's textarea is empty (not populated with the first task's response)
EOF
)