### PR TITLE
chore: release v0.1.136

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.136-alpha",
+  "version": "0.1.136",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.136-alpha",
+      "version": "0.1.136",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.136-alpha",
+  "version": "0.1.136",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.136`.

- Mode: **promote**
- Tag (post-merge): `v0.1.136`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only; no runtime, API, or dependency changes beyond the semver label.
> 
> **Overview**
> Promotes **`@layerfi/components`** from **`0.1.136-alpha`** to **`0.1.136`** in **`package.json`** and **`package-lock.json`**, aligning the published package version with release **`v0.1.136`** (no application or library source changes in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee245a3a83a16a82d32a02b9b626d4760e094435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->