### PR TITLE
feat: extract frontend filtering into useFilterBankTransactions hook

### DIFF
--- a/src/hooks/features/bankTransactions/useAugmentedBankTransactions.tsx
+++ b/src/hooks/features/bankTransactions/useAugmentedBankTransactions.tsx
@@ -7,54 +7,15 @@ import {
 import { Direction } from '@internal-types/general'
 import { type TagFilterInput } from '@internal-types/tags'
 import { isAnyBankAccountSyncing } from '@utils/bankAccount'
-import { type BankTransactionFilters, filterVisibility, type NumericRangeFilter } from '@utils/bankTransactions/shared'
+import { type BankTransactionFilters } from '@utils/bankTransactions/shared'
 import { useBankTransactions, type UseBankTransactionsOptions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
+import { useFilterBankTransactions } from '@hooks/features/bankTransactions/useFilterBankTransactions'
 import { useLinkedAccounts } from '@hooks/legacy/useLinkedAccounts'
 import { CategorizationRulesContext } from '@contexts/CategorizationRulesContext/CategorizationRulesContext'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const INITIAL_POLL_INTERVAL_MS = 1000
 const POLL_INTERVAL_AFTER_TXNS_RECEIVED_MS = 5000
-
-const applyAccountFilter = (
-  data?: BankTransaction[],
-  filter?: string[],
-) => data?.filter(x => filter && x.sourceAccountId != null && filter.includes(x.sourceAccountId))
-
-const applyCategorizationStatusFilter = (
-  data?: BankTransaction[],
-  filter?: DisplayState,
-) => {
-  if (!filter) return data
-
-  return data?.filter(
-    tx =>
-      filterVisibility(filter, tx)
-      || filter === DisplayState.all
-      || (filter === DisplayState.review && tx.recentlyCategorized)
-      || (filter === DisplayState.categorized && tx.recentlyCategorized),
-  )
-}
-
-const applyAmountFilter = (
-  data?: BankTransaction[],
-  filter?: NumericRangeFilter,
-) => {
-  return data?.filter((x) => {
-    if ((filter?.min || filter?.min === 0)
-      && (filter?.max || filter?.max === 0)) {
-      return x.amount >= filter.min * 100 && x.amount <= filter.max * 100
-    }
-
-    if (filter?.min || filter?.min === 0) {
-      return x.amount >= filter.min * 100
-    }
-
-    if (filter?.max || filter?.max === 0) {
-      return x.amount <= filter.max * 100
-    }
-  })
-}
 
 const tagFilterToQueryString = (tagFilter: TagFilterInput): string => {
   if (tagFilter != 'None' && tagFilter.tagValues.length > 0) {
@@ -146,28 +107,7 @@ export const useAugmentedBankTransactions = (
     return undefined
   }, [rawResponseData])
 
-  const filteredData = useMemo(() => {
-    let filtered = data
-
-    if (!filtered) return
-
-    if (filters?.categorizationStatus) {
-      filtered = applyCategorizationStatusFilter(
-        filtered,
-        filters.categorizationStatus,
-      )
-    }
-
-    if (filters?.amount?.min || filters?.amount?.max) {
-      filtered = applyAmountFilter(filtered, filters.amount)
-    }
-
-    if (filters?.account) {
-      filtered = applyAccountFilter(filtered, filters.account)
-    }
-
-    return filtered
-  }, [filters, data])
+  const filteredData = useFilterBankTransactions({ data, filters })
 
   const updateLocalBankTransactions = useCallback((newBankTransactions: BankTransaction[]) => {
     const transactionsById = new Map(

--- a/src/hooks/features/bankTransactions/useFilterBankTransactions.tsx
+++ b/src/hooks/features/bankTransactions/useFilterBankTransactions.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react'
+
+import { type BankTransaction, DisplayState } from '@internal-types/bankTransactions'
+import { type BankTransactionFilters, filterVisibility, type NumericRangeFilter } from '@utils/bankTransactions/shared'
+
+const applyAccountFilter = (data: BankTransaction[], filter: string[]) =>
+  data.filter(x => !!x.sourceAccountId && filter.includes(x.sourceAccountId))
+
+const applyCategorizationStatusFilter = (data: BankTransaction[], filter: DisplayState) =>
+  data.filter(
+    tx =>
+      filterVisibility(filter, tx)
+      || filter === DisplayState.all
+      || (filter === DisplayState.review && tx.recentlyCategorized)
+      || (filter === DisplayState.categorized && tx.recentlyCategorized),
+  )
+
+const applyAmountFilter = (data: BankTransaction[], filter: NumericRangeFilter) =>
+  data.filter(x =>
+    (filter.min === undefined || x.amount >= filter.min * 100)
+    && (filter.max === undefined || x.amount <= filter.max * 100),
+  )
+
+export const useFilterBankTransactions = ({
+  data,
+  filters,
+}: {
+  data?: BankTransaction[]
+  filters?: BankTransactionFilters
+}) => {
+  return useMemo(() => {
+    if (!data) return
+
+    let filtered = data
+
+    if (filters?.categorizationStatus) {
+      filtered = applyCategorizationStatusFilter(filtered, filters.categorizationStatus)
+    }
+
+    if (filters?.amount?.min !== undefined || filters?.amount?.max !== undefined) {
+      filtered = applyAmountFilter(filtered, filters.amount)
+    }
+
+    if (filters?.account) {
+      filtered = applyAccountFilter(filtered, filters.account)
+    }
+
+    return filtered
+  }, [filters, data])
+}

--- a/src/hooks/features/bankTransactions/useFilterBankTransactions.tsx
+++ b/src/hooks/features/bankTransactions/useFilterBankTransactions.tsx
@@ -21,13 +21,12 @@ const applyAmountFilter = (data: BankTransaction[], filter: NumericRangeFilter) 
     && (filter.max === undefined || x.amount <= filter.max * 100),
   )
 
-export const useFilterBankTransactions = ({
-  data,
-  filters,
-}: {
+type UseFilterBankTransactionsOptions = {
   data?: BankTransaction[]
   filters?: BankTransactionFilters
-}) => {
+}
+
+export const useFilterBankTransactions = ({ data, filters }: UseFilterBankTransactionsOptions) => {
   return useMemo(() => {
     if (!data) return
 


### PR DESCRIPTION
Refactors the frontend filtering logic out of `useAugmentedBankTransactions` into its own `useFilterBankTransactions` hook.

## Changes
- New `useFilterBankTransactions` hook owns the client-side filter helpers (`applyAccountFilter`, `applyCategorizationStatusFilter`, `applyAmountFilter`) and the memoized filtering pipeline.
- `useAugmentedBankTransactions` now delegates to it, replacing the inline `filteredData` memo.

## Cleanups within the hook
- All three `apply*` helpers take non-optional args; redundant internal null-guards removed since the caller already guards each filter's presence.
- `applyAmountFilter` collapsed from nested `if`s into a single predicate.
- Amount guard changed from `min || max` to `!= null`, fixing a latent bug where a `min`/`max` of `0` was treated as "no filter".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of UI filtering logic with a targeted bugfix for zero amount bounds; no auth, API, or data-persistence changes.
> 
> **Overview**
> Moves client-side bank transaction filtering out of `useAugmentedBankTransactions` into a dedicated **`useFilterBankTransactions`** hook. The augmented hook now passes fetched `data` and `filters` into that hook instead of owning inline `apply*` helpers and a local `filteredData` memo.
> 
> The new hook keeps the same filter pipeline (categorization status, amount range, account) with small cleanups: **`apply*`** helpers take required args after the caller guards each filter, and **`applyAmountFilter`** uses a single predicate. Amount filtering now treats **`min`/`max` of `0`** as real bounds (`!== undefined`) instead of falsy checks that skipped zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ffd16115f7fb1bf27c2968a3b7e32bcff139038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->