### PR TITLE
feat: disable account linking for demo mode

### DIFF
--- a/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
+++ b/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { getBankAccountDisplayName, getBankAccountInstitution } from '@utils/bankAccount'
 import { tPlural } from '@utils/i18n/plural'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
 import ChevronRight from '@icons/ChevronRight'
 import LinkIcon from '@icons/Link'
@@ -15,6 +16,7 @@ import { ActionableRow } from '@components/ActionableRow/ActionableRow'
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
 import { LinkAccountsListContainer } from '@components/LinkAccounts/LinkAccountsListContainer'
 import { BasicLinkedAccountContainer, BasicLinkedAccountContent } from '@components/LinkedAccounts/BasicLinkedAccount/BasicLinkedAccount'
+import { LinkAccountDemoTooltip } from '@components/LinkedAccounts/LinkAccountDemoTooltip'
 import { Loader } from '@components/Loader/Loader'
 import { Separator } from '@components/Separator/Separator'
 import { Text } from '@components/Typography/Text'
@@ -32,6 +34,8 @@ export function LinkAccountsLinkStep() {
     refetchAccounts,
     addConnection,
   } = useContext(LinkedAccountsContext)
+  const { business } = useLayerContext()
+  const isDemoBusiness = business?.isDemo ?? false
 
   const { next } = useWizard()
 
@@ -48,13 +52,15 @@ export function LinkAccountsLinkStep() {
               <Text status='disabled'>
                 {t('linkedAccounts:label.connect_bank_accounts_and_credit_cards', 'Connect your bank accounts and credit cards to automatically import your business transactions.')}
               </Text>
-              <Button
-                onClick={() => { void addConnection('PLAID') }}
-                isDisabled={loadingStatus !== 'complete' || isLinking}
-              >
-                {t('linkedAccounts:action.connect_my_bank', 'Connect my bank')}
-                <LinkIcon size={12} />
-              </Button>
+              <LinkAccountDemoTooltip active={isDemoBusiness}>
+                <Button
+                  onClick={() => { void addConnection('PLAID') }}
+                  isDisabled={isDemoBusiness || loadingStatus !== 'complete' || isLinking}
+                >
+                  {t('linkedAccounts:action.connect_my_bank', 'Connect my bank')}
+                  <LinkIcon size={12} />
+                </Button>
+              </LinkAccountDemoTooltip>
             </VStack>
           </ElevatedLoadingSpinnerContainer>
         )}
@@ -82,14 +88,16 @@ export function LinkAccountsLinkStep() {
                 <ActionableRow
                   title={t('linkedAccounts:prompt.use_other_bank_accounts_or_cards', 'Do you use any other bank accounts or credit cards for your business?')}
                   button={(
-                    <Button
-                      onClick={() => { void addConnection('PLAID') }}
-                      isDisabled={loadingStatus !== 'complete' || isLinking}
-                      variant='outlined'
-                    >
-                      {t('linkedAccounts:action.link_another_bank', 'Link another bank')}
-                      <LinkIcon size={12} />
-                    </Button>
+                    <LinkAccountDemoTooltip active={isDemoBusiness}>
+                      <Button
+                        onClick={() => { void addConnection('PLAID') }}
+                        isDisabled={isDemoBusiness || loadingStatus !== 'complete' || isLinking}
+                        variant='outlined'
+                      >
+                        {t('linkedAccounts:action.link_another_bank', 'Link another bank')}
+                        <LinkIcon size={12} />
+                      </Button>
+                    </LinkAccountDemoTooltip>
                   )}
                 />
               </VStack>

--- a/src/components/LinkedAccounts/LinkAccountDemoTooltip.tsx
+++ b/src/components/LinkedAccounts/LinkAccountDemoTooltip.tsx
@@ -1,0 +1,34 @@
+import { type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@ui/Tooltip/Tooltip'
+
+type LinkAccountDemoTooltipProps = {
+  active: boolean
+  asChild?: boolean
+  children: ReactNode
+}
+
+export const LinkAccountDemoTooltip = ({ active, asChild = false, children }: LinkAccountDemoTooltipProps) => {
+  const { t } = useTranslation()
+
+  if (!active) {
+    return <>{children}</>
+  }
+
+  return (
+    <Tooltip placement='top'>
+      <TooltipTrigger asChild={asChild}>
+        {children}
+      </TooltipTrigger>
+      <TooltipContent width='sm'>
+        <span className='Layer__UI__tooltip-content--text'>
+          {t(
+            'linkedAccounts:tooltip.cannot_link_demo_business',
+            'Account linking is not available for demo businesses. This is a sample business that uses example data instead of real bank connections.',
+          )}
+        </span>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/components/LinkedAccounts/LinkedAccountsContent.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountsContent.tsx
@@ -2,11 +2,13 @@ import { useContext } from 'react'
 import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 
+import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
 import PlusIcon from '@icons/PlusIcon'
 import { HStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { LinkedAccountsConfirmationModal } from '@components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal'
+import { LinkAccountDemoTooltip } from '@components/LinkedAccounts/LinkAccountDemoTooltip'
 import { LinkedAccountItemThumb } from '@components/LinkedAccounts/LinkedAccountItemThumb'
 
 interface LinkedAccountsDataProps {
@@ -24,6 +26,8 @@ export const LinkedAccountsContent = ({
 }: LinkedAccountsDataProps) => {
   const { t } = useTranslation()
   const { data, addConnection } = useContext(LinkedAccountsContext)
+  const { business } = useLayerContext()
+  const isDemoBusiness = business?.isDemo ?? true
 
   const linkedAccountsNewAccountClassName = classNames(
     'Layer__linked-accounts__new-account',
@@ -31,6 +35,7 @@ export const LinkedAccountsContent = ({
     showLedgerBalance && '--show-ledger-balance',
     showUnlinkItem && '--show-unlink-item',
     showBreakConnection && '--show-break-connection',
+    isDemoBusiness && '--disabled',
   )
 
   return (
@@ -46,19 +51,25 @@ export const LinkedAccountsContent = ({
             asWidget={asWidget}
           />
         ))}
-        <div
-          role='button'
-          tabIndex={0}
-          onClick={() => { void addConnection('PLAID') }}
-          className={linkedAccountsNewAccountClassName}
-        >
-          <HStack align='center' gap='2xs'>
-            <PlusIcon size={14} />
-            <Span variant='placeholder'>
-              {t('linkedAccounts:action.add_account', 'Add Account')}
-            </Span>
-          </HStack>
-        </div>
+        <LinkAccountDemoTooltip active={isDemoBusiness} asChild>
+          <div
+            role='button'
+            tabIndex={isDemoBusiness ? -1 : 0}
+            aria-disabled={isDemoBusiness}
+            onClick={() => {
+              if (isDemoBusiness) return
+              void addConnection('PLAID')
+            }}
+            className={linkedAccountsNewAccountClassName}
+          >
+            <HStack align='center' gap='2xs'>
+              <PlusIcon size={14} />
+              <Span variant='placeholder'>
+                {t('linkedAccounts:action.add_account', 'Add Account')}
+              </Span>
+            </HStack>
+          </div>
+        </LinkAccountDemoTooltip>
       </div>
       <LinkedAccountsConfirmationModal />
     </>

--- a/src/components/LinkedAccounts/LinkedAccountsContent.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountsContent.tsx
@@ -27,7 +27,7 @@ export const LinkedAccountsContent = ({
   const { t } = useTranslation()
   const { data, addConnection } = useContext(LinkedAccountsContext)
   const { business } = useLayerContext()
-  const isDemoBusiness = business?.isDemo ?? true
+  const isDemoBusiness = business?.isDemo ?? false
 
   const linkedAccountsNewAccountClassName = classNames(
     'Layer__linked-accounts__new-account',
@@ -54,7 +54,7 @@ export const LinkedAccountsContent = ({
         <LinkAccountDemoTooltip active={isDemoBusiness} asChild>
           <div
             role='button'
-            tabIndex={isDemoBusiness ? -1 : 0}
+            tabIndex={0}
             aria-disabled={isDemoBusiness}
             onClick={() => {
               if (isDemoBusiness) return

--- a/src/components/Onboarding/ConnectAccount.tsx
+++ b/src/components/Onboarding/ConnectAccount.tsx
@@ -6,6 +6,7 @@ import { type OnboardingStep } from '@internal-types/layerContext'
 import { countTransactionsToReview } from '@utils/bankTransactions/shared'
 import { useAugmentedBankTransactions } from '@hooks/features/bankTransactions/useAugmentedBankTransactions'
 import { useBankTransactionsFilters } from '@contexts/BankTransactionsFiltersContext/useBankTransactionsFilters'
+import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
 import BellIcon from '@icons/Bell'
 import CreditCardIcon from '@icons/CreditCard'
@@ -18,6 +19,7 @@ import { Badge, BadgeVariant } from '@components/Badge/Badge'
 import { BadgeSize } from '@components/Badge/Badge'
 import { Button } from '@components/Button/Button'
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
+import { LinkAccountDemoTooltip } from '@components/LinkedAccounts/LinkAccountDemoTooltip'
 import { Text } from '@components/Typography/Text'
 
 export interface ConnectAccountProps {
@@ -32,6 +34,8 @@ export const ConnectAccount = ({
 }: ConnectAccountProps) => {
   const { t } = useTranslation()
   const { addConnection } = useContext(LinkedAccountsContext)
+  const { business } = useLayerContext()
+  const isDemoBusiness = business?.isDemo ?? false
   const { filters } = useBankTransactionsFilters({
     scope: DisplayState.review,
   })
@@ -58,12 +62,15 @@ export const ConnectAccount = ({
           title={t('linkedAccounts:label.connect_accounts', 'Connect accounts')}
           description={t('linkedAccounts:label.import_data_simple_integration', 'Import data with one simple integration.')}
           button={(
-            <Button
-              onClick={() => { void addConnection('PLAID') }}
-              rightIcon={<LinkIcon size={12} />}
-            >
-              {t('common:action.connect_label', 'Connect')}
-            </Button>
+            <LinkAccountDemoTooltip active={isDemoBusiness}>
+              <Button
+                onClick={() => { void addConnection('PLAID') }}
+                disabled={isDemoBusiness}
+                rightIcon={<LinkIcon size={12} />}
+              >
+                {t('common:action.connect_label', 'Connect')}
+              </Button>
+            </LinkAccountDemoTooltip>
           )}
         />
       </>

--- a/src/schemas/business.ts
+++ b/src/schemas/business.ts
@@ -7,6 +7,11 @@ export const BusinessSchema = Schema.Struct({
     Schema.propertySignature(Schema.Date),
     Schema.fromKey('activation_at'),
   ),
+
+  isDemo: pipe(
+    Schema.propertySignature(Schema.Boolean),
+    Schema.fromKey('is_demo'),
+  ),
 })
 
 export type Business = typeof BusinessSchema.Type

--- a/src/styles/linked_accounts.scss
+++ b/src/styles/linked_accounts.scss
@@ -77,6 +77,15 @@
   &:hover {
     background: var(--base-transparent-2);
   }
+
+  &.--disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+
+    &:hover {
+      background: var(--base-transparent-1);
+    }
+  }
 }
 
 /* stylelint-disable-next-line keyframes-name-pattern */


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating on bank linking entry points; risk is mainly if `is_demo` is missing or wrong from the API, which could block or allow linking unexpectedly.
> 
> **Overview**
> Demo businesses can no longer start Plaid account linking from linked-accounts, onboarding, or the link-accounts wizard.
> 
> **`Business`** now includes **`isDemo`** (from API **`is_demo`**). A shared **`LinkAccountDemoTooltip`** wraps connect/add/link actions when demo mode is on: controls are disabled and a tooltip explains that linking is unavailable for sample businesses. The linked-accounts **Add Account** tile gets a **`--disabled`** style (reduced opacity, no hover) plus **`aria-disabled`** and a click guard.
> 
> **`LinkAccountsLinkStep`**, **`LinkedAccountsContent`**, and onboarding **`ConnectAccount`** all read **`business?.isDemo`** from **`LayerContext`** and apply the same pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5526dbaffa5f531367e94ebff09af7267bf32e01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->