### PR TITLE
feat: make Confirm Accounts modal list scrollable

### DIFF
--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
@@ -16,6 +16,8 @@ import { P } from '@ui/Typography/Text'
 import { LinkedAccountToConfirm } from '@components/LinkedAccounts/ConfirmationModal/LinkedAccountToConfirm'
 import { ConditionalList } from '@components/utility/ConditionalList'
 
+import './linkedAccountsConfirmationModal.scss'
+
 function useLinkedAccountsConfirmationModal() {
   const { data, refetchAccounts } = useLinkedAccounts()
   const accountsNeedingConfirmation = getAccountsNeedingConfirmation(data ?? [])
@@ -171,7 +173,7 @@ function LinkedAccountsConfirmationModalContent({ onClose }: { onClose: () => vo
               </P>
             </VStack>
           )}
-          Container={({ children }) => <VStack gap='md'>{children}</VStack>}
+          Container={({ children }) => <VStack gap='md' className='Layer__LinkedAccountsConfirmationModal__Content'>{children}</VStack>}
         >
           {({ item }) => (
             <LinkedAccountToConfirm

--- a/src/components/LinkedAccounts/ConfirmationModal/linkedAccountsConfirmationModal.scss
+++ b/src/components/LinkedAccounts/ConfirmationModal/linkedAccountsConfirmationModal.scss
@@ -1,12 +1,12 @@
 .Layer__LinkedAccountsConfirmationModal {
   &__Content {
     overflow-y: auto;
-    height: 24rem;
+    max-block-size: 24rem;
     padding: var(--spacing-md);
     border: 1px solid var(--border-color);
 
-    @media (height < 48rem) {
-      height: 18rem;
+    @media (height <= 48rem) {
+      max-block-size: 18rem;
     }
   }
 }

--- a/src/components/LinkedAccounts/ConfirmationModal/linkedAccountsConfirmationModal.scss
+++ b/src/components/LinkedAccounts/ConfirmationModal/linkedAccountsConfirmationModal.scss
@@ -1,0 +1,12 @@
+.Layer__LinkedAccountsConfirmationModal {
+  &__Content {
+    overflow-y: auto;
+    height: 24rem;
+    padding: var(--spacing-md);
+    border: 1px solid var(--border-color);
+
+    @media (height < 48rem) {
+      height: 18rem;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

We have an issue with confirming our plaid accounts modal.

<img width="1971" height="1116" alt="image" src="https://github.com/user-attachments/assets/8e059515-1956-4b27-a999-98c7adc484f4" />

This PR caps the height of the account list in the Confirm Accounts modal and lets it scroll, with a reduced height on short viewports. This keeps the modal actions (Connect / Exclude buttons) reachable when many accounts are pulled from the institution — improving the mobile/short-viewport experience.

## Changes
- `LinkedAccountsConfirmationModal.tsx`: the account-list `Container` now uses a dedicated class.
- `linkedAccountsConfirmationModal.scss` (new): `overflow-y: auto` + capped height, with a `@media (height < 48rem)` reduction.

iPhone SE
<img width="412" height="696" alt="image" src="https://github.com/user-attachments/assets/bee8f94c-e8ad-4174-86af-8dd04d0146ca" />

iPad Mini

<img width="784" height="1046" alt="image" src="https://github.com/user-attachments/assets/55c794d2-be9b-4123-a51f-14c855719a91" />

Added border

<img width="633" height="687" alt="image" src="https://github.com/user-attachments/assets/a4dee283-bba9-4f21-90d5-7d043739b1c1" />

## Linear
[LAY-2306 — Plaid connection confirm accounts / reconnect modal](https://linear.app/layerfi/issue/LAY-2306/plaid-connection-confirm-accounts-reconnect-modal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and a className on the modal list container; no API, auth, or account-confirmation logic changes.
> 
> **Overview**
> The **Confirm Accounts** modal no longer grows without bound when Plaid returns many accounts. The account list `Container` now uses `Layer__LinkedAccountsConfirmationModal__Content`, backed by new `linkedAccountsConfirmationModal.scss`.
> 
> That wrapper applies **vertical scrolling**, a **max height** (24rem, 18rem when viewport height ≤ 48rem), **padding**, and a **border** so the list stays in view and **Connect / Exclude** actions remain reachable on mobile and short viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d083f28d1f3b1f8124e63334b05a35f3d0fd6614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->