### PR TITLE
Put special chars after alphanumerics when sorting parent accounts

### DIFF
--- a/src/components/ChartOfAccountsForm/useParentOptions.ts
+++ b/src/components/ChartOfAccountsForm/useParentOptions.ts
@@ -4,13 +4,33 @@ import { type BaseSelectOption } from '@internal-types/general'
 import { type LedgerBalancesSchemaType } from '@schemas/generalLedger/ledgerAccount'
 import { flattenAccounts } from '@hooks/legacy/useChartOfAccounts'
 
+const isAlphanumeric = (char: string) => /[\p{L}\p{N}]/u.test(char)
+
+const compareSpecialCharsLast = (a: string, b: string): number => {
+  const length = Math.min(a.length, b.length)
+  for (let i = 0; i < length; i++) {
+    const aSpecial = !isAlphanumeric(a[i])
+    const bSpecial = !isAlphanumeric(b[i])
+    if (aSpecial !== bSpecial) {
+      return aSpecial ? 1 : -1
+    }
+    const comparison = a[i].localeCompare(b[i])
+    if (comparison !== 0) {
+      return comparison
+    }
+  }
+  return a.length - b.length
+}
+
 export const useParentOptions = (
   data?: LedgerBalancesSchemaType,
 ): BaseSelectOption[] =>
   useMemo(
     () =>
       flattenAccounts(data?.accounts || [])
-        .sort((a, b) => (a?.name && b?.name ? a.name.localeCompare(b.name) : 0))
+        .sort((a, b) =>
+          a?.name && b?.name ? compareSpecialCharsLast(a.name, b.name) : 0,
+        )
         .map((x) => {
           return {
             label: x.name,


### PR DESCRIPTION
<img width="650" height="536" alt="useParentBefore" src="https://github.com/user-attachments/assets/f2d4bc3f-e3fd-439b-a2d6-20e65cb76e29" />

<img width="590" height="439" alt="useParentAfter" src="https://github.com/user-attachments/assets/fa1e09fa-5db5-4282-a271-01ff48ae1b38" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only ordering change in a form select with no API or business-logic impact.
> 
> **Overview**
> **Parent account dropdown order** in the chart of accounts form now uses a custom sort instead of plain `localeCompare` on account names.
> 
> Names are compared character-by-character with Unicode letters and numbers (`\p{L}`, `\p{N}`) sorted before punctuation and other symbols; ties still use `localeCompare` per character, then shorter names first. Only `useParentOptions` changes—options are still flattened accounts mapped to label/value pairs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c9e418dcafe6f02093d20e8fce1aa44b47fd9b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->