### PR TITLE
fix: expense card intermediate width glitch

### DIFF
--- a/src/components/DetailedTable/detailedTable.scss
+++ b/src/components/DetailedTable/detailedTable.scss
@@ -49,7 +49,6 @@
     }
 
     &--percent {
-      width: 4ch;
       padding-left: 0;
       text-align: right;
 

--- a/src/components/ExpensesSummaryCard/expensesSummaryCard.scss
+++ b/src/components/ExpensesSummaryCard/expensesSummaryCard.scss
@@ -18,7 +18,7 @@
   .Layer__profit-and-loss-detailed-charts__content {
     display: flex;
     align-items: stretch;
-    justify-content: center;
+    justify-content: start;
     overflow: hidden;
   }
 
@@ -30,7 +30,6 @@
   }
 
   .Layer__profit-and-loss-detailed-charts__content > .Layer__DetailedTable {
-    flex: unset;
     overflow-x: hidden;
     overflow-y: auto;
     min-block-size: 0;
@@ -56,8 +55,7 @@
   }
 
   .Layer__profit-and-loss-detailed-charts .Layer__DetailedChart__container {
-    padding-inline-start: var(--spacing-xs);
-    padding-inline-end: var(--spacing-xs);
+    padding-inline: var(--spacing-md);
   }
 
   .Layer__DetailedTable {


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->
- Removed constant width on detailed table %
- Removed expense card styling (flex unset)

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: SCSS-only layout tweaks (flex alignment/sizing and padding) with no changes to business logic or data handling.
> 
> **Overview**
> Reduces layout glitches in the Expenses Summary Card at intermediate widths by removing a fixed width constraint on the detailed table percent column and letting the table flex/scroll naturally.
> 
> Adjusts the card’s flex layout to left-align content (`justify-content: start`) and updates chart container padding to a single `padding-inline` value for more consistent spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f7bca9509ccf8cb4317edd11b12d6de2341f03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->