### PR TITLE
migration: heading pt. 2

### DIFF
--- a/src/components/BankTransactions/BankTransactionsHeader.tsx
+++ b/src/components/BankTransactions/BankTransactionsHeader.tsx
@@ -176,7 +176,7 @@ export const BankTransactionsHeader = ({
   const headerTopRow = useMemo(() => (
     <div className='Layer__bank-transactions__header__content'>
       <HStack align='center'>
-        <Heading level={2} size='sm'>
+        <Heading level={3} size='sm'>
           {stringOverrides?.header || t('common:label.transactions', 'Transactions')}
         </Heading>
         {isSyncing && (

--- a/src/components/ChartOfAccountsForm/ChartOfAccountsForm.tsx
+++ b/src/components/ChartOfAccountsForm/ChartOfAccountsForm.tsx
@@ -99,7 +99,7 @@ const ChartOfAccountsFormContent = (props: ChartOfAccountsFormContentProps) => {
   return (
     <Form className='Layer__ChartOfAccountsForm' onSubmit={blockNativeOnSubmit}>
       <HStack className='Layer__ChartOfAccountsForm__Header' justify='space-between' align='center' gap='md'>
-        <Heading level={2} size='sm'>
+        <Heading level={3} size='sm'>
           {isEdit
             ? stringOverrides?.editModeHeader || t('chartOfAccounts:action.edit_account', 'Edit Account')
             : stringOverrides?.createModeHeader || t('chartOfAccounts:action.add_new_account', 'Add New Account')}

--- a/src/components/ChartOfAccountsTable/ChartOfAccountsTableHeader.tsx
+++ b/src/components/ChartOfAccountsTable/ChartOfAccountsTableHeader.tsx
@@ -45,7 +45,7 @@ export const ChartOfAccountsTableHeader = ({
       <Header asHeader rounded>
         <HeaderRow>
           <HeaderCol>
-            <Heading level={2} size={asWidget ? 'md' : 'lg'}>
+            <Heading level={asWidget ? 3 : 2} size={asWidget ? 'md' : 'lg'}>
               {stringOverrides?.headerText || t('chartOfAccounts:label.chart_of_accounts', 'Chart of Accounts')}
             </Heading>
           </HeaderCol>
@@ -54,16 +54,12 @@ export const ChartOfAccountsTableHeader = ({
       <Header sticky>
         <HeaderRow>
           <HeaderCol>
-            <Heading level={2} size='sm'>
-              {withDateControl || withExpandAllButton
-                ? (
-                  <HStack align='center' gap='xs'>
-                    {withDateControl && <GlobalMonthPicker />}
-                    {withExpandAllButton && <ExpandableDataTableToggleButton />}
-                  </HStack>
-                )
-                : null}
-            </Heading>
+            {(withDateControl || withExpandAllButton) && (
+              <HStack align='center' gap='xs'>
+                {withDateControl && <GlobalMonthPicker />}
+                {withExpandAllButton && <ExpandableDataTableToggleButton />}
+              </HStack>
+            )}
           </HeaderCol>
           <HeaderCol className='Layer__chart-of-accounts__actions'>
             <SearchField

--- a/src/components/Integrations/Integrations.tsx
+++ b/src/components/Integrations/Integrations.tsx
@@ -37,7 +37,7 @@ export const IntegrationsComponent = ({
   return (
     <Container name={COMPONENT_NAME}>
       <Header className='Layer__linked-accounts__header'>
-        <Heading level={2} size='sm'>
+        <Heading level={3} size='sm'>
           {stringOverrides?.title || t('integrations:label.integrations', 'Integrations')}
         </Heading>
         <IntegrationsConnectMenu />

--- a/src/components/JournalTable/JournalTableWithPanel.tsx
+++ b/src/components/JournalTable/JournalTableWithPanel.tsx
@@ -68,7 +68,7 @@ export const JournalTableWithPanel = ({
       <Header>
         <HeaderRow>
           <HeaderCol>
-            <Heading level={2} size='sm'>
+            <Heading level={3} size='sm'>
               {stringOverrides?.componentSubtitle || t('generalLedger:label.entries', 'Entries')}
             </Heading>
           </HeaderCol>

--- a/src/components/LinkedAccounts/BasicLinkedAccount/BasicLinkedAccount.tsx
+++ b/src/components/LinkedAccounts/BasicLinkedAccount/BasicLinkedAccount.tsx
@@ -61,7 +61,7 @@ export function BasicLinkedAccountContent({ account }: BasicLinkedAccountContain
     <HStack gap='md'>
       <BasicLinkedAccountLogo account={account} />
       <VStack>
-        <Heading level={3} size='xs' pbe='3xs'>{account.externalAccountName}</Heading>
+        <Heading level={4} size='xs' pbe='3xs'>{account.externalAccountName}</Heading>
         <HStack gap='xs'>
           <P size='sm'>
             {account.institution?.name}

--- a/src/components/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/components/LinkedAccounts/LinkedAccounts.tsx
@@ -59,7 +59,7 @@ export const LinkedAccountsComponent = ({
   return (
     <Container name={COMPONENT_NAME} elevated={elevated}>
       <Header className='Layer__linked-accounts__header'>
-        <Heading level={2} size='sm'>
+        <Heading level={3} size='sm'>
           {stringOverrides?.title || t('linkedAccounts:label.linked_accounts', 'Linked Accounts')}
         </Heading>
       </Header>

--- a/src/components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedChartsHeader.tsx
+++ b/src/components/ProfitAndLossDetailedCharts/ProfitAndLossDetailedChartsHeader.tsx
@@ -6,6 +6,7 @@ import { DateFormat } from '@utils/i18n/date/patterns'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { Button } from '@ui/Button/Button'
 import { VStack } from '@ui/Stack/Stack'
+import { Heading } from '@ui/Typography/Heading'
 import { Span } from '@ui/Typography/Text'
 import { BackButton } from '@components/Button/BackButton'
 import { GlobalMonthPicker } from '@components/GlobalMonthPicker/GlobalMonthPicker'
@@ -21,9 +22,9 @@ type HeaderTitleProps = {
 
 const HeaderTitle = ({ title, dateLabel, isTablet, showDatePicker }: HeaderTitleProps) => (
   <VStack className='Layer__ProfitAndLossDetailedChartsHeader__head'>
-    <Span size='lg' weight='bold'>
+    <Heading level={3} size='sm'>
       {title}
-    </Span>
+    </Heading>
     <Span
       size='sm'
       variant={isTablet ? undefined : 'subtle'}

--- a/src/components/ProfitAndLossHeader/ProfitAndLossHeader.tsx
+++ b/src/components/ProfitAndLossHeader/ProfitAndLossHeader.tsx
@@ -62,7 +62,7 @@ export const ProfitAndLossHeader = ({
   return (
     <Header className={className}>
       <span className='Layer__component-header__title-wrapper Layer__profit-and-loss__header'>
-        <Heading level={2} size='sm' align='left'>
+        <Heading level={3} size='sm' align='left'>
           {stringOverrides?.title || text || t('common:label.profit_loss', 'Profit & Loss')}
         </Heading>
         {isSyncing && <SyncingBadge />}

--- a/src/components/Tasks/TasksPending.tsx
+++ b/src/components/Tasks/TasksPending.tsx
@@ -48,7 +48,7 @@ export const TasksPending = () => {
   return (
     <div className='Layer__tasks-pending'>
       <div className='Layer__tasks-pending-header'>
-        <Heading level={2} size='sm'>
+        <Heading level={3} size='sm'>
           {formatDate(date, DateFormat.MonthYear)}
         </Heading>
         {activePeriod?.tasks && activePeriod.tasks.length > 0

--- a/src/components/UnifiedReports/UnifiedReportBaseHeader.tsx
+++ b/src/components/UnifiedReports/UnifiedReportBaseHeader.tsx
@@ -3,7 +3,7 @@ import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { useBaseUnifiedReport } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { type DefaultVariant, ResponsiveComponent } from '@ui/ResponsiveComponent/ResponsiveComponent'
 import { HStack, VStack } from '@ui/Stack/Stack'
-import { Span } from '@ui/Typography/Text'
+import { Heading } from '@ui/Typography/Heading'
 import { ReportsMegaMenu } from '@components/ReportsNavigation/ReportsMegaMenu'
 import { SkeletonLoader } from '@components/SkeletonLoader/SkeletonLoader'
 import { UnifiedReportControls } from '@components/UnifiedReports/UnifiedReportControls'
@@ -37,7 +37,7 @@ const UnifiedReportBaseHeaderRow = (props: UnifiedReportBaseHeaderRowProps) => {
       {!isMobile && (
         <HStack align='center' gap='lg'>
           {baseReport
-            ? <Span size='lg' weight='bold'>{baseReport.displayName}</Span>
+            ? <Heading level={3} size='sm'>{baseReport.displayName}</Heading>
             : <SkeletonLoader width='192px' height='24px' />}
           {props.navigationVariant === 'menu' && <ReportsMegaMenu />}
         </HStack>

--- a/src/components/ui/Typography/heading.scss
+++ b/src/components/ui/Typography/heading.scss
@@ -8,7 +8,7 @@
   font-weight: var(--font-weight-bold);
 
   text-wrap: pretty;
-  color: var(--color-base-900);
+  color: var(--text-color-primary);
 
   &[data-variant='subtle'] {
     color: var(--fg-subtle);


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only typography and heading semantics; no data, auth, or business logic changes.
> 
> **Overview**
> Continues the **Heading** migration by adjusting semantic `level` values and replacing a few bold text headers with `Heading`.
> 
> Most feature section titles (Transactions, Chart of Accounts form, Integrations, Linked Accounts, P&amp;L, Tasks, Journal “Entries”, etc.) move from **`level={2}` to `level={3}`** so nested page structure uses a shallower heading rank. Chart of Accounts keeps the main title at **`level={2}`** in full view but uses **`level={3}`** in widget mode; the sticky toolbar row no longer wraps month picker / expand controls in an empty `Heading`. Linked account row titles drop from **`level={3}` to `level={4}`**.
> 
> **Profit &amp; Loss detailed charts** and **unified report** headers switch from `Span` (bold/large) to **`Heading level={3} size='sm'`**. Base **`Heading`** styles now use **`--text-color-primary`** instead of **`--color-base-900`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd1e3b3b819fa5bd6b780807442768ca4c17eca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->