### PR TITLE
fix: moved state field on tax estimates to the correct object

### DIFF
--- a/src/schemas/taxEstimates/details.ts
+++ b/src/schemas/taxEstimates/details.ts
@@ -6,8 +6,7 @@ import {
   UnifiedCellValuePercentageSchema,
   UnifiedCellValueUnknownSchema,
 } from '@schemas/reports/unifiedReport'
-
-import { TransformedTaxSummaryStateSchema } from './summary'
+import { TransformedTaxSummaryStateSchema } from '@schemas/taxEstimates/summary'
 
 const TaxDetailsValueSchema = Schema.Union(
   UnifiedCellValueCurrencySchema,

--- a/src/schemas/taxEstimates/details.ts
+++ b/src/schemas/taxEstimates/details.ts
@@ -6,7 +6,8 @@ import {
   UnifiedCellValuePercentageSchema,
   UnifiedCellValueUnknownSchema,
 } from '@schemas/reports/unifiedReport'
-import { TransformedTaxSummaryStateSchema } from '@schemas/taxEstimates/summary'
+
+import { TransformedTaxSummaryStateSchema } from './summary'
 
 const TaxDetailsValueSchema = Schema.Union(
   UnifiedCellValueCurrencySchema,
@@ -46,6 +47,7 @@ const TaxDetailsRowSchema = Schema.Struct({
 
 const TaxDetailsMetaSchema = Schema.Struct({
   year: Schema.Number,
+  state: TransformedTaxSummaryStateSchema,
   filingStatus: pipe(
     Schema.propertySignature(Schema.String),
     Schema.fromKey('filing_status'),
@@ -56,7 +58,6 @@ export type TaxDetailsMeta = typeof TaxDetailsMetaSchema.Type
 
 const TaxDetailsSchema = Schema.Struct({
   type: Schema.String,
-  state: TransformedTaxSummaryStateSchema,
   meta: TaxDetailsMetaSchema,
   rows: Schema.Array(TaxDetailsRowSchema),
 })


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the response schema shape for tax estimate details; this can be breaking if any callers or backend responses still expect `state` at the top level.
> 
> **Overview**
> Fixes the `TaxDetailsResponseSchema` shape by moving the `state` field from the top-level `TaxDetails` object into `meta` (`TaxDetailsMetaSchema`).
> 
> This aligns decoding/typing for `/tax-estimates/details` responses so `meta` now consistently contains `year`, `state`, and `filingStatus`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fc6e209f23e80bf8062a20b29414ac779cff1c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->