### PR TITLE
feat: extract shared DataStateContainer component

### DIFF
--- a/src/components/BankTransactions/BankTransactionsTableEmptyState.tsx
+++ b/src/components/BankTransactions/BankTransactionsTableEmptyState.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { Inbox, SearchX } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -6,6 +6,7 @@ import { DisplayState } from '@internal-types/bankTransactions'
 import { useBankTransactionsContext } from '@contexts/BankTransactionsContext/BankTransactionsContext'
 import { useBankTransactionsFiltersContext } from '@contexts/BankTransactionsFiltersContext/BankTransactionsFiltersContext'
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
+import { DataStateContainer } from '@components/DataStateContainer/DataStateContainer'
 
 type BankTransactionsTableEmptyStatesProps = {
   isEmpty: boolean
@@ -14,12 +15,6 @@ type BankTransactionsTableEmptyStatesProps = {
     List: ReactNode
   }
 }
-
-const DataStateContainer = ({ children }: PropsWithChildren) => (
-  <div className='Layer__table-state-container'>
-    {children}
-  </div>
-)
 
 export const BankTransactionsTableEmptyState = () => {
   const { t } = useTranslation()

--- a/src/components/DataStateContainer/DataStateContainer.tsx
+++ b/src/components/DataStateContainer/DataStateContainer.tsx
@@ -1,9 +1,17 @@
 import { type PropsWithChildren } from 'react'
 
+import { VStack } from '@ui/Stack/Stack'
+
 import './dataStateContainer.scss'
 
 export const DataStateContainer = ({ children }: PropsWithChildren) => (
-  <div className='Layer__DataStateContainer'>
+  <VStack
+    className='Layer__DataStateContainer'
+    align='center'
+    justify='center'
+    pb='2xl'
+    pi='sm'
+  >
     {children}
-  </div>
+  </VStack>
 )

--- a/src/components/DataStateContainer/DataStateContainer.tsx
+++ b/src/components/DataStateContainer/DataStateContainer.tsx
@@ -1,0 +1,9 @@
+import { type PropsWithChildren } from 'react'
+
+import './dataStateContainer.scss'
+
+export const DataStateContainer = ({ children }: PropsWithChildren) => (
+  <div className='Layer__DataStateContainer'>
+    {children}
+  </div>
+)

--- a/src/components/DataStateContainer/dataStateContainer.scss
+++ b/src/components/DataStateContainer/dataStateContainer.scss
@@ -1,12 +1,7 @@
 .Layer__DataStateContainer {
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   height: calc(100vh - 200px);
   width: 100%;
-  padding: var(--spacing-2xl) var(--spacing-sm);
 }
 
 .Layer__component--as-widget .Layer__DataStateContainer {

--- a/src/components/DataStateContainer/dataStateContainer.scss
+++ b/src/components/DataStateContainer/dataStateContainer.scss
@@ -1,0 +1,14 @@
+.Layer__DataStateContainer {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - 200px);
+  width: 100%;
+  padding: var(--spacing-2xl) var(--spacing-sm);
+}
+
+.Layer__component--as-widget .Layer__DataStateContainer {
+  height: calc(100% - 160px);
+}

--- a/src/components/ProfitAndLossView/ProfitAndLossView.tsx
+++ b/src/components/ProfitAndLossView/ProfitAndLossView.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { ProfitAndLossContext } from '@contexts/ProfitAndLossContext/ProfitAndLossContext'
 import { Container } from '@components/Container/Container'
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
+import { DataStateContainer } from '@components/DataStateContainer/DataStateContainer'
 import { GlobalMonthPicker } from '@components/GlobalMonthPicker/GlobalMonthPicker'
 import { Panel } from '@components/Panel/Panel'
 import { ProfitAndLoss } from '@components/ProfitAndLoss/ProfitAndLoss'
@@ -81,7 +82,7 @@ const Components = ({
 
   if (!isLoading && isError) {
     return (
-      <div className='Layer__table-state-container'>
+      <DataStateContainer>
         <DataState
           status={DataStateStatus.failed}
           title={t('common:error.something_went_wrong', 'Something went wrong')}
@@ -89,7 +90,7 @@ const Components = ({
           onRefresh={() => refetch()}
           isLoading={isValidating}
         />
-      </div>
+      </DataStateContainer>
     )
   }
 

--- a/src/components/ReportsTableState/ReportsTableErrorState.tsx
+++ b/src/components/ReportsTableState/ReportsTableErrorState.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 
 import { DataState, DataStateStatus } from '@components/DataState/DataState'
+import { DataStateContainer } from '@components/DataStateContainer/DataStateContainer'
 
 type ReportsTableErrorStateProps = {
   isLoading?: boolean
@@ -11,13 +12,13 @@ export const ReportsTableErrorState = ({
 }: ReportsTableErrorStateProps) => {
   const { t } = useTranslation()
   return (
-    <div className='Layer__table-state-container'>
+    <DataStateContainer>
       <DataState
         status={DataStateStatus.failed}
         title={t('common:error.something_went_wrong', 'Something went wrong')}
         description={t('common:error.couldnt_load_data', 'We couldn\'t load your data.')}
         isLoading={isLoading}
       />
-    </div>
+    </DataStateContainer>
   )
 }

--- a/src/styles/component.scss
+++ b/src/styles/component.scss
@@ -74,18 +74,3 @@
     margin-bottom: 0;
   }
 }
-
-.Layer__table-state-container {
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: calc(100vh - 200px);
-  width: 100%;
-  padding: var(--spacing-2xl) var(--spacing-sm);
-}
-
-.Layer__component--as-widget .Layer__table-state-container {
-  height: calc(100% - 160px);
-}


### PR DESCRIPTION
## Summary
- Replace the three `Layer__table-state-container` usages (`ReportsTableErrorState`, `ProfitAndLossView`, `BankTransactionsTableEmptyState`) with a single shared `DataStateContainer` component
- Colocate its styles with the component instead of the global `component.scss`, renaming the class to `Layer__DataStateContainer` (PascalCase BEM)
- Express the flex layout and padding via `VStack` props; only the height/width sizing remains in scss

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor with equivalent sizing rules; low risk aside from minor visual differences if VStack spacing does not match the old flex padding exactly.
> 
> **Overview**
> Introduces a shared **`DataStateContainer`** wrapper for centered empty/error **`DataState`** views and swaps it in for the old **`Layer__table-state-container`** markup in bank transactions empty/error states, profit & loss load errors, and reports table errors.
> 
> Layout centering and padding now come from **`VStack`** props; height/width (including widget mode) live in colocated **`dataStateContainer.scss`** under **`Layer__DataStateContainer`**. The duplicate global rules are removed from **`component.scss`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3856f23e6ac83c45a92c60853add07f573e84b54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->