### PR TITLE
fix: allow large category names, wraps to at most 2 lines, then ellipsis

### DIFF
--- a/src/components/DetailedCharts/DetailedChart.tsx
+++ b/src/components/DetailedCharts/DetailedChart.tsx
@@ -97,7 +97,7 @@ export const DetailedChart = <T extends SeriesData>({
           verticalAnchor='middle'
           breakAll={true}
           maxLines={2}
-          width={width - 40}
+          width={Math.max(width - 40, 0)}
           className='Layer__DetailedChart__centerLabelTitle'
         >
           {text}

--- a/src/components/DetailedCharts/DetailedChart.tsx
+++ b/src/components/DetailedCharts/DetailedChart.tsx
@@ -95,6 +95,9 @@ export const DetailedChart = <T extends SeriesData>({
           x={x + width / 2}
           textAnchor='middle'
           verticalAnchor='middle'
+          breakAll={true}
+          maxLines={2}
+          width={width - 40}
           className='Layer__DetailedChart__centerLabelTitle'
         >
           {text}


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

<img width="771" height="419" alt="image" src="https://github.com/user-attachments/assets/951feea9-9116-4f7d-bae8-a7fb3449b336" />


## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks `recharts` text rendering for the center label; main risk is minor layout/ellipsis behavior differences across browsers/sizes.
> 
> **Overview**
> Improves `DetailedChart` center label rendering by constraining the title text to the available radius and enabling word breaking with a **2-line max** (then ellipsis) via `ChartText` props.
> 
> This prevents long hovered category names from overflowing the chart center while leaving value/share rendering unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5431a615cca71884493bc7ad281d880fb68d4fea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->