### PR TITLE
chore: release v0.1.132

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.132-alpha.5",
+  "version": "0.1.132",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.132-alpha.5",
+      "version": "0.1.132",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.132-alpha.5",
+  "version": "0.1.132",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.132`.

- Mode: **promote**
- Tag (post-merge): `v0.1.132`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping change that only updates package version metadata in `package.json` and `package-lock.json`. No runtime code or dependency changes are introduced.
> 
> **Overview**
> Promotes the package version from `0.1.132-alpha.5` to the stable `0.1.132` by updating version fields in `package.json` and `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca230849d34e8317353982c019e5292a8f162d11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->