### PR TITLE
Align Tax Estimate AmountWithLabel Symbols to Amount

### DIFF
--- a/src/components/TaxDetails/TaxSummaryCard/TaxSummaryCardEquation.tsx
+++ b/src/components/TaxDetails/TaxSummaryCard/TaxSummaryCardEquation.tsx
@@ -16,7 +16,7 @@ type AmountWithLabelProps = {
 }
 
 const AmountWithLabel = ({ slotProps }: AmountWithLabelProps) => (
-  <VStack className='Layer__TaxSummaryCard__AmountWithLabel' gap='2xs' align='start'>
+  <VStack className='Layer__TaxSummaryCard__AmountWithLabel' gap='2xs' align='center'>
     <MoneySpan {...slotProps.MoneySpan} />
     <Badge size={BadgeSize.SMALL} variant={BadgeVariant.NEUTRAL} {...slotProps.Badge} />
   </VStack>

--- a/src/components/TaxDetails/TaxSummaryCard/TaxSummaryCardEquation.tsx
+++ b/src/components/TaxDetails/TaxSummaryCard/TaxSummaryCardEquation.tsx
@@ -38,14 +38,14 @@ export const EquationRow = ({ section, size = 'md' }: EquationRowProps) => {
           Badge: { children: t('common:label.total', 'Total') },
         }}
       />
-      <Span className='Layer__TaxSummaryCard__Operator' size={size} variant='subtle'>-</Span>
+      <Span size={size} variant='subtle'>-</Span>
       <AmountWithLabel
         slotProps={{
           MoneySpan: { amount: section.taxesPaid, size },
           Badge: { children: t('taxEstimates:label.taxes_paid', 'Taxes Paid') },
         }}
       />
-      <Span className='Layer__TaxSummaryCard__Operator' size={size} variant='subtle'>=</Span>
+      <Span size={size} variant='subtle'>=</Span>
       <AmountWithLabel
         slotProps={{
           MoneySpan: { amount: section.taxesOwed, size },

--- a/src/components/TaxDetails/TaxSummaryCard/taxSummaryCard.scss
+++ b/src/components/TaxDetails/TaxSummaryCard/taxSummaryCard.scss
@@ -41,7 +41,7 @@
   }
 
   &__AmountWithLabel {
-    min-width: 0;
+    width: 5.5rem;
   }
 
   &__Operator {

--- a/src/components/TaxDetails/TaxSummaryCard/taxSummaryCard.scss
+++ b/src/components/TaxDetails/TaxSummaryCard/taxSummaryCard.scss
@@ -44,10 +44,6 @@
     width: 5.5rem;
   }
 
-  &__Operator {
-    align-self: center;
-  }
-
   &--mobile {
     width: 100%;
   }

--- a/src/components/TaxDetails/TaxSummaryCard/taxSummaryCard.scss
+++ b/src/components/TaxDetails/TaxSummaryCard/taxSummaryCard.scss
@@ -41,7 +41,7 @@
   }
 
   &__AmountWithLabel {
-    width: 5.5rem;
+    min-inline-size: 5.5rem;
   }
 
   &--mobile {


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?

### Before

<img width="1107" height="380" alt="image" src="https://github.com/user-attachments/assets/1294b089-b738-435f-801f-13b63aaf720a" />

### After

<img width="1100" height="390" alt="image" src="https://github.com/user-attachments/assets/a6669a35-f4bf-4300-9e52-0640d1f001e6" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling/layout-only change to the tax summary equation; no business logic or data handling is modified.
> 
> **Overview**
> Adjusts the `TaxSummaryCard` equation layout so each amount+label stack is center-aligned and given a consistent minimum inline width, improving alignment of totals with the `-`/`=` operators.
> 
> Removes the dedicated operator CSS class from the equation symbols and relies on the base `Span` styling instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5b9ed33081a912780a298bb11f245999c51d378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->