### PR TITLE
feat: display draft invoices

### DIFF
--- a/src/assets/locales/en-US/invoices.json
+++ b/src/assets/locales/en-US/invoices.json
@@ -100,6 +100,7 @@
     "discard_changes_invoice": "Discard changes to this invoice?"
   },
   "state": {
+    "draft": "Draft",
     "due_count_days_ago_one": "Due {{displayCount}} day ago",
     "due_count_days_ago_other": "Due {{displayCount}} days ago",
     "due_in_count_days_one": "Due in {{displayCount}} day",

--- a/src/assets/locales/fr-CA/invoices.json
+++ b/src/assets/locales/fr-CA/invoices.json
@@ -100,6 +100,7 @@
     "discard_changes_invoice": "Annuler les modifications apportées à cette facture?"
   },
   "state": {
+    "draft": "",
     "due_count_days_ago_one": "Échue depuis {{displayCount}} jour",
     "due_count_days_ago_other": "Échue depuis {{displayCount}} jours",
     "due_in_count_days_one": "Échéance dans {{displayCount}} jour",

--- a/src/components/Invoices/InvoiceDetail/InvoiceDetailHeaderMenu.tsx
+++ b/src/components/Invoices/InvoiceDetail/InvoiceDetailHeaderMenu.tsx
@@ -31,6 +31,9 @@ type InvoiceActionModalType = Exclude<
 >
 
 const availableActions: Record<InvoiceStatus, InvoiceDetailHeaderMenuActions[]> = {
+  [InvoiceStatus.Draft]: [
+    InvoiceDetailHeaderMenuActions.Edit,
+  ],
   [InvoiceStatus.Saved]: [
     InvoiceDetailHeaderMenuActions.Edit,
     InvoiceDetailHeaderMenuActions.DownloadPdf,

--- a/src/components/Invoices/InvoiceStatusCell/InvoiceStatusCell.tsx
+++ b/src/components/Invoices/InvoiceStatusCell/InvoiceStatusCell.tsx
@@ -8,6 +8,7 @@ import { getDueDifference } from '@utils/time/timeUtils'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import AlertCircle from '@icons/AlertCircle'
 import CheckCircle from '@icons/CheckCircle'
+import File from '@icons/File'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { Badge, BadgeSize, BadgeVariant } from '@components/Badge/Badge'
@@ -22,6 +23,12 @@ const getDueStatusConfig = (
   const iconSize = inline ? 10 : 12
 
   switch (invoice.status) {
+    case InvoiceStatus.Draft: {
+      return {
+        text: t('invoices:state.draft', 'Draft'),
+        badge: <Badge variant={BadgeVariant.NEUTRAL} size={badgeSize} icon={<File size={iconSize} />} iconOnly />,
+      }
+    }
     case InvoiceStatus.WrittenOff: {
       return { text: t('invoices:state.written_off', 'Written Off') }
     }

--- a/src/components/Invoices/InvoiceTable/InvoiceTable.tsx
+++ b/src/components/Invoices/InvoiceTable/InvoiceTable.tsx
@@ -40,6 +40,7 @@ enum InvoiceColumns {
 
 enum InvoiceStatusFilter {
   All = 'All',
+  Draft = 'Draft',
   Unpaid = 'Unpaid',
   Overdue = 'Overdue',
   Saved = 'Saved',
@@ -56,6 +57,7 @@ export type InvoiceStatusOption = {
 
 const INVOICE_STATUS_CONFIG = [
   { value: InvoiceStatusFilter.All, ...translationKey('common:label.all', 'All') },
+  { value: InvoiceStatusFilter.Draft, ...translationKey('invoices:state.draft', 'Draft') },
   { value: InvoiceStatusFilter.Unpaid, ...translationKey('invoices:state.unpaid', 'Unpaid') },
   { value: InvoiceStatusFilter.Overdue, ...translationKey('invoices:state.overdue', 'Overdue') },
   { value: InvoiceStatusFilter.Saved, ...translationKey('invoices:state.saved', 'Saved') },
@@ -75,6 +77,7 @@ const AmountCell = ({ invoice }: { invoice: Invoice }) => {
   const outstandingBalanceLabel = t('invoices:label.amount_outstanding', '{{amount}} outstanding', { amount: outstandingBalance })
 
   switch (invoice.status) {
+    case InvoiceStatus.Draft:
     case InvoiceStatus.Paid:
     case InvoiceStatus.PartiallyWrittenOff:
     case InvoiceStatus.WrittenOff:
@@ -155,6 +158,9 @@ const getStatusFilterParams = (statusFilter: InvoiceStatusFilter) => {
   switch (statusFilter) {
     case InvoiceStatusFilter.All:
       return {}
+
+    case InvoiceStatusFilter.Draft:
+      return { status: [InvoiceStatus.Draft] }
 
     case InvoiceStatusFilter.Unpaid:
       return { status: UNPAID_STATUSES }

--- a/src/schemas/invoices/invoice.ts
+++ b/src/schemas/invoices/invoice.ts
@@ -8,6 +8,7 @@ import { TagKeyValueSchema, TransactionTagSchema } from '@schemas/tag'
 import { InvoiceTermsValues } from '@components/Invoices/InvoiceTermsComboBox/InvoiceTermsComboBox'
 
 export enum InvoiceStatus {
+  Draft = 'DRAFT',
   Voided = 'VOIDED',
   Paid = 'PAID',
   WrittenOff = 'WRITTEN_OFF',


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly invoice list/detail presentation and filtering; draft invoices are excluded from unpaid/overdue filters and payment actions by design.
> 
> **Overview**
> Adds first-class support for **`DRAFT`** invoices in the client so draft records from the API can be listed, filtered, and labeled like other statuses.
> 
> The `InvoiceStatus` enum gains **`Draft`**, with **`invoices:state.draft`** in English (French locale key is present but empty). The invoice table adds a **Draft** status filter that requests `{ status: [InvoiceStatus.Draft] }`, and draft rows show **total only** in the amount column (same as saved/paid-style rows). **`InvoiceStatusCell`** renders draft as a neutral **File** icon badge with “Draft” text. On invoice detail, **`InvoiceDetailHeaderMenu`** limits draft invoices to **Edit** only (no PDF, void, write-off, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 118dd6d77e697c1dfad6934fcb4b67b4894b008a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->