### PR TITLE
i18n: fix Crowdin action git config permissions

### DIFF
--- a/.github/workflows/crowdin-french-sync.yml
+++ b/.github/workflows/crowdin-french-sync.yml
@@ -114,7 +114,7 @@ jobs:
       run: |
         ls -ld src/assets/locales/fr-CA
         find src/assets/locales/fr-CA -maxdepth 1 -type f -exec ls -l {} +
-        sudo chown -R "$USER:$(id -gn)" src/assets/locales/fr-CA
+        sudo chown -R "$(id -u):$(id -g)" src/assets/locales/fr-CA
         chmod -R u+rwX src/assets/locales/fr-CA
         ls -ld src/assets/locales/fr-CA
         find src/assets/locales/fr-CA -maxdepth 1 -type f -exec ls -l {} +

--- a/.github/workflows/crowdin-french-sync.yml
+++ b/.github/workflows/crowdin-french-sync.yml
@@ -54,7 +54,6 @@ jobs:
       if: ${{ github.event_name == 'push' || inputs.pretranslate }}
       uses: crowdin/github-action@v2
       with:
-        user: auto
         upload_sources: true
         upload_translations: false
         download_translations: false
@@ -68,7 +67,6 @@ jobs:
       if: ${{ github.event_name == 'push' || inputs.pretranslate }}
       uses: crowdin/github-action@v2
       with:
-        user: auto
         command: pre-translate
         command_args: -l fr-CA --method tm --translate-untranslated-only
       env:
@@ -89,7 +87,6 @@ jobs:
       if: ${{ github.event_name == 'push' || inputs.pretranslate }}
       uses: crowdin/github-action@v2
       with:
-        user: auto
         command: pre-translate
         command_args: -l fr-CA --method ai --ai-prompt ${{ vars.CROWDIN_AI_PROMPT_ID }} --translate-untranslated-only
       env:
@@ -102,7 +99,6 @@ jobs:
     - name: Download fr-CA translations
       uses: crowdin/github-action@v2
       with:
-        user: auto
         upload_sources: false
         upload_translations: false
         download_translations: true
@@ -118,6 +114,7 @@ jobs:
       run: |
         ls -ld src/assets/locales/fr-CA
         find src/assets/locales/fr-CA -maxdepth 1 -type f -exec ls -l {} +
+        sudo chown -R "$USER:$(id -gn)" src/assets/locales/fr-CA
         chmod -R u+rwX src/assets/locales/fr-CA
         ls -ld src/assets/locales/fr-CA
         find src/assets/locales/fr-CA -maxdepth 1 -type f -exec ls -l {} +


### PR DESCRIPTION
## Summary

- Removes `user: auto` from the `crowdin/github-action@v2` steps because it causes the action to try writing global git config to `//.gitconfig`.
- Restores ownership after the Crowdin download with `sudo chown -R "$USER:$(id -gn)" src/assets/locales/fr-CA` before `chmod`.
- Keeps before/after locale tree permission logging so the next workflow run shows what the Crowdin action produced.

## Validation

- `actionlint .github/workflows/crowdin-french-sync.yml`
- YAML parse for `.github/workflows/crowdin-french-sync.yml`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to a GitHub Actions i18n workflow with no application runtime impact.
> 
> **Overview**
> Fixes the **Crowdin French sync** workflow so Crowdin steps no longer use `user: auto`, which was causing `crowdin/github-action@v2` to attempt writing global git config to `//.gitconfig`.
> 
> After downloading **fr-CA** translations, the normalize step now runs **`sudo chown`** on `src/assets/locales/fr-CA` (using the runner’s uid/gid) before **`chmod`**, so later merge/commit steps can write the locale tree. Existing before/after permission logging on that directory is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 765c2e1b5ab1771226bc2bf26adbecb0a57e3a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->