### PR TITLE
chore: release v0.1.132-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.132-alpha.2",
+  "version": "0.1.132-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.132-alpha.2",
+      "version": "0.1.132-alpha.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.132-alpha.2",
+  "version": "0.1.132-alpha.3",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.132-alpha.3`.

- Mode: **alpha**
- Tag (post-merge): `v0.1.132-alpha.3`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the package version in `package.json` and `package-lock.json` with no code or dependency changes.
> 
> **Overview**
> Updates the `@layerfi/components` release metadata by bumping the version from `0.1.132-alpha.2` to `0.1.132-alpha.3` in `package.json` and `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7096a939248d7072932ee90c4892e559ac95b187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->