### PR TITLE
[LAY-2730] fix: mileage tracking trips table breakpoint depends on table minimum width

### DIFF
--- a/src/components/Trips/TripsView/ResponsiveTripsView.tsx
+++ b/src/components/Trips/TripsView/ResponsiveTripsView.tsx
@@ -4,7 +4,6 @@ import { Car } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import type { Trip } from '@schemas/trip'
-import { BREAKPOINTS } from '@utils/screenSizeBreakpoints'
 import { useListTrips } from '@hooks/api/businesses/[business-id]/mileage/trips/useListTrips'
 import { useAutoResetPageIndex } from '@hooks/utils/pagination/useAutoResetPageIndex'
 import { useGlobalDateRange } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
@@ -17,8 +16,10 @@ import { TripPurposeFilterValue } from '@components/Trips/TripPurposeToggle/Trip
 import { TripsMobileList } from '@components/Trips/TripsMobileList/TripsMobileList'
 import { TripsTable } from '@components/Trips/TripsTable/TripsTable'
 
+const MIN_WIDTH_NEEDED_FOR_DESKTOP_PX = 1024
+
 const resolveVariant = ({ width }: { width: number }): DefaultVariant =>
-  width < BREAKPOINTS.TABLET ? 'Mobile' : 'Desktop'
+  width < MIN_WIDTH_NEEDED_FOR_DESKTOP_PX ? 'Mobile' : 'Desktop'
 
 const TripsViewEmptyState = () => {
   const { t } = useTranslation()


### PR DESCRIPTION
Instead of depending on the breakpoints for mobile, we depend on the actual legitimate minimum width necessary for desktop variant to determine the breakpoint threshold.

## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

https://www.loom.com/share/00516d92c75044b28945d274dfaee6bf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized responsive layout change in TripsView with no auth, data, or API impact.
> 
> **Overview**
> **Trips mileage view** now switches between mobile list and desktop table at **1024px** instead of the shared `BREAKPOINTS.TABLET` (760px).
> 
> `TripsView` defines `MIN_WIDTH_NEEDED_FOR_DESKTOP_PX` and uses it in `resolveVariant` so the desktop `TripsTable` only renders when there is enough width for the table layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0861f15e858d605de91a14d1f617ec553334703d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->