### PR TITLE
fix: stabilize customer selector

### DIFF
--- a/src/components/CustomerSelector/CustomerSelector.tsx
+++ b/src/components/CustomerSelector/CustomerSelector.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useId, useMemo } from 'react'
 import classNames from 'classnames'
-import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 
 import { type Customer } from '@schemas/customer'
@@ -57,11 +56,6 @@ type CustomerSelectorProps = CustomerSelectorBaseProps & (
   | { isCreatable: true, onCreateCustomer: (name: string) => void }
   | { isCreatable?: false, onCreateCustomer?: (name: string) => void }
 )
-
-const formatCreateLabel = (inputValue: string, t: TFunction) =>
-  inputValue
-    ? t('customerVendor:action.create_customer_input_value', 'Create customer "{{inputValue}}"', { inputValue })
-    : t('customerVendor:action.create_new_customer', 'Create new customer')
 
 export function CustomerSelector({
   selectedCustomer,
@@ -171,13 +165,15 @@ export function CustomerSelector({
   const isLoadingWithoutFallback = isLoading && !data
   const shouldDisableComboBox = isLoadingWithoutFallback || isError
 
+  const slots = useMemo(() => ({ EmptyMessage, ErrorMessage }), [EmptyMessage, ErrorMessage])
+
   const sharedProps = {
     selectedValue: selectedCustomerForComboBox,
     onSelectedValueChange: handleSelectionChange,
     onInputValueChange: handleInputChange,
     inputId,
     placeholder,
-    slots: { EmptyMessage, ErrorMessage },
+    slots,
     isDisabled: shouldDisableComboBox,
     isError: shouldShowError,
     isLoading: isLoadingWithoutFallback,
@@ -185,14 +181,24 @@ export function CustomerSelector({
     ['aria-label']: showLabel ? undefined : resolvedLabel,
   }
 
-  const creatableProps = isCreatable
-    ? {
-      isCreatable: true as const,
-      onCreateOption: onCreateCustomer,
-      formatCreateLabel: (inputValue: string) => formatCreateLabel(inputValue, t),
-      groups: [{ label: t('customerVendor:label.customers', 'Customers'), options }],
-    }
-    : { isCreatable: false as const, options }
+  const formatCreateLabel = useCallback((inputValue: string) =>
+    inputValue
+      ? t('customerVendor:action.create_customer_input_value', 'Create customer "{{inputValue}}"', { inputValue })
+      : t('customerVendor:action.create_new_customer', 'Create new customer'),
+  [t],
+  )
+
+  const groups = useMemo(
+    () => [{ label: t('customerVendor:label.customers', 'Customers'), options }],
+    [t, options],
+  )
+
+  const creatableProps = useMemo(
+    () => isCreatable
+      ? ({ isCreatable: true as const, onCreateOption: onCreateCustomer, formatCreateLabel, groups })
+      : ({ isCreatable: false as const, options }),
+    [isCreatable, onCreateCustomer, formatCreateLabel, groups, options],
+  )
 
   return (
     <VStack className={combinedClassName}>


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small React memoization refactor in a single UI component with no API or business-logic changes.
> 
> **Overview**
> **Stabilizes `CustomerSelector`** so `MaybeCreatableComboBox` gets stable prop references across re-renders (e.g. while customer search/list data updates).
> 
> The **`slots`** object (`EmptyMessage` / `ErrorMessage`) is now built with `useMemo` instead of a fresh inline object each render. **Creatable mode** props are split into memoized pieces: `formatCreateLabel` moves from a module helper into `useCallback`, customer **groups** into `useMemo`, and the full **`creatableProps`** union into `useMemo` with explicit dependencies. The unused `TFunction` import is removed.
> 
> Behavior and copy for create-customer labels are unchanged; only referential stability of props passed into the combo box.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3fcbd694feeb7818da11e63640f3f12c75e7496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->