### PR TITLE
feat: enable hosted link for Plaid

### DIFF
--- a/src/components/LinkAccounts/LinkAccounts.tsx
+++ b/src/components/LinkAccounts/LinkAccounts.tsx
@@ -2,6 +2,7 @@ import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { Awaitable } from '@internal-types/utility/promises'
+import { type PlaidHostedLinkConfig } from '@schemas/linkedAccounts/plaid'
 import { getAccountsNeedingConfirmation } from '@hooks/legacy/useLinkedAccounts'
 import { LinkedAccountsProvider } from '@providers/LinkedAccountsProvider/LinkedAccountsProvider'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
@@ -14,11 +15,12 @@ import './linkAccounts.scss'
 
 type LinkAccountsProps = {
   onComplete?: () => Awaitable<void>
+  plaidHostedLinkConfig?: PlaidHostedLinkConfig
 }
 
-export function LinkAccounts(props: LinkAccountsProps) {
+export function LinkAccounts({ plaidHostedLinkConfig, ...props }: LinkAccountsProps) {
   return (
-    <LinkedAccountsProvider>
+    <LinkedAccountsProvider plaidHostedLinkConfig={plaidHostedLinkConfig}>
       <LinkAccountsContent {...props} />
     </LinkedAccountsProvider>
   )

--- a/src/components/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/components/LinkedAccounts/LinkedAccounts.tsx
@@ -1,6 +1,7 @@
 import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { type PlaidHostedLinkConfig } from '@schemas/linkedAccounts/plaid'
 import { AccountConfirmationStoreProvider } from '@providers/AccountConfirmationStoreProvider'
 import { LinkedAccountsProvider } from '@providers/LinkedAccountsProvider/LinkedAccountsProvider'
 import { OpeningBalanceModalProvider } from '@providers/OpeningBalanceModalProvider/OpeningBalanceModalProvider'
@@ -21,15 +22,16 @@ export interface LinkedAccountsProps {
   showLedgerBalance?: boolean
   showUnlinkItem?: boolean
   showBreakConnection?: boolean
+  plaidHostedLinkConfig?: PlaidHostedLinkConfig
   stringOverrides?: {
     title?: string
   }
 }
 
-export const LinkedAccounts = (props: LinkedAccountsProps) => {
+export const LinkedAccounts = ({ plaidHostedLinkConfig, ...props }: LinkedAccountsProps) => {
   return (
     <AccountConfirmationStoreProvider>
-      <LinkedAccountsProvider>
+      <LinkedAccountsProvider plaidHostedLinkConfig={plaidHostedLinkConfig}>
         <OpeningBalanceModalProvider>
           <LinkedAccountsComponent {...props} />
         </OpeningBalanceModalProvider>

--- a/src/components/Onboarding/Onboarding.tsx
+++ b/src/components/Onboarding/Onboarding.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from 'react'
 
 import { type OnboardingStep } from '@internal-types/layerContext'
+import { type PlaidHostedLinkConfig } from '@schemas/linkedAccounts/plaid'
 import { AccountConfirmationStoreProvider } from '@providers/AccountConfirmationStoreProvider'
 import { LinkedAccountsProvider } from '@providers/LinkedAccountsProvider/LinkedAccountsProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
@@ -27,11 +28,12 @@ const EXPANDED_STYLE = {
 export interface OnboardingProps {
   onTransactionsToReviewClick?: () => void
   onboardingStepOverride?: OnboardingStep
+  plaidHostedLinkConfig?: PlaidHostedLinkConfig
 }
 
-export const Onboarding = (props: OnboardingProps) => (
+export const Onboarding = ({ plaidHostedLinkConfig, ...props }: OnboardingProps) => (
   <AccountConfirmationStoreProvider>
-    <LinkedAccountsProvider>
+    <LinkedAccountsProvider plaidHostedLinkConfig={plaidHostedLinkConfig}>
       <OnboardingContent {...props} />
     </LinkedAccountsProvider>
   </AccountConfirmationStoreProvider>

--- a/src/components/SolopreneurOnboardingBanner/SolopreneurOnboardingBanner.tsx
+++ b/src/components/SolopreneurOnboardingBanner/SolopreneurOnboardingBanner.tsx
@@ -2,6 +2,7 @@ import { useCallback, useContext } from 'react'
 import { Info } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { type PlaidHostedLinkConfig } from '@schemas/linkedAccounts/plaid'
 import { useTaxProfile } from '@hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { LinkedAccountsProvider } from '@providers/LinkedAccountsProvider/LinkedAccountsProvider'
@@ -81,11 +82,12 @@ function SolopreneurOnboardingBannerInternal({ onSetupTaxProfile }: Pick<Solopre
 }
 export type SolopreneurOnboardingBannerProps = {
   onSetupTaxProfile?: () => void
+  plaidHostedLinkConfig?: PlaidHostedLinkConfig
 }
 
-export function SolopreneurOnboardingBanner({ onSetupTaxProfile }: SolopreneurOnboardingBannerProps) {
+export function SolopreneurOnboardingBanner({ onSetupTaxProfile, plaidHostedLinkConfig }: SolopreneurOnboardingBannerProps) {
   return (
-    <LinkedAccountsProvider>
+    <LinkedAccountsProvider plaidHostedLinkConfig={plaidHostedLinkConfig}>
       <SolopreneurOnboardingBannerInternal onSetupTaxProfile={onSetupTaxProfile} />
     </LinkedAccountsProvider>
   )

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { type LoadedStatus } from '@internal-types/general'
 import { type AccountSource, type BankAccount, type ExternalAccountConnection } from '@internal-types/linkedAccounts'
+import { type PlaidHostedLinkConfig, toCreatePlaidLinkParams } from '@schemas/linkedAccounts/plaid'
 import { useListBankAccounts } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
 import { useUnlinkBankAccount } from '@hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount'
 import { useConfirmExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm'
@@ -22,7 +23,11 @@ export function getAccountsNeedingConfirmation(bankAccounts: ReadonlyArray<BankA
   )
 }
 
-type UseLinkedAccounts = () => {
+type UseLinkedAccountsOptions = {
+  plaidHostedLinkConfig?: PlaidHostedLinkConfig
+}
+
+type UseLinkedAccounts = (options?: UseLinkedAccountsOptions) => {
   data?: BankAccount[]
   isLoading: boolean
   loadingStatus: LoadedStatus
@@ -61,7 +66,7 @@ const usePlaidOnlyAction = <Args extends unknown[]>(
     [operation, action],
   )
 
-export const useLinkedAccounts: UseLinkedAccounts = () => {
+export const useLinkedAccounts: UseLinkedAccounts = ({ plaidHostedLinkConfig } = {}) => {
   const { addToast } = useLayerContext()
   const { t } = useTranslation()
 
@@ -137,12 +142,22 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   const fetchLinkToken = useCallback(
     (
       mode: LinkMode,
-      requestToken: () => Promise<{ linkToken: string } | undefined>,
+      requestToken: () => Promise<{ linkToken: string, hostedLink?: string | null } | undefined>,
       errorMessage: string,
+      // Snapshotted with the request so the response is handled with the same
+      // config, even if the prop changes while the request is in flight.
+      hostedLinkConfig?: PlaidHostedLinkConfig,
     ) =>
       requestToken().then(
-        (result) => {
+        async (result) => {
           if (!result) return
+
+          // When a hosted-link config is supplied, hand the Plaid-owned URL to the
+          // customer platform to navigate to rather than opening the embedded modal.
+          if (hostedLinkConfig && result.hostedLink) {
+            await hostedLinkConfig.navigateToHostedLink(result.hostedLink)
+            return
+          }
 
           setLinkMode(mode)
           setLinkToken(result.linkToken)
@@ -158,10 +173,11 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
   const fetchPlaidLinkToken = useCallback(
     () => fetchLinkToken(
       'add',
-      () => triggerCreatePlaidLink({}),
-      t('linkedAccounts:error.start_connection', 'We couldn’t start connecting your account. Please try again.'),
+      () => triggerCreatePlaidLink(toCreatePlaidLinkParams(plaidHostedLinkConfig)),
+      t('linkedAccounts:error.start_connection', 'We couldn’t initiate the Plaid connection flow. Please try again.'),
+      plaidHostedLinkConfig,
     ),
-    [fetchLinkToken, triggerCreatePlaidLink, t],
+    [fetchLinkToken, triggerCreatePlaidLink, plaidHostedLinkConfig, t],
   )
 
   /**
@@ -171,9 +187,10 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
     (plaidItemPlaidId: string) => fetchLinkToken(
       'update',
       () => triggerCreatePlaidUpdateModeLink({ plaidItemId: plaidItemPlaidId }),
-      t('linkedAccounts:error.repair_connection', 'We couldn’t start reconnecting your account. Please try again.'),
+      t('linkedAccounts:error.repair_connection', 'We couldn’t repair the Plaid connection with your account. Please try again.'),
+      plaidHostedLinkConfig,
     ),
-    [fetchLinkToken, triggerCreatePlaidUpdateModeLink, t],
+    [fetchLinkToken, triggerCreatePlaidUpdateModeLink, plaidHostedLinkConfig, t],
   )
 
   const addConnection = usePlaidOnlyAction('Adding a connection', fetchPlaidLinkToken)
@@ -220,10 +237,6 @@ export const useLinkedAccounts: UseLinkedAccounts = () => {
    */
   const breakConnection = usePlaidOnlyAction('Breaking a sandbox connection', handleBreakConnection)
 
-  // Note: not routed through mutateAndRefetchAccounts — this is confirmed via
-  // BaseConfirmationModal, which surfaces failures (errorText + Retry, stays
-  // open) by catching a rejected onConfirm. Swallowing the error into a toast
-  // would let the modal dismiss as if the unlink succeeded.
   const unlinkBankAccount = useCallback(
     async (bankAccountId: string) => {
       await triggerUnlinkBankAccount(bankAccountId)

--- a/src/providers/LinkedAccountsProvider/LinkedAccountsProvider.tsx
+++ b/src/providers/LinkedAccountsProvider/LinkedAccountsProvider.tsx
@@ -1,10 +1,15 @@
 import { type PropsWithChildren } from 'react'
 
+import { type PlaidHostedLinkConfig } from '@schemas/linkedAccounts/plaid'
 import { useLinkedAccounts } from '@hooks/legacy/useLinkedAccounts'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
 
-export function LinkedAccountsProvider({ children }: PropsWithChildren) {
-  const linkedAccountsContextData = useLinkedAccounts()
+type LinkedAccountsProviderProps = PropsWithChildren<{
+  plaidHostedLinkConfig?: PlaidHostedLinkConfig
+}>
+
+export function LinkedAccountsProvider({ children, plaidHostedLinkConfig }: LinkedAccountsProviderProps) {
+  const linkedAccountsContextData = useLinkedAccounts({ plaidHostedLinkConfig })
 
   return (
     <LinkedAccountsContext.Provider value={linkedAccountsContextData}>

--- a/src/schemas/linkedAccounts/plaid.ts
+++ b/src/schemas/linkedAccounts/plaid.ts
@@ -1,5 +1,7 @@
 import { pipe, Schema } from 'effect'
 
+import type { Awaitable } from '@internal-types/utility/promises'
+
 export const HostedLinkParamsSchema = Schema.Struct({
   completionRedirectUri: Schema.optional(Schema.String).pipe(
     Schema.fromKey('completion_redirect_uri'),
@@ -27,6 +29,63 @@ export type CreatePlaidLinkParams = typeof CreatePlaidLinkParamsSchema.Type
 export type CreatePlaidLinkParamsEncoded = typeof CreatePlaidLinkParamsSchema.Encoded
 
 export const encodeCreatePlaidLinkParams = Schema.encodeSync(CreatePlaidLinkParamsSchema)
+
+/**
+ * Public configuration for the Plaid Hosted Link flow, accepted as a prop by
+ * exported components that allow linking accounts.
+ *
+ * When `isMobileApp` is `true`, both `redirectUri` and `completionRedirectUri`
+ * are required so the hosted flow can return the user to the app. Otherwise all
+ * fields are optional. Modelled as a union so the type system enforces the
+ * mobile-app requirements.
+ */
+export const PlaidHostedLinkConfigSchema = Schema.Union(
+  Schema.Struct({
+    isMobileApp: Schema.Literal(true),
+    redirectUri: Schema.String,
+    completionRedirectUri: Schema.String,
+  }),
+  Schema.Struct({
+    isMobileApp: Schema.optional(Schema.Literal(false)),
+    redirectUri: Schema.optional(Schema.String),
+    completionRedirectUri: Schema.optional(Schema.String),
+  }),
+)
+
+export type PlaidHostedLinkParams = typeof PlaidHostedLinkConfigSchema.Type
+
+export type PlaidHostedLinkConfig = PlaidHostedLinkParams & {
+  /**
+   * Navigates the customer platform to the Plaid Hosted Link URL. The link
+   * flow continues on a Plaid-owned page and returns via `completionRedirectUri`.
+   */
+  navigateToHostedLink: (hostedLinkUrl: string) => Awaitable<void>
+}
+
+const CreatePlaidLinkParamsFromHostedLinkConfigSchema = Schema.transform(
+  PlaidHostedLinkConfigSchema,
+  Schema.typeSchema(CreatePlaidLinkParamsSchema),
+  {
+    strict: false,
+    decode: ({ isMobileApp, redirectUri, completionRedirectUri }) => ({
+      redirectUri,
+      hostedLinkParams: { isMobileApp, completionRedirectUri },
+    }),
+    encode: ({ redirectUri, hostedLinkParams }) => ({
+      isMobileApp: hostedLinkParams?.isMobileApp,
+      redirectUri,
+      completionRedirectUri: hostedLinkParams?.completionRedirectUri,
+    }),
+  },
+)
+
+const decodeCreatePlaidLinkParamsFromHostedLinkConfig = Schema.decodeSync(
+  CreatePlaidLinkParamsFromHostedLinkConfigSchema,
+)
+
+export function toCreatePlaidLinkParams(config?: PlaidHostedLinkConfig): CreatePlaidLinkParams {
+  return config ? decodeCreatePlaidLinkParamsFromHostedLinkConfig(config) : {}
+}
 
 export const ApiLinkTokenSchema = Schema.Struct({
   type: Schema.Literal('Link_Token'),

--- a/src/views/AccountingOverview/AccountingOverview.tsx
+++ b/src/views/AccountingOverview/AccountingOverview.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { type OnboardingStep } from '@internal-types/layerContext'
+import { type PlaidHostedLinkConfig } from '@schemas/linkedAccounts/plaid'
 import type { Variants } from '@utils/styleUtils/sizeVariants'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { Container } from '@components/Container/Container'
@@ -40,6 +41,7 @@ export interface AccountingOverviewProps {
   showTitle?: boolean
   enableOnboarding?: boolean
   onboardingStepOverride?: OnboardingStep
+  plaidHostedLinkConfig?: PlaidHostedLinkConfig
   onTransactionsToReviewClick?: () => void
   middleBanner?: ReactNode
   chartColorsList?: string[]
@@ -59,6 +61,7 @@ export const AccountingOverview = ({
   showTitle = true,
   enableOnboarding = false,
   onboardingStepOverride = undefined,
+  plaidHostedLinkConfig,
   onTransactionsToReviewClick,
   middleBanner,
   chartColorsList,
@@ -98,6 +101,7 @@ export const AccountingOverview = ({
           <Onboarding
             onTransactionsToReviewClick={onTransactionsToReviewClick}
             onboardingStepOverride={onboardingStepOverride}
+            plaidHostedLinkConfig={plaidHostedLinkConfig}
           />
         )}
         <ProfitAndLossSummaries

--- a/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
+++ b/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { type PlaidHostedLinkConfig } from '@schemas/linkedAccounts/plaid'
 import { type BankTransactionsMode } from '@providers/LegacyModeProvider/LegacyModeProvider'
 import { type LinkingMetadata } from '@contexts/InAppLinkContext'
 import {
@@ -39,6 +40,7 @@ export interface BankTransactionsWithLinkedAccountsProps {
   stringOverrides?: BankTransactionsWithLinkedAccountsStringOverrides
   renderInAppLink?: (details: LinkingMetadata) => ReactNode
   showCategorizationRules?: boolean
+  plaidHostedLinkConfig?: PlaidHostedLinkConfig
 }
 
 export const BankTransactionsWithLinkedAccounts = ({
@@ -61,6 +63,7 @@ export const BankTransactionsWithLinkedAccounts = ({
   stringOverrides,
   renderInAppLink,
   showCategorizationRules,
+  plaidHostedLinkConfig,
 }: BankTransactionsWithLinkedAccountsProps) => {
   const { t } = useTranslation()
   return (
@@ -74,6 +77,7 @@ export const BankTransactionsWithLinkedAccounts = ({
         showUnlinkItem={showUnlinkItem}
         showBreakConnection={showBreakConnection}
         stringOverrides={stringOverrides?.linkedAccounts}
+        plaidHostedLinkConfig={plaidHostedLinkConfig}
       />
       <BankTransactions
         asWidget

--- a/src/views/SolopreneurOverview/SolopreneurOverview.tsx
+++ b/src/views/SolopreneurOverview/SolopreneurOverview.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
+import { type PlaidHostedLinkConfig } from '@schemas/linkedAccounts/plaid'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { type SummaryCardInteractionProps, type SummaryCardStringOverrides } from '@ui/SummaryCard/useSummaryCardSlots'
 import { ExpensesSummaryCard } from '@components/ExpensesSummaryCard/ExpensesSummaryCard'
@@ -53,12 +54,14 @@ export interface SolopreneurOverviewProps {
   chartColorsList?: string[]
   stringOverrides?: SolopreneurOverviewStringOverrides
   interactionProps?: SolopreneurOverviewInteractionProps
+  plaidHostedLinkConfig?: PlaidHostedLinkConfig
 }
 
 export const SolopreneurOverview = ({
   interactionProps,
   chartColorsList,
   stringOverrides,
+  plaidHostedLinkConfig,
 }: SolopreneurOverviewProps) => {
   const { t } = useTranslation()
   const { value: sizeClass } = useSizeClass()
@@ -81,6 +84,7 @@ export const SolopreneurOverview = ({
       >
         <SolopreneurOnboardingBanner
           onSetupTaxProfile={interactionProps?.banner?.onSetupTaxProfile}
+          plaidHostedLinkConfig={plaidHostedLinkConfig}
         />
         <ProfitAndLossSummaries
           stringOverrides={stringOverrides?.profitAndLossSummaries}


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core bank-linking initiation and redirect handling; misconfigured mobile redirect URIs or navigation callbacks could break connect/repair flows for integrators who opt in.
> 
> **Overview**
> Adds optional **`plaidHostedLinkConfig`** on exported linking surfaces (`LinkAccounts`, `LinkedAccounts`, `Onboarding`, solopreneur banner, and overview/bank-transactions views) and threads it through **`LinkedAccountsProvider`** into **`useLinkedAccounts`**.
> 
> When that config is present and the create-link API returns a **`hostedLink`** URL, the SDK calls the host’s **`navigateToHostedLink`** instead of opening the embedded Plaid modal; add/repair flows still send hosted-link params via new **`PlaidHostedLinkConfig`** / **`toCreatePlaidLinkParams`** schema helpers (including stricter mobile redirect requirements). Without the prop, behavior stays on the embedded link-token modal path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00e441f30ad7e81ae807e4b58dfc0ddf1d0be4c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->