### PR TITLE
fix: prevent mobile task list from submitting the wrong/duplicate task

### DIFF
--- a/src/components/Tasks/TasksListItem.tsx
+++ b/src/components/Tasks/TasksListItem.tsx
@@ -29,8 +29,8 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
   const [userResponse, setUserResponse] = useState(task.user_response ?? '')
   const [selectedFiles, setSelectedFiles] = useState<File[]>()
 
-  const { trigger: handleSubmitUserResponseForTask } = useSubmitUserResponseForTask()
-  const { trigger: handleUploadDocumentsForTask } = useUploadDocumentsForTask()
+  const { trigger: handleSubmitUserResponseForTask, isMutating: isSubmittingResponse } = useSubmitUserResponseForTask()
+  const { trigger: handleUploadDocumentsForTask, isMutating: isUploadingDocuments } = useUploadDocumentsForTask()
   const { trigger: handleDeleteUploadsOnTask } = useDeleteUploadsOnTask()
   const { trigger: handleUpdateTaskUploadDescription } = useUpdateTaskUploadDescription()
 
@@ -102,6 +102,7 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
               <Button
                 variant={ButtonVariant.primary}
                 onClick={() => void submit()}
+                disabled={isUploadingDocuments}
               >
                 {t('common:action.submit_label', 'Submit')}
               </Button>
@@ -143,7 +144,7 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
       else { return null }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [t, task, selectedFiles, userResponse])
+  }, [t, task, selectedFiles, userResponse, isUploadingDocuments])
 
   return (
     <div className='Layer__tasks-list-item-wrapper' ref={ref}>
@@ -204,7 +205,8 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
                 : (
                   <Button
                     disabled={
-                      userResponse.length === 0
+                      isSubmittingResponse
+                      || userResponse.length === 0
                       || userResponse === task.user_response
                     }
                     variant={ButtonVariant.secondary}

--- a/src/components/Tasks/TasksListMobile.tsx
+++ b/src/components/Tasks/TasksListMobile.tsx
@@ -38,7 +38,7 @@ export const TasksListMobile = ({
     <div className='Layer__tasks-list'>
       {unresolvedTasks.map((task, index) => (
         <TasksListItem
-          key={index}
+          key={task.id}
           task={task}
           defaultOpen={index === indexFirstIncomplete}
         />
@@ -69,7 +69,7 @@ export const TasksListMobile = ({
             <div className='Layer__tasks-list'>
               {sortedTasks.map((task, index) => (
                 <TasksListItem
-                  key={index}
+                  key={task.id}
                   task={task}
                   defaultOpen={index === indexFirstIncomplete}
                 />


### PR DESCRIPTION
## Summary

Fixes the long-standing, rarely-reproduced bug where submitting one task in the **mobile** task list could submit a *different* task — appearing as "two tasks submitted at basically the same time."

## Root cause

`TasksListMobile` rendered task items with `key={index}` instead of `key={task.id}`. When a task is answered it transitions to `USER_MARKED_COMPLETED` and drops out of the incomplete list, so the item at a given index now corresponds to a **different** task. Because React keys elements by array index, it reused the previous task's component instance — including its local `userResponse` state — for the new task. The user could then submit the previous task's typed response against the next task.

## Changes

- `TasksListMobile.tsx`: key task items by `task.id` (both the unresolved list and the full panel list) so each task retains its own component state across re-sorts.
- `TasksListItem.tsx`: disable the submit buttons while a submission is in flight (via the hook's existing `isMutating` flag) so a task cannot be double-submitted by a rapid second click.

Scoped intentionally small: no dependency changes, no test tooling. **A follow-up PR (stacked on this branch) adds a Vitest harness and deterministic regression tests** that reproduce both failure modes (red on `main`, green here).

## Test plan

- [ ] Mobile: answer the first task in the list, then confirm the next task's textarea is empty (not pre-filled with the previous task's response).
- [ ] Confirm the submit button disables while a request is in flight and a rapid double-click submits only once.
- [ ] Desktop list unaffected (already keyed by `task.id`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only changes to React keys and button disabled state in the mobile tasks flow; no auth, API, or data-model changes.
> 
> **Overview**
> Fixes a mobile bookkeeping bug where submitting one task could apply another task’s draft response after the list reordered when a task completed.
> 
> **`TasksListMobile`** now keys each **`TasksListItem`** with **`task.id`** (short unresolved list and full mobile panel), matching desktop behavior so local **`userResponse`** state stays tied to the correct task when incomplete items shift.
> 
> **`TasksListItem`** disables text and document submit actions while the corresponding mutation hooks report **`isMutating`**, blocking double submits during in-flight requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12bd7f6f6b63bac5e07b4ad6d3e8656aacf6a9a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->