### PR TITLE
fix: improving 'business not found' error state on time tracking

### DIFF
--- a/src/components/CustomerSelector/CustomerSelector.tsx
+++ b/src/components/CustomerSelector/CustomerSelector.tsx
@@ -4,6 +4,7 @@ import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 
 import { type Customer } from '@schemas/customer'
+import { ApiEnumErrorType, APIError } from '@utils/api/apiError'
 import { getCustomerName } from '@utils/customerVendor'
 import { useListCustomers } from '@hooks/api/businesses/[business-id]/customers/useListCustomers'
 import { useDebouncedSearchInput } from '@hooks/utils/debouncing/useDebouncedSearchQuery'
@@ -49,6 +50,7 @@ type CustomerSelectorBaseProps = {
   inline?: boolean
 
   className?: string
+  hideSpecifiedIdNotFoundError?: boolean
 }
 
 type CustomerSelectorProps = CustomerSelectorBaseProps & (
@@ -61,6 +63,14 @@ const formatCreateLabel = (inputValue: string, t: TFunction) =>
     ? t('customerVendor:action.create_customer_input_value', 'Create customer "{{inputValue}}"', { inputValue })
     : t('customerVendor:action.create_new_customer', 'Create new customer')
 
+const isSpecifiedIdNotFoundError = (error: unknown) => {
+  if (!(error instanceof APIError)) {
+    return false
+  }
+
+  return error.messages?.some(message => message.error_enum === ApiEnumErrorType.SpecifiedIdNotFound) === true
+}
+
 export function CustomerSelector({
   selectedCustomer,
   onSelectedCustomerChange,
@@ -71,6 +81,7 @@ export function CustomerSelector({
   isReadOnly,
   inline,
   className,
+  hideSpecifiedIdNotFoundError,
   showLabel = true,
 }: CustomerSelectorProps) {
   const { t } = useTranslation()
@@ -89,7 +100,9 @@ export function CustomerSelector({
     ? undefined
     : searchQuery
 
-  const { data, isLoading, isError } = useListCustomers({ query: effectiveSearchQuery })
+  const { data, isLoading, isError, error } = useListCustomers({ query: effectiveSearchQuery })
+  const shouldHideError = hideSpecifiedIdNotFoundError && isSpecifiedIdNotFoundError(error)
+  const shouldShowError = isError && !shouldHideError
 
   const options = useMemo(() =>
     data?.flatMap(({ data }) => data).map(customer => new CustomerAsOption(customer)) || [],
@@ -174,7 +187,7 @@ export function CustomerSelector({
     placeholder,
     slots: { EmptyMessage, ErrorMessage },
     isDisabled: shouldDisableComboBox,
-    isError,
+    isError: shouldShowError,
     isLoading: isLoadingWithoutFallback,
     isReadOnly,
     ['aria-label']: showLabel ? undefined : resolvedLabel,

--- a/src/components/CustomerSelector/CustomerSelector.tsx
+++ b/src/components/CustomerSelector/CustomerSelector.tsx
@@ -4,7 +4,7 @@ import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 
 import { type Customer } from '@schemas/customer'
-import { ApiEnumErrorType, APIError } from '@utils/api/apiError'
+import { ApiEnumErrorType, isAPIErrorOfType } from '@utils/api/apiError'
 import { getCustomerName } from '@utils/customerVendor'
 import { useListCustomers } from '@hooks/api/businesses/[business-id]/customers/useListCustomers'
 import { useDebouncedSearchInput } from '@hooks/utils/debouncing/useDebouncedSearchQuery'
@@ -63,14 +63,6 @@ const formatCreateLabel = (inputValue: string, t: TFunction) =>
     ? t('customerVendor:action.create_customer_input_value', 'Create customer "{{inputValue}}"', { inputValue })
     : t('customerVendor:action.create_new_customer', 'Create new customer')
 
-const isSpecifiedIdNotFoundError = (error: unknown) => {
-  if (!(error instanceof APIError)) {
-    return false
-  }
-
-  return error.messages?.some(message => message.error_enum === ApiEnumErrorType.SpecifiedIdNotFound) === true
-}
-
 export function CustomerSelector({
   selectedCustomer,
   onSelectedCustomerChange,
@@ -101,7 +93,7 @@ export function CustomerSelector({
     : searchQuery
 
   const { data, isLoading, isError, error } = useListCustomers({ query: effectiveSearchQuery })
-  const shouldHideError = hideSpecifiedIdNotFoundError && isSpecifiedIdNotFoundError(error)
+  const shouldHideError = hideSpecifiedIdNotFoundError && isAPIErrorOfType(error, ApiEnumErrorType.SpecifiedIdNotFound)
   const shouldShowError = isError && !shouldHideError
 
   const options = useMemo(() =>

--- a/src/components/TimeEntries/ActiveTimeTracker/ActiveTimeTracker.tsx
+++ b/src/components/TimeEntries/ActiveTimeTracker/ActiveTimeTracker.tsx
@@ -1,13 +1,9 @@
 import { useMemo } from 'react'
-import { useTranslation } from 'react-i18next'
 
 import { useActiveTimeTracker } from '@hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker'
 import { useElapsedSeconds } from '@hooks/utils/dates/useElapsedSeconds'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
-import { VStack } from '@ui/Stack/Stack'
-import { Container } from '@components/Container/Container'
-import { DataState, DataStateStatus } from '@components/DataState/DataState'
 import { ActiveTimeTrackerBanner } from '@components/TimeEntries/ActiveTimeTracker/ActiveTimeTrackerBanner'
 import { ActiveTimeTrackerStartDrawer } from '@components/TimeEntries/ActiveTimeTracker/ActiveTimeTrackerStartDrawer'
 
@@ -19,7 +15,6 @@ interface ActiveTimeTrackerProps {
 }
 
 export const ActiveTimeTracker = ({ isDrawerOpen, onDrawerOpenChange }: ActiveTimeTrackerProps) => {
-  const { t } = useTranslation()
   const { isMobile } = useSizeClass()
   const { formatSecondsAsDuration } = useIntlFormatter()
 
@@ -36,16 +31,7 @@ export const ActiveTimeTracker = ({ isDrawerOpen, onDrawerOpenChange }: ActiveTi
   }
 
   if (isError) {
-    return (
-      <Container name='ActiveTimeTracker'>
-        <VStack pi='lg' pbe='md'>
-          <DataState
-            status={DataStateStatus.failed}
-            title={t('timeTracking:error.load_active_timer', 'Failed to load active timer. Please check your connection and try again.')}
-          />
-        </VStack>
-      </Container>
-    )
+    return null
   }
 
   if (activeEntry) {

--- a/src/components/TimeEntries/ActiveTimeTracker/ActiveTimeTracker.tsx
+++ b/src/components/TimeEntries/ActiveTimeTracker/ActiveTimeTracker.tsx
@@ -1,9 +1,14 @@
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 
+import { ApiEnumErrorType, isAPIErrorOfType } from '@utils/api/apiError'
 import { useActiveTimeTracker } from '@hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker'
 import { useElapsedSeconds } from '@hooks/utils/dates/useElapsedSeconds'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import { VStack } from '@ui/Stack/Stack'
+import { Container } from '@components/Container/Container'
+import { DataState, DataStateStatus } from '@components/DataState/DataState'
 import { ActiveTimeTrackerBanner } from '@components/TimeEntries/ActiveTimeTracker/ActiveTimeTrackerBanner'
 import { ActiveTimeTrackerStartDrawer } from '@components/TimeEntries/ActiveTimeTracker/ActiveTimeTrackerStartDrawer'
 
@@ -15,10 +20,11 @@ interface ActiveTimeTrackerProps {
 }
 
 export const ActiveTimeTracker = ({ isDrawerOpen, onDrawerOpenChange }: ActiveTimeTrackerProps) => {
+  const { t } = useTranslation()
   const { isMobile } = useSizeClass()
   const { formatSecondsAsDuration } = useIntlFormatter()
 
-  const { data: activeEntry, isLoading, isError } = useActiveTimeTracker()
+  const { data: activeEntry, isLoading, isError, error } = useActiveTimeTracker()
 
   const elapsedSeconds = useElapsedSeconds(activeEntry?.createdAt)
   const timerDisplayValue = useMemo(
@@ -31,7 +37,20 @@ export const ActiveTimeTracker = ({ isDrawerOpen, onDrawerOpenChange }: ActiveTi
   }
 
   if (isError) {
-    return null
+    if (isAPIErrorOfType(error, ApiEnumErrorType.SpecifiedIdNotFound)) {
+      return null
+    }
+
+    return (
+      <Container name='ActiveTimeTracker'>
+        <VStack pi='lg' pbe='md'>
+          <DataState
+            status={DataStateStatus.failed}
+            title={t('timeTracking:error.load_active_timer', 'Failed to load active timer. Please check your connection and try again.')}
+          />
+        </VStack>
+      </Container>
+    )
   }
 
   if (activeEntry) {

--- a/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTableHeader.tsx
+++ b/src/components/TimeEntries/TimeEntriesTable/TimeEntriesTableHeader.tsx
@@ -47,6 +47,7 @@ export const TimeEntriesTableHeader = () => {
         showLabel={false}
         allowArchived
         inline
+        hideSpecifiedIdNotFoundError
       />
       <CustomerSelector
         selectedCustomer={selectedCustomer}
@@ -56,6 +57,7 @@ export const TimeEntriesTableHeader = () => {
         placeholder={t('timeTracking:label.all_customers', 'All Customers')}
         showLabel={false}
         inline
+        hideSpecifiedIdNotFoundError
       />
     </HStack>
   ), [selectedCustomer, setSelectedCustomer, selectedServiceId, setSelectedServiceId, t])

--- a/src/components/TimeEntries/TimeEntryForm/TimeEntryForm.tsx
+++ b/src/components/TimeEntries/TimeEntryForm/TimeEntryForm.tsx
@@ -54,6 +54,7 @@ const TimeEntryCustomerField = ({ value, entryCustomer, isReadOnly, onChange }: 
       label={t('timeTracking:label.customer_optional', 'Customer (optional)')}
       placeholder={t('timeTracking:label.select_customer_short', 'Select a customer')}
       className='Layer__TimeEntryForm__Field__Customer'
+      hideSpecifiedIdNotFoundError
     />
   )
 }
@@ -126,6 +127,7 @@ export const TimeEntryForm = ({ onSuccess, entry, isReadOnly }: TimeEntryFormPro
             className='Layer__TimeEntryForm__Field__Service'
             isCreatable={!isReadOnly}
             onCreateService={handleCreateService}
+            hideSpecifiedIdNotFoundError
           />
         )}
       </form.Field>

--- a/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
+++ b/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
@@ -5,6 +5,7 @@ import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { type CatalogService } from '@schemas/catalogService'
+import { ApiEnumErrorType, APIError } from '@utils/api/apiError'
 import { useListCatalogServices } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
 import { MaybeCreatableComboBox } from '@ui/ComboBox/MaybeCreatableComboBox'
 import { VStack } from '@ui/Stack/Stack'
@@ -53,6 +54,7 @@ type TimeEntryServiceSelectorSharedProps = {
   inline?: boolean
   className?: string
   showLabel?: boolean
+  hideSpecifiedIdNotFoundError?: boolean
 }
 
 type TimeEntryServiceSelectorProps =
@@ -76,6 +78,14 @@ const formatCreateLabel = (inputValue: string, t: TFunction) => (
   </Span>
 )
 
+const isSpecifiedIdNotFoundError = (error: unknown) => {
+  if (!(error instanceof APIError)) {
+    return false
+  }
+
+  return error.messages?.some(message => message.error_enum === ApiEnumErrorType.SpecifiedIdNotFound) === true
+}
+
 export function TimeEntryServiceSelector({
   selectedServiceId,
   onSelectedServiceIdChange,
@@ -85,15 +95,18 @@ export function TimeEntryServiceSelector({
   inline,
   className,
   showLabel = true,
+  hideSpecifiedIdNotFoundError,
   allowArchived,
   isCreatable,
   onCreateService,
 }: TimeEntryServiceSelectorProps) {
   const { t } = useTranslation()
 
-  const { data: servicesResponse, isLoading, isError } = useListCatalogServices({ allowArchived })
+  const { data: servicesResponse, isLoading, isError, error } = useListCatalogServices({ allowArchived })
 
   const isLoadingWithoutFallback = isLoading && !servicesResponse
+  const shouldHideError = hideSpecifiedIdNotFoundError && isSpecifiedIdNotFoundError(error)
+  const shouldShowError = isError && !shouldHideError
   const shouldDisableComboBox = isLoadingWithoutFallback || isError
 
   const serviceOptions = useMemo<ServiceAsOption[]>(
@@ -136,7 +149,7 @@ export function TimeEntryServiceSelector({
 
   const ErrorMessage = useMemo(
     () => {
-      if (!isError) {
+      if (!shouldShowError) {
         return null
       }
 
@@ -146,7 +159,7 @@ export function TimeEntryServiceSelector({
         </P>
       )
     },
-    [isError, t],
+    [shouldShowError, t],
   )
 
   const inputId = useId()
@@ -160,7 +173,7 @@ export function TimeEntryServiceSelector({
     slots: { EmptyMessage, ErrorMessage },
     isClearable,
     isDisabled: shouldDisableComboBox,
-    isError,
+    isError: shouldShowError,
     isLoading: isLoadingWithoutFallback,
     isReadOnly,
     ['aria-label']: showLabel ? undefined : t('timeTracking:label.service', 'Service'),

--- a/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
+++ b/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
@@ -5,7 +5,7 @@ import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { type CatalogService } from '@schemas/catalogService'
-import { ApiEnumErrorType, APIError } from '@utils/api/apiError'
+import { ApiEnumErrorType, isAPIErrorOfType } from '@utils/api/apiError'
 import { useListCatalogServices } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
 import { MaybeCreatableComboBox } from '@ui/ComboBox/MaybeCreatableComboBox'
 import { VStack } from '@ui/Stack/Stack'
@@ -78,14 +78,6 @@ const formatCreateLabel = (inputValue: string, t: TFunction) => (
   </Span>
 )
 
-const isSpecifiedIdNotFoundError = (error: unknown) => {
-  if (!(error instanceof APIError)) {
-    return false
-  }
-
-  return error.messages?.some(message => message.error_enum === ApiEnumErrorType.SpecifiedIdNotFound) === true
-}
-
 export function TimeEntryServiceSelector({
   selectedServiceId,
   onSelectedServiceIdChange,
@@ -105,7 +97,7 @@ export function TimeEntryServiceSelector({
   const { data: servicesResponse, isLoading, isError, error } = useListCatalogServices({ allowArchived })
 
   const isLoadingWithoutFallback = isLoading && !servicesResponse
-  const shouldHideError = hideSpecifiedIdNotFoundError && isSpecifiedIdNotFoundError(error)
+  const shouldHideError = hideSpecifiedIdNotFoundError && isAPIErrorOfType(error, ApiEnumErrorType.SpecifiedIdNotFound)
   const shouldShowError = isError && !shouldHideError
   const shouldDisableComboBox = isLoadingWithoutFallback || isError
 

--- a/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
@@ -60,10 +60,17 @@ export type UseListCatalogServicesOptions = {
   isEnabled?: boolean
 }
 
+export class ListCatalogServicesSWRResponse extends SWRQueryResult<ListCatalogServicesResponse> {
+  get error(): unknown {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return this.swrResponse.error
+  }
+}
+
 export function useListCatalogServices({
   allowArchived,
   isEnabled = true,
-}: UseListCatalogServicesOptions = {}): SWRQueryResult<ListCatalogServicesResponse> & { error: unknown } {
+}: UseListCatalogServicesOptions = {}): ListCatalogServicesSWRResponse {
   const withLocale = useLocalizedKey()
   const { data } = useAuth()
   const { businessId } = useLayerContext()
@@ -84,12 +91,7 @@ export function useListCatalogServices({
     )().then(Schema.decodeUnknownPromise(ListCatalogServicesResponseSchema)),
   )
 
-  const error: unknown = response.error
-
-  return Object.assign(
-    new SWRQueryResult<ListCatalogServicesResponse>(response),
-    { error },
-  )
+  return new ListCatalogServicesSWRResponse(response)
 }
 
 export const useCatalogServicesGlobalCacheActions = () => {

--- a/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
@@ -60,7 +60,10 @@ export type UseListCatalogServicesOptions = {
   isEnabled?: boolean
 }
 
-export function useListCatalogServices({ allowArchived, isEnabled = true }: UseListCatalogServicesOptions = {}) {
+export function useListCatalogServices({
+  allowArchived,
+  isEnabled = true,
+}: UseListCatalogServicesOptions = {}): SWRQueryResult<ListCatalogServicesResponse> & { error: unknown } {
   const withLocale = useLocalizedKey()
   const { data } = useAuth()
   const { businessId } = useLayerContext()
@@ -81,7 +84,12 @@ export function useListCatalogServices({ allowArchived, isEnabled = true }: UseL
     )().then(Schema.decodeUnknownPromise(ListCatalogServicesResponseSchema)),
   )
 
-  return new SWRQueryResult<ListCatalogServicesResponse>(response)
+  const error: unknown = response.error
+
+  return Object.assign(
+    new SWRQueryResult<ListCatalogServicesResponse>(response),
+    { error },
+  )
 }
 
 export const useCatalogServicesGlobalCacheActions = () => {

--- a/src/hooks/api/businesses/[business-id]/customers/useListCustomers.ts
+++ b/src/hooks/api/businesses/[business-id]/customers/useListCustomers.ts
@@ -89,7 +89,7 @@ type UseListCustomersParams = {
   isEnabled?: boolean
 }
 
-export function useListCustomers({ query, isEnabled = true }: UseListCustomersParams = {}) {
+export function useListCustomers({ query, isEnabled = true }: UseListCustomersParams = {}): SWRInfiniteResult<ListCustomersRawResult> & { error: unknown } {
   const withLocale = useLocalizedKey()
   const { data } = useAuth()
   const { businessId } = useLayerContext()
@@ -131,7 +131,12 @@ export function useListCustomers({ query, isEnabled = true }: UseListCustomersPa
 
   usePreserveInfiniteSize(swrResponse)
 
-  return new SWRInfiniteResult(swrResponse)
+  const error: unknown = swrResponse.error
+
+  return Object.assign(
+    new SWRInfiniteResult(swrResponse),
+    { error },
+  )
 }
 
 export function usePreloadCustomers(parameters?: UseListCustomersParams) {

--- a/src/hooks/api/businesses/[business-id]/customers/useListCustomers.ts
+++ b/src/hooks/api/businesses/[business-id]/customers/useListCustomers.ts
@@ -89,7 +89,14 @@ type UseListCustomersParams = {
   isEnabled?: boolean
 }
 
-export function useListCustomers({ query, isEnabled = true }: UseListCustomersParams = {}): SWRInfiniteResult<ListCustomersRawResult> & { error: unknown } {
+export class ListCustomersSWRResponse extends SWRInfiniteResult<ListCustomersRawResult> {
+  get error(): unknown {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return this.swrResponse.error
+  }
+}
+
+export function useListCustomers({ query, isEnabled = true }: UseListCustomersParams = {}): ListCustomersSWRResponse {
   const withLocale = useLocalizedKey()
   const { data } = useAuth()
   const { businessId } = useLayerContext()
@@ -131,12 +138,7 @@ export function useListCustomers({ query, isEnabled = true }: UseListCustomersPa
 
   usePreserveInfiniteSize(swrResponse)
 
-  const error: unknown = swrResponse.error
-
-  return Object.assign(
-    new SWRInfiniteResult(swrResponse),
-    { error },
-  )
+  return new ListCustomersSWRResponse(swrResponse)
 }
 
 export function usePreloadCustomers(parameters?: UseListCustomersParams) {

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker.ts
@@ -45,7 +45,14 @@ function buildKey({
   }
 }
 
-export function useActiveTimeTracker() {
+export class ActiveTimeTrackerSWRResponse extends SWRQueryResult<TimeEntry | null> {
+  get error(): unknown {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return this.swrResponse.error
+  }
+}
+
+export function useActiveTimeTracker(): ActiveTimeTrackerSWRResponse {
   const withLocale = useLocalizedKey()
   const { data } = useAuth()
   const { businessId } = useLayerContext()
@@ -66,7 +73,7 @@ export function useActiveTimeTracker() {
       .then(({ data }) => data.timeEntry ?? null),
   )
 
-  return new SWRQueryResult<TimeEntry | null>(response)
+  return new ActiveTimeTrackerSWRResponse(response)
 }
 
 export function useActiveTimeTrackerGlobalCacheActions() {

--- a/src/utils/api/apiError.ts
+++ b/src/utils/api/apiError.ts
@@ -32,3 +32,11 @@ export class APIError extends Error {
     return this.messages?.map(x => x.description)
   }
 }
+
+export const isAPIErrorOfType = (error: unknown, errorType: ApiEnumErrorType) => {
+  if (!(error instanceof APIError)) {
+    return false
+  }
+
+  return error.messages?.some(message => message.error_enum === errorType) === true
+}


### PR DESCRIPTION
## Description
Cleaning up Time Tracking error state when 404's are thrown specifically for Active Timer, Get Customers, and Get Services.

This would happen if the business is not yet created in Layer or it was deleted (entire app in an error state because find business by id is throwing).

BEFORE:
<img width="1680" height="868" alt="image" src="https://github.com/user-attachments/assets/95ec07a4-0e3d-41ea-a35e-30b4da9c4d5b" />

AFTER:
<img width="1503" height="733" alt="Screenshot 2026-05-13 at 5 23 23 PM" src="https://github.com/user-attachments/assets/e987d194-8885-4976-b486-2674a19872e7" />


## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change that only alters how a specific API error (`SpecifiedIdNotFound`) is surfaced; main risk is inadvertently hiding real error states if the backend misclassifies errors.
> 
> **Overview**
> **Improves the “business not found”/missing-resource UX** by suppressing UI error states when the API returns `ApiEnumErrorType.SpecifiedIdNotFound`.
> 
> `CustomerSelector` and `TimeEntryServiceSelector` now accept `hideSpecifiedIdNotFoundError` and, when enabled, avoid showing error styling/messages for that specific error while still showing other failures. `ActiveTimeTracker` similarly returns `null` (no banner/error) on `SpecifiedIdNotFound` instead of rendering a failed `DataState`, and time entry filters/forms opt into the new suppression flag.
> 
> To support this, the SWR hooks `useListCustomers`, `useListCatalogServices`, and `useActiveTimeTracker` now return typed response wrappers exposing the underlying SWR `error`, and `apiError.ts` adds `isAPIErrorOfType` to detect enum-coded API errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a3878e13a15898e6a2ce6d77431fda9adf024a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->