### PR TITLE
Show non-leaf categories in rules, fallback counterparty to description filter

### DIFF
--- a/src/components/CategorizationRules/CategorizationRulesMobileList/CategorizationRulesMobileList.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesMobileList/CategorizationRulesMobileList.tsx
@@ -9,7 +9,7 @@ import { PaginatedMobileList } from '@ui/MobileList/PaginatedMobileList'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { ResolvedCategoryName } from '@components/CategorizationRules/ResolvedCategoryName'
-import { getCategorizationRuleDirectionLabel, parseTransactionDescriptionFilter } from '@components/CategorizationRules/utils'
+import { getCategorizationRuleCounterpartyLabel, getCategorizationRuleDirectionLabel } from '@components/CategorizationRules/utils'
 import type { TablePaginationProps } from '@components/PaginatedDataTable/PaginatedDataTable'
 
 import './categorizationRulesMobileList.scss'
@@ -26,8 +26,7 @@ const CategorizationRuleMobileListItem = ({
   onDeletePress,
 }: CategorizationRuleMobileListItemProps) => {
   const { t } = useTranslation()
-  const counterpartyLabel = rule.counterpartyFilter?.name
-    ?? (rule.transactionDescriptionFilter ? parseTransactionDescriptionFilter(rule.transactionDescriptionFilter) : undefined)
+  const counterpartyLabel = getCategorizationRuleCounterpartyLabel(rule)
   return (
     <HStack justify='space-between' align='center' gap='sm' className='Layer__CategorizationRulesMobileListItem'>
       <VStack gap='2xs' className='Layer__CategorizationRulesMobileListItem__Content'>

--- a/src/components/CategorizationRules/CategorizationRulesMobileList/CategorizationRulesMobileList.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesMobileList/CategorizationRulesMobileList.tsx
@@ -9,7 +9,7 @@ import { PaginatedMobileList } from '@ui/MobileList/PaginatedMobileList'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { ResolvedCategoryName } from '@components/CategorizationRules/ResolvedCategoryName'
-import { getCategorizationRuleDirectionLabel } from '@components/CategorizationRules/utils'
+import { getCategorizationRuleDirectionLabel, parseTransactionDescriptionFilter } from '@components/CategorizationRules/utils'
 import type { TablePaginationProps } from '@components/PaginatedDataTable/PaginatedDataTable'
 
 import './categorizationRulesMobileList.scss'
@@ -26,10 +26,12 @@ const CategorizationRuleMobileListItem = ({
   onDeletePress,
 }: CategorizationRuleMobileListItemProps) => {
   const { t } = useTranslation()
+  const counterpartyLabel = rule.counterpartyFilter?.name
+    ?? (rule.transactionDescriptionFilter ? parseTransactionDescriptionFilter(rule.transactionDescriptionFilter) : undefined)
   return (
     <HStack justify='space-between' align='center' gap='sm' className='Layer__CategorizationRulesMobileListItem'>
       <VStack gap='2xs' className='Layer__CategorizationRulesMobileListItem__Content'>
-        <Span weight='bold' ellipsis>{rule.counterpartyFilter?.name}</Span>
+        <Span weight='bold' ellipsis>{counterpartyLabel}</Span>
         <HStack gap='3xs' align='center'>
           <Span size='sm' variant='subtle'>{t('common:label.direction', 'Direction:')}</Span>
           <Span size='sm' variant='subtle'>{getCategorizationRuleDirectionLabel(rule.bankDirectionFilter, t)}</Span>

--- a/src/components/CategorizationRules/CategorizationRulesTable/CategorizationRulesTable.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesTable/CategorizationRulesTable.tsx
@@ -8,7 +8,7 @@ import type { NestedCategorization } from '@schemas/categorization'
 import { Button } from '@ui/Button/Button'
 import { Span } from '@ui/Typography/Text'
 import { ResolvedCategoryName } from '@components/CategorizationRules/ResolvedCategoryName'
-import { getCategorizationRuleDirectionLabel } from '@components/CategorizationRules/utils'
+import { getCategorizationRuleDirectionLabel, parseTransactionDescriptionFilter } from '@components/CategorizationRules/utils'
 import type { NestedColumnConfig } from '@components/DataTable/columnUtils'
 import { PaginatedTable, type TablePaginationProps } from '@components/PaginatedDataTable/PaginatedDataTable'
 
@@ -50,9 +50,12 @@ export const CategorizationRulesTable = ({
     {
       id: CategorizationRuleColumns.Counterparty,
       header: t('common:label.counterparty', 'Counterparty'),
-      cell: (row: Row<CategorizationRule>) => (
-        <Span ellipsis>{row.original.counterpartyFilter?.name}</Span>
-      ),
+      cell: (row: Row<CategorizationRule>) => {
+        const counterpartyName = row.original.counterpartyFilter?.name
+        const descriptionFilter = row.original.transactionDescriptionFilter
+        const label = counterpartyName ?? (descriptionFilter ? parseTransactionDescriptionFilter(descriptionFilter) : undefined)
+        return <Span ellipsis>{label}</Span>
+      },
     },
     {
       id: CategorizationRuleColumns.Direction,

--- a/src/components/CategorizationRules/CategorizationRulesTable/CategorizationRulesTable.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesTable/CategorizationRulesTable.tsx
@@ -8,7 +8,7 @@ import type { NestedCategorization } from '@schemas/categorization'
 import { Button } from '@ui/Button/Button'
 import { Span } from '@ui/Typography/Text'
 import { ResolvedCategoryName } from '@components/CategorizationRules/ResolvedCategoryName'
-import { getCategorizationRuleDirectionLabel, parseTransactionDescriptionFilter } from '@components/CategorizationRules/utils'
+import { getCategorizationRuleCounterpartyLabel, getCategorizationRuleDirectionLabel } from '@components/CategorizationRules/utils'
 import type { NestedColumnConfig } from '@components/DataTable/columnUtils'
 import { PaginatedTable, type TablePaginationProps } from '@components/PaginatedDataTable/PaginatedDataTable'
 
@@ -50,12 +50,9 @@ export const CategorizationRulesTable = ({
     {
       id: CategorizationRuleColumns.Counterparty,
       header: t('common:label.counterparty', 'Counterparty'),
-      cell: (row: Row<CategorizationRule>) => {
-        const counterpartyName = row.original.counterpartyFilter?.name
-        const descriptionFilter = row.original.transactionDescriptionFilter
-        const label = counterpartyName ?? (descriptionFilter ? parseTransactionDescriptionFilter(descriptionFilter) : undefined)
-        return <Span ellipsis>{label}</Span>
-      },
+      cell: (row: Row<CategorizationRule>) => (
+        <Span ellipsis>{getCategorizationRuleCounterpartyLabel(row.original)}</Span>
+      ),
     },
     {
       id: CategorizationRuleColumns.Direction,

--- a/src/components/CategorizationRules/CategorizationRulesView/ResponsiveCategorizationRulesView.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesView/ResponsiveCategorizationRulesView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { PencilRuler } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { getLeafCategories } from '@internal-types/categories'
+import { flattenCategories } from '@internal-types/categories'
 import type { CategorizationRule } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { CategoriesListMode } from '@schemas/categorization'
 import { BREAKPOINTS } from '@utils/screenSizeBreakpoints'
@@ -81,7 +81,7 @@ export const ResponsiveCategorizationRulesView = () => {
   const { data: categories, isLoading: categoriesAreLoading } = useCategories({ mode: CategoriesListMode.All })
   const options = useMemo(() => {
     if (!categories) return []
-    return getLeafCategories(categories)
+    return flattenCategories(categories)
   }, [categories])
 
   const { data, hasMore, isLoading: rulesAreLoading, isError, size, setSize } = useListCategorizationRules({})

--- a/src/components/CategorizationRules/CategorizationRulesView/ResponsiveCategorizationRulesView.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesView/ResponsiveCategorizationRulesView.tsx
@@ -162,6 +162,9 @@ export const ResponsiveCategorizationRulesView = () => {
     </VStack>
   ), [toBankTransactionsTable, categorizationRules, isLoading, isError, paginationProps, options, onDeleteRule])
 
+  const selectedRuleCounterpartyLabel = (selectedRule && getCategorizationRuleCounterpartyLabel(selectedRule))
+    ?? t('bankTransactions:label.selected_counterparty', 'this counterparty')
+
   return (
     <>
       <ResponsiveComponent
@@ -172,7 +175,7 @@ export const ResponsiveCategorizationRulesView = () => {
         isOpen={showDeletionConfirmationModal}
         onOpenChange={setShowDeletionConfirmationModal}
         title={t('categorizationRules:prompt.delete_categorization_rule', 'Delete categorization rule?')}
-        description={t('categorizationRules:label.transaction_no_longer_automatically_categorized', 'Transactions will no longer automatically be categorized by this rule. Any transactions previously categorized to {{counterparty}} will not be affected.', { counterparty: selectedRule ? getCategorizationRuleCounterpartyLabel(selectedRule) : t('bankTransactions:label.selected_counterparty', 'this counterparty') })}
+        description={t('categorizationRules:label.transaction_no_longer_automatically_categorized', 'Transactions will no longer automatically be categorized by this rule. Any transactions previously categorized to {{counterparty}} will not be affected.', { counterparty: selectedRuleCounterpartyLabel })}
         onConfirm={archiveCategorizationRule}
         confirmLabel={t('common:action.delete_label', 'Delete')}
         cancelLabel={t('common:action.cancel_label', 'Cancel')}

--- a/src/components/CategorizationRules/CategorizationRulesView/ResponsiveCategorizationRulesView.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesView/ResponsiveCategorizationRulesView.tsx
@@ -172,7 +172,7 @@ export const ResponsiveCategorizationRulesView = () => {
         isOpen={showDeletionConfirmationModal}
         onOpenChange={setShowDeletionConfirmationModal}
         title={t('categorizationRules:prompt.delete_categorization_rule', 'Delete categorization rule?')}
-        description={t('categorizationRules:label.transaction_no_longer_automatically_categorized', 'Transactions will no longer automatically be categorized by this rule. Any transactions previously categorized to {{counterparty}} will not be affected.', { counterparty: (selectedRule ? getCategorizationRuleCounterpartyLabel(selectedRule) : undefined) ?? t('bankTransactions:label.selected_counterparty', 'this counterparty') })}
+        description={t('categorizationRules:label.transaction_no_longer_automatically_categorized', 'Transactions will no longer automatically be categorized by this rule. Any transactions previously categorized to {{counterparty}} will not be affected.', { counterparty: selectedRule ? getCategorizationRuleCounterpartyLabel(selectedRule) : t('bankTransactions:label.selected_counterparty', 'this counterparty') })}
         onConfirm={archiveCategorizationRule}
         confirmLabel={t('common:action.delete_label', 'Delete')}
         cancelLabel={t('common:action.cancel_label', 'Cancel')}

--- a/src/components/CategorizationRules/CategorizationRulesView/ResponsiveCategorizationRulesView.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesView/ResponsiveCategorizationRulesView.tsx
@@ -21,6 +21,7 @@ import { BaseConfirmationModal } from '@blocks/BaseConfirmationModal/BaseConfirm
 import { BaseDetailView } from '@components/BaseDetailView/BaseDetailView'
 import { CategorizationRulesMobileList } from '@components/CategorizationRules/CategorizationRulesMobileList/CategorizationRulesMobileList'
 import { CategorizationRulesTable } from '@components/CategorizationRules/CategorizationRulesTable/CategorizationRulesTable'
+import { getCategorizationRuleCounterpartyLabel } from '@components/CategorizationRules/utils'
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
 
 const CategorizationRulesEmptyState = () => {
@@ -171,7 +172,7 @@ export const ResponsiveCategorizationRulesView = () => {
         isOpen={showDeletionConfirmationModal}
         onOpenChange={setShowDeletionConfirmationModal}
         title={t('categorizationRules:prompt.delete_categorization_rule', 'Delete categorization rule?')}
-        description={t('categorizationRules:label.transaction_no_longer_automatically_categorized', 'Transactions will no longer automatically be categorized by this rule. Any transactions previously categorized to {{counterparty}} will not be affected.', { counterparty: selectedRule?.counterpartyFilter?.name ?? t('bankTransactions:label.selected_counterparty', 'this counterparty') })}
+        description={t('categorizationRules:label.transaction_no_longer_automatically_categorized', 'Transactions will no longer automatically be categorized by this rule. Any transactions previously categorized to {{counterparty}} will not be affected.', { counterparty: (selectedRule ? getCategorizationRuleCounterpartyLabel(selectedRule) : undefined) ?? t('bankTransactions:label.selected_counterparty', 'this counterparty') })}
         onConfirm={archiveCategorizationRule}
         confirmLabel={t('common:action.delete_label', 'Delete')}
         cancelLabel={t('common:action.cancel_label', 'Cancel')}

--- a/src/components/CategorizationRules/utils.ts
+++ b/src/components/CategorizationRules/utils.ts
@@ -20,16 +20,6 @@ export const getCategorizationRuleDirectionLabel = (
   return entry ? t(entry.i18nKey, entry.defaultValue) : t('categorizationRules:label.any_direction', 'Any direction')
 }
 
-// Strip Java-style `\Q...\E` literal-quote markers from a regex-based
-// transaction_description_filter so it reads as plain text. Only strips when
-// the whole filter is a single `\Q...\E` block — anything more elaborate falls
-// through unchanged so we don't silently hide unquoted regex parts.
-export const parseTransactionDescriptionFilter = (filter: string): string => {
-  return filter.match(/^\\Q(.*)\\E$/)?.[1] ?? filter
-}
-
 export const getCategorizationRuleCounterpartyLabel = (rule: CategorizationRule): string | undefined => {
-  if (rule.counterpartyFilter?.name) return rule.counterpartyFilter.name
-  if (rule.transactionDescriptionFilter) return parseTransactionDescriptionFilter(rule.transactionDescriptionFilter)
-  return undefined
+  return rule.counterpartyFilter?.name ?? rule.readableTransactionDescriptionFilter ?? undefined
 }

--- a/src/components/CategorizationRules/utils.ts
+++ b/src/components/CategorizationRules/utils.ts
@@ -1,5 +1,6 @@
 import type { TFunction } from 'i18next'
 
+import type { CategorizationRule } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { BankDirectionFilter } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { translationKey } from '@utils/i18n/translationKey'
 
@@ -20,8 +21,15 @@ export const getCategorizationRuleDirectionLabel = (
 }
 
 // Strip Java-style `\Q...\E` literal-quote markers from a regex-based
-// transaction_description_filter so it reads as plain text.
-// Fall through unchanged if the pattern doesn't match.
+// transaction_description_filter so it reads as plain text. Only strips when
+// the whole filter is a single `\Q...\E` block — anything more elaborate falls
+// through unchanged so we don't silently hide unquoted regex parts.
 export const parseTransactionDescriptionFilter = (filter: string): string => {
-  return filter.match(/\\Q(.*?)\\E/)?.[1] ?? filter
+  return filter.match(/^\\Q(.*)\\E$/)?.[1] ?? filter
+}
+
+export const getCategorizationRuleCounterpartyLabel = (rule: CategorizationRule): string | undefined => {
+  if (rule.counterpartyFilter?.name) return rule.counterpartyFilter.name
+  if (rule.transactionDescriptionFilter) return parseTransactionDescriptionFilter(rule.transactionDescriptionFilter)
+  return undefined
 }

--- a/src/components/CategorizationRules/utils.ts
+++ b/src/components/CategorizationRules/utils.ts
@@ -18,3 +18,10 @@ export const getCategorizationRuleDirectionLabel = (
   const entry = DIRECTION_CONFIG.find(c => c.value === bankDirectionFilter)
   return entry ? t(entry.i18nKey, entry.defaultValue) : t('categorizationRules:label.any_direction', 'Any direction')
 }
+
+// Strip Java-style `\Q...\E` literal-quote markers from a regex-based
+// transaction_description_filter so it reads as plain text.
+// Fall through unchanged if the pattern doesn't match.
+export const parseTransactionDescriptionFilter = (filter: string): string => {
+  return filter.match(/\\Q(.*?)\\E/)?.[1] ?? filter
+}

--- a/src/schemas/bankTransactions/categorizationRules/categorizationRule.ts
+++ b/src/schemas/bankTransactions/categorizationRules/categorizationRule.ts
@@ -159,9 +159,9 @@ export const CategorizationRuleSchema = Schema.Struct({
     Schema.propertySignature(Schema.NullishOr(BankTransactionCounterpartySchema)),
     Schema.fromKey('counterparty_filter'),
   ),
-  transactionDescriptionFilter: pipe(
+  readableTransactionDescriptionFilter: pipe(
     Schema.propertySignature(Schema.NullishOr(Schema.String)),
-    Schema.fromKey('transaction_description_filter'),
+    Schema.fromKey('readable_transaction_description_filter'),
   ),
   bankDirectionFilter: pipe(
     Schema.propertySignature(Schema.NullishOr(BankDirectionFilterSchema)),

--- a/src/schemas/bankTransactions/categorizationRules/categorizationRule.ts
+++ b/src/schemas/bankTransactions/categorizationRules/categorizationRule.ts
@@ -159,6 +159,10 @@ export const CategorizationRuleSchema = Schema.Struct({
     Schema.propertySignature(Schema.NullishOr(BankTransactionCounterpartySchema)),
     Schema.fromKey('counterparty_filter'),
   ),
+  transactionDescriptionFilter: pipe(
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
+    Schema.fromKey('transaction_description_filter'),
+  ),
   bankDirectionFilter: pipe(
     Schema.propertySignature(Schema.NullishOr(BankDirectionFilterSchema)),
     Schema.fromKey('bank_direction_filter'),

--- a/src/types/categories.ts
+++ b/src/types/categories.ts
@@ -72,3 +72,10 @@ export const getLeafCategories = (categories: NestedCategorization[]): NestedCat
     return getLeafCategories(category.subCategories)
   })
 }
+
+export const flattenCategories = (categories: NestedCategorization[]): NestedCategorization[] => {
+  return categories.flatMap(category => [
+    category,
+    ...(category.subCategories ? flattenCategories(category.subCategories) : []),
+  ])
+}


### PR DESCRIPTION
Some categorization rules imported from a third party API map to non-leaf ledger accounts, resulting in our table leaving the category field blank. 
Additionally, these rules operate by raw string matching rather than counterparty matching, so we now fall back to the description filter field when no counterparty is present on the rule.

Before:
<img width="1073" height="761" alt="Screenshot 2026-05-11 at 2 52 23 PM" src="https://github.com/user-attachments/assets/f965a843-629a-4c2b-8930-92ad2cad3d29" />

After:
<img width="1183" height="754" alt="Screenshot 2026-05-12 at 5 59 09 PM" src="https://github.com/user-attachments/assets/c3d3924b-eaa6-4810-9bf2-c8fcfe05d915" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes how categorization rule data is decoded (new `readableTransactionDescriptionFilter`) and how category/counterparty labels are resolved in multiple views, which could affect displayed values if backend payloads vary.
> 
> **Overview**
> Categorization rules now resolve category names against a **flattened category list** (not just leaf nodes), allowing rules pointing at parent/non-leaf accounts to display a category label.
> 
> Rule counterparty display is centralized via `getCategorizationRuleCounterpartyLabel`, which falls back to `readableTransactionDescriptionFilter`; this label is used in the table, mobile list, and the delete confirmation modal.
> 
> The rule schema is updated to decode the new `readable_transaction_description_filter` field from the API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a52ea6d210871466aac9717011ec839dc927568b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->