### PR TITLE
chore: release v0.1.134-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.133",
+  "version": "0.1.134-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.133",
+      "version": "0.1.134-alpha",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.133",
+  "version": "0.1.134-alpha",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.134-alpha`.

- Mode: **alpha**
- Tag (post-merge): `v0.1.134-alpha`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the package version in `package.json` and `package-lock.json`, with no runtime or dependency changes beyond metadata.
> 
> **Overview**
> Bumps `@layerfi/components` version from `0.1.133` to `0.1.134-alpha` in `package.json` and `package-lock.json` for the alpha release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f20f35205ba210a7f37863a4f162d297272fb7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->