### PR TITLE
fix: small revisions on categorization rules crud

### DIFF
--- a/src/components/CategorizationRules/CategorizationRulesMobileList/CategorizationRulesMobileList.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesMobileList/CategorizationRulesMobileList.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import { Pencil, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { getResolvedCategoryName } from '@internal-types/categories'
 import type { CategorizationRule } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import type { NestedCategorization } from '@schemas/categorization'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
@@ -9,7 +10,6 @@ import { Button } from '@ui/Button/Button'
 import { PaginatedMobileList } from '@ui/MobileList/PaginatedMobileList'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
-import { ResolvedCategoryName } from '@components/CategorizationRules/ResolvedCategoryName'
 import { getCategorizationRuleAmountLabel, getCategorizationRuleCounterpartyLabel, getCategorizationRuleDirectionLabel } from '@components/CategorizationRules/utils'
 import type { TablePaginationProps } from '@components/PaginatedDataTable/PaginatedDataTable'
 
@@ -32,29 +32,24 @@ const CategorizationRuleMobileListItem = ({
   const { formatCurrencyFromCents } = useIntlFormatter()
   const counterpartyLabel = getCategorizationRuleCounterpartyLabel(rule)
   const hasAmountFilter = rule.amountMinFilter != null || rule.amountMaxFilter != null
+  const categoryName = rule.category ? getResolvedCategoryName(rule.category, options) : undefined
+
   return (
     <HStack justify='space-between' align='center' gap='sm' className='Layer__CategorizationRulesMobileListItem'>
       <VStack gap='2xs' className='Layer__CategorizationRulesMobileListItem__Content'>
         <Span weight='bold' ellipsis>{counterpartyLabel}</Span>
-        <HStack gap='3xs' align='center'>
-          <Span size='sm' variant='subtle'>{t('common:label.direction', 'Direction:')}</Span>
-          <Span size='sm' variant='subtle'>{getCategorizationRuleDirectionLabel(rule.bankDirectionFilter, t)}</Span>
-        </HStack>
+        <Span size='sm' variant='subtle'>
+          {t('categorizationRules:label.direction_value', 'Direction: {{value}}', { value: getCategorizationRuleDirectionLabel(rule.bankDirectionFilter, t) })}
+        </Span>
         {hasAmountFilter && (
-          <HStack gap='3xs' align='center'>
-            <Span size='sm' variant='subtle'>{t('common:label.amount', 'Amount:')}</Span>
-            <Span size='sm' variant='subtle'>{getCategorizationRuleAmountLabel(rule, formatCurrencyFromCents, t)}</Span>
-          </HStack>
+          <Span size='sm' variant='subtle'>
+            {t('categorizationRules:label.amount_value', 'Amount: {{value}}', { value: getCategorizationRuleAmountLabel(rule, formatCurrencyFromCents, t) })}
+          </Span>
         )}
-        {rule.category && (
-          <HStack gap='3xs' align='center'>
-            <Span size='sm' variant='subtle'>{t('common:label.category', 'Category:')}</Span>
-            <ResolvedCategoryName
-              accountIdentifier={rule.category}
-              options={options}
-              slotProps={{ Span: { size: 'sm', variant: 'subtle' } }}
-            />
-          </HStack>
+        {categoryName && (
+          <Span size='sm' variant='subtle'>
+            {t('categorizationRules:label.category_value', 'Category: {{value}}', { value: categoryName })}
+          </Span>
         )}
       </VStack>
       <HStack gap='3xs' align='center'>

--- a/src/components/CategorizationRules/CategorizationRulesTable/categorizationRulesTable.scss
+++ b/src/components/CategorizationRules/CategorizationRulesTable/categorizationRulesTable.scss
@@ -6,11 +6,10 @@
   .Layer__UI__Table-TableHeader > tr {
     display: grid;
     grid-template-columns:
-      minmax(8rem, 26%)
+      minmax(8rem, 30%)
       minmax(6rem, 14%)
       minmax(7rem, 20%)
-      minmax(8rem, 1fr)
-      auto
+      minmax(8rem, 30%)
       auto;
   }
 

--- a/src/components/CategorizationRules/ResolvedCategoryName.tsx
+++ b/src/components/CategorizationRules/ResolvedCategoryName.tsx
@@ -1,4 +1,4 @@
-import { accountIdentifierIsForCategory } from '@internal-types/categories'
+import { getResolvedCategoryName } from '@internal-types/categories'
 import type { AccountIdentifier } from '@schemas/accountIdentifier'
 import type { NestedCategorization } from '@schemas/categorization'
 import { Span, type TextStyleProps } from '@ui/Typography/Text'
@@ -12,11 +12,9 @@ type ResolvedCategoryNameProps = {
 }
 
 export const ResolvedCategoryName = ({ accountIdentifier, options, slotProps }: ResolvedCategoryNameProps) => {
-  const category = options.find(cat =>
-    accountIdentifierIsForCategory(accountIdentifier, cat),
-  )
+  const name = getResolvedCategoryName(accountIdentifier, options)
 
-  if (!category) return null
+  if (!name) return null
 
-  return <Span {...slotProps?.Span} ellipsis>{category.displayName}</Span>
+  return <Span {...slotProps?.Span} ellipsis>{name}</Span>
 }

--- a/src/types/categories.ts
+++ b/src/types/categories.ts
@@ -64,6 +64,12 @@ export const accountIdentifierIsForCategory = (accountIdentifier: AccountIdentif
   }
 }
 
+export const getResolvedCategoryName = (
+  accountIdentifier: AccountIdentifier,
+  options: NestedCategorization[],
+): string | undefined =>
+  options.find(option => accountIdentifierIsForCategory(accountIdentifier, option))?.displayName
+
 export const getLeafCategories = (categories: NestedCategorization[]): NestedCategorization[] => {
   return categories.flatMap((category) => {
     if (!category.subCategories || category.subCategories.length === 0) {

--- a/src/utils/i18n/init.ts
+++ b/src/utils/i18n/init.ts
@@ -32,6 +32,9 @@ export const initI18n = (locale: SupportedLocale) => {
       lng: locale,
       fallbackLng: DEFAULT_LOCALE,
       defaultNS: 'common',
+      // React escapes interpolated values at render time, so i18next's own HTML
+      // escaping is redundant and would turn characters like `&` into `&amp;`.
+      interpolation: { escapeValue: false },
       resources: {
         'en-US': enUS,
         'fr-CA': frCA,


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and i18n display tweaks only; `escapeValue: false` is scoped to Layer’s i18n instance and relies on React text escaping for interpolated strings.
> 
> **Overview**
> Polishes categorization rules CRUD presentation: **mobile list rows** now show direction, amount, and category as single translated strings (`direction_value`, `amount_value`, `category_value`) instead of separate label/value stacks, and resolve category text via shared **`getResolvedCategoryName`** instead of the **`ResolvedCategoryName`** component.
> 
> **Category resolution** is centralized in **`getResolvedCategoryName`** in `categories.ts`; **`ResolvedCategoryName`** (still used on the desktop table) delegates to that helper.
> 
> **Desktop table** grid columns are rebalanced in SCSS (wider counterparty/category columns, category no longer uses `1fr`).
> 
> **Layer i18n** sets **`interpolation.escapeValue: false`** so React-rendered copy does not double-escape characters like `&` in interpolated values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e05990b68cea46e063bbd816f1912193ad592d8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->