### PR TITLE
refactor: use SWR mutation for all linked accounts API calls

### DIFF
--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
@@ -91,9 +91,7 @@ function LinkedAccountsConfirmationModalContent({ onClose }: { onClose: () => vo
     accounts.map(({ id }) => [id, true]),
   ))
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const { trigger, isMutating, error } = useConfirmAndExcludeMultiple({ onSuccess: refetchAccounts })
-  const hasError = Boolean(error)
+  const { trigger, isMutating, isError } = useConfirmAndExcludeMultiple({ onSuccess: refetchAccounts })
 
   const handleFinish = async () => {
     const success = await trigger(formState)
@@ -191,7 +189,7 @@ function LinkedAccountsConfirmationModalContent({ onClose }: { onClose: () => vo
       </ModalContent>
       <ModalActions>
         <VStack gap='md'>
-          {hasError
+          {isError
             ? (
               <>
                 <P size='sm'>

--- a/src/components/LinkedAccounts/LinkedAccountItemThumb.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountItemThumb.tsx
@@ -5,6 +5,7 @@ import { type BankAccount } from '@internal-types/linkedAccounts'
 import { getBankAccountInstitution, isAllExternalAccountsUserCreatedCustom } from '@utils/bankAccount'
 import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
+import { OpeningBalanceModalContext } from '@contexts/OpeningBalanceModalContext/OpeningBalanceModalContext'
 import type { HoverMenuProps } from '@components/HoverMenu/HoverMenu'
 import { LinkedAccountOptions } from '@components/LinkedAccountOptions/LinkedAccountOptions'
 import { LinkedAccountPill } from '@components/LinkedAccountPill/LinkedAccountPill'
@@ -58,8 +59,8 @@ export const LinkedAccountItemThumb = ({
     confirmAccount,
     excludeAccount,
     breakConnection,
-    setAccountsToAddOpeningBalanceInModal,
   } = useContext(LinkedAccountsContext)
+  const { setAccountsToAddOpeningBalanceInModal } = useContext(OpeningBalanceModalContext)
   const { environment } = useEnvironment()
   const [isUnlinkConfirmationModalOpen, setIsUnlinkConfirmationModalOpen] = useState(false)
 

--- a/src/components/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/components/LinkedAccounts/LinkedAccounts.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { AccountConfirmationStoreProvider } from '@providers/AccountConfirmationStoreProvider'
 import { LinkedAccountsProvider } from '@providers/LinkedAccountsProvider/LinkedAccountsProvider'
+import { OpeningBalanceModalProvider } from '@providers/OpeningBalanceModalProvider/OpeningBalanceModalProvider'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
 import { Container } from '@components/Container/Container'
 import { Header } from '@components/Container/Header'
@@ -29,7 +30,9 @@ export const LinkedAccounts = (props: LinkedAccountsProps) => {
   return (
     <AccountConfirmationStoreProvider>
       <LinkedAccountsProvider>
-        <LinkedAccountsComponent {...props} />
+        <OpeningBalanceModalProvider>
+          <LinkedAccountsComponent {...props} />
+        </OpeningBalanceModalProvider>
       </LinkedAccountsProvider>
     </AccountConfirmationStoreProvider>
   )

--- a/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
+++ b/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
@@ -13,7 +13,7 @@ import {
   useBulkSetOpeningBalanceAndDate,
 } from '@hooks/legacy/useUpdateOpeningBalanceAndDate'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
-import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
+import { OpeningBalanceModalContext } from '@contexts/OpeningBalanceModalContext/OpeningBalanceModalContext'
 import { Button } from '@ui/Button/Button'
 import { Modal } from '@ui/Modal/Modal'
 import { ModalActions, ModalContent, ModalHeading, ModalTitleWithClose } from '@ui/Modal/ModalSlots'
@@ -172,7 +172,7 @@ export function OpeningBalanceModal({
   const {
     accountsToAddOpeningBalanceInModal,
     setAccountsToAddOpeningBalanceInModal,
-  } = useContext(LinkedAccountsContext)
+  } = useContext(OpeningBalanceModalContext)
 
   const shouldShowModal = Boolean(accountsToAddOpeningBalanceInModal.length)
 

--- a/src/contexts/LinkedAccountsContext/LinkedAccountsContext.ts
+++ b/src/contexts/LinkedAccountsContext/LinkedAccountsContext.ts
@@ -10,7 +10,6 @@ export const LinkedAccountsContext = createContext<LinkedAccountsContextType>({
   isValidating: false,
   isLinking: false,
   error: undefined,
-  updateConnectionStatus: () => Promise.resolve(),
   addConnection: () => Promise.resolve(),
   removeConnection: () => Promise.resolve(),
   repairConnection: () => Promise.resolve(),
@@ -19,7 +18,4 @@ export const LinkedAccountsContext = createContext<LinkedAccountsContextType>({
   excludeAccount: () => Promise.resolve(),
   confirmAccount: () => Promise.resolve(),
   breakConnection: () => Promise.resolve(),
-  syncAccounts: () => Promise.resolve(),
-  accountsToAddOpeningBalanceInModal: [],
-  setAccountsToAddOpeningBalanceInModal: () => {},
 })

--- a/src/contexts/OpeningBalanceModalContext/OpeningBalanceModalContext.ts
+++ b/src/contexts/OpeningBalanceModalContext/OpeningBalanceModalContext.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react'
+
+import { type BankAccount } from '@internal-types/linkedAccounts'
+
+export type OpeningBalanceModalContextType = {
+  accountsToAddOpeningBalanceInModal: BankAccount[]
+  setAccountsToAddOpeningBalanceInModal: (accounts: BankAccount[]) => void
+}
+
+export const OpeningBalanceModalContext = createContext<OpeningBalanceModalContextType>({
+  accountsToAddOpeningBalanceInModal: [],
+  setAccountsToAddOpeningBalanceInModal: () => {},
+})

--- a/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm.ts
+++ b/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm.ts
@@ -1,27 +1,33 @@
 import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
-import { del } from '@utils/api/authenticatedHttp'
+import type { OneOf } from '@internal-types/utility/oneOf'
+import { post } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
-const UNLINK_BANK_ACCOUNT_TAG_KEY = '#unlink-bank-account'
+const CONFIRM_EXTERNAL_ACCOUNT_TAG_KEY = '#confirm-external-account'
 
-const unlinkBankAccount = del<
+export type ConfirmAccountBodyStrict = OneOf<[
+  { is_unique: true },
+  { is_relevant: true },
+]>
+
+export const confirmExternalAccount = post<
   Record<string, unknown>,
-  Record<string, unknown>,
-  {
-    businessId: string
-    bankAccountId: string
-  }
+  ConfirmAccountBodyStrict,
+  { businessId: string, accountId: string }
 >(
-  ({ businessId, bankAccountId }) =>
-    `/v1/businesses/${businessId}/bank-accounts/${bankAccountId}`,
+  ({ businessId, accountId }) =>
+    `/v1/businesses/${businessId}/external-accounts/${accountId}/confirm`,
 )
+
+type ConfirmExternalAccountArg = {
+  accountId: string
+  body?: ConfirmAccountBodyStrict
+}
 
 function buildKey({
   access_token: accessToken,
@@ -37,28 +43,29 @@ function buildKey({
       accessToken,
       apiUrl,
       businessId,
-      tags: [UNLINK_BANK_ACCOUNT_TAG_KEY],
+      tags: [CONFIRM_EXTERNAL_ACCOUNT_TAG_KEY],
     } as const
   }
 }
 
-export function useUnlinkBankAccount() {
+export function useConfirmExternalAccount() {
   const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
   const { data: auth } = useAuth()
-  const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
+  const { businessId } = useLayerContext()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
       access_token: auth?.access_token,
-      apiUrl,
+      apiUrl: auth?.apiUrl,
       businessId,
     })),
-    ({ accessToken, apiUrl, businessId }, { arg: bankAccountId }: { arg: string }) =>
-      unlinkBankAccount(apiUrl, accessToken, {
-        params: { businessId, bankAccountId },
-      }),
+    (
+      { accessToken, apiUrl, businessId },
+      { arg: { accountId, body } }: { arg: ConfirmExternalAccountArg },
+    ) => confirmExternalAccount(apiUrl, accessToken, {
+      params: { businessId, accountId },
+      body,
+    }),
     {
       revalidate: false,
     },
@@ -69,12 +76,9 @@ export function useUnlinkBankAccount() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const triggerResult = await originalTrigger(...triggerParameters)
-      void forceReloadBankTransactions()
-      return triggerResult
-    },
-    [originalTrigger, forceReloadBankTransactions],
+    (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters),
+    [originalTrigger],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude.ts
+++ b/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude.ts
@@ -1,27 +1,33 @@
 import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
-import { del } from '@utils/api/authenticatedHttp'
+import type { OneOf } from '@internal-types/utility/oneOf'
+import { post } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
-const UNLINK_BANK_ACCOUNT_TAG_KEY = '#unlink-bank-account'
+const EXCLUDE_EXTERNAL_ACCOUNT_TAG_KEY = '#exclude-external-account'
 
-const unlinkBankAccount = del<
+export type ExcludeAccountBodyStrict = OneOf<[
+  { is_irrelevant: true },
+  { is_duplicate: true },
+]>
+
+export const excludeExternalAccount = post<
   Record<string, unknown>,
-  Record<string, unknown>,
-  {
-    businessId: string
-    bankAccountId: string
-  }
+  ExcludeAccountBodyStrict,
+  { businessId: string, accountId: string }
 >(
-  ({ businessId, bankAccountId }) =>
-    `/v1/businesses/${businessId}/bank-accounts/${bankAccountId}`,
+  ({ businessId, accountId }) =>
+    `/v1/businesses/${businessId}/external-accounts/${accountId}/exclude`,
 )
+
+type ExcludeExternalAccountArg = {
+  accountId: string
+  body?: ExcludeAccountBodyStrict
+}
 
 function buildKey({
   access_token: accessToken,
@@ -37,28 +43,29 @@ function buildKey({
       accessToken,
       apiUrl,
       businessId,
-      tags: [UNLINK_BANK_ACCOUNT_TAG_KEY],
+      tags: [EXCLUDE_EXTERNAL_ACCOUNT_TAG_KEY],
     } as const
   }
 }
 
-export function useUnlinkBankAccount() {
+export function useExcludeExternalAccount() {
   const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
   const { data: auth } = useAuth()
-  const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
+  const { businessId } = useLayerContext()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
       access_token: auth?.access_token,
-      apiUrl,
+      apiUrl: auth?.apiUrl,
       businessId,
     })),
-    ({ accessToken, apiUrl, businessId }, { arg: bankAccountId }: { arg: string }) =>
-      unlinkBankAccount(apiUrl, accessToken, {
-        params: { businessId, bankAccountId },
-      }),
+    (
+      { accessToken, apiUrl, businessId },
+      { arg: { accountId, body } }: { arg: ExcludeExternalAccountArg },
+    ) => excludeExternalAccount(apiUrl, accessToken, {
+      params: { businessId, accountId },
+      body,
+    }),
     {
       revalidate: false,
     },
@@ -69,12 +76,9 @@ export function useUnlinkBankAccount() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const triggerResult = await originalTrigger(...triggerParameters)
-      void forceReloadBankTransactions()
-      return triggerResult
-    },
-    [originalTrigger, forceReloadBankTransactions],
+    (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters),
+    [originalTrigger],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/api/businesses/[business-id]/external-accounts/update-connection-status.ts
+++ b/src/hooks/api/businesses/[business-id]/external-accounts/update-connection-status.ts
@@ -1,26 +1,21 @@
 import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
-import { del } from '@utils/api/authenticatedHttp'
+import { post } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
-const UNLINK_BANK_ACCOUNT_TAG_KEY = '#unlink-bank-account'
+const UPDATE_CONNECTION_STATUS_TAG_KEY = '#update-connection-status'
 
-const unlinkBankAccount = del<
+const updateConnectionStatus = post<
   Record<string, unknown>,
   Record<string, unknown>,
-  {
-    businessId: string
-    bankAccountId: string
-  }
+  { businessId: string }
 >(
-  ({ businessId, bankAccountId }) =>
-    `/v1/businesses/${businessId}/bank-accounts/${bankAccountId}`,
+  ({ businessId }) =>
+    `/v1/businesses/${businessId}/external-accounts/update-connection-status`,
 )
 
 function buildKey({
@@ -37,27 +32,25 @@ function buildKey({
       accessToken,
       apiUrl,
       businessId,
-      tags: [UNLINK_BANK_ACCOUNT_TAG_KEY],
+      tags: [UPDATE_CONNECTION_STATUS_TAG_KEY],
     } as const
   }
 }
 
-export function useUnlinkBankAccount() {
+export function useUpdateConnectionStatus() {
   const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
   const { data: auth } = useAuth()
-  const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
+  const { businessId } = useLayerContext()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
       access_token: auth?.access_token,
-      apiUrl,
+      apiUrl: auth?.apiUrl,
       businessId,
     })),
-    ({ accessToken, apiUrl, businessId }, { arg: bankAccountId }: { arg: string }) =>
-      unlinkBankAccount(apiUrl, accessToken, {
-        params: { businessId, bankAccountId },
+    ({ accessToken, apiUrl, businessId }) =>
+      updateConnectionStatus(apiUrl, accessToken, {
+        params: { businessId },
       }),
     {
       revalidate: false,
@@ -69,12 +62,9 @@ export function useUnlinkBankAccount() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const triggerResult = await originalTrigger(...triggerParameters)
-      void forceReloadBankTransactions()
-      return triggerResult
-    },
-    [originalTrigger, forceReloadBankTransactions],
+    (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters),
+    [originalTrigger],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/sandbox-reset-item-login.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/sandbox-reset-item-login.ts
@@ -1,26 +1,25 @@
 import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
-import { del } from '@utils/api/authenticatedHttp'
+import { post } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
-const UNLINK_BANK_ACCOUNT_TAG_KEY = '#unlink-bank-account'
+const BREAK_PLAID_ITEM_CONNECTION_TAG_KEY = '#break-plaid-item-connection'
 
-const unlinkBankAccount = del<
+/**
+ * Test utility that puts a Plaid connection into a broken state; only works in
+ * non-production environments.
+ */
+const breakPlaidItemConnection = post<
   Record<string, unknown>,
   Record<string, unknown>,
-  {
-    businessId: string
-    bankAccountId: string
-  }
+  { businessId: string, plaidItemId: string }
 >(
-  ({ businessId, bankAccountId }) =>
-    `/v1/businesses/${businessId}/bank-accounts/${bankAccountId}`,
+  ({ businessId, plaidItemId }) =>
+    `/v1/businesses/${businessId}/plaid/items/${plaidItemId}/sandbox-reset-item-login`,
 )
 
 function buildKey({
@@ -37,28 +36,28 @@ function buildKey({
       accessToken,
       apiUrl,
       businessId,
-      tags: [UNLINK_BANK_ACCOUNT_TAG_KEY],
+      tags: [BREAK_PLAID_ITEM_CONNECTION_TAG_KEY],
     } as const
   }
 }
 
-export function useUnlinkBankAccount() {
+export function useBreakPlaidItemConnection() {
   const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
   const { data: auth } = useAuth()
-  const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
+  const { businessId } = useLayerContext()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
       access_token: auth?.access_token,
-      apiUrl,
+      apiUrl: auth?.apiUrl,
       businessId,
     })),
-    ({ accessToken, apiUrl, businessId }, { arg: bankAccountId }: { arg: string }) =>
-      unlinkBankAccount(apiUrl, accessToken, {
-        params: { businessId, bankAccountId },
-      }),
+    (
+      { accessToken, apiUrl, businessId },
+      { arg: { plaidItemId } }: { arg: { plaidItemId: string } },
+    ) => breakPlaidItemConnection(apiUrl, accessToken, {
+      params: { businessId, plaidItemId },
+    }),
     {
       revalidate: false,
     },
@@ -69,12 +68,9 @@ export function useUnlinkBankAccount() {
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const triggerResult = await originalTrigger(...triggerParameters)
-      void forceReloadBankTransactions()
-      return triggerResult
-    },
-    [originalTrigger, forceReloadBankTransactions],
+    (...triggerParameters: Parameters<typeof originalTrigger>) =>
+      originalTrigger(...triggerParameters),
+    [originalTrigger],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/unlink.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/unlink.ts
@@ -1,26 +1,22 @@
 import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
-import { del } from '@utils/api/authenticatedHttp'
+import { post } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
-const UNLINK_BANK_ACCOUNT_TAG_KEY = '#unlink-bank-account'
+const UNLINK_PLAID_ITEM_TAG_KEY = '#unlink-plaid-item'
 
-const unlinkBankAccount = del<
+const unlinkPlaidItem = post<
   Record<string, unknown>,
   Record<string, unknown>,
-  {
-    businessId: string
-    bankAccountId: string
-  }
+  { businessId: string, plaidItemId: string }
 >(
-  ({ businessId, bankAccountId }) =>
-    `/v1/businesses/${businessId}/bank-accounts/${bankAccountId}`,
+  ({ businessId, plaidItemId }) =>
+    `/v1/businesses/${businessId}/plaid/items/${plaidItemId}/unlink`,
 )
 
 function buildKey({
@@ -37,28 +33,29 @@ function buildKey({
       accessToken,
       apiUrl,
       businessId,
-      tags: [UNLINK_BANK_ACCOUNT_TAG_KEY],
+      tags: [UNLINK_PLAID_ITEM_TAG_KEY],
     } as const
   }
 }
 
-export function useUnlinkBankAccount() {
+export function useUnlinkPlaidItem() {
   const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
   const { data: auth } = useAuth()
+  const { businessId } = useLayerContext()
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
       access_token: auth?.access_token,
-      apiUrl,
+      apiUrl: auth?.apiUrl,
       businessId,
     })),
-    ({ accessToken, apiUrl, businessId }, { arg: bankAccountId }: { arg: string }) =>
-      unlinkBankAccount(apiUrl, accessToken, {
-        params: { businessId, bankAccountId },
-      }),
+    (
+      { accessToken, apiUrl, businessId },
+      { arg: { plaidItemId } }: { arg: { plaidItemId: string } },
+    ) => unlinkPlaidItem(apiUrl, accessToken, {
+      params: { businessId, plaidItemId },
+    }),
     {
       revalidate: false,
     },

--- a/src/hooks/api/businesses/[business-id]/plaid/link/exchange.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/link/exchange.ts
@@ -1,27 +1,21 @@
 import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
-import { del } from '@utils/api/authenticatedHttp'
+import type { PublicToken } from '@internal-types/linkedAccounts'
+import { post } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
-const UNLINK_BANK_ACCOUNT_TAG_KEY = '#unlink-bank-account'
+const EXCHANGE_PLAID_PUBLIC_TOKEN_TAG_KEY = '#exchange-plaid-public-token'
 
-const unlinkBankAccount = del<
+const exchangePlaidPublicToken = post<
   Record<string, unknown>,
-  Record<string, unknown>,
-  {
-    businessId: string
-    bankAccountId: string
-  }
->(
-  ({ businessId, bankAccountId }) =>
-    `/v1/businesses/${businessId}/bank-accounts/${bankAccountId}`,
-)
+  PublicToken,
+  { businessId: string }
+>(({ businessId }) => `/v1/businesses/${businessId}/plaid/link/exchange`)
 
 function buildKey({
   access_token: accessToken,
@@ -37,28 +31,34 @@ function buildKey({
       accessToken,
       apiUrl,
       businessId,
-      tags: [UNLINK_BANK_ACCOUNT_TAG_KEY],
+      tags: [EXCHANGE_PLAID_PUBLIC_TOKEN_TAG_KEY],
     } as const
   }
 }
 
-export function useUnlinkBankAccount() {
+export function useExchangePlaidPublicToken() {
   const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
   const { data: auth } = useAuth()
+  const { businessId } = useLayerContext()
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
       access_token: auth?.access_token,
-      apiUrl,
+      apiUrl: auth?.apiUrl,
       businessId,
     })),
-    ({ accessToken, apiUrl, businessId }, { arg: bankAccountId }: { arg: string }) =>
-      unlinkBankAccount(apiUrl, accessToken, {
-        params: { businessId, bankAccountId },
-      }),
+    (
+      { accessToken, apiUrl, businessId },
+      { arg: body }: { arg: PublicToken },
+    ) => exchangePlaidPublicToken(
+      apiUrl,
+      accessToken,
+      {
+        params: { businessId },
+        body,
+      },
+    ),
     {
       revalidate: false,
     },

--- a/src/hooks/api/businesses/[business-id]/plaid/link/index.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/link/index.ts
@@ -1,15 +1,31 @@
 import { useCallback } from 'react'
+import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
-import type { Awaitable } from '@internal-types/utility/promises'
+import {
+  ApiLinkTokenSchema,
+  type CreatePlaidLinkParams,
+  type CreatePlaidLinkParamsEncoded,
+  encodeCreatePlaidLinkParams,
+} from '@schemas/linkedAccounts/plaid'
+import { post } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { confirmExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm'
-import { excludeExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
-export type AccountConfirmExcludeFormState = Record<string, boolean>
+const CREATE_PLAID_LINK_TAG_KEY = '#create-plaid-link'
+
+const CreatePlaidLinkReturnSchema = Schema.Struct({
+  data: ApiLinkTokenSchema,
+})
+type CreatePlaidLinkReturn = typeof CreatePlaidLinkReturnSchema.Type
+
+const createPlaidLink = post<
+  CreatePlaidLinkReturn,
+  CreatePlaidLinkParamsEncoded,
+  { businessId: string }
+>(({ businessId }) => `/v1/businesses/${businessId}/plaid/link`)
 
 function buildKey({
   access_token: accessToken,
@@ -25,12 +41,12 @@ function buildKey({
       accessToken,
       apiUrl,
       businessId,
-      tags: ['#bulk-confirm', '#bulk-exclude'],
-    }
+      tags: [CREATE_PLAID_LINK_TAG_KEY],
+    } as const
   }
 }
 
-export function useConfirmAndExcludeMultiple({ onSuccess }: { onSuccess?: () => Awaitable<unknown> }) {
+export function useCreatePlaidLink() {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
@@ -43,23 +59,17 @@ export function useConfirmAndExcludeMultiple({ onSuccess }: { onSuccess?: () => 
     })),
     (
       { accessToken, apiUrl, businessId },
-      { arg }: { arg: AccountConfirmExcludeFormState },
-    ) =>
-      Promise.all(
-        Object.entries(arg).map(([accountId, isConfirmed]) =>
-          isConfirmed
-            ? confirmExternalAccount(apiUrl, accessToken, {
-              params: { businessId, accountId },
-              body: { is_relevant: true },
-            })
-            : excludeExternalAccount(apiUrl, accessToken, {
-              params: { businessId, accountId },
-              body: { is_irrelevant: true },
-            }),
-        ),
-      )
-        .then(() => onSuccess?.())
-        .then(() => true as const),
+      { arg: params }: { arg: CreatePlaidLinkParams },
+    ) => createPlaidLink(
+      apiUrl,
+      accessToken,
+      {
+        params: { businessId },
+        body: encodeCreatePlaidLinkParams(params),
+      },
+    )
+      .then(Schema.decodeUnknownPromise(CreatePlaidLinkReturnSchema))
+      .then(({ data }) => data),
     {
       revalidate: false,
       throwOnError: false,

--- a/src/hooks/api/businesses/[business-id]/plaid/link/index.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/link/index.ts
@@ -72,7 +72,6 @@ export function useCreatePlaidLink() {
       .then(({ data }) => data),
     {
       revalidate: false,
-      throwOnError: false,
     },
   )
 

--- a/src/hooks/api/businesses/[business-id]/plaid/update-mode-link.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/update-mode-link.ts
@@ -1,15 +1,30 @@
 import { useCallback } from 'react'
+import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
-import type { Awaitable } from '@internal-types/utility/promises'
+import { ApiLinkTokenSchema } from '@schemas/linkedAccounts/plaid'
+import { post } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { confirmExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm'
-import { excludeExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
-export type AccountConfirmExcludeFormState = Record<string, boolean>
+const CREATE_PLAID_UPDATE_MODE_LINK_TAG_KEY = '#create-plaid-update-mode-link'
+
+const CreatePlaidUpdateModeLinkReturnSchema = Schema.Struct({
+  data: ApiLinkTokenSchema,
+})
+type CreatePlaidUpdateModeLinkReturn = typeof CreatePlaidUpdateModeLinkReturnSchema.Type
+
+type CreatePlaidUpdateModeLinkBody = {
+  plaid_item_id: string
+}
+
+const createPlaidUpdateModeLink = post<
+  CreatePlaidUpdateModeLinkReturn,
+  CreatePlaidUpdateModeLinkBody,
+  { businessId: string }
+>(({ businessId }) => `/v1/businesses/${businessId}/plaid/update-mode-link`)
 
 function buildKey({
   access_token: accessToken,
@@ -25,12 +40,12 @@ function buildKey({
       accessToken,
       apiUrl,
       businessId,
-      tags: ['#bulk-confirm', '#bulk-exclude'],
-    }
+      tags: [CREATE_PLAID_UPDATE_MODE_LINK_TAG_KEY],
+    } as const
   }
 }
 
-export function useConfirmAndExcludeMultiple({ onSuccess }: { onSuccess?: () => Awaitable<unknown> }) {
+export function useCreatePlaidUpdateModeLink() {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
@@ -43,26 +58,19 @@ export function useConfirmAndExcludeMultiple({ onSuccess }: { onSuccess?: () => 
     })),
     (
       { accessToken, apiUrl, businessId },
-      { arg }: { arg: AccountConfirmExcludeFormState },
-    ) =>
-      Promise.all(
-        Object.entries(arg).map(([accountId, isConfirmed]) =>
-          isConfirmed
-            ? confirmExternalAccount(apiUrl, accessToken, {
-              params: { businessId, accountId },
-              body: { is_relevant: true },
-            })
-            : excludeExternalAccount(apiUrl, accessToken, {
-              params: { businessId, accountId },
-              body: { is_irrelevant: true },
-            }),
-        ),
-      )
-        .then(() => onSuccess?.())
-        .then(() => true as const),
+      { arg: { plaidItemId } }: { arg: { plaidItemId: string } },
+    ) => createPlaidUpdateModeLink(
+      apiUrl,
+      accessToken,
+      {
+        params: { businessId },
+        body: { plaid_item_id: plaidItemId },
+      },
+    )
+      .then(Schema.decodeUnknownPromise(CreatePlaidUpdateModeLinkReturnSchema))
+      .then(({ data }) => data),
     {
       revalidate: false,
-      throwOnError: false,
     },
   )
 

--- a/src/hooks/features/linkedAccounts/usePlaidLinkModal.ts
+++ b/src/hooks/features/linkedAccounts/usePlaidLinkModal.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { type PlaidLinkOnSuccessMetadata, usePlaidLink } from 'react-plaid-link'
+
+import type { Awaitable } from '@internal-types/utility/promises'
+import { useUpdateConnectionStatus } from '@hooks/api/businesses/[business-id]/external-accounts/update-connection-status'
+import { useExchangePlaidPublicToken } from '@hooks/api/businesses/[business-id]/plaid/link/exchange'
+import { useAccountConfirmationStoreActions } from '@providers/AccountConfirmationStoreProvider'
+import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
+import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+
+export type LinkMode = 'update' | 'add'
+
+type UsePlaidLinkModalOptions = {
+  /** Link token to open the Plaid modal with, or null when idle. */
+  token: string | null
+  /** Whether the open token is for adding a connection or repairing one. */
+  linkMode: LinkMode
+  /** Called after the connection set changes, so the caller can refresh accounts. */
+  onSuccess: () => Awaitable<void>
+  /** Updates the active link mode; reset to 'add' when a flow completes or the modal exits. */
+  setLinkMode: (mode: LinkMode) => void
+}
+
+/**
+ * Drives the embedded Plaid Link modal for a token owned by the caller: opening
+ * the widget, exchanging the public token (add) or refreshing connection status
+ * (repair) on completion, and notifying the caller to refresh accounts.
+ */
+export function usePlaidLinkModal({
+  token,
+  linkMode,
+  onSuccess,
+  setLinkMode,
+}: UsePlaidLinkModalOptions) {
+  const { usePlaidSandbox } = useEnvironment()
+  const { addToast } = useLayerContext()
+  const { t } = useTranslation()
+  const {
+    preload: preloadAccountConfirmation,
+    reset: resetAccountConfirmation,
+  } = useAccountConfirmationStoreActions()
+
+  const { trigger: triggerExchangePlaidPublicToken } = useExchangePlaidPublicToken()
+  const { trigger: triggerUpdateConnectionStatus } = useUpdateConnectionStatus()
+
+  const [isLinking, setIsLinking] = useState(false)
+
+  /**
+   * When the user has finished entering credentials, send the resulting
+   * token to the backend where it will fetch and save the Plaid access token
+   * and item id.
+   */
+  const exchangePlaidPublicToken = useCallback(
+    async (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => {
+      setIsLinking(true)
+      preloadAccountConfirmation()
+
+      await triggerExchangePlaidPublicToken({
+        public_token: publicToken,
+        institution: metadata.institution,
+      })
+        .then(
+          // Only refresh once the link has actually persisted.
+          () => onSuccess(),
+          () => addToast({
+            content: t('linkedAccounts:error.connect_account', 'We couldn’t connect your account. Please try again.'),
+            type: 'error',
+          }),
+        )
+        .finally(() => {
+          setIsLinking(false)
+          resetAccountConfirmation()
+        })
+    },
+    [triggerExchangePlaidPublicToken, onSuccess, addToast, t, preloadAccountConfirmation, resetAccountConfirmation],
+  )
+
+  const { open: plaidLinkStart, ready: plaidLinkReady } = usePlaidLink({
+    token,
+
+    // If in update mode, we don't need to exchange the public token for an access token.
+    // The existing access token will automatically become valid again
+    onSuccess: (
+      publicToken: string,
+      metadata: PlaidLinkOnSuccessMetadata,
+    ) => {
+      if (linkMode == 'add') {
+        // Note: a sync is kicked off in the backend in this endpoint
+        void exchangePlaidPublicToken(publicToken, metadata)
+      }
+      else {
+        // Refresh the account connections, which should remove the error
+        // pills from any broken accounts
+        void triggerUpdateConnectionStatus().then(() => {
+          void onSuccess()
+          setLinkMode('add')
+        })
+      }
+    },
+    onExit: () => setLinkMode('add'),
+    env: usePlaidSandbox ? 'sandbox' : undefined,
+  })
+
+  useEffect(() => {
+    if (plaidLinkReady) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      plaidLinkStart()
+    }
+  }, [plaidLinkStart, plaidLinkReady])
+
+  return { isLinking }
+}

--- a/src/hooks/features/linkedAccounts/usePlaidLinkModal.ts
+++ b/src/hooks/features/linkedAccounts/usePlaidLinkModal.ts
@@ -13,7 +13,7 @@ export type LinkMode = 'update' | 'add'
 
 type UsePlaidLinkModalOptions = {
   /** Link token to open the Plaid modal with, or null when idle. */
-  token: string | null
+  linkToken: string | null
   /** Whether the open token is for adding a connection or repairing one. */
   linkMode: LinkMode
   /** Called after the connection set changes, so the caller can refresh accounts. */
@@ -28,7 +28,7 @@ type UsePlaidLinkModalOptions = {
  * (repair) on completion, and notifying the caller to refresh accounts.
  */
 export function usePlaidLinkModal({
-  token,
+  linkToken,
   linkMode,
   onSuccess,
   setLinkMode,
@@ -77,7 +77,7 @@ export function usePlaidLinkModal({
   )
 
   const { open: plaidLinkStart, ready: plaidLinkReady } = usePlaidLink({
-    token,
+    token: linkToken,
 
     // If in update mode, we don't need to exchange the public token for an access token.
     // The existing access token will automatically become valid again

--- a/src/hooks/legacy/useDataSync.tsx
+++ b/src/hooks/legacy/useDataSync.tsx
@@ -15,18 +15,12 @@ type UseDataSync = () => {
 const ALL_TOUCHABLE = [
   DataModel.BUSINESS,
   DataModel.BANK_TRANSACTIONS,
-  DataModel.LINKED_ACCOUNTS,
 ]
 
 const DEPENDENCIES: Partial<Record<DataModel, DataModel[]>> = {
   [DataModel.BALANCE_SHEET]: ALL_TOUCHABLE,
-  [DataModel.LINKED_ACCOUNTS]: [
-    DataModel.BUSINESS,
-    DataModel.LINKED_ACCOUNTS,
-  ],
   [DataModel.STATEMENT_OF_CASH_FLOWS]: ALL_TOUCHABLE,
   [DataModel.BANK_TRANSACTIONS]: [
-    DataModel.LINKED_ACCOUNTS,
     DataModel.BANK_TRANSACTIONS,
     DataModel.BUSINESS,
   ],
@@ -40,7 +34,6 @@ export const useDataSync: UseDataSync = () => {
     Partial<Record<DataModel, number>>
   >({
     [DataModel.BALANCE_SHEET]: initialTimestamp,
-    [DataModel.LINKED_ACCOUNTS]: initialTimestamp,
     [DataModel.STATEMENT_OF_CASH_FLOWS]: initialTimestamp,
     [DataModel.BANK_TRANSACTIONS]: initialTimestamp,
   })
@@ -91,7 +84,6 @@ export const useDataSync: UseDataSync = () => {
     void invalidateProfitAndLoss()
     setSyncTimestamps({
       [DataModel.BALANCE_SHEET]: now,
-      [DataModel.LINKED_ACCOUNTS]: now,
       [DataModel.STATEMENT_OF_CASH_FLOWS]: now,
       [DataModel.BANK_TRANSACTIONS]: now,
     })

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { type PlaidLinkOnSuccessMetadata, usePlaidLink } from 'react-plaid-link'
 
 import { type LoadedStatus } from '@internal-types/general'
@@ -13,9 +14,9 @@ import { useUnlinkPlaidItem } from '@hooks/api/businesses/[business-id]/plaid/it
 import { useCreatePlaidLink } from '@hooks/api/businesses/[business-id]/plaid/link'
 import { useExchangePlaidPublicToken } from '@hooks/api/businesses/[business-id]/plaid/link/exchange'
 import { useCreatePlaidUpdateModeLink } from '@hooks/api/businesses/[business-id]/plaid/update-mode-link'
-import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useAccountConfirmationStoreActions } from '@providers/AccountConfirmationStoreProvider'
 import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
+import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export function getAccountsNeedingConfirmation(bankAccounts: ReadonlyArray<BankAccount>): ExternalAccountConnection[] {
   return bankAccounts.flatMap(ba =>
@@ -46,9 +47,30 @@ type UseLinkedAccounts = () => {
 
 type LinkMode = 'update' | 'add'
 
+/**
+ * Returns a memoized action that only runs for Plaid-sourced connections,
+ * logging a consistent "not yet supported" message for any other source.
+ */
+const usePlaidOnlyAction = <Args extends unknown[]>(
+  operation: string,
+  action: (...args: Args) => Promise<void>,
+) =>
+  useCallback(
+    async (source: AccountSource, ...args: Args) => {
+      if (source !== 'PLAID') {
+        console.error(`${operation} with source ${source} not yet supported`)
+        return
+      }
+
+      await action(...args)
+    },
+    [operation, action],
+  )
+
 export const useLinkedAccounts: UseLinkedAccounts = () => {
   const { usePlaidSandbox } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { addToast } = useLayerContext()
+  const { t } = useTranslation()
   const {
     preload: preloadAccountConfirmation,
     reset: resetAccountConfirmation,
@@ -93,56 +115,93 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading])
 
+  const refetchAccounts = useCallback(async () => {
+    await mutate()
+  }, [mutate])
+
+  /**
+   * Runs a mutation, refreshing the account list on success and surfacing an
+   * error toast on failure. A failed refresh is not reported as a mutation
+   * failure, since the mutation itself succeeded.
+   */
+  const mutateAndRefetchAccounts = useCallback(
+    (mutation: () => Promise<unknown>, errorMessage: string) =>
+      mutation().then(
+        () => refetchAccounts(),
+        () => addToast({ content: errorMessage, type: 'error' }),
+      ),
+    [refetchAccounts, addToast],
+  )
+
+  /**
+   * Requests a Plaid link token, opening the relevant flow on success and
+   * surfacing an error toast on failure.
+   */
+  const fetchLinkToken = useCallback(
+    (
+      mode: LinkMode,
+      requestToken: () => Promise<{ linkToken: string } | undefined>,
+      errorMessage: string,
+    ) =>
+      requestToken().then(
+        (result) => {
+          if (!result) return
+
+          setLinkMode(mode)
+          setLinkToken(result.linkToken)
+        },
+        () => addToast({ content: errorMessage, type: 'error' }),
+      ),
+    [addToast],
+  )
+
   /**
    * Initiates an add connection flow with Plaid
    */
-  const fetchPlaidLinkToken = async () => {
-    if (auth?.access_token) {
-      const result = await triggerCreatePlaidLink({})
-      if (!result) return
-
-      setLinkMode('add')
-      setLinkToken(result.linkToken)
-    }
-  }
+  const fetchPlaidLinkToken = useCallback(
+    () => fetchLinkToken(
+      'add',
+      () => triggerCreatePlaidLink({}),
+      t('linkedAccounts:error.start_connection', 'We couldn’t initiate the Plaid connection flow. Please try again.'),
+    ),
+    [fetchLinkToken, triggerCreatePlaidLink, t],
+  )
 
   /**
    * Initiates a connection repair flow with Plaid
    */
-  const fetchPlaidUpdateModeLinkToken = async (plaidItemPlaidId: string) => {
-    if (auth?.access_token) {
-      const result = await triggerCreatePlaidUpdateModeLink({ plaidItemId: plaidItemPlaidId })
-      if (!result) return
-
-      setLinkMode('update')
-      setLinkToken(result.linkToken)
-    }
-  }
+  const fetchPlaidUpdateModeLinkToken = useCallback(
+    (plaidItemPlaidId: string) => fetchLinkToken(
+      'update',
+      () => triggerCreatePlaidUpdateModeLink({ plaidItemId: plaidItemPlaidId }),
+      t('linkedAccounts:error.repair_connection', 'We couldn’t start the connection repair flow. Please try again.'),
+    ),
+    [fetchLinkToken, triggerCreatePlaidUpdateModeLink, t],
+  )
 
   /**
    * When the user has finished entering credentials, send the resulting
    * token to the backend where it will fetch and save the Plaid access token
-   * and item id
-   * */
-  const exchangePlaidPublicToken = async (
-    publicToken: string,
-    metadata: PlaidLinkOnSuccessMetadata,
-  ) => {
-    setIsLinking(true)
-    preloadAccountConfirmation()
+   * and item id.
+   */
+  const exchangePlaidPublicToken = useCallback(
+    async (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => {
+      setIsLinking(true)
+      preloadAccountConfirmation()
 
-    try {
-      await triggerExchangePlaidPublicToken({
-        public_token: publicToken,
-        institution: metadata.institution,
+      await mutateAndRefetchAccounts(
+        () => triggerExchangePlaidPublicToken({
+          public_token: publicToken,
+          institution: metadata.institution,
+        }),
+        t('linkedAccounts:error.connect_account', 'We couldn’t finish connecting your account. Please try again.'),
+      ).finally(() => {
+        setIsLinking(false)
+        resetAccountConfirmation()
       })
-      await refetchAccounts()
-    }
-    finally {
-      setIsLinking(false)
-      resetAccountConfirmation()
-    }
-  }
+    },
+    [mutateAndRefetchAccounts, triggerExchangePlaidPublicToken, t, preloadAccountConfirmation, resetAccountConfirmation],
+  )
 
   const { open: plaidLinkStart, ready: plaidLinkReady } = usePlaidLink({
     token: linkToken,
@@ -177,105 +236,57 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     }
   }, [plaidLinkStart, plaidLinkReady])
 
-  const addConnection = async (source: AccountSource) => {
-    if (source === 'PLAID') {
-      await fetchPlaidLinkToken()
-    }
-    else {
-      console.error(
-        `Adding a connection with source ${source} not yet supported`,
-      )
-    }
-  }
+  const addConnection = usePlaidOnlyAction('Adding a connection', fetchPlaidLinkToken)
 
-  const repairConnection = async (
-    source: AccountSource,
-    connectionExternalId: string,
-  ) => {
-    if (source === 'PLAID') {
-      await fetchPlaidUpdateModeLinkToken(connectionExternalId)
-    }
-    else {
-      console.error(
-        `Repairing a connection with source ${source} not yet supported`,
-      )
-    }
-  }
+  const repairConnection = usePlaidOnlyAction('Repairing a connection', fetchPlaidUpdateModeLinkToken)
 
-  const removeConnection = async (
-    source: AccountSource,
-    connectionExternalId: string,
-  ) => {
-    if (source === 'PLAID') {
-      await unlinkPlaidItem(connectionExternalId)
-      await refetchAccounts()
-    }
-    else {
-      console.error(
-        `Removing a connection with source ${source} not yet supported`,
-      )
-    }
-  }
+  const handleRemoveConnection = useCallback(
+    (connectionExternalId: string) => mutateAndRefetchAccounts(
+      () => triggerUnlinkPlaidItem({ plaidItemId: connectionExternalId }),
+      t('linkedAccounts:error.remove_connection', 'We couldn’t remove the connection. Please try again.'),
+    ),
+    [mutateAndRefetchAccounts, triggerUnlinkPlaidItem, t],
+  )
+  const removeConnection = usePlaidOnlyAction('Removing a connection', handleRemoveConnection)
 
-  const unlinkBankAccount = async (bankAccountId: string) => {
-    await triggerUnlinkBankAccount(bankAccountId)
-    await refetchAccounts()
-  }
+  const handleConfirmAccount = useCallback(
+    (accountId: string) => mutateAndRefetchAccounts(
+      () => triggerConfirmExternalAccount({ accountId }),
+      t('linkedAccounts:error.confirm_account', 'We couldn’t confirm the account. Please try again.'),
+    ),
+    [mutateAndRefetchAccounts, triggerConfirmExternalAccount, t],
+  )
+  const confirmAccount = usePlaidOnlyAction('Confirming an account', handleConfirmAccount)
 
-  const confirmAccount = async (source: AccountSource, accountId: string) => {
-    if (source === 'PLAID') {
-      await triggerConfirmExternalAccount({ accountId })
-      await refetchAccounts()
-    }
-    else {
-      console.error(
-        `Confirming an account with source ${source} not yet supported`,
-      )
-    }
-  }
+  const handleExcludeAccount = useCallback(
+    (accountId: string) => mutateAndRefetchAccounts(
+      () => triggerExcludeExternalAccount({ accountId, body: { is_duplicate: true } }),
+      t('linkedAccounts:error.exclude_account', 'We couldn’t exclude the account. Please try again.'),
+    ),
+    [mutateAndRefetchAccounts, triggerExcludeExternalAccount, t],
+  )
+  const excludeAccount = usePlaidOnlyAction('Excluding an account', handleExcludeAccount)
 
-  const excludeAccount = async (source: AccountSource, accountId: string) => {
-    if (source === 'PLAID') {
-      await triggerExcludeExternalAccount({
-        accountId,
-        body: { is_duplicate: true },
-      })
-      await refetchAccounts()
-    }
-    else {
-      console.error(
-        `Excluding an account with source ${source} not yet supported`,
-      )
-    }
-  }
-
+  const handleBreakConnection = useCallback(
+    (connectionExternalId: string) => mutateAndRefetchAccounts(
+      () => triggerBreakPlaidItemConnection({ plaidItemId: connectionExternalId }),
+      t('linkedAccounts:error.break_connection', 'We couldn’t reset the connection. Please try again.'),
+    ),
+    [mutateAndRefetchAccounts, triggerBreakPlaidItemConnection, t],
+  )
   /**
    * Test utility that puts a connection into a broken state; only works in non-production
    * environments.
    */
-  const breakConnection = async (
-    source: AccountSource,
-    connectionExternalId: string,
-  ) => {
-    if (source === 'PLAID') {
-      await triggerBreakPlaidItemConnection({ plaidItemId: connectionExternalId })
-      await refetchAccounts()
-    }
-    else {
-      console.error(
-        `Breaking a sandbox connection with source ${source} not yet supported`,
-      )
-    }
-  }
+  const breakConnection = usePlaidOnlyAction('Breaking a sandbox connection', handleBreakConnection)
 
-  const refetchAccounts = async () => {
-    await mutate()
-  }
-
-  const unlinkPlaidItem = async (plaidItemPlaidId: string) => {
-    await triggerUnlinkPlaidItem({ plaidItemId: plaidItemPlaidId })
-    await refetchAccounts()
-  }
+  const unlinkBankAccount = useCallback(
+    (bankAccountId: string) => mutateAndRefetchAccounts(
+      () => triggerUnlinkBankAccount(bankAccountId),
+      t('linkedAccounts:error.unlink_account', 'We couldn’t unlink the account. Please try again.'),
+    ),
+    [mutateAndRefetchAccounts, triggerUnlinkBankAccount, t],
+  )
 
   return {
     data: bankAccounts ?? [],

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { type PlaidLinkOnSuccessMetadata, usePlaidLink } from 'react-plaid-link'
 
 import { type LoadedStatus } from '@internal-types/general'
 import { type AccountSource, type BankAccount, type ExternalAccountConnection } from '@internal-types/linkedAccounts'
@@ -8,14 +7,11 @@ import { useListBankAccounts } from '@hooks/api/businesses/[business-id]/bank-ac
 import { useUnlinkBankAccount } from '@hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount'
 import { useConfirmExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm'
 import { useExcludeExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude'
-import { useUpdateConnectionStatus } from '@hooks/api/businesses/[business-id]/external-accounts/update-connection-status'
 import { useBreakPlaidItemConnection } from '@hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/sandbox-reset-item-login'
 import { useUnlinkPlaidItem } from '@hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/unlink'
 import { useCreatePlaidLink } from '@hooks/api/businesses/[business-id]/plaid/link'
-import { useExchangePlaidPublicToken } from '@hooks/api/businesses/[business-id]/plaid/link/exchange'
 import { useCreatePlaidUpdateModeLink } from '@hooks/api/businesses/[business-id]/plaid/update-mode-link'
-import { useAccountConfirmationStoreActions } from '@providers/AccountConfirmationStoreProvider'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
+import { type LinkMode, usePlaidLinkModal } from '@hooks/features/linkedAccounts/usePlaidLinkModal'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export function getAccountsNeedingConfirmation(bankAccounts: ReadonlyArray<BankAccount>): ExternalAccountConnection[] {
@@ -45,8 +41,6 @@ type UseLinkedAccounts = () => {
   breakConnection: (source: AccountSource, connectionExternalId: string) => Promise<void>
 }
 
-type LinkMode = 'update' | 'add'
-
 /**
  * Returns a memoized action that only runs for Plaid-sourced connections,
  * logging a consistent "not yet supported" message for any other source.
@@ -68,18 +62,12 @@ const usePlaidOnlyAction = <Args extends unknown[]>(
   )
 
 export const useLinkedAccounts: UseLinkedAccounts = () => {
-  const { usePlaidSandbox } = useEnvironment()
   const { addToast } = useLayerContext()
   const { t } = useTranslation()
-  const {
-    preload: preloadAccountConfirmation,
-    reset: resetAccountConfirmation,
-  } = useAccountConfirmationStoreActions()
 
   const [linkToken, setLinkToken] = useState<string | null>(null)
   const [loadingStatus, setLoadingStatus] = useState<LoadedStatus>('initial')
   const [linkMode, setLinkMode] = useState<LinkMode>('add')
-  const [isLinking, setIsLinking] = useState(false)
 
   const {
     data: bankAccounts,
@@ -91,10 +79,8 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   const { trigger: triggerUnlinkBankAccount } = useUnlinkBankAccount()
   const { trigger: triggerCreatePlaidLink } = useCreatePlaidLink()
   const { trigger: triggerCreatePlaidUpdateModeLink } = useCreatePlaidUpdateModeLink()
-  const { trigger: triggerExchangePlaidPublicToken } = useExchangePlaidPublicToken()
   const { trigger: triggerConfirmExternalAccount } = useConfirmExternalAccount()
   const { trigger: triggerExcludeExternalAccount } = useExcludeExternalAccount()
-  const { trigger: triggerUpdateConnectionStatus } = useUpdateConnectionStatus()
   const { trigger: triggerUnlinkPlaidItem } = useUnlinkPlaidItem()
   const { trigger: triggerBreakPlaidItemConnection } = useBreakPlaidItemConnection()
 
@@ -162,7 +148,7 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     () => fetchLinkToken(
       'add',
       () => triggerCreatePlaidLink({}),
-      t('linkedAccounts:error.start_connection', 'We couldn’t initiate the Plaid connection flow. Please try again.'),
+      t('linkedAccounts:error.start_connection', 'We couldn’t start connecting your account. Please try again.'),
     ),
     [fetchLinkToken, triggerCreatePlaidLink, t],
   )
@@ -174,67 +160,17 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     (plaidItemPlaidId: string) => fetchLinkToken(
       'update',
       () => triggerCreatePlaidUpdateModeLink({ plaidItemId: plaidItemPlaidId }),
-      t('linkedAccounts:error.repair_connection', 'We couldn’t start the connection repair flow. Please try again.'),
+      t('linkedAccounts:error.repair_connection', 'We couldn’t start reconnecting your account. Please try again.'),
     ),
     [fetchLinkToken, triggerCreatePlaidUpdateModeLink, t],
   )
 
-  /**
-   * When the user has finished entering credentials, send the resulting
-   * token to the backend where it will fetch and save the Plaid access token
-   * and item id.
-   */
-  const exchangePlaidPublicToken = useCallback(
-    async (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => {
-      setIsLinking(true)
-      preloadAccountConfirmation()
-
-      await mutateAndRefetchAccounts(
-        () => triggerExchangePlaidPublicToken({
-          public_token: publicToken,
-          institution: metadata.institution,
-        }),
-        t('linkedAccounts:error.connect_account', 'We couldn’t finish connecting your account. Please try again.'),
-      ).finally(() => {
-        setIsLinking(false)
-        resetAccountConfirmation()
-      })
-    },
-    [mutateAndRefetchAccounts, triggerExchangePlaidPublicToken, t, preloadAccountConfirmation, resetAccountConfirmation],
-  )
-
-  const { open: plaidLinkStart, ready: plaidLinkReady } = usePlaidLink({
+  const { isLinking } = usePlaidLinkModal({
     token: linkToken,
-
-    // If in update mode, we don't need to exchange the public token for an access token.
-    // The existing access token will automatically become valid again
-    onSuccess: (
-      publicToken: string,
-      metadata: PlaidLinkOnSuccessMetadata,
-    ) => {
-      if (linkMode == 'add') {
-        // Note: a sync is kicked off in the backend in this endpoint
-        void exchangePlaidPublicToken(publicToken, metadata)
-      }
-      else {
-        // Refresh the account connections, which should remove the error
-        // pills from any broken accounts
-        void triggerUpdateConnectionStatus().then(() => {
-          void refetchAccounts()
-          setLinkMode('add')
-        })
-      }
-    },
-    onExit: () => setLinkMode('add'),
-    env: usePlaidSandbox ? 'sandbox' : undefined,
+    onSuccess: refetchAccounts,
+    linkMode,
+    setLinkMode,
   })
-
-  useEffect(() => {
-    if (plaidLinkReady) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      plaidLinkStart()
-    }
-  }, [plaidLinkStart, plaidLinkReady])
 
   const addConnection = usePlaidOnlyAction('Adding a connection', fetchPlaidLinkToken)
 
@@ -243,7 +179,7 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   const handleRemoveConnection = useCallback(
     (connectionExternalId: string) => mutateAndRefetchAccounts(
       () => triggerUnlinkPlaidItem({ plaidItemId: connectionExternalId }),
-      t('linkedAccounts:error.remove_connection', 'We couldn’t remove the connection. Please try again.'),
+      t('linkedAccounts:error.remove_connection', 'We couldn’t remove this connection. Please try again.'),
     ),
     [mutateAndRefetchAccounts, triggerUnlinkPlaidItem, t],
   )
@@ -252,7 +188,7 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   const handleConfirmAccount = useCallback(
     (accountId: string) => mutateAndRefetchAccounts(
       () => triggerConfirmExternalAccount({ accountId }),
-      t('linkedAccounts:error.confirm_account', 'We couldn’t confirm the account. Please try again.'),
+      t('linkedAccounts:error.confirm_account', 'We couldn’t confirm your account. Please try again.'),
     ),
     [mutateAndRefetchAccounts, triggerConfirmExternalAccount, t],
   )
@@ -261,7 +197,7 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   const handleExcludeAccount = useCallback(
     (accountId: string) => mutateAndRefetchAccounts(
       () => triggerExcludeExternalAccount({ accountId, body: { is_duplicate: true } }),
-      t('linkedAccounts:error.exclude_account', 'We couldn’t exclude the account. Please try again.'),
+      t('linkedAccounts:error.exclude_account', 'We couldn’t exclude your account. Please try again.'),
     ),
     [mutateAndRefetchAccounts, triggerExcludeExternalAccount, t],
   )
@@ -270,7 +206,7 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   const handleBreakConnection = useCallback(
     (connectionExternalId: string) => mutateAndRefetchAccounts(
       () => triggerBreakPlaidItemConnection({ plaidItemId: connectionExternalId }),
-      t('linkedAccounts:error.break_connection', 'We couldn’t reset the connection. Please try again.'),
+      t('linkedAccounts:error.break_connection', 'We couldn’t reset this connection. Please try again.'),
     ),
     [mutateAndRefetchAccounts, triggerBreakPlaidItemConnection, t],
   )
@@ -283,7 +219,7 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   const unlinkBankAccount = useCallback(
     (bankAccountId: string) => mutateAndRefetchAccounts(
       () => triggerUnlinkBankAccount(bankAccountId),
-      t('linkedAccounts:error.unlink_account', 'We couldn’t unlink the account. Please try again.'),
+      t('linkedAccounts:error.unlink_account', 'We couldn’t unlink your account. Please try again.'),
     ),
     [mutateAndRefetchAccounts, triggerUnlinkBankAccount, t],
   )

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -105,6 +105,13 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     await mutate()
   }, [mutate])
 
+  const { isLinking } = usePlaidLinkModal({
+    linkToken,
+    linkMode,
+    setLinkMode,
+    onSuccess: refetchAccounts,
+  })
+
   /**
    * Runs a mutation, refreshing the account list on success and surfacing an
    * error toast on failure. A failed refresh is not reported as a mutation
@@ -169,13 +176,6 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     [fetchLinkToken, triggerCreatePlaidUpdateModeLink, t],
   )
 
-  const { isLinking } = usePlaidLinkModal({
-    token: linkToken,
-    onSuccess: refetchAccounts,
-    linkMode,
-    setLinkMode,
-  })
-
   const addConnection = usePlaidOnlyAction('Adding a connection', fetchPlaidLinkToken)
 
   const repairConnection = usePlaidOnlyAction('Repairing a connection', fetchPlaidUpdateModeLinkToken)
@@ -220,7 +220,7 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
    */
   const breakConnection = usePlaidOnlyAction('Breaking a sandbox connection', handleBreakConnection)
 
-  // Note: not routed through mutateAndRefetchAccountsWithToast — this is confirmed via
+  // Note: not routed through mutateAndRefetchAccounts — this is confirmed via
   // BaseConfirmationModal, which surfaces failures (errorText + Retry, stays
   // open) by catching a rejected onConfirm. Swallowing the error into a toast
   // would let the modal dismiss as if the unlink succeeded.

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -1,97 +1,21 @@
 import { useEffect, useState } from 'react'
 import { type PlaidLinkOnSuccessMetadata, usePlaidLink } from 'react-plaid-link'
 
-import { DataModel, type LoadedStatus } from '@internal-types/general'
-import type { PublicToken } from '@internal-types/linkedAccounts'
+import { type LoadedStatus } from '@internal-types/general'
 import { type AccountSource, type BankAccount, type ExternalAccountConnection } from '@internal-types/linkedAccounts'
-import type { OneOf } from '@internal-types/utility/oneOf'
-import { post } from '@utils/api/authenticatedHttp'
 import { useListBankAccounts } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
 import { useUnlinkBankAccount } from '@hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount'
-import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
+import { useConfirmExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm'
+import { useExcludeExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude'
+import { useUpdateConnectionStatus } from '@hooks/api/businesses/[business-id]/external-accounts/update-connection-status'
+import { useBreakPlaidItemConnection } from '@hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/sandbox-reset-item-login'
+import { useUnlinkPlaidItem } from '@hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/unlink'
+import { useCreatePlaidLink } from '@hooks/api/businesses/[business-id]/plaid/link'
+import { useExchangePlaidPublicToken } from '@hooks/api/businesses/[business-id]/plaid/link/exchange'
+import { useCreatePlaidUpdateModeLink } from '@hooks/api/businesses/[business-id]/plaid/update-mode-link'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useAccountConfirmationStoreActions } from '@providers/AccountConfirmationStoreProvider'
 import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
-
-const getPlaidLinkToken = post<
-  { data: { type: 'Link_Token', link_token: string } },
-  Record<string, unknown>,
-  { businessId: string }
->(({ businessId }) => `/v1/businesses/${businessId}/plaid/link`)
-
-const getPlaidUpdateModeLinkToken = post<
-  { data: { type: 'Link_Token', link_token: string } },
-  Record<string, unknown>,
-  { businessId: string }
->(({ businessId }) => `/v1/businesses/${businessId}/plaid/update-mode-link`)
-
-const exchangePlaidPublicTokenApi = post<
-  Record<string, unknown>,
-  PublicToken,
-  { businessId: string }
->(({ businessId }) => `/v1/businesses/${businessId}/plaid/link/exchange`)
-
-export type ConfirmAccountBodyStrict = OneOf<[
-  { is_unique: true },
-  { is_relevant: true },
-]>
-
-export const confirmAccountApi = post<
-  never,
-  ConfirmAccountBodyStrict,
-  { businessId: string, accountId: string }
->(
-  ({ businessId, accountId }) =>
-    `/v1/businesses/${businessId}/external-accounts/${accountId}/confirm`,
-)
-
-export type ExcludeAccountBodyStrict = OneOf<[
-  { is_irrelevant: true },
-  { is_duplicate: true },
-]>
-
-export const excludeAccountApi = post<
-  never,
-  ExcludeAccountBodyStrict,
-  { businessId: string, accountId: string }
->(
-  ({ businessId, accountId }) =>
-    `/v1/businesses/${businessId}/external-accounts/${accountId}/exclude`,
-)
-
-const breakPlaidItemConnection = post<
-  Record<string, unknown>,
-  Record<string, unknown>,
-  { businessId: string, plaidItemPlaidId: string }
->(
-  ({ businessId, plaidItemPlaidId }) =>
-    `/v1/businesses/${businessId}/plaid/items/${plaidItemPlaidId}/sandbox-reset-item-login`,
-)
-
-const syncConnection = post<
-  Record<string, unknown>,
-  Record<string, unknown>,
-  { businessId: string }
->(({ businessId }) => `/v1/businesses/${businessId}/sync`)
-
-const updateConnectionStatusApi = post<
-  Record<string, unknown>,
-  Record<string, unknown>,
-  { businessId: string }
->(
-  ({ businessId }) =>
-    `/v1/businesses/${businessId}/external-accounts/update-connection-status`,
-)
-
-const unlinkPlaidItemApi = post<
-  Record<string, unknown>,
-  Record<string, unknown>,
-  { businessId: string, plaidItemPlaidId: string }
->(
-  ({ businessId, plaidItemPlaidId }) =>
-    `/v1/businesses/${businessId}/plaid/items/${plaidItemPlaidId}/unlink`,
-)
 
 export function getAccountsNeedingConfirmation(bankAccounts: ReadonlyArray<BankAccount>): ExternalAccountConnection[] {
   return bankAccounts.flatMap(ba =>
@@ -111,14 +35,10 @@ type UseLinkedAccounts = () => {
   addConnection: (source: AccountSource) => Promise<void>
   removeConnection: (source: AccountSource, sourceId: string) => Promise<void>
   repairConnection: (source: AccountSource, sourceId: string) => Promise<void>
-  updateConnectionStatus: () => Promise<void>
   refetchAccounts: () => Promise<void>
-  syncAccounts: () => Promise<void>
   unlinkBankAccount: (bankAccountId: string) => Promise<void>
   confirmAccount: (source: AccountSource, accountId: string) => Promise<void>
   excludeAccount: (source: AccountSource, accountId: string) => Promise<void>
-  accountsToAddOpeningBalanceInModal: BankAccount[]
-  setAccountsToAddOpeningBalanceInModal: (accounts: BankAccount[]) => void
 
   // Only works in non-production environments for test purposes
   breakConnection: (source: AccountSource, connectionExternalId: string) => Promise<void>
@@ -127,15 +47,7 @@ type UseLinkedAccounts = () => {
 type LinkMode = 'update' | 'add'
 
 export const useLinkedAccounts: UseLinkedAccounts = () => {
-  const {
-    businessId,
-    touch,
-    read,
-    syncTimestamps,
-    hasBeenTouched,
-  } = useLayerContext()
-
-  const { apiUrl, usePlaidSandbox } = useEnvironment()
+  const { usePlaidSandbox } = useEnvironment()
   const { data: auth } = useAuth()
   const {
     preload: preloadAccountConfirmation,
@@ -146,10 +58,6 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   const [loadingStatus, setLoadingStatus] = useState<LoadedStatus>('initial')
   const [linkMode, setLinkMode] = useState<LinkMode>('add')
   const [isLinking, setIsLinking] = useState(false)
-  const [accountsToAddOpeningBalanceInModal, setAccountsToAddOpeningBalanceInModal] =
-    useState<BankAccount[]>([])
-
-  const queryKey = businessId && auth?.access_token && `linked-accounts-${businessId}`
 
   const {
     data: bankAccounts,
@@ -159,7 +67,14 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     mutate,
   } = useListBankAccounts()
   const { trigger: triggerUnlinkBankAccount } = useUnlinkBankAccount()
-  const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
+  const { trigger: triggerCreatePlaidLink } = useCreatePlaidLink()
+  const { trigger: triggerCreatePlaidUpdateModeLink } = useCreatePlaidUpdateModeLink()
+  const { trigger: triggerExchangePlaidPublicToken } = useExchangePlaidPublicToken()
+  const { trigger: triggerConfirmExternalAccount } = useConfirmExternalAccount()
+  const { trigger: triggerExcludeExternalAccount } = useExcludeExternalAccount()
+  const { trigger: triggerUpdateConnectionStatus } = useUpdateConnectionStatus()
+  const { trigger: triggerUnlinkPlaidItem } = useUnlinkPlaidItem()
+  const { trigger: triggerBreakPlaidItemConnection } = useBreakPlaidItemConnection()
 
   useEffect(() => {
     if (!isLoading && bankAccounts) {
@@ -183,13 +98,11 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
    */
   const fetchPlaidLinkToken = async () => {
     if (auth?.access_token) {
-      const linkToken = (
-        await getPlaidLinkToken(apiUrl, auth.access_token, {
-          params: { businessId },
-        })
-      ).data.link_token
+      const result = await triggerCreatePlaidLink({})
+      if (!result) return
+
       setLinkMode('add')
-      setLinkToken(linkToken)
+      setLinkToken(result.linkToken)
     }
   }
 
@@ -198,14 +111,11 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
    */
   const fetchPlaidUpdateModeLinkToken = async (plaidItemPlaidId: string) => {
     if (auth?.access_token) {
-      const linkToken = (
-        await getPlaidUpdateModeLinkToken(apiUrl, auth.access_token, {
-          params: { businessId },
-          body: { plaid_item_id: plaidItemPlaidId },
-        })
-      ).data.link_token
+      const result = await triggerCreatePlaidUpdateModeLink({ plaidItemId: plaidItemPlaidId })
+      if (!result) return
+
       setLinkMode('update')
-      setLinkToken(linkToken)
+      setLinkToken(result.linkToken)
     }
   }
 
@@ -222,13 +132,11 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     preloadAccountConfirmation()
 
     try {
-      await exchangePlaidPublicTokenApi(apiUrl, auth?.access_token, {
-        params: { businessId },
-        body: { public_token: publicToken, institution: metadata.institution },
+      await triggerExchangePlaidPublicToken({
+        public_token: publicToken,
+        institution: metadata.institution,
       })
       await refetchAccounts()
-
-      void forceReloadBankTransactions()
     }
     finally {
       setIsLinking(false)
@@ -252,10 +160,9 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
       else {
         // Refresh the account connections, which should remove the error
         // pills from any broken accounts
-        void updateConnectionStatus().then(() => {
+        void triggerUpdateConnectionStatus().then(() => {
           void refetchAccounts()
           setLinkMode('add')
-          touch(DataModel.LINKED_ACCOUNTS)
         })
       }
     },
@@ -313,20 +220,12 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   const unlinkBankAccount = async (bankAccountId: string) => {
     await triggerUnlinkBankAccount(bankAccountId)
     await refetchAccounts()
-    void forceReloadBankTransactions()
-    touch(DataModel.LINKED_ACCOUNTS)
   }
 
   const confirmAccount = async (source: AccountSource, accountId: string) => {
     if (source === 'PLAID') {
-      await confirmAccountApi(apiUrl, auth?.access_token, {
-        params: {
-          businessId,
-          accountId,
-        },
-      })
+      await triggerConfirmExternalAccount({ accountId })
       await refetchAccounts()
-      touch(DataModel.LINKED_ACCOUNTS)
     }
     else {
       console.error(
@@ -337,17 +236,11 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
 
   const excludeAccount = async (source: AccountSource, accountId: string) => {
     if (source === 'PLAID') {
-      await excludeAccountApi(apiUrl, auth?.access_token, {
-        params: {
-          businessId,
-          accountId,
-        },
-        body: {
-          is_duplicate: true,
-        },
+      await triggerExcludeExternalAccount({
+        accountId,
+        body: { is_duplicate: true },
       })
       await refetchAccounts()
-      touch(DataModel.LINKED_ACCOUNTS)
     }
     else {
       console.error(
@@ -365,14 +258,8 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     connectionExternalId: string,
   ) => {
     if (source === 'PLAID') {
-      await breakPlaidItemConnection(apiUrl, auth?.access_token, {
-        params: {
-          businessId,
-          plaidItemPlaidId: connectionExternalId,
-        },
-      })
+      await triggerBreakPlaidItemConnection({ plaidItemId: connectionExternalId })
       await refetchAccounts()
-      touch(DataModel.LINKED_ACCOUNTS)
     }
     else {
       console.error(
@@ -385,41 +272,10 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     await mutate()
   }
 
-  const syncAccounts = async () => {
-    await syncConnection(apiUrl, auth?.access_token, {
-      params: { businessId },
-    })
-  }
-
-  const updateConnectionStatus = async () => {
-    await updateConnectionStatusApi(apiUrl, auth?.access_token, {
-      params: { businessId },
-    })
-  }
-
   const unlinkPlaidItem = async (plaidItemPlaidId: string) => {
-    await unlinkPlaidItemApi(apiUrl, auth?.access_token, {
-      params: { businessId, plaidItemPlaidId },
-    })
+    await triggerUnlinkPlaidItem({ plaidItemId: plaidItemPlaidId })
     await refetchAccounts()
-    void forceReloadBankTransactions()
-    touch(DataModel.LINKED_ACCOUNTS)
   }
-
-  // Refetch data if related models has been changed since last fetch
-  useEffect(() => {
-    if (queryKey && (isLoading || isValidating)) {
-      read(DataModel.LINKED_ACCOUNTS, queryKey)
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading, isValidating])
-
-  useEffect(() => {
-    if (queryKey && hasBeenTouched(queryKey)) {
-      void refetchAccounts()
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [syncTimestamps])
 
   return {
     data: bankAccounts ?? [],
@@ -436,9 +292,5 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     confirmAccount,
     excludeAccount,
     breakConnection,
-    syncAccounts,
-    updateConnectionStatus,
-    accountsToAddOpeningBalanceInModal,
-    setAccountsToAddOpeningBalanceInModal,
   }
 }

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -109,8 +109,12 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
    * Runs a mutation, refreshing the account list on success and surfacing an
    * error toast on failure. A failed refresh is not reported as a mutation
    * failure, since the mutation itself succeeded.
+   *
+   * Note: this swallows rejections (the failure becomes a toast and the returned
+   * promise resolves), so it must not back an `onConfirm`/submit handler whose
+   * caller relies on a rejection to show errors — e.g. BaseConfirmationModal.
    */
-  const mutateAndRefetchAccounts = useCallback(
+  const mutateAndRefetchAccountsWithToast = useCallback(
     (mutation: () => Promise<unknown>, errorMessage: string) =>
       mutation().then(
         () => refetchAccounts(),
@@ -177,38 +181,38 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   const repairConnection = usePlaidOnlyAction('Repairing a connection', fetchPlaidUpdateModeLinkToken)
 
   const handleRemoveConnection = useCallback(
-    (connectionExternalId: string) => mutateAndRefetchAccounts(
+    (connectionExternalId: string) => mutateAndRefetchAccountsWithToast(
       () => triggerUnlinkPlaidItem({ plaidItemId: connectionExternalId }),
       t('linkedAccounts:error.remove_connection', 'We couldn’t remove this connection. Please try again.'),
     ),
-    [mutateAndRefetchAccounts, triggerUnlinkPlaidItem, t],
+    [mutateAndRefetchAccountsWithToast, triggerUnlinkPlaidItem, t],
   )
   const removeConnection = usePlaidOnlyAction('Removing a connection', handleRemoveConnection)
 
   const handleConfirmAccount = useCallback(
-    (accountId: string) => mutateAndRefetchAccounts(
+    (accountId: string) => mutateAndRefetchAccountsWithToast(
       () => triggerConfirmExternalAccount({ accountId }),
       t('linkedAccounts:error.confirm_account', 'We couldn’t confirm your account. Please try again.'),
     ),
-    [mutateAndRefetchAccounts, triggerConfirmExternalAccount, t],
+    [mutateAndRefetchAccountsWithToast, triggerConfirmExternalAccount, t],
   )
   const confirmAccount = usePlaidOnlyAction('Confirming an account', handleConfirmAccount)
 
   const handleExcludeAccount = useCallback(
-    (accountId: string) => mutateAndRefetchAccounts(
+    (accountId: string) => mutateAndRefetchAccountsWithToast(
       () => triggerExcludeExternalAccount({ accountId, body: { is_duplicate: true } }),
       t('linkedAccounts:error.exclude_account', 'We couldn’t exclude your account. Please try again.'),
     ),
-    [mutateAndRefetchAccounts, triggerExcludeExternalAccount, t],
+    [mutateAndRefetchAccountsWithToast, triggerExcludeExternalAccount, t],
   )
   const excludeAccount = usePlaidOnlyAction('Excluding an account', handleExcludeAccount)
 
   const handleBreakConnection = useCallback(
-    (connectionExternalId: string) => mutateAndRefetchAccounts(
+    (connectionExternalId: string) => mutateAndRefetchAccountsWithToast(
       () => triggerBreakPlaidItemConnection({ plaidItemId: connectionExternalId }),
       t('linkedAccounts:error.break_connection', 'We couldn’t reset this connection. Please try again.'),
     ),
-    [mutateAndRefetchAccounts, triggerBreakPlaidItemConnection, t],
+    [mutateAndRefetchAccountsWithToast, triggerBreakPlaidItemConnection, t],
   )
   /**
    * Test utility that puts a connection into a broken state; only works in non-production
@@ -216,12 +220,16 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
    */
   const breakConnection = usePlaidOnlyAction('Breaking a sandbox connection', handleBreakConnection)
 
+  // Note: not routed through mutateAndRefetchAccountsWithToast — this is confirmed via
+  // BaseConfirmationModal, which surfaces failures (errorText + Retry, stays
+  // open) by catching a rejected onConfirm. Swallowing the error into a toast
+  // would let the modal dismiss as if the unlink succeeded.
   const unlinkBankAccount = useCallback(
-    (bankAccountId: string) => mutateAndRefetchAccounts(
-      () => triggerUnlinkBankAccount(bankAccountId),
-      t('linkedAccounts:error.unlink_account', 'We couldn’t unlink your account. Please try again.'),
-    ),
-    [mutateAndRefetchAccounts, triggerUnlinkBankAccount, t],
+    async (bankAccountId: string) => {
+      await triggerUnlinkBankAccount(bankAccountId)
+      await refetchAccounts()
+    },
+    [triggerUnlinkBankAccount, refetchAccounts],
   )
 
   return {

--- a/src/providers/OpeningBalanceModalProvider/OpeningBalanceModalProvider.tsx
+++ b/src/providers/OpeningBalanceModalProvider/OpeningBalanceModalProvider.tsx
@@ -1,0 +1,23 @@
+import { type PropsWithChildren, useMemo, useState } from 'react'
+
+import { type BankAccount } from '@internal-types/linkedAccounts'
+import { OpeningBalanceModalContext } from '@contexts/OpeningBalanceModalContext/OpeningBalanceModalContext'
+
+export function OpeningBalanceModalProvider({ children }: PropsWithChildren) {
+  const [accountsToAddOpeningBalanceInModal, setAccountsToAddOpeningBalanceInModal] =
+    useState<BankAccount[]>([])
+
+  const value = useMemo(
+    () => ({
+      accountsToAddOpeningBalanceInModal,
+      setAccountsToAddOpeningBalanceInModal,
+    }),
+    [accountsToAddOpeningBalanceInModal],
+  )
+
+  return (
+    <OpeningBalanceModalContext.Provider value={value}>
+      {children}
+    </OpeningBalanceModalContext.Provider>
+  )
+}

--- a/src/schemas/linkedAccounts/plaid.ts
+++ b/src/schemas/linkedAccounts/plaid.ts
@@ -36,7 +36,8 @@ export const ApiLinkTokenSchema = Schema.Struct({
     Schema.fromKey('link_token'),
   ),
 
-  hostedLink: Schema.optional(Schema.NullOr(Schema.String)).pipe(
+  hostedLink: pipe(
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
     Schema.fromKey('hosted_link'),
   ),
 })

--- a/src/schemas/linkedAccounts/plaid.ts
+++ b/src/schemas/linkedAccounts/plaid.ts
@@ -1,0 +1,44 @@
+import { pipe, Schema } from 'effect'
+
+export const HostedLinkParamsSchema = Schema.Struct({
+  completionRedirectUri: Schema.optional(Schema.String).pipe(
+    Schema.fromKey('completion_redirect_uri'),
+  ),
+
+  isMobileApp: Schema.optional(Schema.Boolean).pipe(
+    Schema.fromKey('is_mobile_app'),
+  ),
+})
+
+export type HostedLinkParams = typeof HostedLinkParamsSchema.Type
+export type HostedLinkParamsEncoded = typeof HostedLinkParamsSchema.Encoded
+
+export const CreatePlaidLinkParamsSchema = Schema.Struct({
+  redirectUri: Schema.optional(Schema.String).pipe(
+    Schema.fromKey('redirect_uri'),
+  ),
+
+  hostedLinkParams: Schema.optional(HostedLinkParamsSchema).pipe(
+    Schema.fromKey('hosted_link_params'),
+  ),
+})
+
+export type CreatePlaidLinkParams = typeof CreatePlaidLinkParamsSchema.Type
+export type CreatePlaidLinkParamsEncoded = typeof CreatePlaidLinkParamsSchema.Encoded
+
+export const encodeCreatePlaidLinkParams = Schema.encodeSync(CreatePlaidLinkParamsSchema)
+
+export const ApiLinkTokenSchema = Schema.Struct({
+  type: Schema.Literal('Link_Token'),
+
+  linkToken: pipe(
+    Schema.propertySignature(Schema.String),
+    Schema.fromKey('link_token'),
+  ),
+
+  hostedLink: Schema.optional(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey('hosted_link'),
+  ),
+})
+
+export type ApiLinkToken = typeof ApiLinkTokenSchema.Type


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Plaid connect/repair/unlink and account confirm flows with changed cache invalidation (no linked-accounts data-sync touch); bank-transaction reload timing moved into mutation side effects.
> 
> **Overview**
> Moves linked-account **writes** out of `useLinkedAccounts` into dedicated **`useSWRMutation`** hooks (confirm/exclude external accounts, Plaid link token, token exchange, update-mode link, unlink item, connection status, sandbox break) wrapped with **`SWRMutationResult`** and stable proxied **`trigger`**s. **`useLinkedAccounts`** now orchestrates those hooks, adds shared toast + refetch helpers, and delegates the Plaid Link widget to new **`usePlaidLinkModal`**.
> 
> **Opening balance** modal state is split into **`OpeningBalanceModalContext`** / **`OpeningBalanceModalProvider`** instead of **`LinkedAccountsContext`**. The confirmation modal uses **`isError`** from the bulk confirm/exclude mutation.
> 
> Cache behavior shifts: **`DataModel.LINKED_ACCOUNTS`** is removed from **`useDataSync`**, along with public **`syncAccounts`** / **`updateConnectionStatus`** on the linked-accounts context; bank-transaction reloads after unlink/exchange/unlink-bank-account run inside the mutation hooks via **`forceReloadBankTransactions`**. Plaid link create/update responses are validated with new **Effect** schemas in **`schemas/linkedAccounts/plaid.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f04655dd581cd1f36c729d44e58924f5059c883d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->