### PR TITLE
fix: center the detailed charts on the expenses summary card

### DIFF
--- a/src/components/ExpensesSummaryCard/expensesSummaryCard.scss
+++ b/src/components/ExpensesSummaryCard/expensesSummaryCard.scss
@@ -27,7 +27,7 @@
     inline-size: auto;
     min-inline-size: 14rem;
     max-inline-size: 18rem;
-    margin: 0 auto;
+    margin-inline: auto;
   }
 
   .Layer__profit-and-loss-detailed-charts__content > .Layer__DetailedTable {
@@ -61,7 +61,7 @@
     padding-inline: var(--spacing-md);
 
     @media (width <= 767px) {
-      padding: 0;
+      padding-inline: 0;
     }
   }
 

--- a/src/components/ExpensesSummaryCard/expensesSummaryCard.scss
+++ b/src/components/ExpensesSummaryCard/expensesSummaryCard.scss
@@ -27,12 +27,14 @@
     inline-size: auto;
     min-inline-size: 14rem;
     max-inline-size: 18rem;
+    margin: 0 auto;
   }
 
   .Layer__profit-and-loss-detailed-charts__content > .Layer__DetailedTable {
     overflow-x: hidden;
     overflow-y: auto;
     min-block-size: 0;
+    inline-size: 100%;
     min-inline-size: 0;
 
     @media (width <= 767px) {
@@ -55,7 +57,12 @@
   }
 
   .Layer__profit-and-loss-detailed-charts .Layer__DetailedChart__container {
+    transition: padding 0.2s ease-in-out;
     padding-inline: var(--spacing-md);
+
+    @media (width <= 767px) {
+      padding: 0;
+    }
   }
 
   .Layer__DetailedTable {


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<img width="363" height="542" alt="image" src="https://github.com/user-attachments/assets/85654fe0-3920-4655-aeef-a2afa5b06345" />

<img width="891" height="423" alt="image" src="https://github.com/user-attachments/assets/ef26738c-f086-4b89-94b8-0debfba349d6" />

<img width="1444" height="1000" alt="image" src="https://github.com/user-attachments/assets/8cf71a4a-c938-41c6-b84f-3f06d695fccf" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change confined to `ExpensesSummaryCard` layout; main risk is unintended responsive layout shifts for the chart/table container widths and padding.
> 
> **Overview**
> Centers the detailed chart within the expenses summary card by adding `margin-inline: auto` to the chart container.
> 
> Tightens layout behavior by forcing the detailed table to `inline-size: 100%` and making the chart container’s horizontal padding responsive (with a small `padding` transition and zero padding on narrow screens).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b645d30d3105053f737f1e1442cec82588fb4bce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->