### PR TITLE
chore: release v0.1.133-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.132",
+  "version": "0.1.133-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.132",
+      "version": "0.1.133-alpha",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.132",
+  "version": "0.1.133-alpha",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.133-alpha`.

- Mode: **alpha**
- Tag (post-merge): `v0.1.133-alpha`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version-only release bump in `package.json` and `package-lock.json` with no functional code changes.
> 
> **Overview**
> Bumps the `@layerfi/components` package version from `0.1.132` to `0.1.133-alpha` in `package.json` and `package-lock.json` to publish an alpha release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d30fd2049e21fcf902fd5fb496b9397b49cd2cee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->