### PR TITLE
i18n: summarize translation workflow PRs

### DIFF
--- a/.github/workflows/crowdin-french-sync.yml
+++ b/.github/workflows/crowdin-french-sync.yml
@@ -109,17 +109,26 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         git add src/assets/locales/fr-CA
-        if git diff --cached --quiet; then
-          echo "No new fr-CA translations."
-          exit 0
-        fi
         BR=i18n/crowdin-fr-ca
         VERSION=$(node -p "require('./package.json').version")
+        if git diff --cached --quiet; then
+          echo "No new fr-CA translations."
+          echo "No fr-CA translation changes for v$VERSION." >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
         git checkout -B "$BR"
         git commit -m "i18n: update fr-CA translations"
         git push -f origin "$BR"
-        if [ -z "$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')" ]; then
+        PR_NUMBER=$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')
+        if [ -z "$PR_NUMBER" ]; then
           gh pr create --base main --head "$BR" \
             --title "i18n: update fr-CA translations for v$VERSION" \
             --body "Downloaded new fr-CA translations from Crowdin for @layerfi/components v$VERSION."
+          PR_NUMBER=$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')
+        else
+          gh pr edit "$PR_NUMBER" \
+            --title "i18n: update fr-CA translations for v$VERSION" \
+            --body "Downloaded new fr-CA translations from Crowdin for @layerfi/components v$VERSION."
         fi
+        PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
+        echo "[fr-CA translations PR for v$VERSION]($PR_URL)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/crowdin-french-sync.yml
+++ b/.github/workflows/crowdin-french-sync.yml
@@ -121,14 +121,17 @@ jobs:
         git push -f origin "$BR"
         PR_NUMBER=$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')
         if [ -z "$PR_NUMBER" ]; then
-          gh pr create --base main --head "$BR" \
+          PR_URL=$(gh pr create --base main --head "$BR" \
             --title "i18n: update fr-CA translations for v$VERSION" \
-            --body "Downloaded new fr-CA translations from Crowdin for @layerfi/components v$VERSION."
-          PR_NUMBER=$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')
+            --body "Downloaded new fr-CA translations from Crowdin for @layerfi/components v$VERSION.")
         else
           gh pr edit "$PR_NUMBER" \
             --title "i18n: update fr-CA translations for v$VERSION" \
             --body "Downloaded new fr-CA translations from Crowdin for @layerfi/components v$VERSION."
+          PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
         fi
-        PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
+        if [ -z "$PR_URL" ]; then
+          echo "::error::Unable to resolve fr-CA translations PR URL."
+          exit 1
+        fi
         echo "[fr-CA translations PR for v$VERSION]($PR_URL)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/i18n-english-keys.yml
+++ b/.github/workflows/i18n-english-keys.yml
@@ -48,17 +48,26 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         git add src/assets/locales/en-US
-        if git diff --cached --quiet; then
-          echo "No English translation key changes."
-          exit 0
-        fi
         BR=i18n/english-keys
         VERSION=$(node -p "require('./package.json').version")
+        if git diff --cached --quiet; then
+          echo "No English translation key changes."
+          echo "No English translation key changes for v$VERSION." >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
         git checkout -B "$BR"
         git commit -m "i18n: extract English translation keys"
         git push -f origin "$BR"
-        if [ -z "$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')" ]; then
+        PR_NUMBER=$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')
+        if [ -z "$PR_NUMBER" ]; then
           gh pr create --base main --head "$BR" \
             --title "i18n: extract English keys for v$VERSION" \
             --body "Extracted English translation keys from source with i18next-cli extract for @layerfi/components v$VERSION."
+          PR_NUMBER=$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')
+        else
+          gh pr edit "$PR_NUMBER" \
+            --title "i18n: extract English keys for v$VERSION" \
+            --body "Extracted English translation keys from source with i18next-cli extract for @layerfi/components v$VERSION."
         fi
+        PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
+        echo "[English keys PR for v$VERSION]($PR_URL)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/i18n-english-keys.yml
+++ b/.github/workflows/i18n-english-keys.yml
@@ -60,14 +60,17 @@ jobs:
         git push -f origin "$BR"
         PR_NUMBER=$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')
         if [ -z "$PR_NUMBER" ]; then
-          gh pr create --base main --head "$BR" \
+          PR_URL=$(gh pr create --base main --head "$BR" \
             --title "i18n: extract English keys for v$VERSION" \
-            --body "Extracted English translation keys from source with i18next-cli extract for @layerfi/components v$VERSION."
-          PR_NUMBER=$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')
+            --body "Extracted English translation keys from source with i18next-cli extract for @layerfi/components v$VERSION.")
         else
           gh pr edit "$PR_NUMBER" \
             --title "i18n: extract English keys for v$VERSION" \
             --body "Extracted English translation keys from source with i18next-cli extract for @layerfi/components v$VERSION."
+          PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
         fi
-        PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
+        if [ -z "$PR_URL" ]; then
+          echo "::error::Unable to resolve English keys PR URL."
+          exit 1
+        fi
         echo "[English keys PR for v$VERSION]($PR_URL)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Adds release-style GitHub step summaries to the English key extraction and French Crowdin sync workflows.
- Shows a direct link to the created or updated translation PR when changes exist.
- Shows an explicit no-op summary line when no translation changes are produced.

## Validation

- `actionlint .github/workflows/i18n-english-keys.yml .github/workflows/crowdin-french-sync.yml`
- YAML parse for both workflows
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI shell steps for i18n automation; no application runtime or security-sensitive logic.
> 
> **Overview**
> The **English keys** and **French Crowdin sync** workflows now write **GitHub step summaries** so each run shows a clear outcome without digging through logs.
> 
> When there are **no locale changes**, the summary records a versioned no-op line (e.g. no English key changes for the current `package.json` version). When a PR is created or updated, the summary includes a **markdown link** to that PR. `BR` and `VERSION` are set before the no-op check so those messages always include the version.
> 
> The open/update PR step is refactored to resolve `PR_URL` after `gh pr create` or, for an existing branch PR, after `gh pr edit` plus `gh pr view`. The workflow **fails** if the URL cannot be resolved. Existing open PRs now get their **title and body refreshed** on each run, not only on first create.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca06d6503c35ec3b91ea704b42e7027be3a5f6e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->