### PR TITLE
chore: release v0.1.133

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.133-alpha",
+  "version": "0.1.133",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.133-alpha",
+      "version": "0.1.133",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.133-alpha",
+  "version": "0.1.133",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.133`.

- Mode: **promote**
- Tag (post-merge): `v0.1.133`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only bumps the package version from `0.1.133-alpha` to `0.1.133` in `package.json` and `package-lock.json`, with no code or dependency changes.
> 
> **Overview**
> Promotes `@layerfi/components` from the prerelease `0.1.133-alpha` to the stable `0.1.133` by updating the version fields in `package.json` and `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 966fbc58caa5a82d1895fd7156440b94a985a82a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->