### PR TITLE
fix: pnl chart indicator

### DIFF
--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -34,6 +34,8 @@ import { ProfitAndLossChartStateCard } from '@components/ProfitAndLossChart/Prof
 import { ProfitAndLossChartTooltip } from '@components/ProfitAndLossChart/ProfitAndLossChartTooltip'
 import { transformPnLData } from '@components/ProfitAndLossChart/transformPnLData'
 
+import './profitAndLossChart.scss'
+
 export interface ProfitAndLossChartProps {
   tagFilter?: {
     key: string
@@ -42,7 +44,7 @@ export interface ProfitAndLossChartProps {
   hideLegend?: boolean
 }
 
-const CHART_MARGINS = { left: 12, right: 12, bottom: 12 }
+const CHART_MARGINS = { left: 12, right: 12, bottom: 12, top: 24 }
 
 export const ProfitAndLossChart = ({ tagFilter, hideLegend = false }: ProfitAndLossChartProps) => {
   const { formatMonthName } = useIntlFormatter()
@@ -138,10 +140,10 @@ export const ProfitAndLossChart = ({ tagFilter, hideLegend = false }: ProfitAndL
   }, [compactView])
 
   return (
-    <div className='Layer__chart-wrapper'>
+    <div className='Layer__ProfitAndLossChart'>
       <ResponsiveContainer
         key='pnl-chart'
-        className='Layer__chart-container'
+        className='Layer__ProfitAndLossChart__Container'
         width='100%'
         height='100%'
         onResize={onResize}
@@ -151,7 +153,7 @@ export const ProfitAndLossChart = ({ tagFilter, hideLegend = false }: ProfitAndL
           margin={CHART_MARGINS}
           data={dataOrPlaceholderData}
           onClick={onClick}
-          className='Layer__profit-and-loss-chart'
+          className='Layer__profit-and-loss-chart Layer__ProfitAndLossChart__Chart'
         >
           <ProfitAndLossChartPatternDefs />
           <ReferenceLine y={0} stroke={getColor(300)?.hex ?? '#EBEDF0'} xAxisId='revenue' zIndex={DefaultZIndexes.bar - 1} />

--- a/src/components/ProfitAndLossChart/ProfitAndLossChartSelectionIndicator.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChartSelectionIndicator.tsx
@@ -23,7 +23,7 @@ export const ProfitAndLossChartSelectionIndicator = ({ viewBox, selected }: Prof
       rx={borderRadius}
       ry={borderRadius}
       x={x - margin}
-      y={-margin + 36}
+      y={24}
       width={boxWidth}
       height='calc(100% - 38px)'
     />

--- a/src/components/ProfitAndLossChart/ProfitAndLossChartSelectionIndicator.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChartSelectionIndicator.tsx
@@ -4,6 +4,8 @@ type ProfitAndLossChartSelectionIndicatorProps = Pick<LabelProps, 'viewBox'> & {
   selected?: boolean
 }
 
+import './profitAndLossChartSelectionIndicator.scss'
+
 export const ProfitAndLossChartSelectionIndicator = ({ viewBox, selected }: ProfitAndLossChartSelectionIndicatorProps) => {
   if (!selected) return null
 
@@ -17,13 +19,13 @@ export const ProfitAndLossChartSelectionIndicator = ({ viewBox, selected }: Prof
 
   return (
     <rect
-      className='Layer__profit-and-loss-chart__selection-indicator'
+      className='Layer__ProfitAndLossChart__SelectionIndicator'
       rx={borderRadius}
       ry={borderRadius}
       x={x - margin}
-      y={16}
+      y={-margin + 36}
       width={boxWidth}
-      height='calc(100% - 30px)'
+      height='calc(100% - 38px)'
     />
   )
 }

--- a/src/components/ProfitAndLossChart/profitAndLossChart.scss
+++ b/src/components/ProfitAndLossChart/profitAndLossChart.scss
@@ -2,6 +2,6 @@
   position: relative;
 
   &__Container {
-    min-height: 300px;
+    min-block-size: 300px;
   }
 }

--- a/src/components/ProfitAndLossChart/profitAndLossChart.scss
+++ b/src/components/ProfitAndLossChart/profitAndLossChart.scss
@@ -1,0 +1,7 @@
+.Layer__ProfitAndLossChart {
+  position: relative;
+
+  &__Container {
+    min-height: 300px;
+  }
+}

--- a/src/components/ProfitAndLossChart/profitAndLossChart.scss
+++ b/src/components/ProfitAndLossChart/profitAndLossChart.scss
@@ -2,6 +2,6 @@
   position: relative;
 
   &__Container {
-    min-block-size: 300px;
+    min-block-size: 18.75rem;
   }
 }

--- a/src/components/ProfitAndLossChart/profitAndLossChartSelectionIndicator.scss
+++ b/src/components/ProfitAndLossChart/profitAndLossChartSelectionIndicator.scss
@@ -1,0 +1,5 @@
+.Layer__ProfitAndLossChart__SelectionIndicator {
+  stroke: var(--chart-indicator-color);
+  fill: none;
+  transition: opacity 0.1s linear;
+}

--- a/src/components/ProfitAndLossHeader/ProfitAndLossHeader.tsx
+++ b/src/components/ProfitAndLossHeader/ProfitAndLossHeader.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { type ReactNode, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { isAnyBankAccountSyncing } from '@utils/bankAccount'
@@ -32,6 +32,7 @@ export interface ProfitAndLossHeaderProps {
   withDownloadButton?: boolean
   withStatus?: boolean
   dateSelectionMode?: DateSelectionMode
+  trailingContent?: ReactNode
 }
 
 export const ProfitAndLossHeader = ({
@@ -43,6 +44,7 @@ export const ProfitAndLossHeader = ({
   withStatus = true,
   stringOverrides,
   dateSelectionMode = 'full',
+  trailingContent,
 }: ProfitAndLossHeaderProps) => {
   const { t } = useTranslation()
   const { data: linkedAccounts } = useLinkedAccounts()
@@ -68,7 +70,8 @@ export const ProfitAndLossHeader = ({
           </span>
         )}
       </span>
-      <HStack gap='xs'>
+      <HStack gap='xs' align='center'>
+        {trailingContent}
         {withDatePicker && <CombinedDateRangeSelection mode={dateSelectionMode} showLabels={false} />}
         {withDownloadButton && <ProfitAndLossDownloadButton stringOverrides={stringOverrides?.downloadButton} />}
       </HStack>

--- a/src/components/ProfitAndLossOverviewDetailedCharts/ProfitAndLossOverviewDetailedCharts.tsx
+++ b/src/components/ProfitAndLossOverviewDetailedCharts/ProfitAndLossOverviewDetailedCharts.tsx
@@ -44,12 +44,12 @@ export const ProfitAndLossOverviewDetailedCharts = ({
   ), [detailedChartsStringOverrides, t])
 
   const chartsWrapperClassName = variant === 'accounting'
-    ? 'Layer__accounting-overview-profit-and-loss-charts'
-    : 'Layer__bookkeeping-overview-profit-and-loss-charts'
+    ? 'Layer__AccountingOverview__ProfitAndLossCharts'
+    : 'Layer__BookkeepingOverview__ProfitAndLossCharts'
 
   const chartContainerName = variant === 'accounting'
-    ? 'accounting-overview-profit-and-loss-chart'
-    : 'bookkeeping-overview-profit-and-loss-chart'
+    ? 'AccountingOverview__ProfitAndLossChart'
+    : 'BookkeepingOverview__ProfitAndLossChart'
 
   return (
     <VStack className={chartsWrapperClassName} gap='md' ref={elementRef}>

--- a/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
+++ b/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
@@ -1,17 +1,3 @@
 .Layer__ProfitAndLossSummaryCard {
-  .Layer__chart-wrapper,
-  .Layer__chart-container {
-    height: 100%;
-    min-block-size: 15.625rem;
-  }
-
-  div.recharts-responsive-container.Layer__chart-container {
-    padding-block-start: var(--spacing-xs);
-  }
-
-  @media (width <= 760px) {
-    .Layer__chart-wrapper {
-      height: unset;
-    }
-  }
+  position: relative;
 }

--- a/src/styles/accounting_overview.scss
+++ b/src/styles/accounting_overview.scss
@@ -4,23 +4,7 @@
   max-width: 1406px;
 }
 
-.Layer__component.Layer__accounting-overview-profit-and-loss .recharts-responsive-container {
-  margin-top: -42px;
-}
-
-@container (max-width: 1023px) {
-  .Layer__accounting-overview-profit-and-loss .recharts-legend-wrapper {
-    margin-top: -40px;
-  }
-}
-
 .Layer__accounting-overview-profit-and-loss-chart {
   box-sizing: border-box;
   width: 100%;
-}
-
-@container (max-width: 460px) {
-  .Layer__component.Layer__accounting-overview-profit-and-loss .recharts-responsive-container {
-    margin-top: -12px;
-  }
 }

--- a/src/styles/accounting_overview.scss
+++ b/src/styles/accounting_overview.scss
@@ -1,10 +1,1 @@
 @forward '../views/AccountingOverview/internal/transactions_to_review';
-
-.Layer__accounting-overview-profit-and-loss-charts {
-  max-width: 1406px;
-}
-
-.Layer__accounting-overview-profit-and-loss-chart {
-  box-sizing: border-box;
-  width: 100%;
-}

--- a/src/styles/bookkeeping_overview.scss
+++ b/src/styles/bookkeeping_overview.scss
@@ -29,3 +29,12 @@
     }
   }
 }
+
+.Layer__bookkeeping-overview-profit-and-loss-chart {
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.Layer__bookkeeping-overview-profit-and-loss-charts {
+  max-width: 1406px;
+}

--- a/src/styles/bookkeeping_overview.scss
+++ b/src/styles/bookkeeping_overview.scss
@@ -29,22 +29,3 @@
     }
   }
 }
-
-.Layer__bookkeeping-overview-profit-and-loss-chart {
-  box-sizing: border-box;
-  width: 100%;
-}
-
-.Layer__bookkeeping-overview-profit-and-loss-charts {
-  max-width: 1406px;
-}
-
-.Layer__bookkeeping-overview-profit-and-loss .recharts-legend-wrapper {
-  top: 16px !important;
-}
-
-@container (max-width: 460px) {
-  .Layer__component.Layer__bookkeeping-overview-profit-and-loss .recharts-responsive-container {
-    margin-top: -12px;
-  }
-}

--- a/src/styles/bookkeeping_overview.scss
+++ b/src/styles/bookkeeping_overview.scss
@@ -29,12 +29,3 @@
     }
   }
 }
-
-.Layer__bookkeeping-overview-profit-and-loss-chart {
-  box-sizing: border-box;
-  width: 100%;
-}
-
-.Layer__bookkeeping-overview-profit-and-loss-charts {
-  max-width: 1406px;
-}

--- a/src/styles/charts.scss
+++ b/src/styles/charts.scss
@@ -20,10 +20,6 @@
   }
 }
 
-.Layer__component .recharts-responsive-container.Layer__chart-container {
-  padding-top: 42px;
-}
-
 .Layer__UI__Chart--focusReset {
   .recharts-wrapper:focus,
   .recharts-wrapper :focus,
@@ -31,10 +27,6 @@
   .recharts-bar-rectangle:focus {
     outline: none;
   }
-}
-
-.Layer__chart-wrapper {
-  position: relative;
 }
 
 .Layer__chart-container {

--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -24,10 +24,6 @@
   font-size: 0.75rem;
 }
 
-.Layer__profit-and-loss-chart .recharts-legend-wrapper {
-  margin-top: -46px;
-}
-
 .Layer__profit-and-loss-chart .recharts-legend-item-text {
   font-size: 12px;
   color: var(--color-base-700);

--- a/src/styles/profit_and_loss.scss
+++ b/src/styles/profit_and_loss.scss
@@ -51,12 +51,6 @@
   fill: var(--base-transparent-16-light);
 }
 
-.Layer__profit-and-loss-chart__selection-indicator {
-  stroke: var(--chart-indicator-color);
-  fill: none;
-  transition: opacity 0.1s linear;
-}
-
 /** ---- */
 .Layer__profit-and-loss__chart_with_summaries {
   display: flex;

--- a/src/views/AccountingOverview/AccountingOverview.tsx
+++ b/src/views/AccountingOverview/AccountingOverview.tsx
@@ -83,6 +83,7 @@ export const AccountingOverview = ({
     >
       <View
         title={stringOverrides?.title || title || t('overview:label.accounting_overview', 'Accounting overview')}
+        viewClassName='Layer__AccountingOverview'
         showHeader={showTitle}
         header={(
           <Header>

--- a/src/views/AccountingOverview/AccountingOverview.tsx
+++ b/src/views/AccountingOverview/AccountingOverview.tsx
@@ -17,8 +17,11 @@ import {
   ProfitAndLossSummaries,
   type ProfitAndLossSummariesStringOverrides,
 } from '@components/ProfitAndLossSummaries/ProfitAndLossSummaries'
+import { PnlLegend } from '@components/ProfitAndLossSummaryCard/PnlLegend'
 import { View } from '@components/View/View'
 import { type TagOption } from '@views/ProjectProfitability/ProjectProfitability'
+
+import './accountingOverview.scss'
 
 interface AccountingOverviewStringOverrides {
   title?: string
@@ -105,10 +108,13 @@ export const AccountingOverview = ({
         />
         <Container
           name='accounting-overview-profit-and-loss'
+          className='Layer__AccountingOverview__ProfitAndLossContainer'
           asWidget
         >
           <ProfitAndLoss.Header
             text={stringOverrides?.header || t('common:label.profit_loss', 'Profit & Loss')}
+            className='Layer__AccountingOverview__ProfitAndLossHeader'
+            trailingContent={<PnlLegend direction='row' />}
           />
           <ProfitAndLoss.Chart
             tagFilter={
@@ -116,6 +122,7 @@ export const AccountingOverview = ({
                 ? { key: tagFilter.tagKey, values: tagFilter.tagValues }
                 : undefined
             }
+            hideLegend
           />
         </Container>
         {middleBanner && (

--- a/src/views/AccountingOverview/accountingOverview.scss
+++ b/src/views/AccountingOverview/accountingOverview.scss
@@ -1,6 +1,4 @@
 .Layer__AccountingOverview {
-  max-width: 1406px;
-
   &__ProfitAndLossHeader {
     padding-block-start: var(--spacing-lg);
     padding-block-end: 0;

--- a/src/views/AccountingOverview/accountingOverview.scss
+++ b/src/views/AccountingOverview/accountingOverview.scss
@@ -1,0 +1,12 @@
+.Layer__AccountingOverview {
+  &__ProfitAndLossHeader {
+    padding-block-start: var(--spacing-lg);
+    padding-block-end: 0;
+    padding-inline: var(--spacing-lg);
+  }
+
+  &__ProfitAndLossContainer {
+    display: flex;
+    flex-direction: column;
+  }
+}

--- a/src/views/AccountingOverview/accountingOverview.scss
+++ b/src/views/AccountingOverview/accountingOverview.scss
@@ -9,4 +9,13 @@
     display: flex;
     flex-direction: column;
   }
+
+  &__ProfitAndLossCharts {
+    max-width: 1406px;
+  }
+
+  &__ProfitAndLossChart {
+    box-sizing: border-box;
+    width: 100%;
+  }
 }

--- a/src/views/AccountingOverview/accountingOverview.scss
+++ b/src/views/AccountingOverview/accountingOverview.scss
@@ -11,11 +11,11 @@
   }
 
   &__ProfitAndLossCharts {
-    max-width: 1406px;
+    max-inline-size: 1406px;
   }
 
   &__ProfitAndLossChart {
     box-sizing: border-box;
-    width: 100%;
+    inline-size: 100%;
   }
 }

--- a/src/views/AccountingOverview/accountingOverview.scss
+++ b/src/views/AccountingOverview/accountingOverview.scss
@@ -1,4 +1,6 @@
 .Layer__AccountingOverview {
+  max-width: 1406px;
+
   &__ProfitAndLossHeader {
     padding-block-start: var(--spacing-lg);
     padding-block-end: 0;

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -22,6 +22,8 @@ import { Tasks, type TasksStringOverrides } from '@components/Tasks/Tasks'
 import { View } from '@components/View/View'
 import { useKeepInMobileViewport } from '@views/BookkeepingOverview/useKeepInMobileViewport'
 
+import './bookkeepingOverview.scss'
+
 type BookkeepingOverviewTasksContentProps = {
   callBooking?: CallBookingData
   showCallBookingCard: boolean

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -114,7 +114,7 @@ export const BookkeepingOverview = ({
   return (
     <ProfitAndLoss asContainer={false}>
       <View
-        viewClassName='Layer__bookkeeping-overview--view'
+        viewClassName='Layer__bookkeeping-overview--view Layer__BookkeepingOverview'
         title={stringOverrides?.title || title || t('overview:label.bookkeeping_overview', 'Bookkeeping overview')}
         header={(
           <Header>

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -17,6 +17,7 @@ import { ProfitAndLoss } from '@components/ProfitAndLoss/ProfitAndLoss'
 import { type ProfitAndLossDetailedChartsStringOverrides } from '@components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedCharts'
 import { ProfitAndLossOverviewDetailedCharts } from '@components/ProfitAndLossOverviewDetailedCharts/ProfitAndLossOverviewDetailedCharts'
 import { type ProfitAndLossSummariesStringOverrides } from '@components/ProfitAndLossSummaries/ProfitAndLossSummaries'
+import { PnlLegend } from '@components/ProfitAndLossSummaryCard/PnlLegend'
 import { Tasks, type TasksStringOverrides } from '@components/Tasks/Tasks'
 import { View } from '@components/View/View'
 import { useKeepInMobileViewport } from '@views/BookkeepingOverview/useKeepInMobileViewport'
@@ -160,6 +161,7 @@ export const BookkeepingOverview = ({
         >
           <Container
             name='bookkeeping-overview-profit-and-loss'
+            className='Layer__BookkeepingOverview__ProfitAndLossContainer'
             asWidget
             style={{
               position: 'relative',
@@ -169,6 +171,7 @@ export const BookkeepingOverview = ({
             <ProfitAndLoss.Header
               text={stringOverrides?.profitAndLoss?.header || t('common:label.profit_loss', 'Profit & Loss')}
               withStatus
+              trailingContent={<PnlLegend direction='row' />}
             />
             <VStack pb='md' pi='md' fluid>
               <ProfitAndLoss.Summaries
@@ -176,7 +179,7 @@ export const BookkeepingOverview = ({
                 variants={profitAndLossSummariesVariants}
               />
             </VStack>
-            <ProfitAndLoss.Chart />
+            <ProfitAndLoss.Chart hideLegend />
           </Container>
         </div>
         <ProfitAndLossOverviewDetailedCharts

--- a/src/views/BookkeepingOverview/bookkeepingOverview.scss
+++ b/src/views/BookkeepingOverview/bookkeepingOverview.scss
@@ -1,10 +1,15 @@
 .Layer__BookkeepingOverview {
+  &__ProfitAndLossContainer {
+    display: flex;
+    flex-direction: column;
+  }
+
   &__ProfitAndLossCharts {
-    max-width: 1406px;
+    max-inline-size: 1406px;
   }
 
   &__ProfitAndLossChart {
     box-sizing: border-box;
-    width: 100%;
+    inline-size: 100%;
   }
 }

--- a/src/views/BookkeepingOverview/bookkeepingOverview.scss
+++ b/src/views/BookkeepingOverview/bookkeepingOverview.scss
@@ -1,7 +1,5 @@
 .Layer__BookkeepingOverview {
-  &__ProfitAndLossCharts {
-    max-width: 1406px;
-  }
+  max-width: 1406px;
 
   &__ProfitAndLossChart {
     box-sizing: border-box;

--- a/src/views/BookkeepingOverview/bookkeepingOverview.scss
+++ b/src/views/BookkeepingOverview/bookkeepingOverview.scss
@@ -1,0 +1,8 @@
+.Layer__BookkeepingOverview {
+  max-width: 1406px;
+
+  &__ProfitAndLossChart {
+    box-sizing: border-box;
+    width: 100%;
+  }
+}

--- a/src/views/BookkeepingOverview/bookkeepingOverview.scss
+++ b/src/views/BookkeepingOverview/bookkeepingOverview.scss
@@ -1,5 +1,7 @@
 .Layer__BookkeepingOverview {
-  max-width: 1406px;
+  &__ProfitAndLossCharts {
+    max-width: 1406px;
+  }
 
   &__ProfitAndLossChart {
     box-sizing: border-box;


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

We want to make sure that the styling on `SummaryCard` or on `AccountingOverview` to be consistent, and no unusual negative margins.

## Changes
<!-- [Optional] List the main changes made in this PR. -->

- No more negative margins 🙏 
- Moved scss into scss files beside their components
- Incremental cleanup inconsistent BEM naming conventions
- Reduced code in grab-bag SCSS files

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

`SolopreneurLayout`

<img width="1685" height="1095" alt="image" src="https://github.com/user-attachments/assets/27c01e46-011b-4e0b-9338-bc8c2da9303c" />

`AccountingOverview`

<img width="1112" height="806" alt="image" src="https://github.com/user-attachments/assets/a1cd157d-6549-47f6-8e9c-2619af3ee980" />

`Zoomed in`

<img width="286" height="299" alt="image" src="https://github.com/user-attachments/assets/bbdfe3ba-d5f0-4ee0-b39e-b71b622137f5" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily styling/layout refactors (CSS class renames, margin/offset tweaks, and legend placement) with minimal logic changes; main risk is minor visual regressions across Profit & Loss views.
> 
> **Overview**
> Cleans up **Profit & Loss chart layout** by moving chart/container/indicator styles into component-scoped SCSS, standardizing BEM class names, and removing negative-margin/padding rules from global `accounting_overview`, `bookkeeping_overview`, `charts`, and `profit_and_loss` stylesheets.
> 
> Updates the chart rendering wrapper (`ProfitAndLossChart`) with new container classes, a `top` chart margin, and adjusted selection-indicator geometry (`y`/height) to match the new spacing.
> 
> Enhances `ProfitAndLossHeader` with optional `trailingContent`, then uses it in `AccountingOverview` and `BookkeepingOverview` to render `PnlLegend` in the header and hide the in-chart legend (`hideLegend`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7561a4158e52f0f35b00ede577facea23e435abb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->