### PR TITLE
fix: handle no transactions, negative taxes owed as possible states on tax summary

### DIFF
--- a/src/components/DataState/dataState.scss
+++ b/src/components/DataState/dataState.scss
@@ -54,6 +54,18 @@
   color: var(--color-base-500);
 }
 
+.Layer__data-state--reset {
+  gap: var(--spacing-xs);
+
+  .Layer__data-state__description {
+    margin-bottom: 0;
+  }
+
+  .Layer__data-state__icon {
+    margin-bottom: 0;
+  }
+}
+
 .Layer__data-state--inline {
   flex-direction: row;
   gap: var(--spacing-xs);

--- a/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
+++ b/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 
 import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
 import { type SummaryCardInteractionProps, type SummaryCardStringOverrides, useSummaryCardSlots } from '@ui/SummaryCard/useSummaryCardSlots'
+import { TaxEstimatesSummaryCardMode } from '@components/TaxEstimatesSummaryCard/constants'
 import { TaxEstimatesSummaryCardError as Error } from '@components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardError'
 import { TaxEstimatesSummaryCardLoading as Loading } from '@components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardLoading'
 import { Content } from '@components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCardContent'
@@ -10,10 +11,7 @@ import { ConditionalBlock } from '@components/utility/ConditionalBlock'
 
 import './taxEstimatesSummaryCard.scss'
 
-export enum TaxEstimatesSummaryCardMode {
-  PieChart = 'PieChart',
-  HorizontalBarChart = 'HorizontalBarChart',
-}
+export { TaxEstimatesSummaryCardMode }
 
 export type TaxEstimatesSummaryCardProps = {
   mode?: TaxEstimatesSummaryCardMode

--- a/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
+++ b/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard.tsx
@@ -1,136 +1,18 @@
-import { useMemo } from 'react'
 import classNames from 'classnames'
-import { useTranslation } from 'react-i18next'
 
-import { type TaxSummarySectionType } from '@schemas/taxEstimates/summary'
-import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
-import { useSizeClass } from '@hooks/utils/size/useWindowSize'
-import { HorizontalBarChart } from '@ui/HorizontalBarChart/HorizontalBarChart'
-import { LegendLayout } from '@ui/Legend/Legend'
-import { HStack, VStack } from '@ui/Stack/Stack'
 import { SummaryCard } from '@ui/SummaryCard/SummaryCard'
 import { type SummaryCardInteractionProps, type SummaryCardStringOverrides, useSummaryCardSlots } from '@ui/SummaryCard/useSummaryCardSlots'
-import { Span } from '@ui/Typography/Text'
-import { DataState, DataStateStatus } from '@components/DataState/DataState'
-import { DetailedChart, type DetailedChartProps } from '@components/DetailedCharts/DetailedChart'
-import { type DetailData, type SeriesData } from '@components/DetailedCharts/types'
-import { NO_OP_INTERACTION_PROPS, NO_SORT_PROPS } from '@components/DetailedCharts/utils'
-import { DetailedTableWithData } from '@components/DetailedTable/DetailedTable'
-import { CircleSkeletonLoader, SkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
-import { resolveCategoryColor } from '@components/TaxEstimatesSummaryCard/constants'
+import { TaxEstimatesSummaryCardError as Error } from '@components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardError'
+import { TaxEstimatesSummaryCardLoading as Loading } from '@components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardLoading'
+import { Content } from '@components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCardContent'
 import { useTaxEstimatesSummaryCard } from '@components/TaxEstimatesSummaryCard/useTaxEstimatesSummaryCard'
 import { ConditionalBlock } from '@components/utility/ConditionalBlock'
 
 import './taxEstimatesSummaryCard.scss'
 
-const LoadingState = ({ mode }: { mode: TaxEstimatesSummaryCardMode }) => {
-  if (mode === TaxEstimatesSummaryCardMode.HorizontalBarChart) {
-    return (
-      <VStack gap='md' className='Layer__TaxEstimatesSummaryCard__Content' pb='md' pi='lg'>
-        <SkeletonLoader height='24px' width='40%' />
-        <SkeletonLoader height='24px' width='100%' />
-        <SkeletonLoader height='16px' width='100%' />
-      </VStack>
-    )
-  }
-  return (
-    <VStack gap='md' className='Layer__TaxEstimatesSummaryCard__Content' pb='md' pi='lg' align='center'>
-      <CircleSkeletonLoader height='128px' width='128px' />
-      <SkeletonLoader height='24px' width='80%' />
-      <SkeletonLoader height='24px' width='80%' />
-      <SkeletonLoader height='24px' width='80%' />
-    </VStack>
-  )
-}
-
-const ErrorState = () => {
-  const { t } = useTranslation()
-  return (
-    <VStack gap='md' className='Layer__TaxEstimatesSummaryCard__Content' pb='md' pi='lg' align='center'>
-      <Span size='lg'>{t('taxEstimates:error.load_tax_estimates_summary', 'We couldn\'t load your tax summary')}</Span>
-    </VStack>
-  )
-}
-
-function allTaxSectionsAreEmpty(summary: DetailData<SeriesData>) {
-  const isEmpty = summary.data.every(section => section.value === 0)
-  return isEmpty
-}
-
-function TaxEstimatesSummaryCardEmpty() {
-  const { t } = useTranslation()
-  return (
-    <DataState
-      className='Layer__TaxEstimatesSummaryCard--empty'
-      status={DataStateStatus.info}
-      title={t('taxEstimates:empty.no_tax_estimates_summary', 'Get started with your tax estimates')}
-      description={t('taxEstimates:empty.no_tax_estimates_summary_description', 'Start by importing and categorizing your bank transactions')}
-    />
-  )
-}
-
-type CommonProps = Pick<DetailedChartProps<SeriesData>, 'interactionProps' | 'stylingProps'>
-
 export enum TaxEstimatesSummaryCardMode {
   PieChart = 'PieChart',
   HorizontalBarChart = 'HorizontalBarChart',
-}
-
-type ContentProps = {
-  data: DetailData<SeriesData>
-  mode: TaxEstimatesSummaryCardMode
-  commonProps: CommonProps
-  layout: 'taxOverview' | 'summaryCard'
-}
-
-const Content = ({ data, mode, commonProps, layout }: ContentProps) => {
-  if (mode === TaxEstimatesSummaryCardMode.HorizontalBarChart) {
-    return <HorizontalBarChartContent data={data} commonProps={commonProps} />
-  }
-  return <PieChartContent data={data} commonProps={commonProps} layout={layout} />
-}
-
-const HorizontalBarChartContent = ({ data, commonProps }: Pick<ContentProps, 'data' | 'commonProps'>) => {
-  const { t } = useTranslation()
-  const { formatCurrencyFromCents } = useIntlFormatter()
-  const { isDesktop } = useSizeClass()
-
-  return (
-    <VStack className='Layer__TaxEstimatesSummaryCard__Content Layer__TaxEstimatesSummaryCard__Content--horizontal' gap='md' pi='lg' pbe='lg'>
-      <HStack className='Layer__TaxEstimatesSummaryCard__TotalRow' justify='space-between' align='baseline' gap='md'>
-        <Span size='md' variant='subtle'>{t('common:label.total', 'Total')}</Span>
-        <Span size='xl' weight='bold' numeric='tabular-nums' className='Layer__TaxEstimatesSummaryCard__TotalValue'>
-          {formatCurrencyFromCents(data.total)}
-        </Span>
-      </HStack>
-      <HorizontalBarChart<SeriesData>
-        data={data}
-        stylingProps={commonProps.stylingProps}
-        formatValue={formatCurrencyFromCents}
-        labelMode={isDesktop ? LegendLayout.Aligned : LegendLayout.Table}
-      />
-    </VStack>
-  )
-}
-
-const PieChartContent = ({ data, commonProps, layout }: Pick<ContentProps, 'data' | 'commonProps' | 'layout'>) => {
-  const { isMobile } = useSizeClass()
-  const isSummaryCardLayout = layout === 'summaryCard'
-  return (
-    isMobile || isSummaryCardLayout
-      ? (
-        <VStack className='Layer__TaxEstimatesSummaryCard__Content Layer__TaxEstimatesSummaryCard__Content--mobile' gap='lg'>
-          <DetailedChart<SeriesData> data={data} {...commonProps} />
-          <DetailedTableWithData<SeriesData> data={data} {...commonProps} {...NO_SORT_PROPS} />
-        </VStack>
-      )
-      : (
-        <HStack className='Layer__TaxEstimatesSummaryCard__Content' align='center' gap='lg'>
-          <DetailedChart<SeriesData> data={data} {...commonProps} />
-          <DetailedTableWithData<SeriesData> data={data} {...commonProps} {...NO_SORT_PROPS} />
-        </HStack>
-      )
-  )
 }
 
 export type TaxEstimatesSummaryCardProps = {
@@ -144,20 +26,8 @@ export const TaxEstimatesSummaryCard = ({
   interactionProps,
   stringOverrides,
 }: TaxEstimatesSummaryCardProps = {}) => {
-  const { detailData, layout, title: defaultTitle, isLoading, isError } = useTaxEstimatesSummaryCard()
+  const { title: defaultTitle, isLoading, isError, layout, detailData, state } = useTaxEstimatesSummaryCard()
   const isSummaryCardLayout = layout === 'summaryCard'
-
-  const commonProps: CommonProps = useMemo(() => {
-    const colorByKey = detailData?.data?.reduce<Record<string, string>>((acc, item) => {
-      acc[item.name] = resolveCategoryColor({ key: item.name as TaxSummarySectionType })
-      return acc
-    }, {})
-
-    return {
-      interactionProps: NO_OP_INTERACTION_PROPS,
-      stylingProps: { colorSelector: (item: SeriesData) => ({ color: colorByKey?.[item.name] ?? 'var(--color-base-300)', opacity: 1 }) },
-    }
-  }, [detailData?.data])
 
   const slots = useSummaryCardSlots({
     defaultTitle,
@@ -170,10 +40,18 @@ export const TaxEstimatesSummaryCard = ({
       className={classNames('Layer__TaxEstimatesSummaryCard', isSummaryCardLayout && 'Layer__TaxEstimatesSummaryCard--summaryCard')}
       slots={slots}
     >
-      <ConditionalBlock data={detailData} isLoading={isLoading} isError={isError} Loading={<LoadingState mode={mode} />} Error={<ErrorState />}>
-        {({ data }) => allTaxSectionsAreEmpty(data)
-          ? <TaxEstimatesSummaryCardEmpty />
-          : <Content data={data} mode={mode} commonProps={commonProps} layout={layout} />}
+      <ConditionalBlock
+        data={detailData}
+        isLoading={isLoading}
+        isError={isError}
+        Loading={(
+          <Loading
+            mode={mode}
+          />
+        )}
+        Error={<Error />}
+      >
+        {({ data }) => <Content state={state} data={data} mode={mode} layout={layout} />}
       </ConditionalBlock>
     </SummaryCard>
   )

--- a/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCardContent.tsx
+++ b/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCardContent.tsx
@@ -17,7 +17,6 @@ import { resolveCategoryColor } from './constants'
 import { TaxEstimatesSummaryCardEmpty } from './states/TaxEstimatesSummaryCardEmpty'
 import { TaxEstimatesSummaryCardNegativeOrZero } from './states/TaxEstimatesSummaryCardNegativeOrZero'
 import { TaxEstimatesSummaryCardMode } from './TaxEstimatesSummaryCard'
-import { useTaxEstimatesSummaryCard } from './useTaxEstimatesSummaryCard'
 
 type CommonProps = Pick<DetailedChartProps<SeriesData>, 'interactionProps' | 'stylingProps'>
 
@@ -29,11 +28,9 @@ export type ContentProps = {
   layout: 'taxOverview' | 'summaryCard'
 }
 
-export const Content = ({ state, data, mode }: Omit<ContentProps, 'commonProps'>) => {
-  const { detailData, layout } = useTaxEstimatesSummaryCard()
-
+export const Content = ({ state, data, mode, layout }: Omit<ContentProps, 'commonProps'>) => {
   const commonProps: CommonProps = useMemo(() => {
-    const colorByKey = detailData?.data?.reduce<Record<string, string>>((acc, item) => {
+    const colorByKey = data?.data?.reduce<Record<string, string>>((acc, item) => {
       acc[item.name] = resolveCategoryColor({ key: item.name as TaxSummarySectionType })
       return acc
     }, {})
@@ -42,7 +39,7 @@ export const Content = ({ state, data, mode }: Omit<ContentProps, 'commonProps'>
       interactionProps: NO_OP_INTERACTION_PROPS,
       stylingProps: { colorSelector: (item: SeriesData) => ({ color: colorByKey?.[item.name] ?? 'var(--color-base-300)', opacity: 1 }) },
     }
-  }, [detailData?.data])
+  }, [data])
 
   switch (state) {
     case TaxSummaryState.NO_TRANSACTIONS:

--- a/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCardContent.tsx
+++ b/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCardContent.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 
 import { type TaxSummarySectionType, TaxSummaryState } from '@schemas/taxEstimates/summary'
@@ -6,7 +7,7 @@ import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { HorizontalBarChart } from '@ui/HorizontalBarChart/HorizontalBarChart'
 import { LegendLayout } from '@ui/Legend/Legend'
-import { HStack, VStack } from '@ui/Stack/Stack'
+import { HStack, Stack, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { DetailedChart, type DetailedChartProps } from '@components/DetailedCharts/DetailedChart'
 import { type DetailData, type SeriesData } from '@components/DetailedCharts/types'
@@ -78,20 +79,20 @@ const HorizontalBarChartContent = ({ data, commonProps }: Pick<ContentProps, 'da
 
 const PieChartContent = ({ data, commonProps, layout }: Pick<ContentProps, 'data' | 'commonProps' | 'layout'>) => {
   const { isMobile } = useSizeClass()
-  const isSummaryCardLayout = layout === 'summaryCard'
+  const isVerticalLayout = isMobile || layout === 'summaryCard'
+  const stackProps = {
+    direction: isVerticalLayout ? 'column' as const : 'row' as const,
+    className: classNames(
+      'Layer__TaxEstimatesSummaryCard__Content',
+      isVerticalLayout && 'Layer__TaxEstimatesSummaryCard__Content--mobile',
+    ),
+    gap: 'lg' as const,
+    align: isVerticalLayout ? undefined : 'center' as const,
+  }
   return (
-    isMobile || isSummaryCardLayout
-      ? (
-        <VStack className='Layer__TaxEstimatesSummaryCard__Content Layer__TaxEstimatesSummaryCard__Content--mobile' gap='lg'>
-          <DetailedChart<SeriesData> data={data} {...commonProps} />
-          <DetailedTableWithData<SeriesData> data={data} {...commonProps} {...NO_SORT_PROPS} />
-        </VStack>
-      )
-      : (
-        <HStack className='Layer__TaxEstimatesSummaryCard__Content' align='center' gap='lg'>
-          <DetailedChart<SeriesData> data={data} {...commonProps} />
-          <DetailedTableWithData<SeriesData> data={data} {...commonProps} {...NO_SORT_PROPS} />
-        </HStack>
-      )
+    <Stack {...stackProps}>
+      <DetailedChart<SeriesData> data={data} {...commonProps} />
+      <DetailedTableWithData<SeriesData> data={data} {...commonProps} {...NO_SORT_PROPS} />
+    </Stack>
   )
 }

--- a/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCardContent.tsx
+++ b/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCardContent.tsx
@@ -42,10 +42,10 @@ export const Content = ({ state, data, mode, layout }: Omit<ContentProps, 'commo
   switch (state) {
     case TaxSummaryState.NO_TRANSACTIONS:
       return <TaxEstimatesSummaryCardEmpty />
-    case TaxSummaryState.NEGATIVE_TAXES_OWED:
+    case TaxSummaryState.NO_TAXES_OWED:
       return <TaxEstimatesSummaryCardNegativeOrZero />
     case TaxSummaryState.UNKNOWN:
-    case TaxSummaryState.ZERO_OR_POSITIVE_TAXES_OWED:
+    case TaxSummaryState.TAXES_OWED:
       if (mode === TaxEstimatesSummaryCardMode.HorizontalBarChart) {
         return <HorizontalBarChartContent data={data} commonProps={commonProps} />
       }

--- a/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCardContent.tsx
+++ b/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCardContent.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { type TaxSummarySectionType, TaxSummaryState } from '@schemas/taxEstimates/summary'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import { HorizontalBarChart } from '@ui/HorizontalBarChart/HorizontalBarChart'
+import { LegendLayout } from '@ui/Legend/Legend'
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+import { DetailedChart, type DetailedChartProps } from '@components/DetailedCharts/DetailedChart'
+import { type DetailData, type SeriesData } from '@components/DetailedCharts/types'
+import { NO_OP_INTERACTION_PROPS, NO_SORT_PROPS } from '@components/DetailedCharts/utils'
+import { DetailedTableWithData } from '@components/DetailedTable/DetailedTable'
+
+import { resolveCategoryColor } from './constants'
+import { TaxEstimatesSummaryCardEmpty } from './states/TaxEstimatesSummaryCardEmpty'
+import { TaxEstimatesSummaryCardNegativeOrZero } from './states/TaxEstimatesSummaryCardNegativeOrZero'
+import { TaxEstimatesSummaryCardMode } from './TaxEstimatesSummaryCard'
+import { useTaxEstimatesSummaryCard } from './useTaxEstimatesSummaryCard'
+
+type CommonProps = Pick<DetailedChartProps<SeriesData>, 'interactionProps' | 'stylingProps'>
+
+export type ContentProps = {
+  state: TaxSummaryState
+  data: DetailData<SeriesData>
+  mode: TaxEstimatesSummaryCardMode
+  commonProps: CommonProps
+  layout: 'taxOverview' | 'summaryCard'
+}
+
+export const Content = ({ state, data, mode }: Omit<ContentProps, 'commonProps'>) => {
+  const { detailData, layout } = useTaxEstimatesSummaryCard()
+
+  const commonProps: CommonProps = useMemo(() => {
+    const colorByKey = detailData?.data?.reduce<Record<string, string>>((acc, item) => {
+      acc[item.name] = resolveCategoryColor({ key: item.name as TaxSummarySectionType })
+      return acc
+    }, {})
+
+    return {
+      interactionProps: NO_OP_INTERACTION_PROPS,
+      stylingProps: { colorSelector: (item: SeriesData) => ({ color: colorByKey?.[item.name] ?? 'var(--color-base-300)', opacity: 1 }) },
+    }
+  }, [detailData?.data])
+
+  switch (state) {
+    case TaxSummaryState.NO_TRANSACTIONS:
+      return <TaxEstimatesSummaryCardEmpty />
+    case TaxSummaryState.NEGATIVE_TAXES_OWED:
+      return <TaxEstimatesSummaryCardNegativeOrZero />
+    case TaxSummaryState.UNKNOWN:
+    case TaxSummaryState.ZERO_OR_POSITIVE_TAXES_OWED:
+      if (mode === TaxEstimatesSummaryCardMode.HorizontalBarChart) {
+        return <HorizontalBarChartContent data={data} commonProps={commonProps} />
+      }
+      return <PieChartContent data={data} commonProps={commonProps} layout={layout} />
+  }
+}
+
+const HorizontalBarChartContent = ({ data, commonProps }: Pick<ContentProps, 'data' | 'commonProps'>) => {
+  const { t } = useTranslation()
+  const { formatCurrencyFromCents } = useIntlFormatter()
+  const { isDesktop } = useSizeClass()
+
+  return (
+    <VStack className='Layer__TaxEstimatesSummaryCard__Content Layer__TaxEstimatesSummaryCard__Content--horizontal' gap='md' pi='lg' pbe='lg'>
+      <HStack className='Layer__TaxEstimatesSummaryCard__TotalRow' justify='space-between' align='baseline' gap='md'>
+        <Span size='md' variant='subtle'>{t('common:label.total', 'Total')}</Span>
+        <Span size='xl' weight='bold' numeric='tabular-nums' className='Layer__TaxEstimatesSummaryCard__TotalValue'>
+          {formatCurrencyFromCents(data.total)}
+        </Span>
+      </HStack>
+      <HorizontalBarChart<SeriesData>
+        data={data}
+        stylingProps={commonProps.stylingProps}
+        formatValue={formatCurrencyFromCents}
+        labelMode={isDesktop ? LegendLayout.Aligned : LegendLayout.Table}
+      />
+    </VStack>
+  )
+}
+
+const PieChartContent = ({ data, commonProps, layout }: Pick<ContentProps, 'data' | 'commonProps' | 'layout'>) => {
+  const { isMobile } = useSizeClass()
+  const isSummaryCardLayout = layout === 'summaryCard'
+  return (
+    isMobile || isSummaryCardLayout
+      ? (
+        <VStack className='Layer__TaxEstimatesSummaryCard__Content Layer__TaxEstimatesSummaryCard__Content--mobile' gap='lg'>
+          <DetailedChart<SeriesData> data={data} {...commonProps} />
+          <DetailedTableWithData<SeriesData> data={data} {...commonProps} {...NO_SORT_PROPS} />
+        </VStack>
+      )
+      : (
+        <HStack className='Layer__TaxEstimatesSummaryCard__Content' align='center' gap='lg'>
+          <DetailedChart<SeriesData> data={data} {...commonProps} />
+          <DetailedTableWithData<SeriesData> data={data} {...commonProps} {...NO_SORT_PROPS} />
+        </HStack>
+      )
+  )
+}

--- a/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCardContent.tsx
+++ b/src/components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCardContent.tsx
@@ -12,11 +12,9 @@ import { DetailedChart, type DetailedChartProps } from '@components/DetailedChar
 import { type DetailData, type SeriesData } from '@components/DetailedCharts/types'
 import { NO_OP_INTERACTION_PROPS, NO_SORT_PROPS } from '@components/DetailedCharts/utils'
 import { DetailedTableWithData } from '@components/DetailedTable/DetailedTable'
-
-import { resolveCategoryColor } from './constants'
-import { TaxEstimatesSummaryCardEmpty } from './states/TaxEstimatesSummaryCardEmpty'
-import { TaxEstimatesSummaryCardNegativeOrZero } from './states/TaxEstimatesSummaryCardNegativeOrZero'
-import { TaxEstimatesSummaryCardMode } from './TaxEstimatesSummaryCard'
+import { resolveCategoryColor, TaxEstimatesSummaryCardMode } from '@components/TaxEstimatesSummaryCard/constants'
+import { TaxEstimatesSummaryCardEmpty } from '@components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardEmpty'
+import { TaxEstimatesSummaryCardNegativeOrZero } from '@components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardNegativeOrZero'
 
 type CommonProps = Pick<DetailedChartProps<SeriesData>, 'interactionProps' | 'stylingProps'>
 

--- a/src/components/TaxEstimatesSummaryCard/constants.ts
+++ b/src/components/TaxEstimatesSummaryCard/constants.ts
@@ -2,3 +2,8 @@ import { type TaxOverviewCategory } from '@schemas/taxEstimates/overview'
 import { DEFAULT_CHART_COLORS } from '@utils/chartColors'
 
 export const resolveCategoryColor = ({ key }: Pick<TaxOverviewCategory, 'key'>) => ({ federal: DEFAULT_CHART_COLORS[0], state: DEFAULT_CHART_COLORS[1] }[key] ?? DEFAULT_CHART_COLORS[0])
+
+export enum TaxEstimatesSummaryCardMode {
+  PieChart = 'PieChart',
+  HorizontalBarChart = 'HorizontalBarChart',
+}

--- a/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardEmpty.tsx
+++ b/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardEmpty.tsx
@@ -9,7 +9,7 @@ export function TaxEstimatesSummaryCardEmpty() {
       className='Layer__TaxEstimatesSummaryCard__DataState Layer__data-state--reset'
       status={DataStateStatus.info}
       title={t('taxEstimates:empty.no_tax_estimates_summary', 'Get started with your tax estimates')}
-      description={t('taxEstimates:empty.no_tax_estimates_summary_description', 'Start by importing and categorizing your bank transactions')}
+      description={t('taxEstimates:empty.no_tax_estimates_summary_description', 'Start by importing and categorizing your bank transactions.')}
     />
   )
 }

--- a/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardEmpty.tsx
+++ b/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardEmpty.tsx
@@ -1,0 +1,15 @@
+import { useTranslation } from 'react-i18next'
+
+import { DataState, DataStateStatus } from '@components/DataState/DataState'
+
+export function TaxEstimatesSummaryCardEmpty() {
+  const { t } = useTranslation()
+  return (
+    <DataState
+      className='Layer__TaxEstimatesSummaryCard__DataState Layer__TaxEstimatesSummaryCard__DataState--empty Layer__data-state--reset'
+      status={DataStateStatus.info}
+      title={t('taxEstimates:empty.no_tax_estimates_summary', 'Get started with your tax estimates')}
+      description={t('taxEstimates:empty.no_tax_estimates_summary_description', 'Start by importing and categorizing your bank transactions')}
+    />
+  )
+}

--- a/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardEmpty.tsx
+++ b/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardEmpty.tsx
@@ -6,7 +6,7 @@ export function TaxEstimatesSummaryCardEmpty() {
   const { t } = useTranslation()
   return (
     <DataState
-      className='Layer__TaxEstimatesSummaryCard__DataState Layer__TaxEstimatesSummaryCard__DataState--empty Layer__data-state--reset'
+      className='Layer__TaxEstimatesSummaryCard__DataState Layer__data-state--reset'
       status={DataStateStatus.info}
       title={t('taxEstimates:empty.no_tax_estimates_summary', 'Get started with your tax estimates')}
       description={t('taxEstimates:empty.no_tax_estimates_summary_description', 'Start by importing and categorizing your bank transactions')}

--- a/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardError.tsx
+++ b/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardError.tsx
@@ -1,0 +1,15 @@
+import { useTranslation } from 'react-i18next'
+
+import { DataState, DataStateStatus } from '@components/DataState/DataState'
+
+export const TaxEstimatesSummaryCardError = () => {
+  const { t } = useTranslation()
+  return (
+    <DataState
+      className='Layer__TaxEstimatesSummaryCard__DataState Layer__TaxEstimatesSummaryCard__DataState--error Layer__data-state--reset'
+      status={DataStateStatus.info}
+      title={t('taxEstimates:error.load_tax_estimates_summary', 'We couldn\'t load your tax summary')}
+      description={t('taxEstimates:error.load_tax_estimates_summary_description', 'An error occurred while loading your tax summary. Please check your connection and try again.')}
+    />
+  )
+}

--- a/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardError.tsx
+++ b/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardError.tsx
@@ -6,7 +6,7 @@ export const TaxEstimatesSummaryCardError = () => {
   const { t } = useTranslation()
   return (
     <DataState
-      className='Layer__TaxEstimatesSummaryCard__DataState Layer__TaxEstimatesSummaryCard__DataState--error Layer__data-state--reset'
+      className='Layer__TaxEstimatesSummaryCard__DataState Layer__data-state--reset'
       status={DataStateStatus.failed}
       title={t('taxEstimates:error.load_tax_estimates_summary', 'We couldn\'t load your tax summary')}
       description={t('taxEstimates:error.while_loading_tax_estimates_summary', 'An error occurred while loading your tax summary. Please check your connection and try again.')}

--- a/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardError.tsx
+++ b/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardError.tsx
@@ -7,9 +7,9 @@ export const TaxEstimatesSummaryCardError = () => {
   return (
     <DataState
       className='Layer__TaxEstimatesSummaryCard__DataState Layer__TaxEstimatesSummaryCard__DataState--error Layer__data-state--reset'
-      status={DataStateStatus.info}
+      status={DataStateStatus.failed}
       title={t('taxEstimates:error.load_tax_estimates_summary', 'We couldn\'t load your tax summary')}
-      description={t('taxEstimates:error.load_tax_estimates_summary_description', 'An error occurred while loading your tax summary. Please check your connection and try again.')}
+      description={t('taxEstimates:error.while_loading_tax_estimates_summary', 'An error occurred while loading your tax summary. Please check your connection and try again.')}
     />
   )
 }

--- a/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardLoading.tsx
+++ b/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardLoading.tsx
@@ -1,0 +1,23 @@
+import { VStack } from '@ui/Stack/Stack'
+import { CircleSkeletonLoader, SkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
+import { TaxEstimatesSummaryCardMode } from '@components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard'
+
+export const TaxEstimatesSummaryCardLoading = ({ mode }: { mode: TaxEstimatesSummaryCardMode }) => {
+  if (mode === TaxEstimatesSummaryCardMode.HorizontalBarChart) {
+    return (
+      <VStack gap='md' className='Layer__TaxEstimatesSummaryCard__Content' pb='md' pi='lg'>
+        <SkeletonLoader height='24px' width='40%' />
+        <SkeletonLoader height='24px' width='100%' />
+        <SkeletonLoader height='16px' width='100%' />
+      </VStack>
+    )
+  }
+  return (
+    <VStack gap='md' className='Layer__TaxEstimatesSummaryCard__Content' pb='md' pi='lg' align='center'>
+      <CircleSkeletonLoader height='128px' width='128px' />
+      <SkeletonLoader height='24px' width='80%' />
+      <SkeletonLoader height='24px' width='80%' />
+      <SkeletonLoader height='24px' width='80%' />
+    </VStack>
+  )
+}

--- a/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardLoading.tsx
+++ b/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardLoading.tsx
@@ -1,6 +1,6 @@
 import { VStack } from '@ui/Stack/Stack'
 import { CircleSkeletonLoader, SkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
-import { TaxEstimatesSummaryCardMode } from '@components/TaxEstimatesSummaryCard/TaxEstimatesSummaryCard'
+import { TaxEstimatesSummaryCardMode } from '@components/TaxEstimatesSummaryCard/constants'
 
 export const TaxEstimatesSummaryCardLoading = ({ mode }: { mode: TaxEstimatesSummaryCardMode }) => {
   if (mode === TaxEstimatesSummaryCardMode.HorizontalBarChart) {

--- a/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardNegativeOrZero.tsx
+++ b/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardNegativeOrZero.tsx
@@ -9,7 +9,7 @@ export const TaxEstimatesSummaryCardNegativeOrZero = () => {
       className='Layer__TaxEstimatesSummaryCard__DataState Layer__TaxEstimatesSummaryCard__DataState--negativeOrZero Layer__data-state--reset'
       status={DataStateStatus.info}
       title={t('taxEstimates:error.tax_due_is_negative_or_zero', 'No taxes owed this year')}
-      description={t('taxEstimates:error.tax_due_is_negative_or_zero_description', 'Your deductible losses exceed your income for this period, bringing your tax liability to $0. You may be able to carry this loss forward to offset future gains.')}
+      description={t('taxEstimates:error.tax_due_is_negative_or_zero_description', 'Your deductible losses exceed your income for this period, bringing your tax liability to zero. You may be able to carry this loss forward to offset future gains.')}
     />
   )
 }

--- a/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardNegativeOrZero.tsx
+++ b/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardNegativeOrZero.tsx
@@ -6,7 +6,7 @@ export const TaxEstimatesSummaryCardNegativeOrZero = () => {
   const { t } = useTranslation()
   return (
     <DataState
-      className='Layer__TaxEstimatesSummaryCard__DataState Layer__TaxEstimatesSummaryCard__DataState--negativeOrZero Layer__data-state--reset'
+      className='Layer__TaxEstimatesSummaryCard__DataState Layer__data-state--reset'
       status={DataStateStatus.info}
       title={t('taxEstimates:error.tax_due_is_negative_or_zero', 'No taxes owed this year')}
       description={t('taxEstimates:error.tax_due_is_negative_or_zero_description', 'Your deductible losses exceed your income for this period, bringing your tax liability to zero.')}

--- a/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardNegativeOrZero.tsx
+++ b/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardNegativeOrZero.tsx
@@ -9,7 +9,7 @@ export const TaxEstimatesSummaryCardNegativeOrZero = () => {
       className='Layer__TaxEstimatesSummaryCard__DataState Layer__TaxEstimatesSummaryCard__DataState--negativeOrZero Layer__data-state--reset'
       status={DataStateStatus.info}
       title={t('taxEstimates:error.tax_due_is_negative_or_zero', 'No taxes owed this year')}
-      description={t('taxEstimates:error.tax_due_is_negative_or_zero_description', 'Your deductible losses exceed your income for this period, bringing your tax liability to zero. You may be able to carry this loss forward to offset future gains.')}
+      description={t('taxEstimates:error.tax_due_is_negative_or_zero_description', 'Your deductible losses exceed your income for this period, bringing your tax liability to zero.')}
     />
   )
 }

--- a/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardNegativeOrZero.tsx
+++ b/src/components/TaxEstimatesSummaryCard/states/TaxEstimatesSummaryCardNegativeOrZero.tsx
@@ -1,0 +1,15 @@
+import { useTranslation } from 'react-i18next'
+
+import { DataState, DataStateStatus } from '@components/DataState/DataState'
+
+export const TaxEstimatesSummaryCardNegativeOrZero = () => {
+  const { t } = useTranslation()
+  return (
+    <DataState
+      className='Layer__TaxEstimatesSummaryCard__DataState Layer__TaxEstimatesSummaryCard__DataState--negativeOrZero Layer__data-state--reset'
+      status={DataStateStatus.info}
+      title={t('taxEstimates:error.tax_due_is_negative_or_zero', 'No taxes owed this year')}
+      description={t('taxEstimates:error.tax_due_is_negative_or_zero_description', 'Your deductible losses exceed your income for this period, bringing your tax liability to $0. You may be able to carry this loss forward to offset future gains.')}
+    />
+  )
+}

--- a/src/components/TaxEstimatesSummaryCard/taxEstimatesSummaryCard.scss
+++ b/src/components/TaxEstimatesSummaryCard/taxEstimatesSummaryCard.scss
@@ -79,8 +79,23 @@
     }
   }
 
-  &--empty {
+  &__DataState--empty {
     height: 100%;
+    min-height: 15rem;
     margin: 0 auto;
+
+    @media (width >= 760px) {
+      max-width: 30rem;
+    }
+  }
+
+  &__DataState--negativeOrZero {
+    height: 100%;
+    min-height: 15rem;
+    margin: 0 auto;
+
+    @media (width >= 760px) {
+      max-width: 30rem;
+    }
   }
 }

--- a/src/components/TaxEstimatesSummaryCard/taxEstimatesSummaryCard.scss
+++ b/src/components/TaxEstimatesSummaryCard/taxEstimatesSummaryCard.scss
@@ -79,17 +79,7 @@
     }
   }
 
-  &__DataState--empty {
-    height: 100%;
-    min-height: 15rem;
-    margin: 0 auto;
-
-    @media (width >= 760px) {
-      max-width: 30rem;
-    }
-  }
-
-  &__DataState--negativeOrZero {
+  &__DataState {
     height: 100%;
     min-height: 15rem;
     margin: 0 auto;

--- a/src/components/TaxEstimatesSummaryCard/useTaxEstimatesSummaryCard.ts
+++ b/src/components/TaxEstimatesSummaryCard/useTaxEstimatesSummaryCard.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { type TaxSummary, type TaxSummarySectionType } from '@schemas/taxEstimates/summary'
+import { type TaxSummary, type TaxSummarySectionType, TaxSummaryState } from '@schemas/taxEstimates/summary'
 import { useTaxSummary } from '@hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { useTaxEstimatesYear } from '@providers/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider'
@@ -33,6 +33,7 @@ export const useTaxEstimatesSummaryCard = () => {
     if (!taxSummaryData) return undefined
 
     const data = prepareTaxSummaryData(taxSummaryData, shortenedDisplayName, isMobile)
+
     return {
       data,
       total: data.reduce((sum, section) => sum + section.value, 0),
@@ -43,6 +44,7 @@ export const useTaxEstimatesSummaryCard = () => {
     detailData,
     isLoading,
     isError,
+    state: taxSummaryData?.state ?? TaxSummaryState.ZERO_OR_POSITIVE_TAXES_OWED,
     layout: isDesktop ? 'taxOverview' as const : 'summaryCard' as const,
     title: t('taxEstimates:label.tax_summary', 'Tax Summary'),
   }

--- a/src/components/TaxEstimatesSummaryCard/useTaxEstimatesSummaryCard.ts
+++ b/src/components/TaxEstimatesSummaryCard/useTaxEstimatesSummaryCard.ts
@@ -44,7 +44,7 @@ export const useTaxEstimatesSummaryCard = () => {
     detailData,
     isLoading,
     isError,
-    state: taxSummaryData?.state ?? TaxSummaryState.ZERO_OR_POSITIVE_TAXES_OWED,
+    state: taxSummaryData?.state ?? TaxSummaryState.TAXES_OWED,
     layout: isDesktop ? 'taxOverview' as const : 'summaryCard' as const,
     title: t('taxEstimates:label.tax_summary', 'Tax Summary'),
   }

--- a/src/schemas/taxEstimates/details.ts
+++ b/src/schemas/taxEstimates/details.ts
@@ -56,7 +56,7 @@ export type TaxDetailsMeta = typeof TaxDetailsMetaSchema.Type
 
 const TaxDetailsSchema = Schema.Struct({
   type: Schema.String,
-  state: Schema.NullishOr(TransformedTaxSummaryStateSchema),
+  state: TransformedTaxSummaryStateSchema,
   meta: TaxDetailsMetaSchema,
   rows: Schema.Array(TaxDetailsRowSchema),
 })

--- a/src/schemas/taxEstimates/details.ts
+++ b/src/schemas/taxEstimates/details.ts
@@ -6,6 +6,7 @@ import {
   UnifiedCellValuePercentageSchema,
   UnifiedCellValueUnknownSchema,
 } from '@schemas/reports/unifiedReport'
+import { TransformedTaxSummaryStateSchema } from '@schemas/taxEstimates/summary'
 
 const TaxDetailsValueSchema = Schema.Union(
   UnifiedCellValueCurrencySchema,
@@ -55,6 +56,7 @@ export type TaxDetailsMeta = typeof TaxDetailsMetaSchema.Type
 
 const TaxDetailsSchema = Schema.Struct({
   type: Schema.String,
+  state: Schema.NullishOr(TransformedTaxSummaryStateSchema),
   meta: TaxDetailsMetaSchema,
   rows: Schema.Array(TaxDetailsRowSchema),
 })

--- a/src/schemas/taxEstimates/summary.ts
+++ b/src/schemas/taxEstimates/summary.ts
@@ -38,7 +38,7 @@ export type TaxSummarySection = typeof TaxSummarySectionSchema.Type
 
 const TaxSummarySchema = Schema.Struct({
   year: Schema.Number,
-  state: Schema.NullishOr(TransformedTaxSummaryStateSchema),
+  state: TransformedTaxSummaryStateSchema,
   projectedTaxesOwed: pipe(
     Schema.propertySignature(Schema.Number),
     Schema.fromKey('projected_taxes_owed'),

--- a/src/schemas/taxEstimates/summary.ts
+++ b/src/schemas/taxEstimates/summary.ts
@@ -11,7 +11,7 @@ export enum TaxSummaryState {
   UNKNOWN = 'UNKNOWN',
 }
 
-const TransformedTaxSummaryStateSchema = createTransformedEnumSchema(
+export const TransformedTaxSummaryStateSchema = createTransformedEnumSchema(
   Schema.Enums(TaxSummaryState),
   TaxSummaryState,
   TaxSummaryState.NO_TRANSACTIONS,

--- a/src/schemas/taxEstimates/summary.ts
+++ b/src/schemas/taxEstimates/summary.ts
@@ -14,7 +14,7 @@ export enum TaxSummaryState {
 export const TransformedTaxSummaryStateSchema = createTransformedEnumSchema(
   Schema.Enums(TaxSummaryState),
   TaxSummaryState,
-  TaxSummaryState.NO_TRANSACTIONS,
+  TaxSummaryState.UNKNOWN,
 )
 
 export type TaxSummarySectionType = typeof TaxSummarySectionTypeSchema.Type

--- a/src/schemas/taxEstimates/summary.ts
+++ b/src/schemas/taxEstimates/summary.ts
@@ -6,8 +6,8 @@ const TaxSummarySectionTypeSchema = Schema.Literal('federal', 'state')
 
 export enum TaxSummaryState {
   NO_TRANSACTIONS = 'NO_TRANSACTIONS',
-  NEGATIVE_TAXES_OWED = 'NEGATIVE_TAXES_OWED',
-  ZERO_OR_POSITIVE_TAXES_OWED = 'ZERO_OR_POSITIVE_TAXES_OWED',
+  NO_TAXES_OWED = 'NO_TAXES_OWED',
+  TAXES_OWED = 'TAXES_OWED',
   UNKNOWN = 'UNKNOWN',
 }
 

--- a/src/schemas/taxEstimates/summary.ts
+++ b/src/schemas/taxEstimates/summary.ts
@@ -1,6 +1,21 @@
 import { pipe, Schema } from 'effect'
 
+import { createTransformedEnumSchema } from '@schemas/utils'
+
 const TaxSummarySectionTypeSchema = Schema.Literal('federal', 'state')
+
+export enum TaxSummaryState {
+  NO_TRANSACTIONS = 'NO_TRANSACTIONS',
+  NEGATIVE_TAXES_OWED = 'NEGATIVE_TAXES_OWED',
+  ZERO_OR_POSITIVE_TAXES_OWED = 'ZERO_OR_POSITIVE_TAXES_OWED',
+  UNKNOWN = 'UNKNOWN',
+}
+
+const TransformedTaxSummaryStateSchema = createTransformedEnumSchema(
+  Schema.Enums(TaxSummaryState),
+  TaxSummaryState,
+  TaxSummaryState.NO_TRANSACTIONS,
+)
 
 export type TaxSummarySectionType = typeof TaxSummarySectionTypeSchema.Type
 
@@ -23,6 +38,7 @@ export type TaxSummarySection = typeof TaxSummarySectionSchema.Type
 
 const TaxSummarySchema = Schema.Struct({
   year: Schema.Number,
+  state: Schema.NullishOr(TransformedTaxSummaryStateSchema),
   projectedTaxesOwed: pipe(
     Schema.propertySignature(Schema.Number),
     Schema.fromKey('projected_taxes_owed'),


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

Handles the nullish/empty cases for tax estimates summary card

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

Empty i.e. no transactions
<img width="673" height="420" alt="Screenshot 2026-05-12 at 11 37 19 AM" src="https://github.com/user-attachments/assets/4d16a310-49d1-4514-9087-299bcf41121a" />

Negative taxes owed i.e. net loss

<img width="670" height="417" alt="Screenshot 2026-05-12 at 11 37 48 AM" src="https://github.com/user-attachments/assets/5a713ece-582e-431b-a8a8-41c868378840" />

# BE integration checks (May 12 - 1:40PM)

## state: No transactions at all

<img width="1512" height="1191" alt="image" src="https://github.com/user-attachments/assets/ecc4cad8-934e-4646-b198-044c6d7f9af5" />

## state: Has expenses, no revenue = net loss

<img width="1675" height="1091" alt="image" src="https://github.com/user-attachments/assets/ad1081f2-413a-47a9-b925-890a49e0c0cf" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new backend-driven `TaxSummaryState` parsing and branches UI rendering on it; schema/decoding changes could surface unexpected state values or affect API compatibility.
> 
> **Overview**
> Updates the Tax Estimates Summary card to render **explicit empty-state messaging** based on a new `TaxSummaryState` from the tax summary API (e.g. *no transactions* and *no taxes owed/negative net*), instead of inferring emptiness from zero-valued sections.
> 
> Refactors the card into smaller state components (`Loading`, `Error`, `Empty`, `NegativeOrZero`) and extracts chart/table rendering into `TaxEstimatesSummaryCardContent`, while adding a `DataState` layout reset modifier and adjusting summary card styling for consistent state layout.
> 
> Extends tax estimate schemas to include a transformed/validated `state` field in both `taxEstimates/summary` and `taxEstimates/details` responses, defaulting unknown values to `UNKNOWN`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f530d386d0879d4691260c55e7059c1e306227c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->