### PR TITLE
fix: tighten up journal schemas and form validation

### DIFF
--- a/src/components/Journal/JournalEntryForm/formUtils.ts
+++ b/src/components/Journal/JournalEntryForm/formUtils.ts
@@ -103,7 +103,7 @@ export function convertJournalEntryFormToParams(form: JournalEntryForm): CreateC
   return {
     ...(form.externalId && { externalId: form.externalId }),
     entryAt: form.entryAt.toDate(),
-    createdBy: form.createdBy,
+    createdBy: form.createdBy.trim(),
     memo: form.memo.trim(),
     ...(form.customer?.id && { customerId: form.customer.id }),
     ...(form.customer?.externalId && { customerExternalId: form.customer.externalId }),

--- a/src/components/Journal/JournalEntryForm/formUtils.ts
+++ b/src/components/Journal/JournalEntryForm/formUtils.ts
@@ -27,7 +27,7 @@ export function isLineItemBlank(lineItem: JournalEntryFormLineItem): boolean {
   const hasCustomer = Boolean(lineItem.customer)
   const hasVendor = Boolean(lineItem.vendor)
   const hasTags = lineItem.tags.length > 0
-  const hasExternalId = Boolean(lineItem.externalId?.trim())
+  const hasExternalId = Boolean(lineItem.externalId)
 
   return !hasAccount && !hasAmount && !hasMemo && !hasCustomer && !hasVendor && !hasTags && !hasExternalId
 }

--- a/src/components/Journal/JournalEntryForm/formUtils.ts
+++ b/src/components/Journal/JournalEntryForm/formUtils.ts
@@ -27,7 +27,7 @@ export function isLineItemBlank(lineItem: JournalEntryFormLineItem): boolean {
   const hasCustomer = Boolean(lineItem.customer)
   const hasVendor = Boolean(lineItem.vendor)
   const hasTags = lineItem.tags.length > 0
-  const hasExternalId = Boolean(lineItem.externalId)
+  const hasExternalId = Boolean(lineItem.externalId?.trim())
 
   return !hasAccount && !hasAmount && !hasMemo && !hasCustomer && !hasVendor && !hasTags && !hasExternalId
 }
@@ -73,8 +73,8 @@ export function getJournalEntryFormInitialValues(journalEntry: ApiCustomJournalE
     entryAt: fromDate(new Date(journalEntry.entry.entryAt), getLocalTimeZone()),
     createdBy: '',
     memo: journalEntry.memo,
-    customer: journalEntry.customer,
-    vendor: journalEntry.vendor,
+    customer: journalEntry.customer ?? null,
+    vendor: journalEntry.vendor ?? null,
     tags: [],
     metadata: null,
     referenceNumber: '',
@@ -87,8 +87,8 @@ export function getJournalEntryFormInitialValues(journalEntry: ApiCustomJournalE
       amount: convertCentsToNonRecursiveBigDecimal(entryLineItemsById.get(lineItem.id)!.amount),
       direction: entryLineItemsById.get(lineItem.id)!.direction,
       memo: lineItem.memo ?? null,
-      customer: lineItem.customer,
-      vendor: lineItem.vendor,
+      customer: lineItem.customer ?? null,
+      vendor: lineItem.vendor ?? null,
       tags: lineItem.transactionTags?.map(makeTagFromTransactionTag) ?? [],
     })),
   }
@@ -134,11 +134,11 @@ export function validateJournalEntryForm({ value }: { value: JournalEntryForm },
     errors.push({ entryAt: t('generalLedger:validation.entry_date_required', 'Entry date is a required field.') })
   }
 
-  if (!value.createdBy) {
+  if (!value.createdBy.trim()) {
     errors.push({ createdBy: t('generalLedger:validation.create_required', 'Created by is a required field.') })
   }
 
-  if (!value.memo) {
+  if (!value.memo.trim()) {
     errors.push({ memo: t('generalLedger:validation.memo_required', 'Memo is a required field.') })
   }
 

--- a/src/components/Journal/JournalEntryForm/journalEntryFormSchemas.ts
+++ b/src/components/Journal/JournalEntryForm/journalEntryFormSchemas.ts
@@ -114,8 +114,8 @@ export const ApiLineItemSchema = Schema.Struct({
   account: SingleChartAccountSchema,
   amount: Schema.Number,
   direction: LedgerEntryDirectionSchema,
-  customer: Schema.NullOr(CustomerSchema),
-  vendor: Schema.NullOr(VendorSchema),
+  customer: Schema.NullishOr(CustomerSchema),
+  vendor: Schema.NullishOr(VendorSchema),
   entryAt: pipe(
     Schema.propertySignature(Schema.Date),
     Schema.fromKey('entry_at'),
@@ -125,11 +125,11 @@ export const ApiLineItemSchema = Schema.Struct({
     Schema.fromKey('createdAt'),
   ),
   entryReversalOf: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.UUID)),
+    Schema.propertySignature(Schema.NullishOr(Schema.UUID)),
     Schema.fromKey('entry_reversal_of'),
   ),
   entryReversedBy: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.UUID)),
+    Schema.propertySignature(Schema.NullishOr(Schema.UUID)),
     Schema.fromKey('entry_reversed_by'),
   ),
 })
@@ -137,18 +137,18 @@ export const ApiLineItemSchema = Schema.Struct({
 export const ApiCustomJournalEntryLineItemSchema = Schema.Struct({
   id: Schema.UUID,
   externalId: pipe(
-    Schema.optional(Schema.NullOr(Schema.String)),
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
     Schema.fromKey('external_id'),
   ),
-  memo: Schema.optional(Schema.NullOr(Schema.String)),
+  memo: Schema.NullishOr(Schema.String),
   lineItemId: pipe(
     Schema.propertySignature(Schema.UUID),
     Schema.fromKey('line_item_id'),
   ),
-  customer: Schema.NullOr(CustomerSchema),
-  vendor: Schema.NullOr(VendorSchema),
+  customer: Schema.NullishOr(CustomerSchema),
+  vendor: Schema.NullishOr(VendorSchema),
   transactionTags: pipe(
-    Schema.optional(Schema.Array(TransactionTagSchema)),
+    Schema.propertySignature(Schema.NullishOr(Schema.Array(TransactionTagSchema))),
     Schema.fromKey('transaction_tags'),
   ),
 })
@@ -167,16 +167,16 @@ export const ApiLedgerEntrySchema = Schema.Struct({
     Schema.fromKey('ledger_id'),
   ),
   entryNumber: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.Number)),
+    Schema.propertySignature(Schema.NullishOr(Schema.Number)),
     Schema.fromKey('entry_number'),
   ),
-  agent: Schema.NullOr(Schema.String),
+  agent: Schema.NullishOr(Schema.String),
   entryType: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.String)),
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
     Schema.fromKey('entry_type'),
   ),
-  customer: Schema.NullOr(Schema.Unknown),
-  vendor: Schema.NullOr(Schema.Unknown),
+  customer: Schema.NullishOr(Schema.Unknown),
+  vendor: Schema.NullishOr(Schema.Unknown),
   createdAt: pipe(
     Schema.propertySignature(Schema.Date),
     Schema.fromKey('date'),
@@ -186,11 +186,11 @@ export const ApiLedgerEntrySchema = Schema.Struct({
     Schema.fromKey('entry_at'),
   ),
   reversalOfId: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.UUID)),
+    Schema.propertySignature(Schema.NullishOr(Schema.UUID)),
     Schema.fromKey('reversal_of_id'),
   ),
   reversalId: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.UUID)),
+    Schema.propertySignature(Schema.NullishOr(Schema.UUID)),
     Schema.fromKey('reversal_id'),
   ),
   lineItems: pipe(
@@ -201,10 +201,10 @@ export const ApiLedgerEntrySchema = Schema.Struct({
     Schema.propertySignature(Schema.Array(Schema.Unknown)),
     Schema.fromKey('transaction_tags'),
   ),
-  memo: Schema.NullOr(Schema.String),
-  metadata: Schema.NullOr(Schema.Unknown),
+  memo: Schema.NullishOr(Schema.String),
+  metadata: Schema.NullishOr(Schema.Unknown),
   referenceNumber: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.String)),
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
     Schema.fromKey('reference_number'),
   ),
 })
@@ -212,7 +212,7 @@ export const ApiLedgerEntrySchema = Schema.Struct({
 export const ApiCustomJournalEntryWithEntrySchema = Schema.Struct({
   id: Schema.UUID,
   externalId: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.String)),
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
     Schema.fromKey('external_id'),
   ),
   createdBy: pipe(
@@ -224,8 +224,8 @@ export const ApiCustomJournalEntryWithEntrySchema = Schema.Struct({
     Schema.propertySignature(Schema.UUID),
     Schema.fromKey('entry_id'),
   ),
-  customer: Schema.NullOr(CustomerSchema),
-  vendor: Schema.NullOr(VendorSchema),
+  customer: Schema.NullishOr(CustomerSchema),
+  vendor: Schema.NullishOr(VendorSchema),
   lineItems: pipe(
     Schema.propertySignature(Schema.Array(ApiCustomJournalEntryLineItemSchema)),
     Schema.fromKey('line_items'),
@@ -235,9 +235,9 @@ export const ApiCustomJournalEntryWithEntrySchema = Schema.Struct({
     Schema.propertySignature(Schema.Array(Schema.Unknown)),
     Schema.fromKey('transaction_tags'),
   ),
-  metadata: Schema.NullOr(Schema.Unknown),
+  metadata: Schema.NullishOr(Schema.Unknown),
   referenceNumber: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.String)),
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
     Schema.fromKey('reference_number'),
   ),
 })

--- a/src/schemas/generalLedger/ledgerAccount.ts
+++ b/src/schemas/generalLedger/ledgerAccount.ts
@@ -139,7 +139,7 @@ const nestedChartAccountFields = {
   ),
   name: Schema.String,
   stableName: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.String)),
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
     Schema.fromKey('stable_name'),
   ),
   accountNumber: pipe(


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches general-ledger journal decode and create/update payload shaping; permissive schemas reduce parse failures but trimmed required fields could block saves that previously sent whitespace-only memo/created-by.
> 
> **Overview**
> **Journal entry API decoding** is relaxed in the right places: optional/nullable fields on ledger and custom journal entry responses now use `Schema.NullishOr` instead of `NullOr`, and some optional keys use explicit `propertySignature` so missing or `undefined` values decode like `null`. Chart account `stableName` in nested chart schemas follows the same pattern.
> 
> **Form behavior** is stricter and more consistent: loading an entry coerces `customer`/`vendor` to `null` when absent; **created by** and **memo** are trimmed on submit and validation rejects whitespace-only values (not just empty strings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d21b4d33ec9cd9f706e12ba2a80f40e5a5df444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->