### PR TITLE
chore: release v0.1.132-alpha.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.132-alpha.4",
+  "version": "0.1.132-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.132-alpha.4",
+      "version": "0.1.132-alpha.5",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.132-alpha.4",
+  "version": "0.1.132-alpha.5",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.132-alpha.5`.

- Mode: **alpha**
- Tag (post-merge): `v0.1.132-alpha.5`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the package version metadata in `package.json` and `package-lock.json`, with no code or dependency changes.
> 
> **Overview**
> Updates `@layerfi/components` release metadata by bumping the version from `0.1.132-alpha.4` to `0.1.132-alpha.5` in `package.json` and `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dab1be224388da29f42abf8317e569c625ece828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->