### PR TITLE
hide rule creation

### DIFF
--- a/src/components/CategorizationRules/CategorizationRulesMobileList/CategorizationRulesMobileList.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesMobileList/CategorizationRulesMobileList.tsx
@@ -18,7 +18,7 @@ import './categorizationRulesMobileList.scss'
 type CategorizationRuleMobileListItemProps = {
   rule: CategorizationRule
   options: NestedCategorization[]
-  onEditPress: (rule: CategorizationRule) => void
+  onEditPress?: (rule: CategorizationRule) => void
   onDeletePress: (rule: CategorizationRule) => void
 }
 
@@ -58,15 +58,17 @@ const CategorizationRuleMobileListItem = ({
         )}
       </VStack>
       <HStack gap='3xs' align='center'>
-        <Button
-          inset
-          icon
-          onPress={() => onEditPress(rule)}
-          aria-label={t('categorizationRules:action.edit_rule', 'Edit Rule')}
-          variant='ghost'
-        >
-          <Pencil size={16} />
-        </Button>
+        {onEditPress && (
+          <Button
+            inset
+            icon
+            onPress={() => onEditPress(rule)}
+            aria-label={t('categorizationRules:action.edit_rule', 'Edit Rule')}
+            variant='ghost'
+          >
+            <Pencil size={16} />
+          </Button>
+        )}
         <Button
           inset
           icon
@@ -87,7 +89,7 @@ export interface CategorizationRulesMobileListProps {
   isError: boolean
   paginationProps: TablePaginationProps
   options: NestedCategorization[]
-  onEditRule: (rule: CategorizationRule) => void
+  onEditRule?: (rule: CategorizationRule) => void
   onDeleteRule: (rule: CategorizationRule) => void
   slots: {
     EmptyState: React.FC

--- a/src/components/CategorizationRules/CategorizationRulesTable/CategorizationRulesTable.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesTable/CategorizationRulesTable.tsx
@@ -32,7 +32,7 @@ export interface CategorizationRulesTableProps {
   isError: boolean
   paginationProps: TablePaginationProps
   options: NestedCategorization[]
-  onEditRule: (rule: CategorizationRule) => void
+  onEditRule?: (rule: CategorizationRule) => void
   onDeleteRule: (rule: CategorizationRule) => void
   slots: {
     EmptyState: React.FC
@@ -85,20 +85,22 @@ export const CategorizationRulesTable = ({
       },
       isRowHeader: true,
     },
-    {
-      id: CategorizationRuleColumns.Edit,
-      cell: (row: Row<CategorizationRule>) => (
-        <Button
-          inset
-          icon
-          onPress={() => onEditRule(row.original)}
-          aria-label={t('categorizationRules:action.edit_rule', 'Edit Rule')}
-          variant='ghost'
-        >
-          <Pencil size={16} />
-        </Button>
-      ),
-    },
+    ...(onEditRule
+      ? [{
+        id: CategorizationRuleColumns.Edit,
+        cell: (row: Row<CategorizationRule>) => (
+          <Button
+            inset
+            icon
+            onPress={() => onEditRule(row.original)}
+            aria-label={t('categorizationRules:action.edit_rule', 'Edit Rule')}
+            variant='ghost'
+          >
+            <Pencil size={16} />
+          </Button>
+        ),
+      }]
+      : []),
     {
       id: CategorizationRuleColumns.Delete,
       cell: (row: Row<CategorizationRule>) => (

--- a/src/components/CategorizationRules/CategorizationRulesTable/categorizationRulesTable.scss
+++ b/src/components/CategorizationRules/CategorizationRulesTable/categorizationRulesTable.scss
@@ -9,7 +9,7 @@
       minmax(8rem, 26%)
       minmax(6rem, 14%)
       minmax(7rem, 20%)
-      minmax(8rem, 32%)
+      minmax(8rem, 1fr)
       auto
       auto;
   }

--- a/src/components/CategorizationRules/CategorizationRulesView/ResponsiveCategorizationRulesView.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesView/ResponsiveCategorizationRulesView.tsx
@@ -53,9 +53,11 @@ const CategorizationRulesErrorState = () => {
   )
 }
 
+const ENABLE_CATEGORIZATION_RULE_EDITING = false
+
 type CategorizationRulesHeaderProps = {
   onGoBack?: () => void
-  onCreateRule: () => void
+  onCreateRule?: () => void
 }
 
 const CategorizationRulesHeader = ({ onGoBack, onCreateRule }: CategorizationRulesHeaderProps) => {
@@ -70,12 +72,14 @@ const CategorizationRulesHeader = ({ onGoBack, onCreateRule }: CategorizationRul
         )}
         <Heading size='sm'>{t('categorizationRules:label.categorization_rules', 'Categorization Rules')}</Heading>
       </HStack>
-      <HStack pie='md' align='center' gap='xs'>
-        <Button onPress={onCreateRule}>
-          {t('categorizationRules:action.create_rule', 'Create Rule')}
-          <Plus size={16} />
-        </Button>
-      </HStack>
+      {onCreateRule && (
+        <HStack pie='md' align='center' gap='xs'>
+          <Button onPress={onCreateRule}>
+            {t('categorizationRules:action.create_rule', 'Create Rule')}
+            <Plus size={16} />
+          </Button>
+        </HStack>
+      )}
     </HStack>
   )
 }
@@ -93,6 +97,8 @@ export const ResponsiveCategorizationRulesView = () => {
 
   const onCreateRule = useCallback(() => setFormState({ mode: 'create' }), [])
   const onEditRule = useCallback((rule: CategorizationRule) => setFormState({ mode: 'edit', rule }), [])
+  const createRuleHandler = ENABLE_CATEGORIZATION_RULE_EDITING ? onCreateRule : undefined
+  const editRuleHandler = ENABLE_CATEGORIZATION_RULE_EDITING ? onEditRule : undefined
   const onFormDrawerOpenChange = useCallback((isOpen: boolean) => {
     if (!isOpen) setFormState(null)
   }, [])
@@ -143,8 +149,8 @@ export const ResponsiveCategorizationRulesView = () => {
   const { toBankTransactionsTable } = useBankTransactionsNavigation()
 
   const DesktopHeader = useCallback(
-    () => <CategorizationRulesHeader onCreateRule={onCreateRule} />,
-    [onCreateRule],
+    () => <CategorizationRulesHeader onCreateRule={createRuleHandler} />,
+    [createRuleHandler],
   )
 
   const DesktopView = useMemo(() => (
@@ -159,7 +165,7 @@ export const ResponsiveCategorizationRulesView = () => {
         isError={isError}
         paginationProps={paginationProps}
         options={options}
-        onEditRule={onEditRule}
+        onEditRule={editRuleHandler}
         onDeleteRule={onDeleteRule}
         slots={{
           EmptyState: CategorizationRulesEmptyState,
@@ -167,18 +173,18 @@ export const ResponsiveCategorizationRulesView = () => {
         }}
       />
     </BaseDetailView>
-  ), [DesktopHeader, toBankTransactionsTable, categorizationRules, isLoading, isError, paginationProps, options, onEditRule, onDeleteRule])
+  ), [DesktopHeader, toBankTransactionsTable, categorizationRules, isLoading, isError, paginationProps, options, editRuleHandler, onDeleteRule])
 
   const MobileView = useMemo(() => (
     <VStack gap='md'>
-      <CategorizationRulesHeader onGoBack={toBankTransactionsTable} onCreateRule={onCreateRule} />
+      <CategorizationRulesHeader onGoBack={toBankTransactionsTable} onCreateRule={createRuleHandler} />
       <CategorizationRulesMobileList
         data={categorizationRules}
         isLoading={isLoading}
         isError={isError}
         paginationProps={paginationProps}
         options={options}
-        onEditRule={onEditRule}
+        onEditRule={editRuleHandler}
         onDeleteRule={onDeleteRule}
         slots={{
           EmptyState: CategorizationRulesEmptyState,
@@ -186,7 +192,7 @@ export const ResponsiveCategorizationRulesView = () => {
         }}
       />
     </VStack>
-  ), [toBankTransactionsTable, onCreateRule, categorizationRules, isLoading, isError, paginationProps, options, onEditRule, onDeleteRule])
+  ), [toBankTransactionsTable, createRuleHandler, categorizationRules, isLoading, isError, paginationProps, options, editRuleHandler, onDeleteRule])
 
   const selectedRuleCounterpartyLabel = (selectedRule && getCategorizationRuleCounterpartyLabel(selectedRule))
     ?? t('bankTransactions:label.selected_counterparty', 'this counterparty')


### PR DESCRIPTION
Hide rule creation so we can ship a stable release without reverting it.

This PR will be reverted after the next stable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating via a local constant; delete and read paths unchanged, with no auth or data-layer changes.
> 
> **Overview**
> **Hides categorization rule create and edit** in the rules UI for a stable release, without removing the underlying form or API wiring.
> 
> `ResponsiveCategorizationRulesView` introduces `ENABLE_CATEGORIZATION_RULE_EDITING` (set to `false`) and only passes create/edit handlers when that flag is on, so the **Create Rule** header action and edit flows are not reachable. **Delete** (archive) behavior is unchanged.
> 
> The table and mobile list now treat `onEditRule` / `onEditPress` as optional and **omit the edit column or pencil button** when no handler is provided. Desktop table grid styling adjusts the category column to `1fr` so layout stays sensible with one fewer action column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f0e46b7bbb4f0593a67b72ba7270aab6e19375e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->