### PR TITLE
feat: gate solopreneur tax profile banner behind enableTaxEstimates flag

### DIFF
--- a/src/components/SolopreneurOnboardingBanner/SolopreneurOnboardingBanner.tsx
+++ b/src/components/SolopreneurOnboardingBanner/SolopreneurOnboardingBanner.tsx
@@ -3,11 +3,12 @@ import { Info } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { type PlaidHostedLinkConfig } from '@schemas/linkedAccounts/plaid'
+import { useAccountingConfiguration } from '@hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration'
 import { useTaxProfile } from '@hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { LinkedAccountsProvider } from '@providers/LinkedAccountsProvider/LinkedAccountsProvider'
-import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
 import { Banner } from '@ui/Banner/Banner'
 import { Button as LayerButton } from '@ui/Button/Button'
 import { HStack } from '@ui/Stack/Stack'
@@ -97,16 +98,12 @@ export function SolopreneurOnboardingBanner({ onSetupTaxProfile, plaidHostedLink
 }
 
 const useSolopreneurOnboardingBannerState = () => {
-  const { accountingConfiguration } = useLayerContext()
+  const { businessId } = useLayerContext()
+  const { data: accountingConfiguration, isLoading: isAccountingConfigLoading } = useAccountingConfiguration({ businessId })
   const { data: linkedAccounts, isLoading: isLinkedAccountsLoading, loadingStatus: linkedAccountsLoadingStatus } = useContext(LinkedAccountsContext)
   const { data: taxProfile, isLoading: isTaxProfileLoading } = useTaxProfile()
 
   const isTaxEstimatesEnabled = !!accountingConfiguration?.enableTaxEstimates
-
-  // Config hasn't loaded yet — we can't tell whether tax estimates are enabled,
-  // so treat undefined config as loading to avoid prematurely resolving to
-  // Onboarded and hiding the tax-profile banner.
-  const isAccountingConfigLoading = accountingConfiguration === undefined
 
   const isLoading =
   isLinkedAccountsLoading

--- a/src/components/SolopreneurOnboardingBanner/SolopreneurOnboardingBanner.tsx
+++ b/src/components/SolopreneurOnboardingBanner/SolopreneurOnboardingBanner.tsx
@@ -7,6 +7,7 @@ import { useTaxProfile } from '@hooks/api/businesses/[business-id]/tax-estimates
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { LinkedAccountsProvider } from '@providers/LinkedAccountsProvider/LinkedAccountsProvider'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
+import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { Banner } from '@ui/Banner/Banner'
 import { Button as LayerButton } from '@ui/Button/Button'
 import { HStack } from '@ui/Stack/Stack'
@@ -24,10 +25,12 @@ const getOnboardingBannerState = ({
   isLoading,
   hasLinkedAccounts,
   hasSavedTaxProfile,
+  isTaxEstimatesEnabled,
 }: {
   isLoading: boolean
   hasLinkedAccounts: boolean
   hasSavedTaxProfile: boolean
+  isTaxEstimatesEnabled: boolean
 }) => {
   if (isLoading) {
     return OnboardingBannerState.Loading
@@ -37,7 +40,7 @@ const getOnboardingBannerState = ({
     return OnboardingBannerState.NoBankAccountsLinked
   }
 
-  if (!hasSavedTaxProfile) {
+  if (isTaxEstimatesEnabled && !hasSavedTaxProfile) {
     return OnboardingBannerState.NoTaxProfile
   }
 
@@ -94,6 +97,7 @@ export function SolopreneurOnboardingBanner({ onSetupTaxProfile, plaidHostedLink
 }
 
 const useSolopreneurOnboardingBannerState = () => {
+  const { accountingConfiguration } = useLayerContext()
   const { data: linkedAccounts, isLoading: isLinkedAccountsLoading, loadingStatus: linkedAccountsLoadingStatus } = useContext(LinkedAccountsContext)
   const { data: taxProfile, isLoading: isTaxProfileLoading } = useTaxProfile()
 
@@ -108,5 +112,7 @@ Array.isArray(linkedAccounts) && linkedAccounts.length > 0
 
   const hasSavedTaxProfile = taxProfile?.userHasSavedTaxProfile === true
 
-  return getOnboardingBannerState({ isLoading, hasLinkedAccounts, hasSavedTaxProfile })
+  const isTaxEstimatesEnabled = !!accountingConfiguration?.enableTaxEstimates
+
+  return getOnboardingBannerState({ isLoading, hasLinkedAccounts, hasSavedTaxProfile, isTaxEstimatesEnabled })
 }

--- a/src/components/SolopreneurOnboardingBanner/SolopreneurOnboardingBanner.tsx
+++ b/src/components/SolopreneurOnboardingBanner/SolopreneurOnboardingBanner.tsx
@@ -101,9 +101,17 @@ const useSolopreneurOnboardingBannerState = () => {
   const { data: linkedAccounts, isLoading: isLinkedAccountsLoading, loadingStatus: linkedAccountsLoadingStatus } = useContext(LinkedAccountsContext)
   const { data: taxProfile, isLoading: isTaxProfileLoading } = useTaxProfile()
 
+  const isTaxEstimatesEnabled = !!accountingConfiguration?.enableTaxEstimates
+
+  // Config hasn't loaded yet — we can't tell whether tax estimates are enabled,
+  // so treat undefined config as loading to avoid prematurely resolving to
+  // Onboarded and hiding the tax-profile banner.
+  const isAccountingConfigLoading = accountingConfiguration === undefined
+
   const isLoading =
   isLinkedAccountsLoading
-  || isTaxProfileLoading
+  || isAccountingConfigLoading
+  || (isTaxEstimatesEnabled && isTaxProfileLoading)
   || linkedAccountsLoadingStatus === 'loading'
   || linkedAccountsLoadingStatus === 'initial'
 
@@ -111,8 +119,6 @@ const useSolopreneurOnboardingBannerState = () => {
 Array.isArray(linkedAccounts) && linkedAccounts.length > 0
 
   const hasSavedTaxProfile = taxProfile?.userHasSavedTaxProfile === true
-
-  const isTaxEstimatesEnabled = !!accountingConfiguration?.enableTaxEstimates
 
   return getOnboardingBannerState({ isLoading, hasLinkedAccounts, hasSavedTaxProfile, isTaxEstimatesEnabled })
 }


### PR DESCRIPTION
## Summary

The "Set up your tax profile" onboarding banner showed for any solopreneur business with linked accounts and no saved tax profile, even when tax estimates were disabled. 

This PR gates the the NoTaxProfile state on accountingConfiguration.enableTaxEstimates so it only appears when the
feature is enabled.

## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

## References
- https://layer-financial.slack.com/archives/C06KH7QKS6M/p1781020866791789

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only onboarding banner logic with no auth or data mutations; adds one accounting-config fetch for banner state.
> 
> **Overview**
> The solopreneur onboarding **“Set up your tax profile”** banner no longer appears for every business with linked accounts and no saved profile. It now only enters the `NoTaxProfile` state when **`accountingConfiguration.enableTaxEstimates`** is true, matching how tax-estimates onboarding is gated elsewhere.
> 
> `SolopreneurOnboardingBanner` loads accounting config via `useAccountingConfiguration` and `useLayerContext`, waits on that config in the loading state, and only fetches/waits on tax profile loading when tax estimates are enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6db5785c35e6181eb964cc3d20e7b9ccd047bcba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->