### PR TITLE
ci: add Linear release automation (prepare/tag/publish + merge sync)

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,0 +1,37 @@
+name: Linear Release — sync on merge
+
+# Attaches issues/PRs to the current in-progress Linear release on every push to
+# main (i.e. every merged PR), so the release stays current as work lands.
+#
+# `sync` is run with NO version, so it targets the pipeline's currently started
+# (In Progress) release — the one seeded by the previous stable ship, or the one
+# a fresh alpha cut creates. It scans the full range since the last completed
+# release, so issues are attached cumulatively.
+#
+# Release — Publish also syncs (and, for stable, completes) at ship time. That
+# is deliberate: this hook runs asynchronously after a merge, so Publish
+# guarantees attachment/completion at the moment that matters without racing it.
+#
+# Requires the `LINEAR_ACCESS_KEY` secret (this pipeline's access key).
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # full history so the commit scan can reach the previous release
+
+    - name: Sync current in-progress release
+      uses: linear/linear-release-action@v0
+      with:
+        access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+        command: sync

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,95 @@
+name: Release — Prepare
+
+# Phase 1 of 2 (manual button). Computes the next version and opens a
+# package.json bump PR. It does NOT merge, tag, publish, or touch Linear — you
+# review and merge the PR like any other, then run "Release — Publish".
+#
+# Versioning model A: the cycle target is fixed at the first alpha
+# (X.Y.Z-alpha.N); stable drops the suffix to ship X.Y.Z.
+#
+#   release_type = alpha
+#     - no cycle in progress (package.json is a plain stable) -> start a cycle:
+#       pre<bump> preid alpha, e.g. 0.1.136 -> 0.1.137-alpha.0 (patch),
+#       0.2.0-alpha.0 (minor), 1.0.0-alpha.0 (major).
+#     - cycle in progress (package.json is a prerelease) -> increment:
+#       0.1.137-alpha.0 -> 0.1.137-alpha.1. `bump` is ignored.
+#   release_type = stable
+#     - finalizing an in-progress alpha -> drop the suffix:
+#       0.1.137-alpha.2 -> 0.1.137. `bump` is ignored.
+#     - shipping straight from stable -> bump per `bump`:
+#       0.1.137 -> 0.1.138 (patch) / 0.2.0 / 1.0.0.
+#
+# Repo setting: Settings -> Actions -> General -> Workflow permissions ->
+#   "Allow GitHub Actions to create and approve pull requests" must be ON.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'What to prepare'
+        type: choice
+        options: [ alpha, stable ]
+        default: alpha
+      bump:
+        description: 'Base bump — used only to START a cycle (alpha from stable) or ship straight from stable; ignored otherwise'
+        type: choice
+        options: [ patch, minor, major ]
+        default: patch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: main
+        fetch-depth: 0
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: Configure git
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - name: Compute next version
+      id: ver
+      run: |
+        CUR=$(node -p "require('./package.json').version")
+        if [ "${{ inputs.release_type }}" = "alpha" ]; then
+          case "$CUR" in
+            *-*) NEWV=$(npm version prerelease --preid=alpha --no-git-tag-version) ;;
+            *)   NEWV=$(npm version "pre${{ inputs.bump }}" --preid=alpha --no-git-tag-version) ;;
+          esac
+        else
+          case "$CUR" in
+            *-*) NEWV=$(npm version patch --no-git-tag-version) ;;          # finalize: drop -alpha.N
+            *)   NEWV=$(npm version "${{ inputs.bump }}" --no-git-tag-version) ;;
+          esac
+        fi
+        NEWV=${NEWV#v}
+        echo "version=$NEWV" >> "$GITHUB_OUTPUT"
+        echo "branch=release/v$NEWV" >> "$GITHUB_OUTPUT"
+        echo "Prepared ${{ inputs.release_type }} version: $NEWV (from $CUR)"
+
+    - name: Open the version bump PR
+      env:
+        GH_TOKEN: ${{ github.token }}
+        V: ${{ steps.ver.outputs.version }}
+        BR: ${{ steps.ver.outputs.branch }}
+      run: |
+        git checkout -b "$BR"
+        git commit -am "chore(release): v$V"
+        git push origin "$BR"
+        URL=$(gh pr create --base main --head "$BR" \
+          --title "chore(release): v$V" \
+          --body "Automated ${{ inputs.release_type }} bump to \`$V\`. Merging triggers Release — Tag (creates tag v$V + GitHub Release); then run Release — Publish to ship to npm and update Linear.")
+        echo "Opened $URL"
+        echo "[Release PR for v$V]($URL)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,129 @@
+name: Release — Publish
+
+# Phase 2b (manual button). Ships the release that Prepare + Tag produced.
+# Reads the version from package.json on main, checks out its tag (created by
+# the Release — Tag hook on PR merge), publishes to npm, and updates Linear:
+#   - alpha  (package.json is a prerelease) -> publish --tag alpha; sync Linear.
+#   - stable (plain version)                -> publish (latest); sync + complete
+#     the Linear release, then queue the next one (next_bump).
+#
+# Tagging is NOT done here — the Release — Tag hook owns that.
+#
+# Set `dry_run` to rehearse: npm publish --dry-run, Linear read-only, and the
+# tag is not required (falls back to main HEAD).
+#
+# Secrets: NPM_TOKEN (npm automation token), LINEAR_ACCESS_KEY (pipeline key).
+
+on:
+  workflow_dispatch:
+    inputs:
+      next_bump:
+        description: 'Next release to queue in Linear when publishing a STABLE (calculated from this release)'
+        type: choice
+        options: [ patch, minor, major ]
+        default: patch
+      dry_run:
+        description: 'Rehearse only: npm publish --dry-run, Linear read-only'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: main
+        fetch-depth: 0
+
+    - name: Resolve release
+      id: r
+      run: |
+        git fetch --tags origin >/dev/null 2>&1 || true
+        V=$(node -p "require('./package.json').version")   # relative file require; no node_modules needed
+        BASE=${V%%-*}
+        case "$V" in *-*) TYPE=alpha ;; *) TYPE=stable ;; esac
+        # Next version: plain bash bump of BASE (X.Y.Z), no semver dependency.
+        IFS=. read -r MA MI PA <<< "$BASE"
+        case "${{ inputs.next_bump }}" in
+          patch) NEXT="$MA.$MI.$((PA + 1))" ;;
+          minor) NEXT="$MA.$((MI + 1)).0" ;;
+          major) NEXT="$((MA + 1)).0.0" ;;
+        esac
+        {
+          echo "version=$V"
+          echo "base=$BASE"
+          echo "type=$TYPE"
+          echo "next=$NEXT"
+        } >> "$GITHUB_OUTPUT"
+        {
+          echo "### Publishing"
+          echo ""
+          echo "| field | value |"
+          echo "| --- | --- |"
+          echo "| version | \`$V\` |"
+          echo "| channel | $TYPE ($([ "$TYPE" = alpha ] && echo 'npm tag: alpha' || echo 'npm tag: latest')) |"
+          [ "$TYPE" = stable ] && echo "| next queued in Linear | \`$NEXT\` (${{ inputs.next_bump }}) |"
+          [ "${{ inputs.dry_run }}" = "true" ] && echo "| mode | DRY RUN |"
+        } >> "$GITHUB_STEP_SUMMARY"
+        echo "Publishing $V ($TYPE)"
+
+    - name: Check out the tagged commit
+      run: |
+        V="${{ steps.r.outputs.version }}"
+        if git rev-parse "v$V" >/dev/null 2>&1; then
+          git checkout "v$V"
+        elif [ "${{ inputs.dry_run }}" = "true" ]; then
+          echo "::notice::DRY RUN — tag v$V not found; using main HEAD."
+        else
+          echo "::error::Tag v$V not found. Merge the Release — Prepare PR first (the Release — Tag hook creates it)."
+          exit 1
+        fi
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Publish to npm
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npm publish --access public --tag ${{ steps.r.outputs.type == 'alpha' && 'alpha' || 'latest' }} ${{ inputs.dry_run && '--dry-run' || '' }}
+
+    - name: Sync release in Linear
+      uses: linear/linear-release-action@v0
+      with:
+        access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+        command: sync
+        version: ${{ steps.r.outputs.base }}
+        name: ${{ steps.r.outputs.base }}
+        dry_run: ${{ inputs.dry_run }}
+
+    - name: Complete release in Linear
+      if: ${{ steps.r.outputs.type == 'stable' }}
+      uses: linear/linear-release-action@v0
+      with:
+        access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+        command: complete
+        version: ${{ steps.r.outputs.base }}
+        dry_run: ${{ inputs.dry_run }}
+
+    # Seed the next release so it exists in Linear right after this one ships.
+    # (CLI can only create it In Progress, not Planned.)
+    - name: Queue the next release in Linear
+      if: ${{ steps.r.outputs.type == 'stable' }}
+      uses: linear/linear-release-action@v0
+      with:
+        access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+        command: sync
+        version: ${{ steps.r.outputs.next }}
+        name: ${{ steps.r.outputs.next }}
+        dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,55 @@
+name: Release — Tag
+
+# Phase 2a (automatic hook). When a "Release — Prepare" bump PR is merged,
+# create the git tag + GitHub Release on the merge commit. The version comes
+# from the PR's head branch name (release/vX.Y.Z[-alpha.N]); an alpha tag is
+# marked as a prerelease. Run "Release — Publish" afterwards to ship to npm and
+# update Linear.
+
+on:
+  pull_request:
+    types: [ closed ]
+    branches: [ main ]
+
+permissions:
+  contents: write       # create the tag + GitHub Release
+  pull-requests: read   # read the merged PR's settled merge_commit_sha
+
+jobs:
+  tag:
+    # Only for merged Release — Prepare PRs.
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: main
+        fetch-depth: 0
+
+    - name: Create the tagged release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR: ${{ github.event.pull_request.number }}
+      run: |
+        V="${HEAD_REF#release/v}"          # X.Y.Z or X.Y.Z-alpha.N
+        # stable -> mark the GitHub Release as Latest; alpha -> prerelease (never Latest)
+        FLAGS=(--latest)
+        case "$V" in *-*) FLAGS=(--prerelease --latest=false) ;; esac
+        if gh release view "v$V" >/dev/null 2>&1; then
+          echo "::notice::Release v$V already exists; nothing to do."
+          exit 0
+        fi
+        # The event payload's merge_commit_sha can be null/stale (race at close,
+        # and it varies by merge method). Fetch the settled value, and fall back
+        # to main's tip if it is still empty.
+        SHA=$(gh api "repos/{owner}/{repo}/pulls/$PR" --jq '.merge_commit_sha')
+        if [ -z "$SHA" ] || [ "$SHA" = "null" ]; then
+          SHA=$(git rev-parse HEAD)
+        fi
+        gh release create "v$V" --target "$SHA" --title "v$V" --generate-notes "${FLAGS[@]}"
+        echo "Created tagged release v$V at $SHA"
+        echo "[Release v$V](https://github.com/${{ github.repository }}/releases/tag/v$V)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Four workflows for the @layerfi/components release stream:

- linear-release.yml: on every push to main, sync the current in-progress Linear release so issues/PRs attach as work merges.
- release-prepare.yml: manual button — pick alpha/stable + bump, open a package.json version-bump PR (you review and merge it).
- release-tag.yml: hook — when a release/v* bump PR merges, create the git tag + GitHub Release on the merge commit (prerelease for alphas).
- release-publish.yml: manual button — read the version from main, check out its tag, npm publish (alpha tag / latest), and update Linear (sync; plus complete + queue next for stable). Supports dry_run.

Channel is inferred from the version's prerelease suffix. Requires LINEAR_ACCESS_KEY and NPM_TOKEN secrets, and the "Allow GitHub Actions to create and approve pull requests" repo setting.

## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces automated npm publishing and external Linear API calls with secrets; mis-runs or bad version logic could ship wrong artifacts or mutate release state, though flows are mostly manual gates plus dry_run.
> 
> **Overview**
> Adds **four GitHub Actions workflows** that wire npm releases for this package to **Linear** release tracking.
> 
> **Release — Prepare** (manual) computes the next version from `package.json` using an alpha/stable model (`X.Y.Z-alpha.N` cycles, then stable `X.Y.Z`), opens a `release/v*` bump PR, and does not publish or touch Linear.
> 
> **Release — Tag** runs when a merged `release/v*` PR lands on `main`, creating the `v*` git tag and GitHub Release (prerelease for alphas).
> 
> **Release — Publish** (manual) reads the version on `main`, checks out the tag, runs `npm publish` (`alpha` vs `latest` from the prerelease suffix), syncs Linear at ship time, and on **stable** completes the release and seeds the next version via `next_bump`. Supports **dry_run**.
> 
> **Linear Release — sync on merge** runs on every push to `main`, syncing the in-progress Linear release without a version so issues attach as PRs merge (complementing Publish’s ship-time sync).
> 
> Requires `LINEAR_ACCESS_KEY`, `NPM_TOKEN`, and repo permission for Actions to create PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5954f651ede1043da2883f5c28b7c4192ef093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->