### PR TITLE
chore: align @ui/Button variant APIs with base Button and migrate callsites

### DIFF
--- a/src/components/BalanceSheet/BalanceSheet.tsx
+++ b/src/components/BalanceSheet/BalanceSheet.tsx
@@ -120,7 +120,7 @@ const BalanceSheetView = ({
                     {isMobileView && <ReportsMobileSelectionTrigger />}
                     <BalanceSheetDownloadButton
                       effectiveDate={effectiveDate}
-                      iconOnly={isMobileView}
+                      icon={isMobileView}
                     />
                   </HStack>
                 </Stack>

--- a/src/components/BalanceSheet/download/BalanceSheetDownloadButton.tsx
+++ b/src/components/BalanceSheet/download/BalanceSheetDownloadButton.tsx
@@ -4,12 +4,12 @@ import InvisibleDownload, { useInvisibleDownload } from '@components/utility/Inv
 
 type BalanceSheetDownloadButtonProps = {
   effectiveDate: Date
-  iconOnly?: boolean
+  icon?: boolean
 }
 
 export function BalanceSheetDownloadButton({
   effectiveDate,
-  iconOnly,
+  icon,
 }: BalanceSheetDownloadButtonProps) {
   const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -21,9 +21,9 @@ export function BalanceSheetDownloadButton({
   return (
     <>
       <DownloadButton
-        iconOnly={iconOnly}
-        onClick={() => { void trigger() }}
-        isDownloading={isMutating}
+        icon={icon}
+        onPress={() => { void trigger() }}
+        isPending={isMutating}
         requestFailed={Boolean(error)}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />

--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -111,8 +111,9 @@ export const BankTransactionRow = ({
       isPending={isProcessing}
       isDisabled={selectedOption === null || isBulkSelectionActive}
       action={displayAsCategorized ? SubmitAction.SAVE : SubmitAction.UPDATE}
-      active={open}
-      error={isError ? t('bankTransactions:error.approval_failed_check_connection', 'Approval failed. Check connection and retry in a few seconds.') : undefined}
+      isActive={open}
+      isError={isError}
+      errorMessage={t('bankTransactions:error.approval_failed_check_connection', 'Approval failed. Check connection and retry in a few seconds.')}
     >
       {isError
         ? t('common:action.retry_label', 'Retry')

--- a/src/components/BankTransactionRow/BankTransactionRow.tsx
+++ b/src/components/BankTransactionRow/BankTransactionRow.tsx
@@ -108,8 +108,8 @@ export const BankTransactionRow = ({
           void save()
         }
       }}
-      processing={isProcessing}
-      disabled={selectedOption === null || isBulkSelectionActive}
+      isPending={isProcessing}
+      isDisabled={selectedOption === null || isBulkSelectionActive}
       action={displayAsCategorized ? SubmitAction.SAVE : SubmitAction.UPDATE}
       active={open}
       error={isError ? t('bankTransactions:error.approval_failed_check_connection', 'Approval failed. Check connection and retry in a few seconds.') : undefined}

--- a/src/components/BankTransactions/BankTransactionsHeader.tsx
+++ b/src/components/BankTransactions/BankTransactionsHeader.tsx
@@ -98,13 +98,13 @@ function TransactionsSearch({ slot, isDisabled }: TransactionsSearchProps) {
 
 const DownloadButton = ({
   downloadButtonTextOverride,
-  iconOnly,
-  disabled,
+  icon,
+  isDisabled,
   isListView = false,
 }: {
   downloadButtonTextOverride?: string
-  iconOnly?: boolean
-  disabled?: boolean
+  icon?: boolean
+  isDisabled?: boolean
   isListView?: boolean
 }) => {
   const { handleDownloadTransactions, invisibleDownloadRef, isMutating, error } = useHandleDownloadTransactions({ isListView })
@@ -112,12 +112,12 @@ const DownloadButton = ({
   return (
     <>
       <DownloadButtonComponent
-        iconOnly={iconOnly}
-        onClick={handleDownloadTransactions}
-        isDownloading={isMutating}
+        icon={icon}
+        onPress={handleDownloadTransactions}
+        isPending={isMutating}
         requestFailed={Boolean(error)}
         text={downloadButtonTextOverride}
-        disabled={disabled}
+        isDisabled={isDisabled}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />
     </>
@@ -328,8 +328,8 @@ export const BankTransactionsHeader = ({
         <HStack slot='download-upload' justify='center' gap='xs'>
           <DownloadButton
             downloadButtonTextOverride={stringOverrides?.downloadButton}
-            iconOnly={isListView}
-            disabled={showBulkActions}
+            icon={isListView}
+            isDisabled={showBulkActions}
             isListView={isListView}
           />
           <BankTransactionsHeaderMenu actions={headerMenuActions} isDisabled={showBulkActions} />

--- a/src/components/BankTransactions/BankTransactionsSubmitButton.tsx
+++ b/src/components/BankTransactions/BankTransactionsSubmitButton.tsx
@@ -8,8 +8,8 @@ import './bankTransactionsSubmitButton.scss'
 type BankTransactionsSubmitButtonProps = {
   children: ReactNode
   onPress: () => void
-  processing?: boolean
-  disabled?: boolean
+  isPending?: boolean
+  isDisabled?: boolean
   error?: string
   action?: SubmitAction
   active?: boolean
@@ -18,8 +18,8 @@ type BankTransactionsSubmitButtonProps = {
 export const BankTransactionsSubmitButton = ({
   children,
   onPress,
-  processing,
-  disabled,
+  isPending,
+  isDisabled,
   error,
   action = SubmitAction.SAVE,
   active,
@@ -31,9 +31,9 @@ export const BankTransactionsSubmitButton = ({
       <SubmitButton
         iconBox
         withRetry
-        onClick={onPress}
-        processing={processing}
-        disabled={disabled}
+        onPress={onPress}
+        isPending={isPending}
+        isDisabled={isDisabled}
         error={error}
         action={action}
       >

--- a/src/components/BankTransactions/BankTransactionsSubmitButton.tsx
+++ b/src/components/BankTransactions/BankTransactionsSubmitButton.tsx
@@ -1,30 +1,28 @@
 import { type ReactNode } from 'react'
 
 import { toDataProperties } from '@utils/styleUtils/toDataProperties'
-import { SubmitAction, SubmitButton } from '@ui/Button/SubmitButton'
+import { SubmitAction, SubmitButton, type SubmitButtonProps } from '@ui/Button/SubmitButton'
 
 import './bankTransactionsSubmitButton.scss'
 
-type BankTransactionsSubmitButtonProps = {
-  children: ReactNode
-  onPress: () => void
-  isPending?: boolean
-  isDisabled?: boolean
-  error?: string
-  action?: SubmitAction
-  active?: boolean
-}
+type BankTransactionsSubmitButtonProps =
+  Pick<SubmitButtonProps, 'isPending' | 'isDisabled' | 'isError' | 'errorMessage' | 'action'> & {
+    children: ReactNode
+    onPress: SubmitButtonProps['onPress']
+    isActive?: boolean
+  }
 
 export const BankTransactionsSubmitButton = ({
   children,
   onPress,
   isPending,
   isDisabled,
-  error,
+  isError,
+  errorMessage,
   action = SubmitAction.SAVE,
-  active,
+  isActive,
 }: BankTransactionsSubmitButtonProps) => {
-  const dataProperties = toDataProperties({ active, error: Boolean(error) })
+  const dataProperties = toDataProperties({ active: isActive, error: isError })
 
   return (
     <span className='Layer__BankTransactionsSubmitButton' {...dataProperties}>
@@ -34,7 +32,8 @@ export const BankTransactionsSubmitButton = ({
         onPress={onPress}
         isPending={isPending}
         isDisabled={isDisabled}
-        error={error}
+        isError={isError}
+        errorMessage={errorMessage}
         action={action}
       >
         {children}

--- a/src/components/BankTransactionsList/BankTransactionsListItem.tsx
+++ b/src/components/BankTransactionsList/BankTransactionsListItem.tsx
@@ -209,9 +209,9 @@ export const BankTransactionsListItem = ({
               />
             )}
             <BankTransactionsSubmitButton
-              disabled={isProcessing}
+              isDisabled={isProcessing}
               onPress={() => { void save() }}
-              processing={isProcessing}
+              isPending={isProcessing}
               action={!displayAsCategorized ? SubmitAction.SAVE : SubmitAction.UPDATE}
               error={isError ? t('bankTransactions:error.approval_failed_check_connection', 'Approval failed. Check connection and retry in a few seconds.') : undefined}
             >

--- a/src/components/BankTransactionsList/BankTransactionsListItem.tsx
+++ b/src/components/BankTransactionsList/BankTransactionsListItem.tsx
@@ -213,7 +213,8 @@ export const BankTransactionsListItem = ({
               onPress={() => { void save() }}
               isPending={isProcessing}
               action={!displayAsCategorized ? SubmitAction.SAVE : SubmitAction.UPDATE}
-              error={isError ? t('bankTransactions:error.approval_failed_check_connection', 'Approval failed. Check connection and retry in a few seconds.') : undefined}
+              isError={isError}
+              errorMessage={t('bankTransactions:error.approval_failed_check_connection', 'Approval failed. Check connection and retry in a few seconds.')}
             >
               {isError
                 ? t('common:action.retry_label', 'Retry')

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
@@ -113,8 +113,8 @@ export const BankTransactionsMobileListBusinessForm = ({
             <FileInput
               onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
               text={t('bankTransactions:action.upload_receipt', 'Upload receipt')}
-              iconOnly={true}
-              icon={<Paperclip size={20} />}
+              icon
+              slots={{ Icon: <Paperclip size={20} /> }}
               accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
             />
           )}

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm.tsx
@@ -105,8 +105,8 @@ export const BankTransactionsMobileListMatchForm = ({
           <FileInput
             onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
             text={t('bankTransactions:action.upload_receipt', 'Upload receipt')}
-            iconOnly={true}
-            icon={<Paperclip size={20} />}
+            icon
+            slots={{ Icon: <Paperclip size={20} /> }}
             accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
           />
         )}

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListPersonalForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListPersonalForm.tsx
@@ -132,8 +132,8 @@ export const BankTransactionsMobileListPersonalForm = ({
           <FileInput
             onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
             text={t('bankTransactions:action.upload_receipt', 'Upload receipt')}
-            iconOnly={true}
-            icon={<Paperclip size={20} />}
+            icon
+            slots={{ Icon: <Paperclip size={20} /> }}
             accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
           />
         )}

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
@@ -209,8 +209,8 @@ export const BankTransactionsMobileListSplitForm = ({
           <FileInput
             onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
             text={t('bankTransactions:action.upload_receipt', 'Upload receipt')}
-            iconOnly={true}
-            icon={<Paperclip size={20} />}
+            icon
+            slots={{ Icon: <Paperclip size={20} /> }}
             accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
           />
         )}

--- a/src/components/ChartOfAccounts/download/AccountBalancesDownloadButton.tsx
+++ b/src/components/ChartOfAccounts/download/AccountBalancesDownloadButton.tsx
@@ -7,13 +7,13 @@ import InvisibleDownload, { useInvisibleDownload } from '@components/utility/Inv
 type AccountBalancesDownloadButtonProps = {
   startCutoff?: Date
   endCutoff?: Date
-  iconOnly?: boolean
+  icon?: boolean
 }
 
 export function AccountBalancesDownloadButton({
   startCutoff,
   endCutoff,
-  iconOnly,
+  icon,
 }: AccountBalancesDownloadButtonProps) {
   const { t } = useTranslation()
   const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
@@ -27,9 +27,9 @@ export function AccountBalancesDownloadButton({
   return (
     <>
       <DownloadButton
-        iconOnly={iconOnly}
-        onClick={() => { void trigger() }}
-        isDownloading={isMutating}
+        icon={icon}
+        onPress={() => { void trigger() }}
+        isPending={isMutating}
         requestFailed={Boolean(error)}
         text={t('common:action.download_csv', 'Download CSV')}
       />

--- a/src/components/ChartOfAccountsTable/ChartOfAccountsTableHeader.tsx
+++ b/src/components/ChartOfAccountsTable/ChartOfAccountsTableHeader.tsx
@@ -69,7 +69,7 @@ export const ChartOfAccountsTableHeader = ({
               onChange={onSearchChange}
             />
             <AccountBalancesDownloadButton
-              iconOnly={!isDesktop}
+              icon={!isDesktop}
             />
             {showAddAccountButton && (
               <Button

--- a/src/components/CustomAccountForm/CustomAccountForm.tsx
+++ b/src/components/CustomAccountForm/CustomAccountForm.tsx
@@ -135,7 +135,8 @@ export const CustomAccountForm = ({ initialAccountName, onCancel, onSuccess }: C
             isPending={isSubmitting}
             noIcon={!isSubmitting}
             withRetry
-            error={submitError}
+            isError={Boolean(submitError)}
+            errorMessage={submitError ?? undefined}
           >
             {submitError
               ? t('common:action.retry_label', 'Retry')

--- a/src/components/CustomAccountForm/CustomAccountForm.tsx
+++ b/src/components/CustomAccountForm/CustomAccountForm.tsx
@@ -132,7 +132,7 @@ export const CustomAccountForm = ({ initialAccountName, onCancel, onSuccess }: C
           )}
           <SubmitButton
             type='submit'
-            processing={isSubmitting}
+            isPending={isSubmitting}
             noIcon={!isSubmitting}
             withRetry
             error={submitError}

--- a/src/components/ExpandableDataTable/ExpandableDataTableToggleButton.tsx
+++ b/src/components/ExpandableDataTable/ExpandableDataTableToggleButton.tsx
@@ -7,14 +7,14 @@ import { Button } from '@ui/Button/Button'
 import { ExpandableDataTableContext } from '@components/ExpandableDataTable/ExpandableDataTableProvider'
 
 type ExpandableDataTableToggleButtonProps = {
-  iconOnly?: boolean
+  icon?: boolean
 }
 
-export const ExpandableDataTableToggleButton = ({ iconOnly }: ExpandableDataTableToggleButtonProps) => {
+export const ExpandableDataTableToggleButton = ({ icon }: ExpandableDataTableToggleButtonProps) => {
   const { t } = useTranslation()
   const { expanded, setExpanded } = useContext(ExpandableDataTableContext)
   const { isDesktop } = useSizeClass()
-  const resolvedIconOnly = iconOnly ?? !isDesktop
+  const resolvedIcon = icon ?? !isDesktop
 
   const shouldCollapse = expanded === true
   const onClickExpandOrCollapse = useCallback(() => {
@@ -34,12 +34,12 @@ export const ExpandableDataTableToggleButton = ({ iconOnly }: ExpandableDataTabl
 
   return (
     <Button
-      icon={resolvedIconOnly}
+      icon={resolvedIcon}
       variant='outlined'
-      onClick={onClickExpandOrCollapse}
-      aria-label={resolvedIconOnly ? buttonText : undefined}
+      onPress={onClickExpandOrCollapse}
+      aria-label={resolvedIcon ? buttonText : undefined}
     >
-      {resolvedIconOnly ? <Icon size={18} /> : buttonText}
+      {resolvedIcon ? <Icon size={18} /> : buttonText}
     </Button>
   )
 }

--- a/src/components/Input/FileInput.tsx
+++ b/src/components/Input/FileInput.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useRef } from 'react'
+import { type ChangeEvent, type ReactNode, useRef } from 'react'
 import { CloudUpload } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -7,10 +7,10 @@ import { Button } from '@ui/Button/Button'
 export interface FileInputProps {
   text?: string
   onUpload?: (files: File[]) => void
-  disabled?: boolean
+  isDisabled?: boolean
   secondary?: boolean
-  iconOnly?: boolean
-  icon?: React.ReactNode
+  icon?: boolean
+  slots?: { Icon?: ReactNode }
   allowMultipleUploads?: boolean
   accept?: string
 }
@@ -18,10 +18,10 @@ export interface FileInputProps {
 export const FileInput = ({
   text,
   onUpload,
-  disabled = false,
+  isDisabled = false,
   secondary,
-  iconOnly = false,
-  icon,
+  icon = false,
+  slots,
   allowMultipleUploads = false,
   accept,
 }: FileInputProps) => {
@@ -46,7 +46,7 @@ export const FileInput = ({
   if (secondary) {
     return (
       <>
-        <Button variant='text' underline onPress={onClick} isDisabled={disabled}>
+        <Button variant='text' underline onPress={onClick} isDisabled={isDisabled}>
           {buttonText}
         </Button>
         <input
@@ -66,12 +66,12 @@ export const FileInput = ({
       <Button
         onPress={onClick}
         variant='outlined'
-        isDisabled={disabled}
-        icon={iconOnly}
-        aria-label={iconOnly ? buttonText : undefined}
+        isDisabled={isDisabled}
+        icon={icon}
+        aria-label={icon ? buttonText : undefined}
       >
-        {!iconOnly && buttonText}
-        {icon ?? <CloudUpload size={18} />}
+        {!icon && buttonText}
+        {slots?.Icon ?? <CloudUpload size={18} />}
       </Button>
       <input
         type='file'

--- a/src/components/Journal/download/JournalEntriesDownloadButton.tsx
+++ b/src/components/Journal/download/JournalEntriesDownloadButton.tsx
@@ -7,13 +7,13 @@ import InvisibleDownload, { useInvisibleDownload } from '@components/utility/Inv
 type JournalEntriesDownloadButtonProps = {
   startCutoff?: Date
   endCutoff?: Date
-  iconOnly?: boolean
+  icon?: boolean
 }
 
 export function JournalEntriesDownloadButton({
   startCutoff,
   endCutoff,
-  iconOnly,
+  icon,
 }: JournalEntriesDownloadButtonProps) {
   const { t } = useTranslation()
   const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
@@ -26,9 +26,9 @@ export function JournalEntriesDownloadButton({
   return (
     <>
       <DownloadButton
-        iconOnly={iconOnly}
-        onClick={() => { void trigger() }}
-        isDownloading={isMutating}
+        icon={icon}
+        onPress={() => { void trigger() }}
+        isPending={isMutating}
         requestFailed={Boolean(error)}
         text={t('common:action.download_csv', 'Download CSV')}
       />

--- a/src/components/JournalTable/JournalTableWithPanel.tsx
+++ b/src/components/JournalTable/JournalTableWithPanel.tsx
@@ -75,7 +75,7 @@ export const JournalTableWithPanel = ({
           </HeaderCol>
           <HeaderCol>
             <JournalEntriesDownloadButton
-              iconOnly={['mobile', 'tablet'].includes(view)}
+              icon={['mobile', 'tablet'].includes(view)}
             />
             <Button
               onPress={() => toCreateEntry()}

--- a/src/components/ProfitAndLossDownloadButton/ProfitAndLossDetailLinesDownloadButton.tsx
+++ b/src/components/ProfitAndLossDownloadButton/ProfitAndLossDetailLinesDownloadButton.tsx
@@ -12,13 +12,13 @@ import InvisibleDownload, { useInvisibleDownload } from '@components/utility/Inv
 type ProfitAndLossDetailLinesDownloadButtonProps = {
   pnlStructureLineItemName: string
   stringOverrides?: ProfitAndLossDownloadButtonStringOverrides
-  iconOnly?: boolean
+  icon?: boolean
 }
 
 export function ProfitAndLossDetailLinesDownloadButton({
   pnlStructureLineItemName,
   stringOverrides,
-  iconOnly,
+  icon,
 }: ProfitAndLossDetailLinesDownloadButtonProps) {
   const { t } = useTranslation()
   const { businessId } = useLayerContext()
@@ -42,9 +42,9 @@ export function ProfitAndLossDetailLinesDownloadButton({
   return (
     <>
       <DownloadButton
-        iconOnly={iconOnly}
-        onClick={() => { void trigger() }}
-        isDownloading={isMutating}
+        icon={icon}
+        onPress={() => { void trigger() }}
+        isPending={isMutating}
         requestFailed={Boolean(error)}
         text={stringOverrides?.downloadButtonText || t('common:action.download_label', 'Download')}
         retryText={stringOverrides?.retryButtonText || t('common:action.retry_label', 'Retry')}

--- a/src/components/ProfitAndLossDownloadButton/ProfitAndLossDownloadButton.tsx
+++ b/src/components/ProfitAndLossDownloadButton/ProfitAndLossDownloadButton.tsx
@@ -9,13 +9,13 @@ import { type ProfitAndLossDownloadButtonStringOverrides } from '@components/Pro
 type ProfitAndLossDownloadButtonProps = {
   stringOverrides?: ProfitAndLossDownloadButtonStringOverrides
   moneyFormat?: MoneyFormat
-  iconOnly?: boolean
+  icon?: boolean
 }
 
 export function ProfitAndLossDownloadButton({
   stringOverrides,
   moneyFormat,
-  iconOnly,
+  icon,
 }: ProfitAndLossDownloadButtonProps) {
   const { selectedLineItem } = useContext(ProfitAndLossContext)
 
@@ -24,7 +24,7 @@ export function ProfitAndLossDownloadButton({
       <ProfitAndLossDetailLinesDownloadButton
         pnlStructureLineItemName={selectedLineItem.lineItemName}
         stringOverrides={stringOverrides}
-        iconOnly={iconOnly}
+        icon={icon}
       />
     )
   }
@@ -33,7 +33,7 @@ export function ProfitAndLossDownloadButton({
     <ProfitAndLossFullReportDownloadButton
       stringOverrides={stringOverrides}
       moneyFormat={moneyFormat}
-      iconOnly={iconOnly}
+      icon={icon}
     />
   )
 }

--- a/src/components/ProfitAndLossDownloadButton/ProfitAndLossFullReportDownloadButton.tsx
+++ b/src/components/ProfitAndLossDownloadButton/ProfitAndLossFullReportDownloadButton.tsx
@@ -14,13 +14,13 @@ import type { ProfitAndLossDownloadButtonStringOverrides } from '@components/Pro
 export interface ProfitAndLossReportDownloadButtonProps {
   stringOverrides?: ProfitAndLossDownloadButtonStringOverrides
   moneyFormat?: MoneyFormat
-  iconOnly?: boolean
+  icon?: boolean
 }
 
 export const ProfitAndLossFullReportDownloadButton = ({
   stringOverrides,
   moneyFormat,
-  iconOnly,
+  icon,
 }: ProfitAndLossReportDownloadButtonProps) => {
   const { t } = useTranslation()
   const { dateRange, tagFilter } = useContext(ProfitAndLossContext)
@@ -79,9 +79,9 @@ export const ProfitAndLossFullReportDownloadButton = ({
 
   return (
     <DownloadButtonComponent
-      iconOnly={iconOnly}
-      onClick={handleClick}
-      isDownloading={isDownloading}
+      icon={icon}
+      onPress={() => { void handleClick() }}
+      isPending={isDownloading}
       requestFailed={requestFailed}
       text={stringOverrides?.downloadButtonText || t('common:action.download_label', 'Download')}
       retryText={stringOverrides?.retryButtonText || t('common:action.retry_label', 'Retry')}

--- a/src/components/ProfitAndLossReport/ProfitAndLossReport.tsx
+++ b/src/components/ProfitAndLossReport/ProfitAndLossReport.tsx
@@ -106,7 +106,7 @@ export const ProfitAndLossReport = ({
                 <ProfitAndLossDownloadButton
                   stringOverrides={stringOverrides?.downloadButton}
                   moneyFormat={csvMoneyFormat}
-                  iconOnly={isMobileView}
+                  icon={isMobileView}
                 />
               </HStack>
             </Stack>

--- a/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
+++ b/src/components/StatementOfCashFlow/StatementOfCashFlow.tsx
@@ -85,7 +85,7 @@ const StatementOfCashFlowView = ({
                     <CashflowStatementDownloadButton
                       startDate={dateRange.startDate}
                       endDate={dateRange.endDate}
-                      iconOnly={isMobileView}
+                      icon={isMobileView}
                     />
                   </HStack>
                 </Stack>

--- a/src/components/StatementOfCashFlow/download/CashflowStatementDownloadButton.tsx
+++ b/src/components/StatementOfCashFlow/download/CashflowStatementDownloadButton.tsx
@@ -5,13 +5,13 @@ import InvisibleDownload, { useInvisibleDownload } from '@components/utility/Inv
 type CashflowStatementDownloadButtonProps = {
   startDate: Date
   endDate: Date
-  iconOnly?: boolean
+  icon?: boolean
 }
 
 export function CashflowStatementDownloadButton({
   startDate,
   endDate,
-  iconOnly,
+  icon,
 }: CashflowStatementDownloadButtonProps) {
   const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -24,9 +24,9 @@ export function CashflowStatementDownloadButton({
   return (
     <>
       <DownloadButton
-        iconOnly={iconOnly}
-        onClick={() => { void trigger() }}
-        isDownloading={isMutating}
+        icon={icon}
+        onPress={() => { void trigger() }}
+        isPending={isMutating}
         requestFailed={Boolean(error)}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />

--- a/src/components/UnifiedReports/UnifiedReportDownloadButton.tsx
+++ b/src/components/UnifiedReports/UnifiedReportDownloadButton.tsx
@@ -10,13 +10,13 @@ import { Button } from '@ui/Button/Button'
 import InvisibleDownload, { useInvisibleDownload } from '@components/utility/InvisibleDownload'
 
 type UnifiedReportDownloadButtonProps = {
-  iconOnly?: boolean
+  icon?: boolean
 }
 
-export function UnifiedReportDownloadButton({ iconOnly }: UnifiedReportDownloadButtonProps) {
+export function UnifiedReportDownloadButton({ icon }: UnifiedReportDownloadButtonProps) {
   const { t } = useTranslation()
   const { isDesktop } = useSizeClass()
-  const resolvedIconOnly = iconOnly ?? !isDesktop
+  const resolvedIcon = icon ?? !isDesktop
   const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
 
   const { trigger, isMutating, isError } = useUnifiedReportExcel({
@@ -48,10 +48,10 @@ export function UnifiedReportDownloadButton({ iconOnly }: UnifiedReportDownloadB
         onPress={onPress}
         isPending={isMutating}
         isDisabled={isMutating}
-        icon={resolvedIconOnly}
-        aria-label={resolvedIconOnly ? buttonText : undefined}
+        icon={resolvedIcon}
+        aria-label={resolvedIcon ? buttonText : undefined}
       >
-        {!resolvedIconOnly && buttonText}
+        {!resolvedIcon && buttonText}
         {isError ? <RefreshCcw size={12} /> : <CloudDownload size={16} /> }
       </Button>
       <InvisibleDownload ref={invisibleDownloadRef} />

--- a/src/components/UnifiedReports/UnifiedReportHeaderButtons.tsx
+++ b/src/components/UnifiedReports/UnifiedReportHeaderButtons.tsx
@@ -26,8 +26,8 @@ export const UnifiedReportHeaderButtons = ({ variant }: UnifiedReportHeaderButto
       })}
     >
       {isMobile && <ReportsMobileSelectionDrawer />}
-      <ExpandableDataTableToggleButton iconOnly={isMobile} />
-      <UnifiedReportDownloadButton iconOnly={isMobile} />
+      <ExpandableDataTableToggleButton icon={isMobile} />
+      <UnifiedReportDownloadButton icon={isMobile} />
     </HStack>
   )
 }

--- a/src/components/UploadTransactions/UploadTransactionsUploadCsvStep.tsx
+++ b/src/components/UploadTransactions/UploadTransactionsUploadCsvStep.tsx
@@ -194,7 +194,7 @@ export function UploadTransactionsUploadCsvStep(
                 tooltip={(selectedFile && !hasSelectedAccount) ? t('upload:action.select_account_label', 'Select an account') : null}
                 isDisabled={!hasSelectedAccount || !selectedFile}
                 isPending={isParsingCsv}
-                error={hasParseCsvError}
+                isError={hasParseCsvError}
                 onPress={onClickContinue}
                 withRetry
                 noIcon={!isParsingCsv}

--- a/src/components/UploadTransactions/UploadTransactionsUploadCsvStep.tsx
+++ b/src/components/UploadTransactions/UploadTransactionsUploadCsvStep.tsx
@@ -192,10 +192,10 @@ export function UploadTransactionsUploadCsvStep(
               <Spacer />
               <SubmitButton
                 tooltip={(selectedFile && !hasSelectedAccount) ? t('upload:action.select_account_label', 'Select an account') : null}
-                disabled={!hasSelectedAccount || !selectedFile}
-                processing={isParsingCsv}
+                isDisabled={!hasSelectedAccount || !selectedFile}
+                isPending={isParsingCsv}
                 error={hasParseCsvError}
-                onClick={onClickContinue}
+                onPress={onClickContinue}
                 withRetry
                 noIcon={!isParsingCsv}
               >

--- a/src/components/UploadTransactions/UploadTransactionsValidateCsvStep.tsx
+++ b/src/components/UploadTransactions/UploadTransactionsValidateCsvStep.tsx
@@ -117,7 +117,7 @@ export function UploadTransactionsValidateCsvStep(
           ? (
             <SubmitButton
               isPending={isMutating}
-              error={!!uploadTransactionsError}
+              isError={!!uploadTransactionsError}
               onPress={onClickUploadTransactions}
               action={SubmitAction.UPLOAD}
               withRetry

--- a/src/components/UploadTransactions/UploadTransactionsValidateCsvStep.tsx
+++ b/src/components/UploadTransactions/UploadTransactionsValidateCsvStep.tsx
@@ -116,9 +116,9 @@ export function UploadTransactionsValidateCsvStep(
         {isValidCsv
           ? (
             <SubmitButton
-              processing={isMutating}
+              isPending={isMutating}
               error={!!uploadTransactionsError}
-              onClick={onClickUploadTransactions}
+              onPress={onClickUploadTransactions}
               action={SubmitAction.UPLOAD}
               withRetry
             >

--- a/src/components/blocks/BaseConfirmationModal/BaseConfirmationModal.tsx
+++ b/src/components/blocks/BaseConfirmationModal/BaseConfirmationModal.tsx
@@ -100,7 +100,8 @@ const BaseConfirmationModalContent = memo(function BaseConfirmationModalContent(
             onPress={onClickConfirm}
             isPending={isProcessing}
             isDisabled={confirmDisabled}
-            error={error ? errorText : undefined}
+            isError={Boolean(error)}
+            errorMessage={errorText}
             withRetry
             noIcon={!isProcessing}
           >

--- a/src/components/blocks/BaseConfirmationModal/BaseConfirmationModal.tsx
+++ b/src/components/blocks/BaseConfirmationModal/BaseConfirmationModal.tsx
@@ -97,9 +97,9 @@ const BaseConfirmationModalContent = memo(function BaseConfirmationModalContent(
             {cancelButtonLabel}
           </Button>
           <SubmitButton
-            onClick={onClickConfirm}
-            processing={isProcessing}
-            disabled={confirmDisabled}
+            onPress={onClickConfirm}
+            isPending={isProcessing}
+            isDisabled={confirmDisabled}
             error={error ? errorText : undefined}
             withRetry
             noIcon={!isProcessing}

--- a/src/components/ui/Button/DownloadButton.tsx
+++ b/src/components/ui/Button/DownloadButton.tsx
@@ -4,27 +4,27 @@ import { useTranslation } from 'react-i18next'
 import { Button, type ButtonProps } from '@ui/Button/Button'
 
 interface DownloadButtonProps {
-  onClick?: () => void | Promise<void>
-  iconOnly?: boolean
-  isDownloading?: boolean
+  onPress?: ButtonProps['onPress']
+  icon?: boolean
+  isPending?: boolean
   requestFailed?: boolean
   text?: string
   retryText?: string
   errorText?: string
   tooltip?: ButtonProps['tooltip']
-  disabled?: boolean
+  isDisabled?: boolean
 }
 
 export const DownloadButton = ({
-  iconOnly,
-  onClick,
-  isDownloading,
+  icon,
+  onPress,
+  isPending,
   requestFailed,
   tooltip,
   text,
   retryText,
   errorText,
-  disabled = false,
+  isDisabled = false,
 }: DownloadButtonProps) => {
   const { t } = useTranslation()
   const displayText = text ?? t('common:action.download_label', 'Download')
@@ -35,13 +35,13 @@ export const DownloadButton = ({
     return (
       <Button
         variant='outlined'
-        onPress={() => void onClick?.()}
-        isDisabled={isDownloading || disabled}
-        icon={iconOnly}
-        aria-label={iconOnly ? displayRetryText : undefined}
+        onPress={onPress}
+        isDisabled={isPending || isDisabled}
+        icon={icon}
+        aria-label={icon ? displayRetryText : undefined}
         tooltip={displayErrorText}
       >
-        {!iconOnly && displayRetryText}
+        {!icon && displayRetryText}
         <RefreshCcw size={12} />
       </Button>
     )
@@ -50,14 +50,14 @@ export const DownloadButton = ({
   return (
     <Button
       variant='outlined'
-      onPress={() => void onClick?.()}
-      isDisabled={isDownloading || disabled}
-      isPending={isDownloading}
-      icon={iconOnly}
-      aria-label={iconOnly ? displayText : undefined}
+      onPress={onPress}
+      isDisabled={isPending || isDisabled}
+      isPending={isPending}
+      icon={icon}
+      aria-label={icon ? displayText : undefined}
       tooltip={tooltip}
     >
-      {!iconOnly && displayText}
+      {!icon && displayText}
       <CloudDownload size={12} />
     </Button>
   )

--- a/src/components/ui/Button/SubmitButton.tsx
+++ b/src/components/ui/Button/SubmitButton.tsx
@@ -7,10 +7,10 @@ import { ButtonIconBox } from '@ui/Button/ButtonIconBox'
 
 export interface SubmitButtonProps {
   children?: ReactNode
-  onClick?: ButtonProps['onClick']
+  onPress?: ButtonProps['onPress']
   type?: ButtonProps['type']
-  processing?: boolean
-  disabled?: boolean
+  isPending?: boolean
+  isDisabled?: boolean
   error?: boolean | string
   action?: SubmitAction
   noIcon?: boolean
@@ -67,8 +67,8 @@ const withRenderedIcon = ({
 }
 
 export const SubmitButton = ({
-  processing,
-  disabled,
+  isPending,
+  isDisabled,
   error,
   children,
   action = SubmitAction.SAVE,
@@ -76,7 +76,7 @@ export const SubmitButton = ({
   iconBox,
   tooltip,
   withRetry,
-  onClick,
+  onPress,
   type,
 }: SubmitButtonProps) => {
   const { t } = useTranslation()
@@ -85,10 +85,10 @@ export const SubmitButton = ({
     return (
       <Button
         variant='outlined'
-        onClick={onClick}
+        onPress={onPress}
         type={type}
-        isDisabled={processing || disabled}
-        isPending={processing}
+        isDisabled={isPending || isDisabled}
+        isPending={isPending}
         tooltip={typeof error === 'string' ? error : t('common:error.something_went_wrong', 'Something went wrong')}
       >
         {children}
@@ -99,10 +99,10 @@ export const SubmitButton = ({
 
   return (
     <Button
-      onClick={onClick}
+      onPress={onPress}
       type={type}
-      isDisabled={processing || disabled}
-      isPending={processing}
+      isDisabled={isPending || isDisabled}
+      isPending={isPending}
       tooltip={typeof error === 'string' ? error : tooltip}
     >
       {children}

--- a/src/components/ui/Button/SubmitButton.tsx
+++ b/src/components/ui/Button/SubmitButton.tsx
@@ -11,7 +11,8 @@ export interface SubmitButtonProps {
   type?: ButtonProps['type']
   isPending?: boolean
   isDisabled?: boolean
-  error?: boolean | string
+  isError?: boolean
+  errorMessage?: string
   action?: SubmitAction
   noIcon?: boolean
   iconBox?: true
@@ -26,11 +27,11 @@ export enum SubmitAction {
 }
 
 const buildIcon = ({
-  error,
+  isError,
   action,
   noIcon,
 }: {
-  error?: boolean | string
+  isError?: boolean
   action: SubmitAction
   noIcon?: boolean
 }) => {
@@ -38,7 +39,7 @@ const buildIcon = ({
     return null
   }
 
-  if (error) {
+  if (isError) {
     return <CircleAlert size={14} />
   }
 
@@ -69,7 +70,8 @@ const withRenderedIcon = ({
 export const SubmitButton = ({
   isPending,
   isDisabled,
-  error,
+  isError,
+  errorMessage,
   children,
   action = SubmitAction.SAVE,
   noIcon,
@@ -81,7 +83,7 @@ export const SubmitButton = ({
 }: SubmitButtonProps) => {
   const { t } = useTranslation()
 
-  if (withRetry && error) {
+  if (withRetry && isError) {
     return (
       <Button
         variant='outlined'
@@ -89,7 +91,7 @@ export const SubmitButton = ({
         type={type}
         isDisabled={isPending || isDisabled}
         isPending={isPending}
-        tooltip={typeof error === 'string' ? error : t('common:error.something_went_wrong', 'Something went wrong')}
+        tooltip={errorMessage ?? t('common:error.something_went_wrong', 'Something went wrong')}
       >
         {children}
         <RefreshCcw size={12} />
@@ -103,10 +105,10 @@ export const SubmitButton = ({
       type={type}
       isDisabled={isPending || isDisabled}
       isPending={isPending}
-      tooltip={typeof error === 'string' ? error : tooltip}
+      tooltip={isError ? (errorMessage ?? tooltip) : tooltip}
     >
       {children}
-      {withRenderedIcon({ error, action, noIcon, iconBox })}
+      {withRenderedIcon({ isError, action, noIcon, iconBox })}
     </Button>
   )
 }


### PR DESCRIPTION
## Summary
Reshapes the `@ui/Button` variant components so their prop structure mirrors the underlying `@ui/Button/Button`, then migrates every callsite to match.

Prop renames applied consistently:
- `onClick` → `onPress`
- `processing` / `isDownloading` → `isPending`
- `disabled` → `isDisabled`
- `iconOnly` → `icon`

## Changes
- **`SubmitButton`** — props now reference `ButtonProps` (`onPress`, `isPending`, `isDisabled`, `tooltip`, `type`)
- **`DownloadButton`** — same alignment; `onPress` passes straight through
- **Wrapper components** propagated: BalanceSheet / Journal / AccountBalances / Cashflow / PnL download buttons, `BankTransactionsSubmitButton`, `ExpandableDataTableToggleButton`, and `FileInput`
- **`FileInput`** — injectable icon content now uses `slots={{ Icon }}` (following the codebase `slots` convention) instead of an ad-hoc prop
- All callsites updated accordingly (30 files)

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical prop renames across many UI callsites with no auth, data, or API logic changes; main risk is missing a callsite or subtle submit/download error-tooltip behavior.
> 
> **Overview**
> Aligns **`SubmitButton`**, **`DownloadButton`**, and feature wrappers with the base **`Button`** contract so variant components use the same interaction and state props end-to-end.
> 
> **Prop renames** are applied consistently at the UI layer and propagated through report download buttons, bank-transaction submit flows, upload/confirmation modals, and table headers: `onClick` → `onPress`, `processing` / `isDownloading` → `isPending`, `disabled` → `isDisabled`, and `iconOnly` → `icon` (boolean layout flag, matching `Button`).
> 
> **`SubmitButton`** now takes `isError` plus `errorMessage` instead of a combined `error` string/boolean; retry tooltips and icons use those fields. **`BankTransactionsSubmitButton`** types are narrowed via `Pick<SubmitButtonProps, …>` and forward the new names.
> 
> **`FileInput`** renames `disabled` → `isDisabled`, treats `icon` as the icon-only layout flag, and moves custom icon content to **`slots={{ Icon }}`** instead of a separate `icon` node prop.
> 
> Behavior is intended to stay the same; this is primarily an API consistency pass across reports, ledger, bank transactions, and CSV upload surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 534ac895320f4c7b55f9cd4b98667469105e9073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->