### PR TITLE
i18n: harden French Crowdin sync workflow

### DIFF
--- a/.github/workflows/crowdin-french-sync.yml
+++ b/.github/workflows/crowdin-french-sync.yml
@@ -110,8 +110,14 @@ jobs:
         CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
         CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
-    - name: Make downloaded fr-CA files writable
-      run: chmod -R u+rwX src/assets/locales/fr-CA
+    - name: Normalize downloaded fr-CA file permissions
+      run: |
+        ls -ld src/assets/locales/fr-CA
+        find src/assets/locales/fr-CA -maxdepth 1 -type f -exec ls -l {} +
+        sudo chown -R "$USER:$(id -gn)" src/assets/locales/fr-CA
+        chmod -R u+rwX src/assets/locales/fr-CA
+        ls -ld src/assets/locales/fr-CA
+        find src/assets/locales/fr-CA -maxdepth 1 -type f -exec ls -l {} +
 
     - name: Keep existing fr-CA keys only
       run: node scripts/i18next/mergeExistingTranslations.mjs "$RUNNER_TEMP/fr-CA-before-crowdin" src/assets/locales/fr-CA

--- a/.github/workflows/crowdin-french-sync.yml
+++ b/.github/workflows/crowdin-french-sync.yml
@@ -11,8 +11,7 @@ name: i18n - Sync French Translations
 # Set pretranslate=true to run the full upload/pre-translate/download flow.
 #
 # Secrets:  CROWDIN_PROJECT_ID, CROWDIN_PERSONAL_TOKEN
-# Variable: CROWDIN_AI_PROMPT_ID (optional) — adds an AI pre-translation pass
-#           for strings that still have no fr-CA translation.
+# Variable: CROWDIN_AI_PROMPT_ID — required for full pre-translation runs.
 
 on:
   workflow_dispatch:
@@ -74,8 +73,18 @@ jobs:
         CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
         CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
+    - name: Require Crowdin AI prompt
+      if: ${{ github.event_name == 'push' || inputs.pretranslate }}
+      env:
+        CROWDIN_AI_PROMPT_ID: ${{ vars.CROWDIN_AI_PROMPT_ID }}
+      run: |
+        if [ -z "$CROWDIN_AI_PROMPT_ID" ]; then
+          echo "::error::Set repository variable CROWDIN_AI_PROMPT_ID to run AI pre-translation."
+          exit 1
+        fi
+
     - name: Pre-translate fr-CA with AI
-      if: ${{ (github.event_name == 'push' || inputs.pretranslate) && vars.CROWDIN_AI_PROMPT_ID != '' }}
+      if: ${{ github.event_name == 'push' || inputs.pretranslate }}
       uses: crowdin/github-action@v2
       with:
         command: pre-translate

--- a/.github/workflows/crowdin-french-sync.yml
+++ b/.github/workflows/crowdin-french-sync.yml
@@ -54,6 +54,7 @@ jobs:
       if: ${{ github.event_name == 'push' || inputs.pretranslate }}
       uses: crowdin/github-action@v2
       with:
+        user: auto
         upload_sources: true
         upload_translations: false
         download_translations: false
@@ -67,6 +68,7 @@ jobs:
       if: ${{ github.event_name == 'push' || inputs.pretranslate }}
       uses: crowdin/github-action@v2
       with:
+        user: auto
         command: pre-translate
         command_args: -l fr-CA --method tm --translate-untranslated-only
       env:
@@ -87,6 +89,7 @@ jobs:
       if: ${{ github.event_name == 'push' || inputs.pretranslate }}
       uses: crowdin/github-action@v2
       with:
+        user: auto
         command: pre-translate
         command_args: -l fr-CA --method ai --ai-prompt ${{ vars.CROWDIN_AI_PROMPT_ID }} --translate-untranslated-only
       env:
@@ -99,6 +102,7 @@ jobs:
     - name: Download fr-CA translations
       uses: crowdin/github-action@v2
       with:
+        user: auto
         upload_sources: false
         upload_translations: false
         download_translations: true
@@ -114,7 +118,6 @@ jobs:
       run: |
         ls -ld src/assets/locales/fr-CA
         find src/assets/locales/fr-CA -maxdepth 1 -type f -exec ls -l {} +
-        sudo chown -R "$USER:$(id -gn)" src/assets/locales/fr-CA
         chmod -R u+rwX src/assets/locales/fr-CA
         ls -ld src/assets/locales/fr-CA
         find src/assets/locales/fr-CA -maxdepth 1 -type f -exec ls -l {} +

--- a/.github/workflows/crowdin-french-sync.yml
+++ b/.github/workflows/crowdin-french-sync.yml
@@ -101,6 +101,9 @@ jobs:
         CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
         CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
+    - name: Make downloaded fr-CA files writable
+      run: chmod -R u+rwX src/assets/locales/fr-CA
+
     - name: Keep existing fr-CA keys only
       run: node scripts/i18next/mergeExistingTranslations.mjs "$RUNNER_TEMP/fr-CA-before-crowdin" src/assets/locales/fr-CA
 


### PR DESCRIPTION
## Summary

- Runs each `crowdin/github-action@v2` step with `user: auto`, so the Docker action writes workspace files as the checkout owner instead of root.
- Keeps a post-download permission normalization step to restore user write bits before `mergeExistingTranslations.mjs` rewrites JSON files.
- Logs the top-level fr-CA locale tree permissions before and after normalization for the next workflow run.
- Fixes the observed `EACCES: permission denied, open 'src/assets/locales/fr-CA/bankTransactions.json'` failure after Crowdin downloads.
- Makes AI pretranslation required for full pretranslation runs instead of silently skipping when `CROWDIN_AI_PROMPT_ID` is missing.
- Keeps manual download-only runs unchanged: they still skip upload, TM pretranslation, and AI pretranslation.

## Validation

- `actionlint .github/workflows/crowdin-french-sync.yml`
- YAML parse for `.github/workflows/crowdin-french-sync.yml`
- `git diff --check`
- Local readonly-file reproduction: merge helper fails on a read-only target JSON and succeeds after restoring write permission

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to the French Crowdin workflow; no app runtime, auth, or data paths. Full pre-translate runs now require `CROWDIN_AI_PROMPT_ID` to be configured.
> 
> **Overview**
> **Hardens the `i18n - Sync French Translations` workflow** so full sync runs (push to `en-US` or manual `pretranslate=true`) fail fast if `CROWDIN_AI_PROMPT_ID` is unset, instead of skipping AI pre-translation quietly. A dedicated check step emits a clear Actions error before the AI pre-translate step, which now always runs on those paths.
> 
> **Crowdin action steps** now pass `user: auto` on upload, TM pre-translate, AI pre-translate, and download so file ownership from Docker-based actions is less likely to block later steps.
> 
> **After downloading fr-CA**, a new step logs locale directory permissions, runs `chmod -R u+rwX` on `src/assets/locales/fr-CA`, and logs again—addressing `EACCES` when `mergeExistingTranslations.mjs` writes JSON. Manual download-only runs are unchanged (no upload/TM/AI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010f53718baaa22099528ce749c1957435894b96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->