### PR TITLE
feat: make invoice summary stats responsive

### DIFF
--- a/src/components/Invoices/InvoiceOverview/InvoiceOverview.tsx
+++ b/src/components/Invoices/InvoiceOverview/InvoiceOverview.tsx
@@ -3,11 +3,15 @@ import { InvoiceSummaryStats } from '@components/Invoices/InvoiceSummaryStats/In
 import { ResponsiveInvoiceView } from '@components/Invoices/InvoiceTable/ResponsiveInvoiceView'
 import { StripeConnectBanner } from '@components/Invoices/StripeConnectBanner/StripeConnectBanner'
 
+import './invoiceOverview.scss'
+
 export const InvoiceOverview = () => {
   return (
-    <VStack>
-      <InvoiceSummaryStats />
-      <StripeConnectBanner />
+    <VStack gap='md' className='Layer__InvoiceOverview'>
+      <VStack gap='md'>
+        <InvoiceSummaryStats />
+        <StripeConnectBanner />
+      </VStack>
       <ResponsiveInvoiceView />
     </VStack>
   )

--- a/src/components/Invoices/InvoiceOverview/invoiceOverview.scss
+++ b/src/components/Invoices/InvoiceOverview/invoiceOverview.scss
@@ -1,0 +1,4 @@
+.Layer__InvoiceOverview {
+  box-sizing: border-box;
+  width: clamp(20rem, 100%, 1406px);
+}

--- a/src/components/Invoices/InvoiceSummaryStats/InvoiceOwedSummary.tsx
+++ b/src/components/Invoices/InvoiceSummaryStats/InvoiceOwedSummary.tsx
@@ -1,0 +1,81 @@
+import { BigDecimal as BD } from 'effect'
+import { Trans, useTranslation } from 'react-i18next'
+
+import { convertBigIntCentsToBigDecimal, convertDecimalToPercent, formatBigDecimalToString, safeDivide } from '@utils/bigDecimalUtils'
+import { useInvoiceSummaryStats } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { Meter } from '@ui/Meter/Meter'
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+import { InvoiceOwedSummaryStatCard } from '@components/Invoices/InvoiceSummaryStats/InvoiceOwedSummaryStatCard'
+import { FallbackWithSkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
+
+import './invoiceOwedSummary.scss'
+
+const getPercentageOverdue = (sentTotal: bigint | undefined, overdueTotal: bigint | undefined): number => {
+  if (!sentTotal && !overdueTotal) return 50
+  if (!sentTotal) return 100
+  if (!overdueTotal) return 0
+
+  const totalAsBigDecimal = convertBigIntCentsToBigDecimal(sentTotal + overdueTotal)
+  const overdueTotalAsBigDecimal = convertBigIntCentsToBigDecimal(overdueTotal)
+
+  const decimalOverdue = safeDivide(overdueTotalAsBigDecimal, totalAsBigDecimal)
+  const percentOverdue = convertDecimalToPercent(decimalOverdue)
+
+  // This is safe because it will always be less than 100
+  return BD.unsafeToNumber(percentOverdue)
+}
+
+export const InvoiceOwedSummary = () => {
+  const { t } = useTranslation()
+  const formatter = useIntlFormatter()
+  const { data, isLoading, isError } = useInvoiceSummaryStats()
+
+  const showSkeleton = !data || isLoading || isError
+  const { overdueCount, overdueTotal, sentCount, sentTotal } = data?.invoices ?? {}
+
+  const invoicesTotal = (overdueTotal || BigInt(0)) + (sentTotal || BigInt(0))
+  const percentageOverdue = getPercentageOverdue(sentTotal, overdueTotal)
+
+  return (
+    <VStack className='Layer__InvoiceOwedSummary' gap='sm' fluid>
+      <HStack gap='md' align='end' justify='space-between'>
+        <HStack align='center' gap='3xs'>
+          <Trans
+            i18nKey='invoices:label.owed_last_12_months'
+            defaults='<owed>Owed to you</owed> <period>last 12 months</period>'
+            components={{
+              owed: <Span size='sm' pbe='3xs' />,
+              period: <Span size='sm' pbe='3xs' variant='subtle' />,
+            }}
+          />
+        </HStack>
+        <FallbackWithSkeletonLoader isLoading={showSkeleton} height='24px' width='120px'>
+          <Span size='xl' numeric='tabular-nums' noWrap>
+            {invoicesTotal !== undefined && formatBigDecimalToString(formatter, convertBigIntCentsToBigDecimal(invoicesTotal), { mode: 'currency' })}
+          </Span>
+        </FallbackWithSkeletonLoader>
+      </HStack>
+
+      <Meter label={t('invoices:label.percentage_invoices_overdue', 'Percentage of invoices overdue')} minValue={0} maxValue={100} value={percentageOverdue} meterOnly className='Layer__InvoiceSummaryStats__Meter' />
+
+      <div className='Layer__InvoiceOwedSummary__StatCards'>
+        <InvoiceOwedSummaryStatCard
+          variant='overdue'
+          label={t('invoices:label.overdue', 'Overdue')}
+          total={overdueTotal}
+          count={overdueCount}
+          showSkeleton={showSkeleton}
+        />
+        <InvoiceOwedSummaryStatCard
+          variant='upcoming'
+          label={t('invoices:label.upcoming', 'Upcoming')}
+          total={sentTotal}
+          count={sentCount}
+          showSkeleton={showSkeleton}
+        />
+      </div>
+    </VStack>
+  )
+}

--- a/src/components/Invoices/InvoiceSummaryStats/InvoiceOwedSummary.tsx
+++ b/src/components/Invoices/InvoiceSummaryStats/InvoiceOwedSummary.tsx
@@ -13,11 +13,12 @@ import { FallbackWithSkeletonLoader } from '@components/SkeletonLoader/SkeletonL
 import './invoiceOwedSummary.scss'
 
 const getPercentageOverdue = (sentTotal: bigint | undefined, overdueTotal: bigint | undefined): number => {
-  if (!sentTotal && !overdueTotal) return 50
-  if (!sentTotal) return 100
-  if (!overdueTotal) return 0
+  if (sentTotal === undefined || overdueTotal === undefined) return 50
 
-  const totalAsBigDecimal = convertBigIntCentsToBigDecimal(sentTotal + overdueTotal)
+  const total = sentTotal + overdueTotal
+  if (total === BigInt(0)) return 0
+
+  const totalAsBigDecimal = convertBigIntCentsToBigDecimal(total)
   const overdueTotalAsBigDecimal = convertBigIntCentsToBigDecimal(overdueTotal)
 
   const decimalOverdue = safeDivide(overdueTotalAsBigDecimal, totalAsBigDecimal)

--- a/src/components/Invoices/InvoiceSummaryStats/InvoiceOwedSummaryStatCard.tsx
+++ b/src/components/Invoices/InvoiceSummaryStats/InvoiceOwedSummaryStatCard.tsx
@@ -1,0 +1,46 @@
+import classNames from 'classnames'
+import { useTranslation } from 'react-i18next'
+
+import { convertBigIntCentsToBigDecimal, formatBigDecimalToString } from '@utils/bigDecimalUtils'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { HStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+import { FallbackWithSkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
+
+import './invoiceOwedSummaryStatCard.scss'
+
+interface InvoiceOwedSummaryStatCardProps {
+  variant: 'overdue' | 'upcoming'
+  label: string
+  total: bigint | undefined
+  count: number | undefined
+  showSkeleton: boolean
+}
+
+export const InvoiceOwedSummaryStatCard = ({ variant, label, total, count, showSkeleton }: InvoiceOwedSummaryStatCardProps) => {
+  const { t } = useTranslation()
+  const formatter = useIntlFormatter()
+
+  return (
+    <div className='Layer__InvoiceOwedSummary__StatCard'>
+      <HStack className='Layer__InvoiceOwedSummary__StatCard__Status' align='center' gap='2xs'>
+        <span className={classNames('Layer__InvoiceOwedSummary__StatCard__Dot', `Layer__InvoiceOwedSummary__StatCard__Dot--${variant}`)} aria-hidden='true' />
+        <Span size='sm'>{label}</Span>
+      </HStack>
+      <div className='Layer__InvoiceOwedSummary__StatCard__Count'>
+        <FallbackWithSkeletonLoader isLoading={showSkeleton} height='14px' width='60px'>
+          <Span size='sm' variant='subtle'>
+            {count !== undefined && t('invoices:label.invoices_count', '{{count}} invoices', { count })}
+          </Span>
+        </FallbackWithSkeletonLoader>
+      </div>
+      <div className='Layer__InvoiceOwedSummary__StatCard__Total'>
+        <FallbackWithSkeletonLoader isLoading={showSkeleton} height='20px' width='90px'>
+          <Span size='lg' numeric='tabular-nums' noWrap>
+            {total !== undefined && formatBigDecimalToString(formatter, convertBigIntCentsToBigDecimal(total), { mode: 'currency' })}
+          </Span>
+        </FallbackWithSkeletonLoader>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Invoices/InvoiceSummaryStats/InvoiceOwedSummaryStatCard.tsx
+++ b/src/components/Invoices/InvoiceSummaryStats/InvoiceOwedSummaryStatCard.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 
 import { convertBigIntCentsToBigDecimal, formatBigDecimalToString } from '@utils/bigDecimalUtils'
+import { tPlural } from '@utils/i18n/plural'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { HStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
@@ -30,7 +31,12 @@ export const InvoiceOwedSummaryStatCard = ({ variant, label, total, count, showS
       <div className='Layer__InvoiceOwedSummary__StatCard__Count'>
         <FallbackWithSkeletonLoader isLoading={showSkeleton} height='14px' width='60px'>
           <Span size='sm' variant='subtle'>
-            {count !== undefined && t('invoices:label.invoices_count', '{{count}} invoices', { count })}
+            {count !== undefined && tPlural(t, 'invoices:label.invoices_count', {
+              count,
+              displayCount: formatter.formatNumber(count),
+              one: '{{displayCount}} invoice',
+              other: '{{displayCount}} invoices',
+            })}
           </Span>
         </FallbackWithSkeletonLoader>
       </div>

--- a/src/components/Invoices/InvoiceSummaryStats/InvoicePaymentsSummary.tsx
+++ b/src/components/Invoices/InvoiceSummaryStats/InvoicePaymentsSummary.tsx
@@ -1,0 +1,43 @@
+import { Check } from 'lucide-react'
+import { Trans } from 'react-i18next'
+
+import { convertBigIntCentsToBigDecimal, formatBigDecimalToString } from '@utils/bigDecimalUtils'
+import { useInvoiceSummaryStats } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+import { Badge, BadgeSize, BadgeVariant } from '@components/Badge/Badge'
+import { FallbackWithSkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
+
+import './invoicePaymentsSummary.scss'
+
+export const InvoicePaymentsSummary = () => {
+  const formatter = useIntlFormatter()
+  const { data, isLoading, isError } = useInvoiceSummaryStats()
+
+  const showSkeleton = !data || isLoading || isError
+  const { sumTotal: invoicePaymentsTotal } = data?.invoicePayments ?? {}
+
+  return (
+    <VStack className='Layer__InvoiceSummaryStats__Payments' gap='3xs'>
+      <HStack align='center' gap='3xs'>
+        <Trans
+          i18nKey='invoices:label.paid_last_30_days'
+          defaults='<paid>Paid</paid> <period>last 30 days</period>'
+          components={{
+            paid: <Span size='sm' />,
+            period: <Span size='sm' variant='subtle' />,
+          }}
+        />
+      </HStack>
+      <HStack align='center' gap='xs'>
+        <Badge variant={BadgeVariant.SUCCESS} size={BadgeSize.EXTRA_SMALL} icon={<Check size={11} />} iconOnly />
+        <FallbackWithSkeletonLoader isLoading={showSkeleton} height='24px' width='120px'>
+          <Span size='xl' numeric='tabular-nums'>
+            {invoicePaymentsTotal !== undefined && formatBigDecimalToString(formatter, convertBigIntCentsToBigDecimal(invoicePaymentsTotal), { mode: 'currency' })}
+          </Span>
+        </FallbackWithSkeletonLoader>
+      </HStack>
+    </VStack>
+  )
+}

--- a/src/components/Invoices/InvoiceSummaryStats/InvoiceSummaryStats.tsx
+++ b/src/components/Invoices/InvoiceSummaryStats/InvoiceSummaryStats.tsx
@@ -1,118 +1,13 @@
-import { BigDecimal as BD } from 'effect'
-import { Check } from 'lucide-react'
-import { Trans, useTranslation } from 'react-i18next'
-
-import { convertBigIntCentsToBigDecimal, convertDecimalToPercent, formatBigDecimalToString, safeDivide } from '@utils/bigDecimalUtils'
-import { useInvoiceSummaryStats } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
-import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
-import { Meter } from '@ui/Meter/Meter'
-import { HStack, VStack } from '@ui/Stack/Stack'
-import { Span } from '@ui/Typography/Text'
-import { Badge, BadgeSize, BadgeVariant } from '@components/Badge/Badge'
-import { BadgeLoader } from '@components/BadgeLoader/BadgeLoader'
-import { FallbackWithSkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
+import { InvoiceOwedSummary } from '@components/Invoices/InvoiceSummaryStats/InvoiceOwedSummary'
+import { InvoicePaymentsSummary } from '@components/Invoices/InvoiceSummaryStats/InvoicePaymentsSummary'
 
 import './invoiceSummaryStats.scss'
 
-const getPercentageOverdue = (sentTotal: bigint | undefined, overdueTotal: bigint | undefined): number => {
-  if (!sentTotal && !overdueTotal) return 50
-  if (!sentTotal) return 100
-  if (!overdueTotal) return 0
-
-  const totalAsBigDecimal = convertBigIntCentsToBigDecimal(sentTotal + overdueTotal)
-  const overdueTotalAsBigDecimal = convertBigIntCentsToBigDecimal(overdueTotal)
-
-  const decimalOverdue = safeDivide(overdueTotalAsBigDecimal, totalAsBigDecimal)
-  const percentOverdue = convertDecimalToPercent(decimalOverdue)
-
-  // This is safe because it will always be less than 100
-  return BD.unsafeToNumber(percentOverdue)
-}
-
 export const InvoiceSummaryStats = () => {
-  const { t } = useTranslation()
-  const formatter = useIntlFormatter()
-  const { data, isLoading, isError } = useInvoiceSummaryStats()
-
-  const showSkeleton = !data || isLoading || isError
-  const { sumTotal: invoicePaymentsTotal } = data?.invoicePayments ?? {}
-  const { overdueCount, overdueTotal, sentCount, sentTotal } = data?.invoices ?? {}
-
-  const invoicesTotal = (overdueTotal || BigInt(0)) + (sentTotal || BigInt(0))
-  const percentageOverdue = getPercentageOverdue(sentTotal, overdueTotal)
-
   return (
-    <HStack className='Layer__InvoiceSummaryStats__Container' gap='lg'>
-      <VStack className='Layer__InvoiceSummaryStats__Payments' gap='3xs'>
-        <HStack align='center' gap='3xs'>
-          <Trans
-            i18nKey='invoices:label.paid_last_30_days'
-            defaults='<paid>Paid</paid> <period>last 30 days</period>'
-            components={{
-              paid: <Span size='sm' />,
-              period: <Span size='sm' variant='subtle' />,
-            }}
-          />
-        </HStack>
-        <HStack align='center' gap='xs'>
-          <Badge variant={BadgeVariant.SUCCESS} size={BadgeSize.EXTRA_SMALL} icon={<Check size={11} />} iconOnly />
-          <FallbackWithSkeletonLoader isLoading={showSkeleton} height='24px' width='120px'>
-            <Span size='xl'>
-              {invoicePaymentsTotal !== undefined && formatBigDecimalToString(formatter, convertBigIntCentsToBigDecimal(invoicePaymentsTotal), { mode: 'currency' })}
-            </Span>
-          </FallbackWithSkeletonLoader>
-        </HStack>
-      </VStack>
-      <VStack gap='sm' fluid>
-        <HStack gap='md' align='end'>
-          <HStack align='center' gap='3xs'>
-            <Trans
-              i18nKey='invoices:label.owed_last_12_months'
-              defaults='<owed>Owed to you</owed> <period>last 12 months</period>'
-              components={{
-                owed: <Span size='sm' pbe='3xs' />,
-                period: <Span size='sm' pbe='3xs' variant='subtle' />,
-              }}
-            />
-          </HStack>
-          <FallbackWithSkeletonLoader isLoading={showSkeleton} height='24px' width='120px'>
-            <Span size='xl'>
-              {invoicesTotal !== undefined && formatBigDecimalToString(formatter, convertBigIntCentsToBigDecimal(invoicesTotal), { mode: 'currency' })}
-            </Span>
-          </FallbackWithSkeletonLoader>
-        </HStack>
-        <HStack justify='space-between'>
-          <HStack gap='xs' align='center'>
-            <FallbackWithSkeletonLoader isLoading={showSkeleton} height='17px' width='80px'>
-              <Span size='md'>
-                {overdueTotal !== undefined && formatBigDecimalToString(formatter, convertBigIntCentsToBigDecimal(overdueTotal), { mode: 'currency' })}
-              </Span>
-            </FallbackWithSkeletonLoader>
-            {!showSkeleton && overdueCount !== undefined
-              ? (
-                <Badge variant={BadgeVariant.WARNING} size={BadgeSize.SMALL}>
-                  {t('invoices:label.overdue_invoices_count', 'Overdue invoices: {{overdueCount}}', { overdueCount: formatter.formatNumber(overdueCount) })}
-                </Badge>
-              )
-              : <BadgeLoader variant={BadgeVariant.WARNING} showLoading />}
-          </HStack>
-          <HStack gap='xs' align='center'>
-            {!showSkeleton && sentCount !== undefined
-              ? (
-                <Badge variant={BadgeVariant.INFO} size={BadgeSize.SMALL}>
-                  {t('invoices:label.upcoming_invoices_sent_count', 'Upcoming invoices: {{sentCount}}', { sentCount: formatter.formatNumber(sentCount) })}
-                </Badge>
-              )
-              : <BadgeLoader variant={BadgeVariant.INFO} showLoading />}
-            <FallbackWithSkeletonLoader isLoading={showSkeleton} height='17px' width='80px'>
-              <Span size='md'>
-                {sentTotal !== undefined && formatBigDecimalToString(formatter, convertBigIntCentsToBigDecimal(sentTotal), { mode: 'currency' })}
-              </Span>
-            </FallbackWithSkeletonLoader>
-          </HStack>
-        </HStack>
-        <Meter label={t('invoices:label.percentage_invoices_overdue', 'Percentage of invoices overdue')} minValue={0} maxValue={100} value={percentageOverdue} meterOnly className='Layer__InvoiceSummaryStats__Meter' />
-      </VStack>
-    </HStack>
+    <div className='Layer__InvoiceSummaryStats__Container'>
+      <InvoicePaymentsSummary />
+      <InvoiceOwedSummary />
+    </div>
   )
 }

--- a/src/components/Invoices/InvoiceSummaryStats/invoiceOwedSummary.scss
+++ b/src/components/Invoices/InvoiceSummaryStats/invoiceOwedSummary.scss
@@ -1,0 +1,17 @@
+.Layer__InvoiceSummaryStats__Meter {
+  &__track {
+    fill: var(--color-info-bg);
+  }
+
+  &__fill {
+    fill: var(--color-info-warning-bg);
+  }
+}
+
+.Layer__InvoiceOwedSummary {
+  &__StatCards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--spacing-xs);
+  }
+}

--- a/src/components/Invoices/InvoiceSummaryStats/invoiceOwedSummaryStatCard.scss
+++ b/src/components/Invoices/InvoiceSummaryStats/invoiceOwedSummaryStatCard.scss
@@ -1,0 +1,68 @@
+.Layer__InvoiceOwedSummary__StatCard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xs);
+
+  min-width: 0;
+  padding: var(--spacing-sm);
+  border-radius: var(--border-radius-xs);
+  border: 1px solid var(--color-base-200);
+  background: var(--color-base-0);
+
+  &__Status { order: 1; }
+  &__Total { order: 2; }
+  &__Count { order: 3; }
+
+  &__Dot {
+    flex-shrink: 0;
+    height: 8px;
+    width: 8px;
+    border-radius: 50%;
+
+    &--overdue {
+      background: var(--color-info-warning);
+    }
+
+    &--upcoming {
+      background: var(--color-info);
+    }
+  }
+
+  &__Total .Layer__Span {
+    line-height: 1;
+  }
+
+  @media (width >= 500px) {
+    flex-flow: row wrap;
+    row-gap: var(--spacing-2xs);
+    column-gap: var(--spacing-2xs);
+    align-items: baseline;
+
+    .Layer__InvoiceOwedSummary__StatCard__Status { order: 1; }
+    .Layer__InvoiceOwedSummary__StatCard__Count { order: 2; }
+
+    .Layer__InvoiceOwedSummary__StatCard__Total {
+      order: 3;
+      flex-basis: 100%;
+    }
+
+    .Layer__InvoiceOwedSummary__StatCard__Count::before {
+      content: '·';
+      display: inline-block;
+      padding-inline-end: var(--spacing-2xs);
+      font-size: var(--text-sm);
+      line-height: 1;
+      color: var(--fg-subtle);
+      vertical-align: middle;
+    }
+  }
+
+  @media (width >= 1200px) {
+    flex-wrap: nowrap;
+
+    .Layer__InvoiceOwedSummary__StatCard__Total {
+      flex-basis: auto;
+      margin-inline-start: auto;
+    }
+  }
+}

--- a/src/components/Invoices/InvoiceSummaryStats/invoiceOwedSummaryStatCard.scss
+++ b/src/components/Invoices/InvoiceSummaryStats/invoiceOwedSummaryStatCard.scss
@@ -32,6 +32,12 @@
     line-height: 1;
   }
 
+  &__Count .Layer__skeleton-loader,
+  &__Total .Layer__skeleton-loader {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
   @media (width >= 500px) {
     flex-flow: row wrap;
     row-gap: var(--spacing-2xs);

--- a/src/components/Invoices/InvoiceSummaryStats/invoicePaymentsSummary.scss
+++ b/src/components/Invoices/InvoiceSummaryStats/invoicePaymentsSummary.scss
@@ -1,0 +1,12 @@
+.Layer__InvoiceSummaryStats__Payments {
+  box-sizing: border-box;
+
+  justify-content: center;
+
+  min-width: 12rem;
+  padding: var(--spacing-md) var(--spacing-lg);
+
+  border-radius: var(--border-radius-xs);
+  border: 1px solid var(--border-color);
+  background-color: var(--color-base-0);
+}

--- a/src/components/Invoices/InvoiceSummaryStats/invoiceSummaryStats.scss
+++ b/src/components/Invoices/InvoiceSummaryStats/invoiceSummaryStats.scss
@@ -1,26 +1,10 @@
 .Layer__InvoiceSummaryStats__Container {
-  box-sizing: border-box;
-  width: clamp(48rem, 100%, 1406px);
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-lg);
 
-  padding: var(--spacing-md) var(--spacing-lg);
-}
-
-.Layer__InvoiceSummaryStats__Payments {
-  box-sizing: border-box;
-
-  min-width: 12rem;
-  padding: var(--spacing-md) var(--spacing-lg);
-
-  border-radius: var(--border-radius-2xs);
-  border: 1px solid var(--border-color);
-}
-
-.Layer__InvoiceSummaryStats__Meter {
-  &__track {
-    fill: var(--color-info-bg);
-  }
-
-  &__fill {
-    fill: var(--color-info-warning-bg);
+  @media (width <= 720px) {
+    flex-direction: column;
+    gap: var(--spacing-md);
   }
 }

--- a/src/components/Invoices/InvoiceSummaryStats/invoiceSummaryStats.scss
+++ b/src/components/Invoices/InvoiceSummaryStats/invoiceSummaryStats.scss
@@ -3,7 +3,7 @@
   flex-direction: row;
   gap: var(--spacing-lg);
 
-  @media (width <= 720px) {
+  @media (width < 760px) {
     flex-direction: column;
     gap: var(--spacing-md);
   }

--- a/src/components/Invoices/StripeConnectBanner/StripeConnectBanner.tsx
+++ b/src/components/Invoices/StripeConnectBanner/StripeConnectBanner.tsx
@@ -5,11 +5,8 @@ import { StripeAccountStatus } from '@schemas/stripeAccountStatus'
 import { useStripeAccountStatus } from '@hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { Banner, type BannerVariant } from '@ui/Banner/Banner'
-import { VStack } from '@ui/Stack/Stack'
 import { ConnectStripeButton } from '@components/Invoices/StripeConnectBanner/ConnectStripeButton'
 import { useStripeConnect } from '@components/Invoices/StripeConnectBanner/useStripeConnect'
-
-import '@components/Invoices/StripeConnectBanner/stripeConnectBanner.scss'
 
 export const StripeConnectBanner = () => {
   const { t } = useTranslation()
@@ -62,21 +59,19 @@ export const StripeConnectBanner = () => {
   const showButton = status === StripeAccountStatus.NotCreated || status === StripeAccountStatus.Incomplete
 
   return (
-    <VStack pi='lg' pbe='md' className='Layer__StripeConnectBanner__wrapper'>
-      <Banner
-        {...bannerConfig}
-        slots={showButton
-          ? {
-            Button: (
-              <ConnectStripeButton
-                isError={isStripeConnectError}
-                isMutating={isMutating}
-                onClick={() => void handleConnectStripe()}
-              />
-            ),
-          }
-          : undefined}
-      />
-    </VStack>
+    <Banner
+      {...bannerConfig}
+      slots={showButton
+        ? {
+          Button: (
+            <ConnectStripeButton
+              isError={isStripeConnectError}
+              isMutating={isMutating}
+              onClick={() => void handleConnectStripe()}
+            />
+          ),
+        }
+        : undefined}
+    />
   )
 }

--- a/src/components/Invoices/StripeConnectBanner/stripeConnectBanner.scss
+++ b/src/components/Invoices/StripeConnectBanner/stripeConnectBanner.scss
@@ -1,5 +1,0 @@
-.Layer__StripeConnectBanner__wrapper {
-  box-sizing: border-box;
-  width: clamp(48rem, 100%, 1406px);
-  container-type: inline-size;
-}


### PR DESCRIPTION
## Summary
<img width="573" height="377" alt="Screenshot 2026-06-11 at 1 11 59 AM" src="https://github.com/user-attachments/assets/7cb65f58-6fa2-47d4-a60b-2577b553f97c" />

Makes the contents of `InvoiceSummaryStats` mobile-compatible, on the same breakpoint family as the invoices mobile list vs. table.

- Split `InvoiceSummaryStats` into `InvoicePaymentsSummary` and `InvoiceOwedSummary`, plus an `InvoiceOwedSummaryStatCard` subcomponent — each with its own SCSS. Each child reads `useInvoiceSummaryStats` directly (shared SWR cache key, so it's deduped to one request).
- The owed stat cards adapt across breakpoints:
  - **< 500px** — stacked (status, total, count)
  - **500–1200px** — invoice count inlined next to the status, total below
  - **> 1200px** — fully inline (`Overdue · 35 invoices`) with the total right-aligned and no separator
- Vertically center the payments summary content within its container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor and styling; summary data still comes from the same hook/SWR cache with minor overdue-percent edge-case handling.
> 
> **Overview**
> Makes the invoice overview and summary stats **responsive** and refactors the owed breakdown into dedicated stat cards.
> 
> **`InvoiceSummaryStats`** is split into **`InvoicePaymentsSummary`** and **`InvoiceOwedSummary`** (each still uses `useInvoiceSummaryStats`). The container stacks **paid** and **owed** vertically below **760px**; the payments block gets bordered card styling and vertical centering. **Owed** keeps the 12‑month total and overdue meter but replaces the old inline badges/amounts with a **two-column grid** of **`InvoiceOwedSummaryStatCard`** components (overdue vs upcoming), with **breakpoint-specific** layouts (stacked &lt; 500px, status + count inline at 500–1200px, full row with right-aligned total at ≥ 1200px). **`getPercentageOverdue`** now treats missing totals as **50%** (loading default) and **0%** when both sums are zero.
> 
> **`InvoiceOverview`** adds a **`Layer__InvoiceOverview`** width clamp (**20rem–1406px**), groups summary stats with the Stripe banner, and drops per-section width wrappers. **`StripeConnectBanner`** renders the banner directly (no wrapper SCSS).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec211d884daa3154d8d85f2979071db14a9f9fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->