### PR TITLE
release: stable solopreneur and tax estimates composite views

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,8 +58,8 @@ export { GeneralLedgerView } from './views/GeneralLedger/GeneralLedger'
 export { unstable_MileageTracking } from './views/MileageTracking'
 export { ProjectProfitabilityView } from './views/ProjectProfitability/ProjectProfitability'
 export { Reports } from './views/Reports/Reports'
-export { SolopreneurOverview as unstable_SolopreneurOverview } from './views/SolopreneurOverview/SolopreneurOverview'
-export { TaxEstimates as unstable_TaxEstimates } from './views/TaxEstimates/TaxEstimates'
+export { SolopreneurOverview } from './views/SolopreneurOverview/SolopreneurOverview'
+export { TaxEstimates } from './views/TaxEstimates/TaxEstimates'
 export { TimeTracking } from './views/TimeTracking'
 
 /*


### PR DESCRIPTION
## Description
Marking our composite views as stable.

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API change in `src/index.tsx` removes the `unstable_` export aliases for these composite views, which may break consumers still importing the old names.
> 
> **Overview**
> Promotes the composite views `SolopreneurOverview` and `TaxEstimates` to stable by exporting them directly from `src/index.tsx` and dropping the prior `unstable_SolopreneurOverview`/`unstable_TaxEstimates` aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19d762ef163701110df5b6de7c404baa9b476ff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->