### PR TITLE
chore: release v0.1.134-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.134-alpha",
+  "version": "0.1.134-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.134-alpha",
+      "version": "0.1.134-alpha.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.134-alpha",
+  "version": "0.1.134-alpha.1",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.134-alpha.1`.

- Mode: **alpha**
- Tag (post-merge): `v0.1.134-alpha.1`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the package version in `package.json` and `package-lock.json` with no functional code changes.
> 
> **Overview**
> Bumps the `@layerfi/components` package version from `0.1.134-alpha` to `0.1.134-alpha.1`, updating both `package.json` and `package-lock.json` for the alpha release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06928c39cd8ccb3bc72a5deb2a9f8a82c2c7a7a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->