### PR TITLE
chore: release v0.1.134

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.134-alpha.1",
+  "version": "0.1.134",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.134-alpha.1",
+      "version": "0.1.134",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.134-alpha.1",
+  "version": "0.1.134",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.134`.

- Mode: **promote**
- Tag (post-merge): `v0.1.134`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only promotes the package version from an alpha prerelease to the stable `0.1.134` in metadata files, with no code or dependency changes.
> 
> **Overview**
> Promotes the `@layerfi/components` release by updating the version from `0.1.134-alpha.1` to `0.1.134` in `package.json` and `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ccef04cd5d1485898cbb50f4531301cde2410b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->