### PR TITLE
i18n: omit versions from translation workflow PRs

### DIFF
--- a/.github/workflows/crowdin-french-sync.yml
+++ b/.github/workflows/crowdin-french-sync.yml
@@ -110,10 +110,9 @@ jobs:
       run: |
         git add src/assets/locales/fr-CA
         BR=i18n/crowdin-fr-ca
-        VERSION=$(node -p "require('./package.json').version")
         if git diff --cached --quiet; then
           echo "No new fr-CA translations."
-          echo "No fr-CA translation changes for v$VERSION." >> "$GITHUB_STEP_SUMMARY"
+          echo "No fr-CA translation changes." >> "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
         git checkout -B "$BR"
@@ -122,16 +121,16 @@ jobs:
         PR_NUMBER=$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')
         if [ -z "$PR_NUMBER" ]; then
           PR_URL=$(gh pr create --base main --head "$BR" \
-            --title "i18n: update fr-CA translations for v$VERSION" \
-            --body "Downloaded new fr-CA translations from Crowdin for @layerfi/components v$VERSION.")
+            --title "i18n: update fr-CA translations" \
+            --body "Downloaded new fr-CA translations from Crowdin for @layerfi/components.")
         else
           gh pr edit "$PR_NUMBER" \
-            --title "i18n: update fr-CA translations for v$VERSION" \
-            --body "Downloaded new fr-CA translations from Crowdin for @layerfi/components v$VERSION."
+            --title "i18n: update fr-CA translations" \
+            --body "Downloaded new fr-CA translations from Crowdin for @layerfi/components."
           PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
         fi
         if [ -z "$PR_URL" ]; then
           echo "::error::Unable to resolve fr-CA translations PR URL."
           exit 1
         fi
-        echo "[fr-CA translations PR for v$VERSION]($PR_URL)" >> "$GITHUB_STEP_SUMMARY"
+        echo "[fr-CA translations PR]($PR_URL)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/i18n-english-keys.yml
+++ b/.github/workflows/i18n-english-keys.yml
@@ -49,10 +49,9 @@ jobs:
       run: |
         git add src/assets/locales/en-US
         BR=i18n/english-keys
-        VERSION=$(node -p "require('./package.json').version")
         if git diff --cached --quiet; then
           echo "No English translation key changes."
-          echo "No English translation key changes for v$VERSION." >> "$GITHUB_STEP_SUMMARY"
+          echo "No English translation key changes." >> "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
         git checkout -B "$BR"
@@ -61,16 +60,16 @@ jobs:
         PR_NUMBER=$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')
         if [ -z "$PR_NUMBER" ]; then
           PR_URL=$(gh pr create --base main --head "$BR" \
-            --title "i18n: extract English keys for v$VERSION" \
-            --body "Extracted English translation keys from source with i18next-cli extract for @layerfi/components v$VERSION.")
+            --title "i18n: extract English keys" \
+            --body "Extracted English translation keys from source with i18next-cli extract for @layerfi/components.")
         else
           gh pr edit "$PR_NUMBER" \
-            --title "i18n: extract English keys for v$VERSION" \
-            --body "Extracted English translation keys from source with i18next-cli extract for @layerfi/components v$VERSION."
+            --title "i18n: extract English keys" \
+            --body "Extracted English translation keys from source with i18next-cli extract for @layerfi/components."
           PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
         fi
         if [ -z "$PR_URL" ]; then
           echo "::error::Unable to resolve English keys PR URL."
           exit 1
         fi
-        echo "[English keys PR for v$VERSION]($PR_URL)" >> "$GITHUB_STEP_SUMMARY"
+        echo "[English keys PR]($PR_URL)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Removes package version text from translation workflow PR titles, bodies, and run summaries.
- Keeps the release-style workflow summary links for the created or updated English keys and fr-CA translation PRs.
- Keeps explicit no-op summary lines when no translation changes are produced.

## Validation

- `actionlint .github/workflows/i18n-english-keys.yml .github/workflows/crowdin-french-sync.yml`
- YAML parse for both workflows
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only copy changes; no runtime, auth, or translation logic is modified.
> 
> **Overview**
> **i18n automation PRs no longer tie titles, bodies, or workflow summaries to `package.json` version.**
> 
> In `i18n-english-keys.yml` and `crowdin-french-sync.yml`, the step that read `VERSION` from `package.json` is removed. English-keys and fr-CA Crowdin PRs use fixed titles and bodies (e.g. `i18n: extract English keys`, `i18n: update fr-CA translations`) without a `v$VERSION` suffix. No-op and success **GitHub step summary** lines drop the version wording as well; PR link labels stay the same apart from that.
> 
> Commit messages and the rest of each workflow (extract, Crowdin sync, branch names) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5bfbd9385a40d18e3ba9f37b2802d7499fe7d10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->