### PR TITLE
feat: add responsive invoices mobile list

### DIFF
--- a/src/components/Invoices/InvoiceOverview/InvoiceOverview.tsx
+++ b/src/components/Invoices/InvoiceOverview/InvoiceOverview.tsx
@@ -1,6 +1,6 @@
 import { VStack } from '@ui/Stack/Stack'
 import { InvoiceSummaryStats } from '@components/Invoices/InvoiceSummaryStats/InvoiceSummaryStats'
-import { InvoiceTable } from '@components/Invoices/InvoiceTable/InvoiceTable'
+import { ResponsiveInvoiceView } from '@components/Invoices/InvoiceTable/ResponsiveInvoiceView'
 import { StripeConnectBanner } from '@components/Invoices/StripeConnectBanner/StripeConnectBanner'
 
 export const InvoiceOverview = () => {
@@ -8,7 +8,7 @@ export const InvoiceOverview = () => {
     <VStack>
       <InvoiceSummaryStats />
       <StripeConnectBanner />
-      <InvoiceTable />
+      <ResponsiveInvoiceView />
     </VStack>
   )
 }

--- a/src/components/Invoices/InvoiceStatusCell/InvoiceStatusCell.tsx
+++ b/src/components/Invoices/InvoiceStatusCell/InvoiceStatusCell.tsx
@@ -1,114 +1,24 @@
-import type { TFunction } from 'i18next'
-import { CircleAlert, CircleCheckBig, File } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
-import { tPlural } from '@utils/i18n/plural'
-import { unsafeAssertUnreachable } from '@utils/switch/assertUnreachable'
-import { getDueDifference } from '@utils/time/timeUtils'
+import { type Invoice } from '@schemas/invoices/invoice'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
-import { Badge, BadgeSize, BadgeVariant } from '@components/Badge/Badge'
-
-const getDueStatusConfig = (
-  invoice: Invoice,
-  { inline }: { inline: boolean },
-  t: TFunction,
-  formatNumber: (value: number) => string,
-) => {
-  const badgeSize = inline ? BadgeSize.EXTRA_SMALL : BadgeSize.SMALL
-  const iconSize = inline ? 10 : 12
-
-  switch (invoice.status) {
-    case InvoiceStatus.Draft: {
-      return {
-        text: t('invoices:state.draft', 'Draft'),
-        badge: <Badge variant={BadgeVariant.NEUTRAL} size={badgeSize} icon={<File size={iconSize} />} iconOnly />,
-      }
-    }
-    case InvoiceStatus.WrittenOff: {
-      return { text: t('invoices:state.written_off', 'Written Off') }
-    }
-    case InvoiceStatus.PartiallyWrittenOff: {
-      return { text: t('invoices:state.partially_written_off', 'Partially Written Off') }
-    }
-    case InvoiceStatus.Refunded: {
-      return { text: t('invoices:state.refunded', 'Refunded') }
-    }
-    case InvoiceStatus.Paid: {
-      return {
-        text: t('invoices:state.paid', 'Paid'),
-        badge: <Badge variant={BadgeVariant.SUCCESS} size={badgeSize} icon={<CircleCheckBig size={iconSize} />} iconOnly />,
-      }
-    }
-    case InvoiceStatus.Voided: {
-      return { text: t('invoices:state.voided', 'Voided') }
-    }
-    case InvoiceStatus.Saved:
-    case InvoiceStatus.PartiallyPaid: {
-      if (invoice.dueAt === null) {
-        return {
-          text: invoice.status === InvoiceStatus.PartiallyPaid
-            ? t('invoices:state.partially_paid', 'Partially Paid')
-            : t('invoices:state.saved', 'Saved'),
-        }
-      }
-
-      const dueDifference = getDueDifference(invoice.dueAt)
-      if (dueDifference === 0) {
-        return {
-          text: t('invoices:state.due_today', 'Due Today'),
-        }
-      }
-
-      if (dueDifference < 0) {
-        const daysAgo = Math.abs(dueDifference)
-        return {
-          text: t('invoices:state.overdue', 'Overdue'),
-          subText: tPlural(t, 'invoices:state.due_count_days_ago', {
-            count: daysAgo,
-            displayCount: formatNumber(daysAgo),
-            one: 'Due {{displayCount}} day ago',
-            other: 'Due {{displayCount}} days ago',
-          }),
-          badge: <Badge variant={BadgeVariant.WARNING} size={badgeSize} icon={<CircleAlert size={iconSize} />} iconOnly />,
-        }
-      }
-
-      const daysUntilDue = Math.abs(dueDifference)
-      return {
-        text: t('invoices:state.saved', 'Saved'),
-        subText: tPlural(t, 'invoices:state.due_in_count_days', {
-          count: daysUntilDue,
-          displayCount: formatNumber(daysUntilDue),
-          one: 'Due in {{displayCount}} day',
-          other: 'Due in {{displayCount}} days',
-        }),
-      }
-    }
-    default: {
-      unsafeAssertUnreachable({
-        value: invoice.status,
-        message: 'Unexpected invoice status',
-      })
-    }
-  }
-}
+import { getInvoiceStatusBadge, getInvoiceStatusComponents } from '@components/Invoices/utils/invoiceStatusComponents'
 
 export const InvoiceStatusCell = ({ invoice, inline = false }: { invoice: Invoice, inline?: boolean }) => {
   const { t } = useTranslation()
   const { formatNumber } = useIntlFormatter()
-  const dueStatus = getDueStatusConfig(invoice, { inline }, t, formatNumber)
+  const status = getInvoiceStatusComponents(invoice, t, formatNumber)
 
   const Stack = inline ? HStack : VStack
-  const subText = (inline && dueStatus.subText) ? `(${dueStatus.subText})` : dueStatus.subText
+  const subText = (inline && status.subText) ? `(${status.subText})` : status.subText
 
   return (
     <HStack gap='xs' align='center'>
-      {dueStatus.badge}
+      {getInvoiceStatusBadge(status, { inline })}
       <Stack {...(inline && { gap: '3xs', align: 'center' })}>
-        <Span>{dueStatus.text}</Span>
+        <Span>{status.text}</Span>
         {subText && <Span variant='subtle' size='sm'>{subText}</Span>}
       </Stack>
     </HStack>

--- a/src/components/Invoices/InvoiceTable/InvoiceTable.tsx
+++ b/src/components/Invoices/InvoiceTable/InvoiceTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import type { Row } from '@tanstack/react-table'
 import type { TFunction } from 'i18next'
 import { Plus } from 'lucide-react'
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { getCustomerName } from '@utils/customerVendor'
 import { unsafeAssertUnreachable } from '@utils/switch/assertUnreachable'
-import { useDebouncedSearchInput } from '@hooks/utils/debouncing/useDebouncedSearchQuery'
+import { type SearchProps } from '@hooks/utils/debouncing/useDebouncedSearchQuery'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useInvoiceTableFilters } from '@providers/InvoicesRouteStore/InvoicesRouteStoreProvider'
 import ChevronRightFill from '@icons/ChevronRightFill'
@@ -127,6 +127,7 @@ export interface InvoiceTableProps {
   paginationProps: TablePaginationProps
   onViewInvoice: (invoice: Invoice) => void
   onCreateInvoice: () => void
+  searchProps: SearchProps
   slots: {
     EmptyState: React.FC
     ErrorState: React.FC
@@ -140,17 +141,12 @@ export const InvoiceTable = ({
   paginationProps,
   onViewInvoice,
   onCreateInvoice,
+  searchProps,
   slots,
 }: InvoiceTableProps) => {
   const { t } = useTranslation()
   const { tableFilters, setTableFilters } = useInvoiceTableFilters()
-  const { status: selectedInvoiceStatusOption, query } = tableFilters
-
-  const { inputValue, searchQuery, handleInputChange } = useDebouncedSearchInput({ initialInputState: query })
-
-  useEffect(() => {
-    setTableFilters({ query: searchQuery })
-  }, [searchQuery, setTableFilters])
+  const { status: selectedInvoiceStatusOption } = tableFilters
 
   const options = useInvoiceStatusOptions()
 
@@ -200,9 +196,8 @@ export const InvoiceTable = ({
         slotProps={{
           SearchField: {
             label: t('invoices:label.search_invoices', 'Search invoices'),
-            value: inputValue,
-            onChange: handleInputChange,
             className: 'Layer__InvoiceTable__SearchField',
+            ...searchProps,
           },
         }}
       />

--- a/src/components/Invoices/InvoiceTable/InvoiceTable.tsx
+++ b/src/components/Invoices/InvoiceTable/InvoiceTable.tsx
@@ -1,29 +1,27 @@
 import { useCallback, useEffect, useMemo } from 'react'
 import type { Row } from '@tanstack/react-table'
-import { endOfYesterday, startOfToday } from 'date-fns'
 import type { TFunction } from 'i18next'
-import { HandCoins, Plus, Search } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { getCustomerName } from '@utils/customerVendor'
-import { translationKey } from '@utils/i18n/translationKey'
 import { unsafeAssertUnreachable } from '@utils/switch/assertUnreachable'
-import { type ListInvoicesFilterParams, useListInvoices } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
 import { useDebouncedSearchInput } from '@hooks/utils/debouncing/useDebouncedSearchQuery'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
-import { type InvoiceTableFilters, useInvoiceNavigation, useInvoiceTableFilters } from '@providers/InvoicesRouteStore/InvoicesRouteStoreProvider'
+import { useInvoiceTableFilters } from '@providers/InvoicesRouteStore/InvoicesRouteStoreProvider'
 import ChevronRightFill from '@icons/ChevronRightFill'
 import { Button } from '@ui/Button/Button'
 import { ComboBox } from '@ui/ComboBox/ComboBox'
 import { VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { Container } from '@components/Container/Container'
-import { DataState, DataStateStatus } from '@components/DataState/DataState'
 import type { NestedColumnConfig } from '@components/DataTable/columnUtils'
 import { DataTableHeader } from '@components/DataTable/DataTableHeader'
 import { InvoiceStatusCell } from '@components/Invoices/InvoiceStatusCell/InvoiceStatusCell'
+import { useInvoiceStatusOptions } from '@components/Invoices/utils/invoiceFilters'
 import { PaginatedTable } from '@components/PaginatedDataTable/PaginatedDataTable'
+import { type TablePaginationProps } from '@components/PaginatedDataTable/PaginatedDataTable'
 
 import './invoiceTable.scss'
 
@@ -37,37 +35,6 @@ enum InvoiceColumns {
   Status = 'Status',
   Expand = 'Expand',
 }
-
-enum InvoiceStatusFilter {
-  All = 'All',
-  Draft = 'Draft',
-  Unpaid = 'Unpaid',
-  Overdue = 'Overdue',
-  Saved = 'Saved',
-  Paid = 'Paid',
-  WrittenOff = 'Written Off',
-  Voided = 'Voided',
-  Refunded = 'Refunded',
-}
-
-export type InvoiceStatusOption = {
-  label: string
-  value: InvoiceStatusFilter
-}
-
-const INVOICE_STATUS_CONFIG = [
-  { value: InvoiceStatusFilter.All, ...translationKey('common:label.all', 'All') },
-  { value: InvoiceStatusFilter.Draft, ...translationKey('invoices:state.draft', 'Draft') },
-  { value: InvoiceStatusFilter.Unpaid, ...translationKey('invoices:state.unpaid', 'Unpaid') },
-  { value: InvoiceStatusFilter.Overdue, ...translationKey('invoices:state.overdue', 'Overdue') },
-  { value: InvoiceStatusFilter.Saved, ...translationKey('invoices:state.saved', 'Saved') },
-  { value: InvoiceStatusFilter.Paid, ...translationKey('invoices:state.paid', 'Paid') },
-  { value: InvoiceStatusFilter.Voided, ...translationKey('invoices:state.voided', 'Voided') },
-  { value: InvoiceStatusFilter.Refunded, ...translationKey('invoices:state.refunded', 'Refunded') },
-  { value: InvoiceStatusFilter.WrittenOff, ...translationKey('invoices:state.written_off', 'Written Off') },
-]
-
-export const ALL_OPTION: InvoiceStatusOption = { value: InvoiceStatusFilter.All, label: 'All' }
 
 const AmountCell = ({ invoice }: { invoice: Invoice }) => {
   const { t } = useTranslation()
@@ -153,52 +120,29 @@ const getColumnConfig = (
   },
 ]
 
-const UNPAID_STATUSES = [InvoiceStatus.Saved, InvoiceStatus.PartiallyPaid]
-const getStatusFilterParams = (statusFilter: InvoiceStatusFilter) => {
-  switch (statusFilter) {
-    case InvoiceStatusFilter.All:
-      return {}
-
-    case InvoiceStatusFilter.Draft:
-      return { status: [InvoiceStatus.Draft] }
-
-    case InvoiceStatusFilter.Unpaid:
-      return { status: UNPAID_STATUSES }
-
-    case InvoiceStatusFilter.Overdue:
-      return { status: UNPAID_STATUSES, dueAtEnd: endOfYesterday() }
-
-    case InvoiceStatusFilter.Saved:
-      return { status: UNPAID_STATUSES, dueAtStart: startOfToday() }
-
-    case InvoiceStatusFilter.Paid:
-      return { status: [InvoiceStatus.Paid, InvoiceStatus.PartiallyWrittenOff] }
-
-    case InvoiceStatusFilter.WrittenOff:
-      return { status: [InvoiceStatus.WrittenOff, InvoiceStatus.PartiallyWrittenOff] }
-
-    case InvoiceStatusFilter.Voided:
-      return { status: [InvoiceStatus.Voided] }
-
-    case InvoiceStatusFilter.Refunded:
-      return { status: [InvoiceStatus.Refunded] }
-
-    default:
-      unsafeAssertUnreachable({
-        value: statusFilter,
-        message: 'Unexpected status filter',
-      })
+export interface InvoiceTableProps {
+  data: Invoice[] | undefined
+  isLoading: boolean
+  isError: boolean
+  paginationProps: TablePaginationProps
+  onViewInvoice: (invoice: Invoice) => void
+  onCreateInvoice: () => void
+  slots: {
+    EmptyState: React.FC
+    ErrorState: React.FC
   }
 }
 
-const getListInvoiceParams = ({ showSalesReceipts, status, query }: InvoiceTableFilters): ListInvoicesFilterParams => {
-  const statusFilterParams = getStatusFilterParams(status.value)
-  return { ...statusFilterParams, showSalesReceipts, query }
-}
-
-export const InvoiceTable = () => {
+export const InvoiceTable = ({
+  data,
+  isLoading,
+  isError,
+  paginationProps,
+  onViewInvoice,
+  onCreateInvoice,
+  slots,
+}: InvoiceTableProps) => {
   const { t } = useTranslation()
-  const { toCreateInvoice, toViewInvoice } = useInvoiceNavigation()
   const { tableFilters, setTableFilters } = useInvoiceTableFilters()
   const { status: selectedInvoiceStatusOption, query } = tableFilters
 
@@ -208,38 +152,7 @@ export const InvoiceTable = () => {
     setTableFilters({ query: searchQuery })
   }, [searchQuery, setTableFilters])
 
-  const listInvoiceParams = useMemo(
-    () => getListInvoiceParams(tableFilters),
-    [tableFilters],
-  )
-
-  const { data, isLoading, isError, size, setSize, refetch } = useListInvoices({ ...listInvoiceParams })
-  const invoices = useMemo(() => data?.flatMap(({ data }) => data), [data])
-
-  const paginationMeta = data?.[data.length - 1].meta.pagination
-  const hasMore = paginationMeta?.hasMore
-
-  const fetchMore = useCallback(() => {
-    if (hasMore) {
-      void setSize(size + 1)
-    }
-  }, [hasMore, setSize, size])
-
-  const paginationProps = useMemo(() => {
-    return {
-      pageSize: 10,
-      hasMore,
-      fetchMore,
-    }
-  }, [fetchMore, hasMore])
-
-  const options: InvoiceStatusOption[] = useMemo(
-    () => INVOICE_STATUS_CONFIG.map(opt => ({
-      value: opt.value,
-      label: t(opt.i18nKey, opt.defaultValue),
-    })),
-    [t],
-  )
+  const options = useInvoiceStatusOptions()
 
   const selectedStatusOption = useMemo(
     () => options.find(o => o.value === selectedInvoiceStatusOption?.value) ?? options[0],
@@ -267,42 +180,14 @@ export const InvoiceTable = () => {
   [SingleValue, options, selectedStatusOption, setTableFilters, t])
 
   const CreateInvoiceButton = useCallback(() => (
-    <Button onPress={toCreateInvoice}>
+    <Button onPress={onCreateInvoice}>
       {t('invoices:action.create_invoice', 'Create Invoice')}
       <Plus size={16} />
     </Button>
   ),
-  [t, toCreateInvoice])
+  [t, onCreateInvoice])
 
-  const InvoiceTableEmptyState = useCallback(() => {
-    const isFiltered = selectedInvoiceStatusOption?.value !== InvoiceStatusFilter.All
-
-    return (
-      <DataState
-        status={DataStateStatus.allDone}
-        title={isFiltered ? t('common:empty.results', 'No results found') : t('invoices:empty.invoices', 'No invoices yet')}
-        description={
-          isFiltered
-            ? t('invoices:empty.invoices_filtered', 'We couldn’t find any invoices with the current filters. Try changing or clearing them to see more results.')
-            : t('invoices:empty.add_first_invoice', 'Add your first invoice to start tracking what your customers owe you.')
-        }
-        icon={isFiltered ? <Search /> : <HandCoins />}
-        spacing
-      />
-    )
-  }, [selectedInvoiceStatusOption, t])
-
-  const InvoiceTableErrorState = useCallback(() => (
-    <DataState
-      status={DataStateStatus.failed}
-      title={t('invoices:error.couldnt_load_invoices', 'We couldn’t load your invoices')}
-      description={t('invoices:error.load_invoices', 'An error occurred while loading your invoices. Please check your connection and try again.')}
-      onRefresh={() => { void refetch() }}
-      spacing
-    />
-  ), [refetch, t])
-
-  const columnConfig = useMemo(() => getColumnConfig(toViewInvoice, t), [toViewInvoice, t])
+  const columnConfig = useMemo(() => getColumnConfig(onViewInvoice, t), [onViewInvoice, t])
 
   return (
     <Container name='InvoiceTable'>
@@ -323,16 +208,13 @@ export const InvoiceTable = () => {
       />
       <PaginatedTable
         ariaLabel={t('invoices:label.invoices', 'Invoices')}
-        data={invoices}
-        isLoading={data === undefined || isLoading}
+        data={data}
+        isLoading={isLoading}
         isError={isError}
         columnConfig={columnConfig}
         paginationProps={paginationProps}
         componentName={COMPONENT_NAME}
-        slots={{
-          EmptyState: InvoiceTableEmptyState,
-          ErrorState: InvoiceTableErrorState,
-        }}
+        slots={slots}
       />
     </Container>
   )

--- a/src/components/Invoices/InvoiceTable/ResponsiveInvoiceView.tsx
+++ b/src/components/Invoices/InvoiceTable/ResponsiveInvoiceView.tsx
@@ -1,0 +1,83 @@
+import { useCallback } from 'react'
+import { HandCoins, Search } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { BREAKPOINTS } from '@utils/screenSizeBreakpoints'
+import { useInvoiceNavigation, useInvoiceTableFilters } from '@providers/InvoicesRouteStore/InvoicesRouteStoreProvider'
+import { type DefaultVariant, ResponsiveComponent } from '@ui/ResponsiveComponent/ResponsiveComponent'
+import { DataState, DataStateStatus } from '@components/DataState/DataState'
+import { InvoicesMobileList } from '@components/Invoices/InvoicesMobileList/InvoicesMobileList'
+import { InvoiceTable } from '@components/Invoices/InvoiceTable/InvoiceTable'
+import { InvoiceStatusFilter } from '@components/Invoices/utils/invoiceFilters'
+import { useInvoicesList } from '@components/Invoices/utils/useInvoicesList'
+
+const resolveVariant = ({ width }: { width: number }): DefaultVariant =>
+  width < BREAKPOINTS.TABLET ? 'Mobile' : 'Desktop'
+
+export const ResponsiveInvoiceView = () => {
+  const { t } = useTranslation()
+  const { toCreateInvoice, toViewInvoice } = useInvoiceNavigation()
+  const { tableFilters } = useInvoiceTableFilters()
+  const { invoices, isLoading, isError, paginationProps, refetch } = useInvoicesList()
+
+  const EmptyState = useCallback(() => {
+    const isFiltered = tableFilters.status?.value !== InvoiceStatusFilter.All
+
+    return (
+      <DataState
+        status={DataStateStatus.allDone}
+        title={isFiltered ? t('common:empty.results', 'No results found') : t('invoices:empty.invoices', 'No invoices yet')}
+        description={
+          isFiltered
+            ? t('invoices:empty.invoices_filtered', 'We couldn’t find any invoices with the current filters. Try changing or clearing them to see more results.')
+            : t('invoices:empty.add_first_invoice', 'Add your first invoice to start tracking what your customers owe you.')
+        }
+        icon={isFiltered ? <Search /> : <HandCoins />}
+        spacing
+      />
+    )
+  }, [tableFilters.status?.value, t])
+
+  const ErrorState = useCallback(() => (
+    <DataState
+      status={DataStateStatus.failed}
+      title={t('invoices:error.couldnt_load_invoices', 'We couldn’t load your invoices')}
+      description={t('invoices:error.load_invoices', 'An error occurred while loading your invoices. Please check your connection and try again.')}
+      onRefresh={() => { void refetch() }}
+      spacing
+    />
+  ), [refetch, t])
+
+  const slots = { EmptyState, ErrorState }
+
+  const DesktopView = (
+    <InvoiceTable
+      data={invoices}
+      isLoading={isLoading}
+      isError={isError}
+      paginationProps={paginationProps}
+      onViewInvoice={toViewInvoice}
+      onCreateInvoice={toCreateInvoice}
+      slots={slots}
+    />
+  )
+
+  const MobileView = (
+    <InvoicesMobileList
+      data={invoices}
+      isLoading={isLoading}
+      isError={isError}
+      paginationProps={paginationProps}
+      onViewInvoice={toViewInvoice}
+      onCreateInvoice={toCreateInvoice}
+      slots={slots}
+    />
+  )
+
+  return (
+    <ResponsiveComponent
+      resolveVariant={resolveVariant}
+      slots={{ Desktop: DesktopView, Mobile: MobileView }}
+    />
+  )
+}

--- a/src/components/Invoices/InvoiceTable/ResponsiveInvoiceView.tsx
+++ b/src/components/Invoices/InvoiceTable/ResponsiveInvoiceView.tsx
@@ -1,8 +1,9 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { HandCoins, Search } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { BREAKPOINTS } from '@utils/screenSizeBreakpoints'
+import { useDebouncedSearchInput } from '@hooks/utils/debouncing/useDebouncedSearchQuery'
 import { useInvoiceNavigation, useInvoiceTableFilters } from '@providers/InvoicesRouteStore/InvoicesRouteStoreProvider'
 import { type DefaultVariant, ResponsiveComponent } from '@ui/ResponsiveComponent/ResponsiveComponent'
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
@@ -17,11 +18,21 @@ const resolveVariant = ({ width }: { width: number }): DefaultVariant =>
 export const ResponsiveInvoiceView = () => {
   const { t } = useTranslation()
   const { toCreateInvoice, toViewInvoice } = useInvoiceNavigation()
-  const { tableFilters } = useInvoiceTableFilters()
+  const { tableFilters, setTableFilters } = useInvoiceTableFilters()
   const { invoices, isLoading, isError, paginationProps, refetch } = useInvoicesList()
 
+  const { inputValue, searchQuery, handleInputChange } = useDebouncedSearchInput({ initialInputState: tableFilters.query })
+
+  useEffect(() => {
+    setTableFilters({ query: searchQuery })
+  }, [searchQuery, setTableFilters])
+
+  const searchProps = { value: inputValue, onChange: handleInputChange }
+
   const EmptyState = useCallback(() => {
-    const isFiltered = tableFilters.status?.value !== InvoiceStatusFilter.All
+    const isFiltered =
+      tableFilters.status?.value !== InvoiceStatusFilter.All
+      || tableFilters.query.trim().length > 0
 
     return (
       <DataState
@@ -36,7 +47,7 @@ export const ResponsiveInvoiceView = () => {
         spacing
       />
     )
-  }, [tableFilters.status?.value, t])
+  }, [tableFilters.status?.value, tableFilters.query, t])
 
   const ErrorState = useCallback(() => (
     <DataState
@@ -58,6 +69,7 @@ export const ResponsiveInvoiceView = () => {
       paginationProps={paginationProps}
       onViewInvoice={toViewInvoice}
       onCreateInvoice={toCreateInvoice}
+      searchProps={searchProps}
       slots={slots}
     />
   )
@@ -70,6 +82,7 @@ export const ResponsiveInvoiceView = () => {
       paginationProps={paginationProps}
       onViewInvoice={toViewInvoice}
       onCreateInvoice={toCreateInvoice}
+      searchProps={searchProps}
       slots={slots}
     />
   )

--- a/src/components/Invoices/InvoicesMobileHeader/InvoicesMobileHeader.tsx
+++ b/src/components/Invoices/InvoicesMobileHeader/InvoicesMobileHeader.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { useDebouncedSearchInput } from '@hooks/utils/debouncing/useDebouncedSearchQuery'
+import { type SearchProps } from '@hooks/utils/debouncing/useDebouncedSearchQuery'
 import { useInvoiceTableFilters } from '@providers/InvoicesRouteStore/InvoicesRouteStoreProvider'
 import { Button } from '@ui/Button/Button'
 import { MobileSelectionDrawerWithTrigger } from '@ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger'
@@ -14,18 +14,13 @@ import { SearchField } from '@components/SearchField/SearchField'
 
 interface InvoicesMobileHeaderProps {
   onCreateInvoice: () => void
+  searchProps: SearchProps
 }
 
-export const InvoicesMobileHeader = ({ onCreateInvoice }: InvoicesMobileHeaderProps) => {
+export const InvoicesMobileHeader = ({ onCreateInvoice, searchProps }: InvoicesMobileHeaderProps) => {
   const { t } = useTranslation()
   const { tableFilters, setTableFilters } = useInvoiceTableFilters()
-  const { status: selectedInvoiceStatusOption, query } = tableFilters
-
-  const { inputValue, searchQuery, handleInputChange } = useDebouncedSearchInput({ initialInputState: query })
-
-  useEffect(() => {
-    setTableFilters({ query: searchQuery })
-  }, [searchQuery, setTableFilters])
+  const { status: selectedInvoiceStatusOption } = tableFilters
 
   const options = useInvoiceStatusOptions()
 
@@ -47,9 +42,8 @@ export const InvoicesMobileHeader = ({ onCreateInvoice }: InvoicesMobileHeaderPr
 
         <SearchField
           label={t('invoices:label.search_invoices', 'Search invoices')}
-          value={inputValue}
-          onChange={handleInputChange}
           className='Layer__InvoicesMobileHeader__SearchField'
+          {...searchProps}
         />
 
         <MobileSelectionDrawerWithTrigger<InvoiceStatusOption>

--- a/src/components/Invoices/InvoicesMobileHeader/InvoicesMobileHeader.tsx
+++ b/src/components/Invoices/InvoicesMobileHeader/InvoicesMobileHeader.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useMemo } from 'react'
+import { Plus } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { useDebouncedSearchInput } from '@hooks/utils/debouncing/useDebouncedSearchQuery'
+import { useInvoiceTableFilters } from '@providers/InvoicesRouteStore/InvoicesRouteStoreProvider'
+import { Button } from '@ui/Button/Button'
+import { MobileSelectionDrawerWithTrigger } from '@ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger'
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { Heading } from '@ui/Typography/Heading'
+import { Header } from '@ui/Typography/Text'
+import { type InvoiceStatusOption, useInvoiceStatusOptions } from '@components/Invoices/utils/invoiceFilters'
+import { SearchField } from '@components/SearchField/SearchField'
+
+interface InvoicesMobileHeaderProps {
+  onCreateInvoice: () => void
+}
+
+export const InvoicesMobileHeader = ({ onCreateInvoice }: InvoicesMobileHeaderProps) => {
+  const { t } = useTranslation()
+  const { tableFilters, setTableFilters } = useInvoiceTableFilters()
+  const { status: selectedInvoiceStatusOption, query } = tableFilters
+
+  const { inputValue, searchQuery, handleInputChange } = useDebouncedSearchInput({ initialInputState: query })
+
+  useEffect(() => {
+    setTableFilters({ query: searchQuery })
+  }, [searchQuery, setTableFilters])
+
+  const options = useInvoiceStatusOptions()
+
+  const selectedStatusOption = useMemo(
+    () => options.find(o => o.value === selectedInvoiceStatusOption?.value) ?? options[0],
+    [options, selectedInvoiceStatusOption?.value],
+  )
+
+  return (
+    <Header>
+      <VStack gap='sm' pbe='md'>
+        <HStack justify='space-between' align='center' gap='sm'>
+          <Heading size='lg'>{t('invoices:label.invoices', 'Invoices')}</Heading>
+          <Button onPress={onCreateInvoice} inset>
+            {t('common:action.create_label', 'Create')}
+            <Plus size={16} />
+          </Button>
+        </HStack>
+
+        <SearchField
+          label={t('invoices:label.search_invoices', 'Search invoices')}
+          value={inputValue}
+          onChange={handleInputChange}
+          className='Layer__InvoicesMobileHeader__SearchField'
+        />
+
+        <MobileSelectionDrawerWithTrigger<InvoiceStatusOption>
+          ariaLabel={t('invoices:label.status_filter', 'Status Filter')}
+          heading={t('common:label.status', 'Status')}
+          options={options}
+          selectedValue={selectedStatusOption}
+          onSelectedValueChange={option => option && setTableFilters({ status: option })}
+          placeholder={t('common:label.status', 'Status')}
+          slotProps={{
+            Trigger: {
+              value: option => option
+                ? t('invoices:label.status_with_label', 'Status: {{label}}', { label: option.label })
+                : t('common:label.status', 'Status'),
+            },
+          }}
+        />
+      </VStack>
+    </Header>
+  )
+}

--- a/src/components/Invoices/InvoicesMobileList/InvoicesMobileList.tsx
+++ b/src/components/Invoices/InvoicesMobileList/InvoicesMobileList.tsx
@@ -1,0 +1,53 @@
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { type Invoice } from '@schemas/invoices/invoice'
+import { PaginatedMobileList } from '@ui/MobileList/PaginatedMobileList'
+import { InvoicesMobileHeader } from '@components/Invoices/InvoicesMobileHeader/InvoicesMobileHeader'
+import { InvoicesMobileListItem } from '@components/Invoices/InvoicesMobileList/InvoicesMobileListItem'
+import { InvoicesMobileListItemStatusFooter } from '@components/Invoices/InvoicesMobileList/InvoicesMobileListItemStatusFooter'
+import { type TablePaginationProps } from '@components/PaginatedDataTable/PaginatedDataTable'
+
+export interface InvoicesMobileListProps {
+  data: Invoice[] | undefined
+  isLoading: boolean
+  isError: boolean
+  paginationProps: TablePaginationProps
+  onViewInvoice: (invoice: Invoice) => void
+  onCreateInvoice: () => void
+  slots: {
+    EmptyState: React.FC
+    ErrorState: React.FC
+  }
+}
+
+export const InvoicesMobileList = ({
+  data,
+  isLoading,
+  isError,
+  paginationProps,
+  onViewInvoice,
+  onCreateInvoice,
+  slots,
+}: InvoicesMobileListProps) => {
+  const { t } = useTranslation()
+  const renderItem = useCallback((invoice: Invoice) => <InvoicesMobileListItem invoice={invoice} />, [])
+  const renderFooter = useCallback((invoice: Invoice) => <InvoicesMobileListItemStatusFooter invoice={invoice} />, [])
+
+  return (
+    <div className='Layer__InvoicesMobileList'>
+      <InvoicesMobileHeader onCreateInvoice={onCreateInvoice} />
+      <PaginatedMobileList
+        ariaLabel={t('invoices:label.invoices', 'Invoices')}
+        data={data}
+        isLoading={isLoading}
+        isError={isError}
+        renderItem={renderItem}
+        renderFooter={renderFooter}
+        paginationProps={paginationProps}
+        onClickItem={onViewInvoice}
+        slots={slots}
+      />
+    </div>
+  )
+}

--- a/src/components/Invoices/InvoicesMobileList/InvoicesMobileList.tsx
+++ b/src/components/Invoices/InvoicesMobileList/InvoicesMobileList.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { type Invoice } from '@schemas/invoices/invoice'
+import { type SearchProps } from '@hooks/utils/debouncing/useDebouncedSearchQuery'
 import { PaginatedMobileList } from '@ui/MobileList/PaginatedMobileList'
 import { InvoicesMobileHeader } from '@components/Invoices/InvoicesMobileHeader/InvoicesMobileHeader'
 import { InvoicesMobileListItem } from '@components/Invoices/InvoicesMobileList/InvoicesMobileListItem'
@@ -15,6 +16,7 @@ export interface InvoicesMobileListProps {
   paginationProps: TablePaginationProps
   onViewInvoice: (invoice: Invoice) => void
   onCreateInvoice: () => void
+  searchProps: SearchProps
   slots: {
     EmptyState: React.FC
     ErrorState: React.FC
@@ -28,6 +30,7 @@ export const InvoicesMobileList = ({
   paginationProps,
   onViewInvoice,
   onCreateInvoice,
+  searchProps,
   slots,
 }: InvoicesMobileListProps) => {
   const { t } = useTranslation()
@@ -36,7 +39,7 @@ export const InvoicesMobileList = ({
 
   return (
     <div className='Layer__InvoicesMobileList'>
-      <InvoicesMobileHeader onCreateInvoice={onCreateInvoice} />
+      <InvoicesMobileHeader onCreateInvoice={onCreateInvoice} searchProps={searchProps} />
       <PaginatedMobileList
         ariaLabel={t('invoices:label.invoices', 'Invoices')}
         data={data}

--- a/src/components/Invoices/InvoicesMobileList/InvoicesMobileListItem.tsx
+++ b/src/components/Invoices/InvoicesMobileList/InvoicesMobileListItem.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from 'react-i18next'
+
+import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
+import { getCustomerName } from '@utils/customerVendor'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+
+import './invoicesMobileListItem.scss'
+
+export const InvoicesMobileListItem = ({ invoice }: { invoice: Invoice }) => {
+  const { t } = useTranslation()
+  const { formatDate, formatCurrencyFromCents } = useIntlFormatter()
+
+  const isPartiallyPaid = invoice.status === InvoiceStatus.PartiallyPaid
+
+  return (
+    <HStack justify='space-between' gap='sm' className='Layer__InvoicesMobileListItem'>
+      <VStack gap='3xs' className='Layer__InvoicesMobileListItem__Identity'>
+        <Span weight='bold' ellipsis>{invoice.invoiceNumber}</Span>
+        <Span size='sm' ellipsis>{getCustomerName(invoice.customer)}</Span>
+        {invoice.sentAt && <Span variant='subtle' size='sm'>{formatDate(invoice.sentAt)}</Span>}
+      </VStack>
+
+      <VStack gap='3xs' align='end' className='Layer__InvoicesMobileListItem__Amount'>
+        <Span weight='bold' numeric='tabular-nums'>{formatCurrencyFromCents(invoice.totalAmount)}</Span>
+        {isPartiallyPaid && (
+          <Span variant='subtle' size='sm' numeric='tabular-nums'>
+            {t('invoices:label.amount_outstanding', '{{amount}} outstanding', {
+              amount: formatCurrencyFromCents(invoice.outstandingBalance),
+            })}
+          </Span>
+        )}
+      </VStack>
+    </HStack>
+  )
+}

--- a/src/components/Invoices/InvoicesMobileList/InvoicesMobileListItemStatusFooter.tsx
+++ b/src/components/Invoices/InvoicesMobileList/InvoicesMobileListItemStatusFooter.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from 'react-i18next'
+
+import { type Invoice } from '@schemas/invoices/invoice'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { HStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+import { getInvoiceStatusComponents } from '@components/Invoices/utils/invoiceStatusComponents'
+
+import './invoicesMobileListItemStatusFooter.scss'
+
+export const InvoicesMobileListItemStatusFooter = ({ invoice }: { invoice: Invoice }) => {
+  const { t } = useTranslation()
+  const { formatNumber } = useIntlFormatter()
+
+  const status = getInvoiceStatusComponents(invoice, t, formatNumber)
+  const StatusFooter__Icon = status.Icon
+
+  return (
+    <HStack
+      align='center'
+      justify='space-between'
+      className='Layer__InvoicesMobileListItem__StatusFooter'
+      data-status-variant={status.variant}
+    >
+      <HStack align='center' gap='2xs'>
+        {StatusFooter__Icon
+          ? <StatusFooter__Icon size={14} className='Layer__InvoicesMobileListItem__StatusFooter__Icon' />
+          : <span className='Layer__InvoicesMobileListItem__StatusFooter__Dot' />}
+        <Span weight='bold' size='sm'>
+          {status.text}
+        </Span>
+      </HStack>
+      {status.subText && (
+        <Span variant='subtle' size='sm'>
+          {status.subText}
+        </Span>
+      )}
+    </HStack>
+  )
+}

--- a/src/components/Invoices/InvoicesMobileList/invoicesMobileListItem.scss
+++ b/src/components/Invoices/InvoicesMobileList/invoicesMobileListItem.scss
@@ -1,0 +1,6 @@
+.Layer__InvoicesMobileListItem {
+  &__Identity,
+  &__Amount {
+    min-inline-size: 0;
+  }
+}

--- a/src/components/Invoices/InvoicesMobileList/invoicesMobileListItemStatusFooter.scss
+++ b/src/components/Invoices/InvoicesMobileList/invoicesMobileListItemStatusFooter.scss
@@ -1,0 +1,31 @@
+.Layer__InvoicesMobileListItem__StatusFooter {
+  --status-bar-bg: var(--color-base-50);
+  --status-bar-icon-color: var(--color-base-700);
+
+  padding: var(--spacing-xs) var(--spacing-sm);
+
+  background-color: var(--status-bar-bg);
+  color: var(--status-bar-icon-color);
+
+  &[data-status-variant='warning'] {
+    --status-bar-bg: color-mix(in srgb, var(--color-info-warning-bg) 50%, var(--color-base-0));
+    --status-bar-icon-color: var(--badge-fg-color-warning);
+  }
+
+  &[data-status-variant='success'] {
+    --status-bar-bg: color-mix(in srgb, var(--color-info-success-bg) 35%, var(--color-base-0));
+    --status-bar-icon-color: var(--badge-fg-color-success);
+  }
+}
+
+.Layer__InvoicesMobileListItem__StatusFooter__Icon {
+  flex-shrink: 0;
+}
+
+.Layer__InvoicesMobileListItem__StatusFooter__Dot {
+  flex-shrink: 0;
+  block-size: 6px;
+  inline-size: 6px;
+  border-radius: var(--border-radius-5xl);
+  background-color: var(--color-base-700);
+}

--- a/src/components/Invoices/utils/invoiceFilters.ts
+++ b/src/components/Invoices/utils/invoiceFilters.ts
@@ -1,0 +1,98 @@
+import { useMemo } from 'react'
+import { endOfYesterday, startOfToday } from 'date-fns'
+import { useTranslation } from 'react-i18next'
+
+import { InvoiceStatus } from '@schemas/invoices/invoice'
+import { translationKey } from '@utils/i18n/translationKey'
+import { unsafeAssertUnreachable } from '@utils/switch/assertUnreachable'
+import { type ListInvoicesFilterParams } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
+import { type InvoiceTableFilters } from '@providers/InvoicesRouteStore/InvoicesRouteStoreProvider'
+
+export enum InvoiceStatusFilter {
+  All = 'All',
+  Draft = 'Draft',
+  Unpaid = 'Unpaid',
+  Overdue = 'Overdue',
+  Saved = 'Saved',
+  Paid = 'Paid',
+  WrittenOff = 'Written Off',
+  Voided = 'Voided',
+  Refunded = 'Refunded',
+}
+
+export type InvoiceStatusOption = {
+  label: string
+  value: InvoiceStatusFilter
+}
+
+export const ALL_OPTION: InvoiceStatusOption = { value: InvoiceStatusFilter.All, label: 'All' }
+
+const INVOICE_STATUS_CONFIG = [
+  { value: InvoiceStatusFilter.All, ...translationKey('common:label.all', 'All') },
+  { value: InvoiceStatusFilter.Draft, ...translationKey('invoices:state.draft', 'Draft') },
+  { value: InvoiceStatusFilter.Unpaid, ...translationKey('invoices:state.unpaid', 'Unpaid') },
+  { value: InvoiceStatusFilter.Overdue, ...translationKey('invoices:state.overdue', 'Overdue') },
+  { value: InvoiceStatusFilter.Saved, ...translationKey('invoices:state.saved', 'Saved') },
+  { value: InvoiceStatusFilter.Paid, ...translationKey('invoices:state.paid', 'Paid') },
+  { value: InvoiceStatusFilter.Voided, ...translationKey('invoices:state.voided', 'Voided') },
+  { value: InvoiceStatusFilter.Refunded, ...translationKey('invoices:state.refunded', 'Refunded') },
+  { value: InvoiceStatusFilter.WrittenOff, ...translationKey('invoices:state.written_off', 'Written Off') },
+]
+
+export const useInvoiceStatusOptions = (): InvoiceStatusOption[] => {
+  const { t } = useTranslation()
+
+  return useMemo(
+    () => INVOICE_STATUS_CONFIG.map(opt => ({
+      value: opt.value,
+      label: t(opt.i18nKey, opt.defaultValue),
+    })),
+    [t],
+  )
+}
+
+const UNPAID_STATUSES = [InvoiceStatus.Saved, InvoiceStatus.PartiallyPaid]
+
+export const getStatusFilterParams = (statusFilter: InvoiceStatusFilter) => {
+  switch (statusFilter) {
+    case InvoiceStatusFilter.All:
+      return {}
+
+    case InvoiceStatusFilter.Draft:
+      return { status: [InvoiceStatus.Draft] }
+
+    case InvoiceStatusFilter.Unpaid:
+      return { status: UNPAID_STATUSES }
+
+    case InvoiceStatusFilter.Overdue:
+      return { status: UNPAID_STATUSES, dueAtEnd: endOfYesterday() }
+
+    case InvoiceStatusFilter.Saved:
+      return { status: UNPAID_STATUSES, dueAtStart: startOfToday() }
+
+    case InvoiceStatusFilter.Paid:
+      return { status: [InvoiceStatus.Paid, InvoiceStatus.PartiallyWrittenOff] }
+
+    case InvoiceStatusFilter.WrittenOff:
+      return { status: [InvoiceStatus.WrittenOff, InvoiceStatus.PartiallyWrittenOff] }
+
+    case InvoiceStatusFilter.Voided:
+      return { status: [InvoiceStatus.Voided] }
+
+    case InvoiceStatusFilter.Refunded:
+      return { status: [InvoiceStatus.Refunded] }
+
+    default:
+      unsafeAssertUnreachable({
+        value: statusFilter,
+        message: 'Unexpected status filter',
+      })
+  }
+}
+
+export const getListInvoiceParamsFromFilters = (
+  { showSalesReceipts, status, query }: InvoiceTableFilters,
+): ListInvoicesFilterParams => {
+  const statusFilterParams = getStatusFilterParams(status.value)
+  return { ...statusFilterParams, showSalesReceipts, query }
+}

--- a/src/components/Invoices/utils/invoiceStatusComponents.tsx
+++ b/src/components/Invoices/utils/invoiceStatusComponents.tsx
@@ -1,0 +1,104 @@
+import type { TFunction } from 'i18next'
+import { CircleAlert, CircleCheckBig, File, type LucideIcon } from 'lucide-react'
+
+import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
+import { tPlural } from '@utils/i18n/plural'
+import { unsafeAssertUnreachable } from '@utils/switch/assertUnreachable'
+import { getDueDifference } from '@utils/time/timeUtils'
+import { Badge, BadgeSize, BadgeVariant } from '@components/Badge/Badge'
+
+export interface InvoiceStatusComponents {
+  variant: BadgeVariant
+  text: string
+  subText?: string
+  Icon?: LucideIcon
+}
+
+export const getInvoiceStatusBadge = (
+  { variant, Icon }: InvoiceStatusComponents,
+  { inline }: { inline: boolean },
+) => {
+  if (!Icon) return null
+
+  const badgeSize = inline ? BadgeSize.EXTRA_SMALL : BadgeSize.SMALL
+  const iconSize = inline ? 10 : 12
+
+  return <Badge variant={variant} size={badgeSize} icon={<Icon size={iconSize} />} iconOnly />
+}
+
+export const getInvoiceStatusComponents = (
+  invoice: Invoice,
+  t: TFunction,
+  formatNumber: (value: number) => string,
+): InvoiceStatusComponents => {
+  switch (invoice.status) {
+    case InvoiceStatus.Draft:
+      return { variant: BadgeVariant.NEUTRAL, text: t('invoices:state.draft', 'Draft'), Icon: File }
+
+    case InvoiceStatus.WrittenOff:
+      return { variant: BadgeVariant.NEUTRAL, text: t('invoices:state.written_off', 'Written Off') }
+
+    case InvoiceStatus.PartiallyWrittenOff:
+      return { variant: BadgeVariant.NEUTRAL, text: t('invoices:state.partially_written_off', 'Partially Written Off') }
+
+    case InvoiceStatus.Refunded:
+      return { variant: BadgeVariant.NEUTRAL, text: t('invoices:state.refunded', 'Refunded') }
+
+    case InvoiceStatus.Paid:
+      return { variant: BadgeVariant.SUCCESS, text: t('invoices:state.paid', 'Paid'), Icon: CircleCheckBig }
+
+    case InvoiceStatus.Voided:
+      return { variant: BadgeVariant.NEUTRAL, text: t('invoices:state.voided', 'Voided') }
+
+    case InvoiceStatus.Saved:
+    case InvoiceStatus.PartiallyPaid: {
+      if (invoice.dueAt === null) {
+        return {
+          variant: BadgeVariant.NEUTRAL,
+          text: invoice.status === InvoiceStatus.PartiallyPaid
+            ? t('invoices:state.partially_paid', 'Partially Paid')
+            : t('invoices:state.saved', 'Saved'),
+        }
+      }
+
+      const dueDifference = getDueDifference(invoice.dueAt)
+
+      if (dueDifference === 0) {
+        return { variant: BadgeVariant.NEUTRAL, text: t('invoices:state.due_today', 'Due Today') }
+      }
+
+      if (dueDifference < 0) {
+        const daysAgo = Math.abs(dueDifference)
+        return {
+          variant: BadgeVariant.WARNING,
+          text: t('invoices:state.overdue', 'Overdue'),
+          subText: tPlural(t, 'invoices:state.due_count_days_ago', {
+            count: daysAgo,
+            displayCount: formatNumber(daysAgo),
+            one: 'Due {{displayCount}} day ago',
+            other: 'Due {{displayCount}} days ago',
+          }),
+          Icon: CircleAlert,
+        }
+      }
+
+      const daysUntilDue = Math.abs(dueDifference)
+      return {
+        variant: BadgeVariant.NEUTRAL,
+        text: t('invoices:state.saved', 'Saved'),
+        subText: tPlural(t, 'invoices:state.due_in_count_days', {
+          count: daysUntilDue,
+          displayCount: formatNumber(daysUntilDue),
+          one: 'Due in {{displayCount}} day',
+          other: 'Due in {{displayCount}} days',
+        }),
+      }
+    }
+
+    default:
+      unsafeAssertUnreachable({
+        value: invoice.status,
+        message: 'Unexpected invoice status',
+      })
+  }
+}

--- a/src/components/Invoices/utils/useInvoicesList.ts
+++ b/src/components/Invoices/utils/useInvoicesList.ts
@@ -29,7 +29,7 @@ export const useInvoicesList = () => {
 
   return {
     invoices,
-    isLoading: data === undefined || isLoading,
+    isLoading,
     isError,
     paginationProps,
     refetch,

--- a/src/components/Invoices/utils/useInvoicesList.ts
+++ b/src/components/Invoices/utils/useInvoicesList.ts
@@ -1,0 +1,37 @@
+import { useCallback, useMemo } from 'react'
+
+import { useListInvoices } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
+import { useInvoiceTableFilters } from '@providers/InvoicesRouteStore/InvoicesRouteStoreProvider'
+import { getListInvoiceParamsFromFilters } from '@components/Invoices/utils/invoiceFilters'
+import { type TablePaginationProps } from '@components/PaginatedDataTable/PaginatedDataTable'
+
+export const useInvoicesList = () => {
+  const { tableFilters } = useInvoiceTableFilters()
+  const listInvoiceParams = useMemo(() => getListInvoiceParamsFromFilters(tableFilters), [tableFilters])
+
+  const { data, isLoading, isError, size, setSize, refetch } = useListInvoices({ ...listInvoiceParams })
+  const invoices = useMemo(() => data?.flatMap(({ data }) => data), [data])
+
+  const paginationMeta = data?.[data.length - 1]?.meta.pagination
+  const hasMore = paginationMeta?.hasMore
+
+  const fetchMore = useCallback(() => {
+    if (hasMore) {
+      void setSize(size + 1)
+    }
+  }, [hasMore, setSize, size])
+
+  const paginationProps: TablePaginationProps = useMemo(() => ({
+    pageSize: 10,
+    hasMore,
+    fetchMore,
+  }), [fetchMore, hasMore])
+
+  return {
+    invoices,
+    isLoading: data === undefined || isLoading,
+    isError,
+    paginationProps,
+    refetch,
+  }
+}

--- a/src/components/ui/MobileList/MobileList.tsx
+++ b/src/components/ui/MobileList/MobileList.tsx
@@ -25,6 +25,7 @@ interface MobileListBaseProps<TData> {
     ErrorState: React.FC
   }
   renderItem: (item: TData) => React.ReactNode
+  renderFooter?: (item: TData) => React.ReactNode
   onClickItem?: (item: TData) => void
   variant?: MobileListVariant
 }
@@ -61,6 +62,7 @@ export const MobileList = <TData extends { id: string }>({
   data,
   slots,
   renderItem,
+  renderFooter,
   onClickItem,
   isLoading,
   isError,
@@ -90,7 +92,7 @@ export const MobileList = <TData extends { id: string }>({
   }
 
   const renderRow = (item: TData) => (
-    <MobileListItem key={item.id} item={item} onClickItem={onClickItem}>
+    <MobileListItem key={item.id} item={item} onClickItem={onClickItem} slots={{ Footer: renderFooter?.(item) }}>
       {renderItem(item)}
     </MobileListItem>
   )
@@ -113,6 +115,7 @@ export const MobileList = <TData extends { id: string }>({
             label={group.label}
             items={group.items}
             renderItem={renderItem}
+            renderFooter={renderFooter}
             onClickItem={onClickItem}
           />
         ))

--- a/src/components/ui/MobileList/MobileList.tsx
+++ b/src/components/ui/MobileList/MobileList.tsx
@@ -92,7 +92,7 @@ export const MobileList = <TData extends { id: string }>({
   }
 
   const renderRow = (item: TData) => (
-    <MobileListItem key={item.id} item={item} onClickItem={onClickItem} slots={{ Footer: renderFooter?.(item) }}>
+    <MobileListItem key={item.id} item={item} onClickItem={onClickItem} renderFooter={renderFooter}>
       {renderItem(item)}
     </MobileListItem>
   )

--- a/src/components/ui/MobileList/MobileListItem.tsx
+++ b/src/components/ui/MobileList/MobileListItem.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren, useCallback } from 'react'
+import { type PropsWithChildren, type ReactNode, useCallback } from 'react'
 import { composeRenderProps } from 'react-aria-components/composeRenderProps'
 import { GridListItem } from 'react-aria-components/GridList'
 
@@ -9,12 +9,16 @@ import './mobileListItem.scss'
 type MobileListItemProps<TData> = PropsWithChildren<{
   item: TData
   onClickItem?: (item: TData) => void
+  slots?: {
+    Footer?: ReactNode
+  }
 }>
 
 export const MobileListItem = <TData extends { id: string }>({
   item,
   onClickItem,
   children,
+  slots,
 }: MobileListItemProps<TData>) => {
   const onAction = useCallback(() => {
     onClickItem?.(item)
@@ -32,7 +36,14 @@ export const MobileListItem = <TData extends { id: string }>({
           {selectionMode !== 'none' && selectionBehavior === 'toggle' && (
             <Checkbox slot='selection' size='md' />
           )}
-          {children}
+          <div className='Layer__MobileListItem__Content'>
+            {children}
+          </div>
+          {slots?.Footer && (
+            <div className='Layer__MobileListItem__Footer'>
+              {slots.Footer}
+            </div>
+          )}
         </>
       ))}
     </GridListItem>

--- a/src/components/ui/MobileList/MobileListItem.tsx
+++ b/src/components/ui/MobileList/MobileListItem.tsx
@@ -9,16 +9,14 @@ import './mobileListItem.scss'
 type MobileListItemProps<TData> = PropsWithChildren<{
   item: TData
   onClickItem?: (item: TData) => void
-  slots?: {
-    Footer?: ReactNode
-  }
+  renderFooter?: (item: TData) => ReactNode
 }>
 
 export const MobileListItem = <TData extends { id: string }>({
   item,
   onClickItem,
   children,
-  slots,
+  renderFooter,
 }: MobileListItemProps<TData>) => {
   const onAction = useCallback(() => {
     onClickItem?.(item)
@@ -39,9 +37,9 @@ export const MobileListItem = <TData extends { id: string }>({
           <div className='Layer__MobileListItem__Content'>
             {children}
           </div>
-          {slots?.Footer && (
+          {renderFooter && (
             <div className='Layer__MobileListItem__Footer'>
-              {slots.Footer}
+              {renderFooter(item)}
             </div>
           )}
         </>

--- a/src/components/ui/MobileList/MobileListSection.tsx
+++ b/src/components/ui/MobileList/MobileListSection.tsx
@@ -9,6 +9,7 @@ type MobileListSectionProps<TData extends { id: string }> = {
   label: string
   items: ReadonlyArray<TData>
   renderItem: (item: TData) => React.ReactNode
+  renderFooter?: (item: TData) => React.ReactNode
   onClickItem?: (item: TData) => void
 }
 
@@ -16,6 +17,7 @@ export const MobileListSection = <TData extends { id: string }>({
   label,
   items,
   renderItem,
+  renderFooter,
   onClickItem,
 }: MobileListSectionProps<TData>) => (
   <GridListSection
@@ -30,6 +32,7 @@ export const MobileListSection = <TData extends { id: string }>({
         key={item.id}
         item={item}
         onClickItem={onClickItem}
+        slots={{ Footer: renderFooter?.(item) }}
       >
         {renderItem(item)}
       </MobileListItem>

--- a/src/components/ui/MobileList/MobileListSection.tsx
+++ b/src/components/ui/MobileList/MobileListSection.tsx
@@ -32,7 +32,7 @@ export const MobileListSection = <TData extends { id: string }>({
         key={item.id}
         item={item}
         onClickItem={onClickItem}
-        slots={{ Footer: renderFooter?.(item) }}
+        renderFooter={renderFooter}
       >
         {renderItem(item)}
       </MobileListItem>

--- a/src/components/ui/MobileList/mobileListItem.scss
+++ b/src/components/ui/MobileList/mobileListItem.scss
@@ -33,11 +33,11 @@
     border: none;
   }
 
-  &[data-variant='compact'] &__Content {
+  [data-variant='compact'] &__Content {
     padding-inline: 0;
   }
 
-  &[data-variant='compact'] &__Footer {
+  [data-variant='compact'] &__Footer {
     border-radius: 0;
   }
 }

--- a/src/components/ui/MobileList/mobileListItem.scss
+++ b/src/components/ui/MobileList/mobileListItem.scss
@@ -1,9 +1,11 @@
 .Layer__MobileListItem {
   display: grid;
-  grid-template-areas: 'content';
+  grid-template-areas:
+    'content'
+    'footer';
   grid-template-columns: 1fr;
+  overflow: hidden;
 
-  padding: var(--spacing-sm);
   border-radius: var(--border-radius-sm);
 
   border: 1px solid var(--border-color);
@@ -11,13 +13,31 @@
 
   &[data-selection-mode='multiple'],
   &[data-selection-mode='single'] {
-    grid-template-areas: 'selection content';
+    grid-template-areas:
+      'selection content'
+      'footer footer';
     grid-template-columns: auto 1fr;
   }
 
+  &__Content {
+    grid-area: content;
+    padding: var(--spacing-sm);
+  }
+
+  &__Footer {
+    grid-area: footer;
+  }
+
   [data-variant='compact'] & {
-    padding-inline: 0;
     border-radius: 0;
     border: none;
+  }
+
+  &[data-variant='compact'] &__Content {
+    padding-inline: 0;
+  }
+
+  &[data-variant='compact'] &__Footer {
+    border-radius: 0;
   }
 }

--- a/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
+++ b/src/components/ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.tsx
@@ -27,6 +27,7 @@ export type MobileSelectionDrawerWithTriggerProps<T extends ComboBoxOption> =
     slotProps?: {
       Trigger?: {
         icon?: ReactNode
+        value?: ReactNode | ((selectedValue: T | null) => ReactNode)
       }
     }
   }
@@ -74,6 +75,19 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
     return resolveSelectedOption(filteredOptionsOrGroups, selectedValue)
   }, [filteredOptionsOrGroups, selectedValue])
 
+  const triggerValue = useMemo(() => {
+    const value = slotProps?.Trigger?.value
+    if (!value) {
+      return resolvedSelectedValue?.label ?? resolvedPlaceholder
+    }
+
+    if (typeof value === 'function') {
+      return value(resolvedSelectedValue ?? null)
+    }
+
+    return value
+  }, [slotProps?.Trigger?.value, resolvedSelectedValue, resolvedPlaceholder])
+
   const Header = useCallback(() => (
     <ModalTitleWithClose
       heading={<ModalHeading size='md' weight='bold'>{heading}</ModalHeading>}
@@ -91,7 +105,7 @@ export const MobileSelectionDrawerWithTrigger = <T extends ComboBoxOption>({
           className='Layer__MobileSelectionDrawerWithTrigger__Trigger'
         >
           <Span size='sm' ellipsis pie='xs'>
-            {resolvedSelectedValue?.label ?? resolvedPlaceholder}
+            {triggerValue}
           </Span>
           {!isDisabled && triggerIcon}
         </HStack>

--- a/src/hooks/utils/debouncing/useDebouncedSearchQuery.ts
+++ b/src/hooks/utils/debouncing/useDebouncedSearchQuery.ts
@@ -6,6 +6,11 @@ type UseDebouncedSearchQueryOptions = {
   initialInputState: string | (() => string)
 }
 
+export interface SearchProps {
+  value: string
+  onChange: (value: string) => void
+}
+
 export function useDebouncedSearchInput({
   initialInputState,
 }: UseDebouncedSearchQueryOptions) {

--- a/src/providers/InvoicesRouteStore/InvoicesRouteStoreProvider.tsx
+++ b/src/providers/InvoicesRouteStore/InvoicesRouteStoreProvider.tsx
@@ -3,7 +3,7 @@ import { createStore, useStore } from 'zustand'
 
 import type { Invoice } from '@schemas/invoices/invoice'
 import { UpsertInvoiceMode } from '@hooks/api/businesses/[business-id]/invoices/useUpsertInvoice'
-import { ALL_OPTION, type InvoiceStatusOption } from '@components/Invoices/InvoiceTable/InvoiceTable'
+import { ALL_OPTION, type InvoiceStatusOption } from '@components/Invoices/utils/invoiceFilters'
 
 export type InvoiceTableFilters = {
   showSalesReceipts: boolean


### PR DESCRIPTION
Add a mobile card variant of the invoices table using the owner-view pattern: ResponsiveInvoiceView fetches once (useInvoicesList) and feeds presentational InvoiceTable (desktop) and InvoicesMobileList (mobile), swapping at the tablet breakpoint. Filter/search state lives in InvoicesRouteStore so it survives the breakpoint switch.

- Extract shared filtering to utils/invoiceFilters and the single fetch owner to utils/useInvoicesList
- Add a no-padding Footer slot to the MobileListItem primitive so the status footer bleeds to the card edges without negative-margin hacks
- Mobile status filter uses MobileSelectionDrawerWithTrigger (new Trigger.value slot) instead of a combobox
- Dedupe invoice status logic into utils/invoiceStatusComponents, shared by InvoiceStatusCell and the mobile status footer

<img width="441" height="553" alt="Screenshot 2026-06-10 at 5 58 21 PM" src="https://github.com/user-attachments/assets/c55c8546-2dbb-42ba-a229-5e8fb8e8f3b8" />

## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI composition and shared utilities; invoice API filter logic is moved, not changed in behavior, with filter state still in the route store.
> 
> **Overview**
> **Invoices overview** now renders `ResponsiveInvoiceView` instead of wiring the table directly, so list UI can switch between desktop and mobile at the tablet breakpoint.
> 
> `ResponsiveInvoiceView` owns a **single** invoice fetch via `useInvoicesList`, debounced search sync into `InvoicesRouteStore`, and shared empty/error slots. It passes the same data and handlers into presentational **`InvoiceTable`** (desktop) and new **`InvoicesMobileList`** (mobile cards with header search, drawer-based status filter, and per-row status footers).
> 
> **Refactors:** status filter enums/API mapping move to `utils/invoiceFilters`; invoice status copy/badges move to `utils/invoiceStatusComponents` (used by `InvoiceStatusCell` and the mobile footer). **`InvoiceTable`** no longer fetches—it only receives props (`data`, pagination, `searchProps`, `slots`, navigation callbacks).
> 
> **UI primitives:** `MobileList` / `MobileListItem` gain an optional **`renderFooter`** with grid layout so footers can span card edges; `MobileSelectionDrawerWithTrigger` adds a customizable **`Trigger.value`** for mobile status labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c209c5b7162d6c21c22764f2530e2bdb60255df4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->