### PR TITLE
chore: release v0.1.135

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.135-alpha",
+  "version": "0.1.135",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.135-alpha",
+      "version": "0.1.135",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.135-alpha",
+  "version": "0.1.135",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.135`.

- Mode: **promote**
- Tag (post-merge): `v0.1.135`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only; no runtime or API code changes in the diff.
> 
> **Overview**
> Promotes **`@layerfi/components`** from **`0.1.135-alpha`** to **`0.1.135`** in **`package.json`** and the root package entry in **`package-lock.json`**, matching the release-tooling **promote** flow and post-merge tag **`v0.1.135`**. No application or library source changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38508ee348fca5ac19115e50e7bcb25257a07712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->