### PR TITLE
ci: npm trusted publishing (OIDC) for Release — Publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -12,7 +12,10 @@ name: Release — Publish
 # Set `dry_run` to rehearse: npm publish --dry-run, Linear read-only, and the
 # tag is not required (falls back to main HEAD).
 #
-# Secrets: NPM_TOKEN (npm automation token), LINEAR_ACCESS_KEY (pipeline key).
+# npm auth: OIDC trusted publishing (no token). Configure the trusted publisher
+# for @layerfi/components on npmjs.com.
+#
+# Secret: LINEAR_ACCESS_KEY.
 
 on:
   workflow_dispatch:
@@ -29,6 +32,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write   # OIDC for npm trusted publishing
 
 jobs:
   publish:
@@ -84,18 +88,20 @@ jobs:
           exit 1
         fi
 
+    # No registry-url: it writes an empty _authToken that makes npm skip OIDC.
     - uses: actions/setup-node@v4
       with:
         node-version: '22'
         cache: 'npm'
-        registry-url: 'https://registry.npmjs.org'
+
+    # Trusted publishing needs npm >= 11.5.1; pin it.
+    - name: Upgrade npm for trusted publishing
+      run: npm install -g npm@11.5.1
 
     - name: Install dependencies
       run: npm ci
 
     - name: Publish to npm
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: npm publish --access public --tag ${{ steps.r.outputs.type == 'alpha' && 'alpha' || 'latest' }} ${{ inputs.dry_run && '--dry-run' || '' }}
 
     - name: Sync release in Linear


### PR DESCRIPTION
Migrates the **Release — Publish** workflow from a long-lived `NPM_TOKEN` to npm **trusted publishing** (OIDC).

## Changes (single commit, `release-publish.yml` only)
- Add `id-token: write` permission so the runner can mint the OIDC credential.
- Drop the `NODE_AUTH_TOKEN` / `NPM_TOKEN` env — no token needed.
- Pin `npm install -g npm@11.5.1` (the minimum for trusted publishing; Node 22.x already meets the ≥ 22.14.0 requirement). Pinned, not `@latest`, so the release toolchain can't shift under us.

Provenance is attached automatically under trusted publishing.

## Required before this can publish (npm.com, one-time)
- Configure a **trusted publisher** for `@layerfi/components`: repo `Layer-Fi/layer-react`, workflow `release-publish.yml`.
- Enable account 2FA; optionally set the package to require 2FA (CI via OIDC is exempt, so it keeps working).

The rest of the release workflows landed previously in #1477; this is the follow-up delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production npm publishes authenticate; publish will fail until npm trusted publisher is configured, but removes long-lived token exposure.
> 
> **Overview**
> **Release — Publish** now authenticates to npm via **OIDC trusted publishing** instead of a long-lived `NPM_TOKEN`.
> 
> The workflow grants `id-token: write`, removes `NODE_AUTH_TOKEN` / registry `registry-url` from `setup-node` (empty `_authToken` would block OIDC), and adds a pinned global `npm@11.5.1` install before `npm publish`. Header comments now document npm trusted-publisher setup for `@layerfi/components` and that only `LINEAR_ACCESS_KEY` remains as a secret.
> 
> **One-time npm.com setup** is required: trusted publisher for this repo and `release-publish.yml` workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f438ba261d50d6cab9fbdc468bfe417b2efd92f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->