### PR TITLE
chore: release v0.1.137-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.136",
+  "version": "0.1.137-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@layerfi/components",
-      "version": "0.1.136",
+      "version": "0.1.137-alpha",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerfi/components",
-  "version": "0.1.136",
+  "version": "0.1.137-alpha",
   "description": "Layer React Components",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",


### PR DESCRIPTION
Releases `0.1.137-alpha`.

- Mode: **alpha**
- Tag (post-merge): `v0.1.137-alpha`

Auto-generated by release-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest version bumps only; no runtime or API code changes.
> 
> **Overview**
> Bumps `@layerfi/components` from **`0.1.136`** to **`0.1.137-alpha`** in **`package.json`** and **`package-lock.json`** so the alpha release can be published and tagged as **`v0.1.137-alpha`**.
> 
> No application or library source changes are included in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f49027de14ff8b16b62e320c4185a5d080798881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->