### PR TITLE
feat: poll syncing accounts correctly

### DIFF
--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -1,7 +1,6 @@
-import { type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { type ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react'
 
 import type { LayerError } from '@utils/api/errorHandler'
-import { isAnyBankAccountSyncing } from '@utils/bankAccount'
 import { type BankTransactionFilters } from '@utils/bankTransactions/shared'
 import { BREAKPOINTS } from '@utils/screenSizeBreakpoints'
 import { unsafeAssertUnreachable } from '@utils/switch/assertUnreachable'
@@ -9,7 +8,6 @@ import { usePreloadCategories } from '@hooks/api/businesses/[business-id]/catego
 import { usePreloadCustomers } from '@hooks/api/businesses/[business-id]/customers/useListCustomers'
 import { usePreloadTagDimensions } from '@hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions'
 import { usePreloadVendors } from '@hooks/api/businesses/[business-id]/vendors/useListVendors'
-import { useLinkedAccounts } from '@hooks/legacy/useLinkedAccounts'
 import { useElementSize } from '@hooks/utils/size/useElementSize'
 import { useIsVisible } from '@hooks/utils/visibility/useIsVisible'
 import { BankTransactionsCategorizationStoreProvider } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
@@ -19,6 +17,7 @@ import { BankTransactionsPaginationProvider } from '@providers/BankTransactionsP
 import { BankTransactionsRoute, BankTransactionsRouteStoreProvider, useBankTransactionsRouteState } from '@providers/BankTransactionsRouteStore/BankTransactionsRouteStoreProvider'
 import { BulkSelectionStoreProvider } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { type BankTransactionsMode, LegacyModeProvider } from '@providers/LegacyModeProvider/LegacyModeProvider'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import {
   useBankTransactionsContext,
 } from '@contexts/BankTransactionsContext/BankTransactionsContext'
@@ -206,15 +205,9 @@ const BankTransactionsTableView = ({
   const { isMonthlyViewMode } = useBankTransactionsFiltersContext()
 
   const { isLoading, hasMore, fetchMore } = useBankTransactionsContext()
+  const { isSyncing } = useBankAccountsContext()
 
   const { setRuleSuggestion, ruleSuggestion } = useContext(CategorizationRulesContext)
-
-  const { data: linkedAccounts } = useLinkedAccounts()
-
-  const isSyncing = useMemo(
-    () => isAnyBankAccountSyncing(linkedAccounts ?? []),
-    [linkedAccounts],
-  )
 
   useEffect(() => {
     // Fetch more when the user scrolls to the bottom of the page

--- a/src/components/LinkAccounts/LinkAccounts.tsx
+++ b/src/components/LinkAccounts/LinkAccounts.tsx
@@ -1,11 +1,10 @@
-import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { Awaitable } from '@internal-types/utility/promises'
 import { type PlaidHostedLinkConfig } from '@schemas/linkedAccounts/plaid'
 import { getAccountsNeedingConfirmation } from '@utils/bankAccount'
 import { LinkedAccountsProvider } from '@providers/LinkedAccountsProvider/LinkedAccountsProvider'
-import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { Heading } from '@ui/Typography/Heading'
 import { LinkAccountsConfirmationStep } from '@components/LinkAccounts/LinkAccountsConfirmationStep'
 import { LinkAccountsLinkStep } from '@components/LinkAccounts/LinkAccountsLinkStep'
@@ -31,7 +30,7 @@ function LinkAccountsContent({
   onComplete,
 }: LinkAccountsProps) {
   const { t } = useTranslation()
-  const { data: linkedAccounts, loadingStatus } = useContext(LinkedAccountsContext)
+  const { data: linkedAccounts, loadingStatus } = useBankAccountsContext()
 
   const linkedAccountsNeedingConfirmation = linkedAccounts
     ? getAccountsNeedingConfirmation(linkedAccounts)

--- a/src/components/LinkAccounts/LinkAccountsConfirmationStep.tsx
+++ b/src/components/LinkAccounts/LinkAccountsConfirmationStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react'
+import { useCallback } from 'react'
 import { useForm } from '@tanstack/react-form'
 import { useTranslation } from 'react-i18next'
 
@@ -6,7 +6,7 @@ import { getAccountsNeedingConfirmation } from '@utils/bankAccount'
 import { tPlural } from '@utils/i18n/plural'
 import { useConfirmAndExcludeMultiple } from '@hooks/features/bankAccounts/useConfirmAndExcludeMultiple'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
-import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
@@ -37,15 +37,15 @@ export function LinkAccountsConfirmationStep() {
   const { formatNumber } = useIntlFormatter()
   const {
     data: linkedAccounts,
+    refetch,
     loadingStatus: linkedAccountsLoadingStatus,
-    refetchAccounts,
-  } = useContext(LinkedAccountsContext)
+  } = useBankAccountsContext()
 
   const effectiveLinkedAccounts = linkedAccounts
     ? getAccountsNeedingConfirmation(linkedAccounts)
     : []
 
-  const { trigger } = useConfirmAndExcludeMultiple({ onSuccess: refetchAccounts })
+  const { trigger } = useConfirmAndExcludeMultiple({ onSuccess: refetch })
 
   const { previous, next } = useWizard()
 

--- a/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
+++ b/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { getBankAccountDisplayName, getBankAccountInstitution } from '@utils/bankAccount'
 import { tPlural } from '@utils/i18n/plural'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
 import { Button } from '@ui/Button/Button'
@@ -25,14 +26,8 @@ import { useWizard } from '@components/Wizard/Wizard'
 export function LinkAccountsLinkStep() {
   const { t } = useTranslation()
   const { formatNumber } = useIntlFormatter()
-  const {
-    data,
-    loadingStatus,
-    isLinking,
-    error,
-    refetchAccounts,
-    addConnection,
-  } = useContext(LinkedAccountsContext)
+  const { isLinking, addConnection } = useContext(LinkedAccountsContext)
+  const { data, isError, refetch, loadingStatus } = useBankAccountsContext()
   const { business } = useLayerContext()
   const isDemoBusiness = business?.isDemo ?? false
 
@@ -103,13 +98,13 @@ export function LinkAccountsLinkStep() {
             </VStack>
           </ElevatedLoadingSpinnerContainer>
         )}
-        isError={Boolean(error)}
+        isError={isError}
         Error={(
           <DataState
             status={DataStateStatus.failed}
             title={t('linkedAccounts:error.load_accounts', 'Failed to load accounts')}
             description={t('common:error.please_try_again_later', 'Please try again later')}
-            onRefresh={() => { void refetchAccounts() }}
+            onRefresh={() => { void refetch() }}
           />
         )}
         isLoading={loadingStatus === 'loading' || loadingStatus === 'initial'}

--- a/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
+++ b/src/components/LinkedAccounts/ConfirmationModal/LinkedAccountsConfirmationModal.tsx
@@ -7,6 +7,7 @@ import { type AccountConfirmExcludeFormState, useConfirmAndExcludeMultiple } fro
 import { useLinkedAccounts } from '@hooks/legacy/useLinkedAccounts'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useAccountConfirmationStore } from '@providers/AccountConfirmationStoreProvider'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { Button } from '@ui/Button/Button'
 import { LoadingSpinner } from '@ui/Loading/LoadingSpinner'
 import { Modal } from '@ui/Modal/Modal'
@@ -19,7 +20,8 @@ import { ConditionalList } from '@components/utility/ConditionalList'
 import './linkedAccountsConfirmationModal.scss'
 
 function useLinkedAccountsConfirmationModal() {
-  const { data, refetchAccounts } = useLinkedAccounts()
+  const { data } = useBankAccountsContext()
+  const { refetchAccountsAndTransactions } = useLinkedAccounts()
   const accountsNeedingConfirmation = getAccountsNeedingConfirmation(data ?? [])
 
   const {
@@ -35,7 +37,7 @@ function useLinkedAccountsConfirmationModal() {
     accounts: accountsNeedingConfirmation,
     onDismiss: dismissAccountConfirmation,
     onFinish: resetAccountConfirmation,
-    refetchAccounts,
+    refetchAccountsAndTransactions,
   }
 
   if (mainIsOpen) {
@@ -88,13 +90,13 @@ function LinkedAccountsConfirmationModalPreloadedContent({ onClose }: { onClose:
 function LinkedAccountsConfirmationModalContent({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation()
   const { formatNumber } = useIntlFormatter()
-  const { accounts, onFinish, refetchAccounts } = useLinkedAccountsConfirmationModal()
+  const { accounts, onFinish, refetchAccountsAndTransactions } = useLinkedAccountsConfirmationModal()
 
   const [formState, setFormState] = useState(() => Object.fromEntries(
     accounts.map(({ id }) => [id, true]),
   ))
 
-  const { trigger, isMutating, isError } = useConfirmAndExcludeMultiple({ onSuccess: refetchAccounts })
+  const { trigger, isMutating, isError } = useConfirmAndExcludeMultiple({ onSuccess: refetchAccountsAndTransactions })
 
   const handleFinish = async () => {
     const success = await trigger(formState)

--- a/src/components/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/components/LinkedAccounts/LinkedAccounts.tsx
@@ -52,12 +52,7 @@ export const LinkedAccountsComponent = ({
   stringOverrides,
 }: LinkedAccountsProps) => {
   const { t } = useTranslation()
-  const {
-    isLoading,
-    isError,
-    isValidating,
-    refetch,
-  } = useBankAccountsContext()
+  const { isLoading, isError, isValidating, refetch } = useBankAccountsContext()
 
   return (
     <Container name={COMPONENT_NAME} elevated={elevated}>

--- a/src/components/LinkedAccounts/LinkedAccounts.tsx
+++ b/src/components/LinkedAccounts/LinkedAccounts.tsx
@@ -1,11 +1,10 @@
-import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { type PlaidHostedLinkConfig } from '@schemas/linkedAccounts/plaid'
 import { AccountConfirmationStoreProvider } from '@providers/AccountConfirmationStoreProvider'
 import { LinkedAccountsProvider } from '@providers/LinkedAccountsProvider/LinkedAccountsProvider'
 import { OpeningBalanceModalProvider } from '@providers/OpeningBalanceModalProvider/OpeningBalanceModalProvider'
-import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { HStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
 import { Container } from '@components/Container/Container'
@@ -55,10 +54,10 @@ export const LinkedAccountsComponent = ({
   const { t } = useTranslation()
   const {
     isLoading,
-    error,
+    isError,
     isValidating,
-    refetchAccounts,
-  } = useContext(LinkedAccountsContext)
+    refetch,
+  } = useBankAccountsContext()
 
   return (
     <Container name={COMPONENT_NAME} elevated={elevated}>
@@ -77,18 +76,18 @@ export const LinkedAccountsComponent = ({
           <Loader />
         </div>
       )}
-      {error && !isLoading
+      {isError && !isLoading
         ? (
           <DataState
             status={DataStateStatus.failed}
             title={t('common:error.something_went_wrong', 'Something went wrong')}
             description={t('common:error.couldnt_load_data', 'We couldn’t load your data.')}
-            onRefresh={() => void refetchAccounts()}
+            onRefresh={() => void refetch()}
             isLoading={isValidating}
           />
         )
         : null}
-      {!error && !isLoading
+      {!isError && !isLoading
         ? (
           <LinkedAccountsContent
             asWidget={asWidget}

--- a/src/components/LinkedAccounts/LinkedAccountsContent.tsx
+++ b/src/components/LinkedAccounts/LinkedAccountsContent.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 
 import { useEmitLayerEvent } from '@hooks/useEmitLayerEvent'
 import { LayerEventComponent, LayerEventType } from '@providers/LayerProvider/layerEvents'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
 import { HStack } from '@ui/Stack/Stack'
@@ -29,7 +30,8 @@ export const LinkedAccountsContent = ({
   showBreakConnection,
 }: LinkedAccountsDataProps) => {
   const { t } = useTranslation()
-  const { data, addConnection } = useContext(LinkedAccountsContext)
+  const { data } = useBankAccountsContext()
+  const { addConnection } = useContext(LinkedAccountsContext)
   const { business } = useLayerContext()
   const emitLayerEvent = useEmitLayerEvent(LayerEventComponent.LinkedAccounts)
   const isDemoBusiness = business?.isDemo ?? false

--- a/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
+++ b/src/components/LinkedAccounts/OpeningBalanceModal/OpeningBalanceModal.tsx
@@ -6,12 +6,12 @@ import { useIntl } from 'react-intl'
 import { type BankAccount } from '@schemas/bankAccounts/bankAccount'
 import { getActivationDate } from '@utils/business'
 import { toLocalizedCents } from '@utils/i18n/number/input'
-import { useLinkedAccounts } from '@hooks/legacy/useLinkedAccounts'
 import {
   type OpeningBalanceAPIResponseResult,
   type OpeningBalanceData,
   useBulkSetOpeningBalanceAndDate,
 } from '@hooks/legacy/useUpdateOpeningBalanceAndDate'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { OpeningBalanceModalContext } from '@contexts/OpeningBalanceModalContext/OpeningBalanceModalContext'
 import { Button } from '@ui/Button/Button'
@@ -67,10 +67,8 @@ function LinkedAccountsOpeningBalanceModalContent({
   const { t } = useTranslation()
   const intl = useIntl()
   const { business } = useLayerContext()
-  const { refetchAccounts } = useLinkedAccounts()
+  const { refetch } = useBankAccountsContext()
 
-  // Mark if any data has been successfully saved with API
-  // so the refetchAccounts should be called on onClose
   const [touched, setTouched] = useState(false)
   const [results, setResults] = useState<ResultsState>({})
 
@@ -109,7 +107,7 @@ function LinkedAccountsOpeningBalanceModalContent({
 
         setTouched(true)
         if (responses.every(x => x.status === 'fulfilled')) {
-          await refetchAccounts()
+          await refetch()
           onClose()
         }
       },
@@ -117,7 +115,7 @@ function LinkedAccountsOpeningBalanceModalContent({
 
   const handleDismiss = () => {
     if (touched) {
-      void refetchAccounts()
+      void refetch()
     }
 
     onClose()

--- a/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -16,15 +16,14 @@ import {
   XAxis,
 } from 'recharts'
 
-import { isAnyBankAccountSyncing } from '@utils/bankAccount'
 import { isDateAllowedToBrowse } from '@utils/business'
 import { useBusinessActivationDate } from '@hooks/features/business/useBusinessActivationDate'
 import { useProfitAndLossLTM } from '@hooks/features/profitAndLoss/useProfitAndLossLTM'
-import { useLinkedAccounts } from '@hooks/legacy/useLinkedAccounts'
 import { useEmitLayerEvent } from '@hooks/useEmitLayerEvent'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useGlobalDate, useGlobalDateRangeActions } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 import { LayerEventComponent, LayerEventType } from '@providers/LayerProvider/layerEvents'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { ChartYAxis } from '@components/Chart/ChartYAxis'
 import { areChartWindowsEqual, getChartWindow } from '@components/ProfitAndLossChart/getChartWindow'
@@ -74,12 +73,7 @@ export const ProfitAndLossChart = ({ tagFilter, hideLegend = false }: ProfitAndL
     chartWindow,
   })
 
-  const { data: linkedAccounts } = useLinkedAccounts()
-
-  const isSyncing = useMemo(
-    () => isAnyBankAccountSyncing(linkedAccounts ?? []),
-    [linkedAccounts],
-  )
+  const { isSyncing } = useBankAccountsContext()
 
   useEffect(() => {
     if (!activationDate) return

--- a/src/components/ProfitAndLossHeader/ProfitAndLossHeader.tsx
+++ b/src/components/ProfitAndLossHeader/ProfitAndLossHeader.tsx
@@ -1,9 +1,8 @@
-import { type ReactNode, useMemo } from 'react'
+import { type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { isAnyBankAccountSyncing } from '@utils/bankAccount'
 import { useActiveBookkeepingPeriod } from '@hooks/features/bookkeeping/useActiveBookkeepingPeriod'
-import { useLinkedAccounts } from '@hooks/legacy/useLinkedAccounts'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
 import { BookkeepingStatus } from '@components/BookkeepingStatus/BookkeepingStatus'
@@ -32,15 +31,10 @@ export const ProfitAndLossHeader = ({
   trailingContent,
 }: ProfitAndLossHeaderProps) => {
   const { t } = useTranslation()
-  const { data: linkedAccounts } = useLinkedAccounts()
+  const { isSyncing } = useBankAccountsContext()
 
   const { activePeriod } = useActiveBookkeepingPeriod()
   const activePeriodStatus = activePeriod?.status
-
-  const isSyncing = useMemo(
-    () => isAnyBankAccountSyncing(linkedAccounts ?? []),
-    [linkedAccounts],
-  )
 
   return (
     <Header className={className}>

--- a/src/components/SolopreneurOnboardingBanner/SolopreneurOnboardingBanner.tsx
+++ b/src/components/SolopreneurOnboardingBanner/SolopreneurOnboardingBanner.tsx
@@ -7,6 +7,7 @@ import { useAccountingConfiguration } from '@hooks/api/businesses/[business-id]/
 import { useTaxProfile } from '@hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { LinkedAccountsProvider } from '@providers/LinkedAccountsProvider/LinkedAccountsProvider'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
 import { Banner } from '@ui/Banner/Banner'
@@ -111,18 +112,13 @@ export function SolopreneurOnboardingBanner({ onSetupTaxProfile, plaidHostedLink
 const useSolopreneurOnboardingBannerState = () => {
   const { businessId } = useLayerContext()
   const { data: accountingConfiguration, isLoading: isAccountingConfigLoading } = useAccountingConfiguration({ businessId })
-  const {
-    data: linkedAccounts,
-    isLoading: isLinkedAccountsLoading,
-    loadingStatus: linkedAccountsLoadingStatus,
-    isHostedLinkError,
-  } = useContext(LinkedAccountsContext)
+  const { data: linkedAccounts, loadingStatus: linkedAccountsLoadingStatus } = useBankAccountsContext()
+  const { isHostedLinkError } = useContext(LinkedAccountsContext)
   const { data: taxProfile, isLoading: isTaxProfileLoading } = useTaxProfile()
 
   const isTaxEstimatesEnabled = !!accountingConfiguration?.enableTaxEstimates
 
-  const isLoading = isLinkedAccountsLoading
-    || isAccountingConfigLoading
+  const isLoading = isAccountingConfigLoading
     || (isTaxEstimatesEnabled && isTaxProfileLoading)
     || linkedAccountsLoadingStatus === 'loading'
     || linkedAccountsLoadingStatus === 'initial'

--- a/src/components/Tasks/TasksPanelNotification.tsx
+++ b/src/components/Tasks/TasksPanelNotification.tsx
@@ -3,10 +3,10 @@ import { useTranslation } from 'react-i18next'
 
 import { DateFormat } from '@utils/i18n/date/patterns'
 import { tPlural } from '@utils/i18n/plural'
-import { useListBankAccounts } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
 import { useBookkeepingYearsStatus } from '@hooks/features/bookkeeping/useBookkeepingYearsStatus'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useGlobalDatePeriodAlignedActions } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { P } from '@ui/Typography/Text'
 
 import './tasksPanelNotification.scss'
@@ -21,10 +21,8 @@ export const TasksPanelNotification = ({
   const { t } = useTranslation()
   const { formatNumber, formatDate } = useIntlFormatter()
   const { setMonthByPeriod } = useGlobalDatePeriodAlignedActions()
-  const { anyPreviousYearIncomplete, earliestIncompletePeriod } =
-    useBookkeepingYearsStatus()
-  const { disconnectedAccountsRequiringNotification, isLoading } =
-    useListBankAccounts()
+  const { anyPreviousYearIncomplete, earliestIncompletePeriod } = useBookkeepingYearsStatus()
+  const { disconnectedAccountsRequiringNotification, isLoading } = useBankAccountsContext()
 
   if (!isLoading && disconnectedAccountsRequiringNotification > 0) {
     return (

--- a/src/contexts/BankAccountsContext/BankAccountsContext.tsx
+++ b/src/contexts/BankAccountsContext/BankAccountsContext.tsx
@@ -12,18 +12,20 @@ type BankAccountsContextValue = Pick<
   | 'isError'
   | 'isLoading'
   | 'isSyncing'
+  | 'isValidating'
   | 'loadingStatus'
   | 'refetch'
 >
 
 const BankAccountsContext = createContext<BankAccountsContextValue>({
   data: undefined,
+  disconnectedAccountsRequiringNotification: 0,
   isLoading: false,
   isError: false,
-  refetch: () => Promise.resolve(undefined),
-  disconnectedAccountsRequiringNotification: 0,
   isSyncing: false,
+  isValidating: false,
   loadingStatus: 'initial',
+  refetch: () => Promise.resolve(undefined),
 })
 
 function useBankAccountsPollingConfig() {
@@ -46,6 +48,7 @@ export function BankAccountsProvider({ children }: PropsWithChildren) {
     isError,
     isLoading,
     isSyncing,
+    isValidating,
     loadingStatus,
     refetch,
   } = useListBankAccounts(pollingConfig)
@@ -56,6 +59,7 @@ export function BankAccountsProvider({ children }: PropsWithChildren) {
     isError,
     isLoading,
     isSyncing,
+    isValidating,
     loadingStatus,
     refetch,
   }), [
@@ -65,6 +69,7 @@ export function BankAccountsProvider({ children }: PropsWithChildren) {
     isLoading,
     isSyncing,
     loadingStatus,
+    isValidating,
     refetch,
   ])
 

--- a/src/contexts/BankAccountsContext/BankAccountsContext.tsx
+++ b/src/contexts/BankAccountsContext/BankAccountsContext.tsx
@@ -1,0 +1,49 @@
+import { createContext, type PropsWithChildren, useCallback, useContext } from 'react'
+
+import { type BankAccount } from '@schemas/bankAccounts/bankAccount'
+import { isAnyBankAccountSyncing } from '@utils/bankAccount'
+import {
+  type ListBankAccountsSWRResponse,
+  useListBankAccounts,
+} from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
+import { usePollingConfig } from '@hooks/utils/swr/usePollingConfig'
+
+type BankAccountsContextValue = Omit<ListBankAccountsSWRResponse, 'swrResponse' | 'error' | 'mutate'>
+
+const BankAccountsContext = createContext<BankAccountsContextValue>({
+  data: undefined,
+  isLoading: false,
+  isValidating: false,
+  isError: false,
+  refetch: () => Promise.resolve(undefined),
+  disconnectedAccountsRequiringNotification: 0,
+  isSyncing: false,
+  loadingStatus: 'initial',
+})
+
+function useBankAccountsPollingConfig() {
+  const shouldContinue = useCallback(
+    (accounts: BankAccount[] | undefined) => accounts === undefined || isAnyBankAccountSyncing(accounts),
+    [],
+  )
+
+  return usePollingConfig<BankAccount[]>({
+    shouldContinue,
+    maxDurationMs: Number.POSITIVE_INFINITY,
+  })
+}
+
+export function BankAccountsProvider({ children }: PropsWithChildren) {
+  const pollingConfig = useBankAccountsPollingConfig()
+  const bankAccounts = useListBankAccounts(pollingConfig)
+
+  return (
+    <BankAccountsContext.Provider value={bankAccounts}>
+      {children}
+    </BankAccountsContext.Provider>
+  )
+}
+
+export function useBankAccountsContext() {
+  return useContext(BankAccountsContext)
+}

--- a/src/contexts/BankAccountsContext/BankAccountsContext.tsx
+++ b/src/contexts/BankAccountsContext/BankAccountsContext.tsx
@@ -23,7 +23,7 @@ const BankAccountsContext = createContext<BankAccountsContextValue>({
 
 function useBankAccountsPollingConfig() {
   const shouldContinue = useCallback(
-    (accounts: BankAccount[] | undefined) => accounts === undefined || isAnyBankAccountSyncing(accounts),
+    (accounts: BankAccount[] | undefined) => accounts !== undefined && isAnyBankAccountSyncing(accounts),
     [],
   )
 

--- a/src/contexts/BankAccountsContext/BankAccountsContext.tsx
+++ b/src/contexts/BankAccountsContext/BankAccountsContext.tsx
@@ -39,7 +39,7 @@ function useBankAccountsPollingConfig() {
 
   return usePollingConfig<BankAccount[]>({
     shouldContinue,
-    shouldResetPollingDeadline: hasNewSyncingAccounts,
+    shouldRestartPolling: hasNewSyncingAccounts,
     intervalMs: BANK_ACCOUNTS_POLL_INTERVAL_MS,
     maxDurationMs: BANK_ACCOUNTS_MAX_POLL_STALL_MS,
   })

--- a/src/contexts/BankAccountsContext/BankAccountsContext.tsx
+++ b/src/contexts/BankAccountsContext/BankAccountsContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, type PropsWithChildren, useCallback, useContext, useMemo } from 'react'
 
 import { type BankAccount } from '@schemas/bankAccounts/bankAccount'
-import { isAnyBankAccountSyncing } from '@utils/bankAccount'
+import { hasNewSyncingAccounts, isAnyBankAccountSyncing } from '@utils/bankAccount'
 import { type ListBankAccountsSWRResponse, useListBankAccounts } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
 import { usePollingConfig } from '@hooks/utils/swr/usePollingConfig'
 
@@ -16,6 +16,9 @@ type BankAccountsContextValue = Pick<
   | 'loadingStatus'
   | 'refetch'
 >
+
+const BANK_ACCOUNTS_POLL_INTERVAL_MS = 5 * 1000
+const BANK_ACCOUNTS_MAX_POLL_STALL_MS = 15 * 60 * 1000
 
 const BankAccountsContext = createContext<BankAccountsContextValue>({
   data: undefined,
@@ -36,7 +39,9 @@ function useBankAccountsPollingConfig() {
 
   return usePollingConfig<BankAccount[]>({
     shouldContinue,
-    maxDurationMs: Number.POSITIVE_INFINITY,
+    shouldResetPollingDeadline: hasNewSyncingAccounts,
+    intervalMs: BANK_ACCOUNTS_POLL_INTERVAL_MS,
+    maxDurationMs: BANK_ACCOUNTS_MAX_POLL_STALL_MS,
   })
 }
 

--- a/src/contexts/BankAccountsContext/BankAccountsContext.tsx
+++ b/src/contexts/BankAccountsContext/BankAccountsContext.tsx
@@ -1,19 +1,24 @@
-import { createContext, type PropsWithChildren, useCallback, useContext } from 'react'
+import { createContext, type PropsWithChildren, useCallback, useContext, useMemo } from 'react'
 
 import { type BankAccount } from '@schemas/bankAccounts/bankAccount'
 import { isAnyBankAccountSyncing } from '@utils/bankAccount'
-import {
-  type ListBankAccountsSWRResponse,
-  useListBankAccounts,
-} from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
+import { type ListBankAccountsSWRResponse, useListBankAccounts } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
 import { usePollingConfig } from '@hooks/utils/swr/usePollingConfig'
 
-type BankAccountsContextValue = Omit<ListBankAccountsSWRResponse, 'swrResponse' | 'error' | 'mutate'>
+type BankAccountsContextValue = Pick<
+  ListBankAccountsSWRResponse,
+  | 'data'
+  | 'disconnectedAccountsRequiringNotification'
+  | 'isError'
+  | 'isLoading'
+  | 'isSyncing'
+  | 'loadingStatus'
+  | 'refetch'
+>
 
 const BankAccountsContext = createContext<BankAccountsContextValue>({
   data: undefined,
   isLoading: false,
-  isValidating: false,
   isError: false,
   refetch: () => Promise.resolve(undefined),
   disconnectedAccountsRequiringNotification: 0,
@@ -35,10 +40,36 @@ function useBankAccountsPollingConfig() {
 
 export function BankAccountsProvider({ children }: PropsWithChildren) {
   const pollingConfig = useBankAccountsPollingConfig()
-  const bankAccounts = useListBankAccounts(pollingConfig)
+  const {
+    data,
+    disconnectedAccountsRequiringNotification,
+    isError,
+    isLoading,
+    isSyncing,
+    loadingStatus,
+    refetch,
+  } = useListBankAccounts(pollingConfig)
+
+  const value = useMemo<BankAccountsContextValue>(() => ({
+    data,
+    disconnectedAccountsRequiringNotification,
+    isError,
+    isLoading,
+    isSyncing,
+    loadingStatus,
+    refetch,
+  }), [
+    data,
+    disconnectedAccountsRequiringNotification,
+    isError,
+    isLoading,
+    isSyncing,
+    loadingStatus,
+    refetch,
+  ])
 
   return (
-    <BankAccountsContext.Provider value={bankAccounts}>
+    <BankAccountsContext.Provider value={value}>
       {children}
     </BankAccountsContext.Provider>
   )

--- a/src/contexts/BankTransactionsContext/BankTransactionsContext.tsx
+++ b/src/contexts/BankTransactionsContext/BankTransactionsContext.tsx
@@ -9,7 +9,6 @@ export const BankTransactionsContext =
   createContext<BankTransactionsContextType>({
     data: undefined,
     isLoading: false,
-    isValidating: false,
     isError: false,
     updateLocalBankTransactions: () => undefined,
     shouldHideAfterCategorize: false,

--- a/src/contexts/LinkedAccountsContext/LinkedAccountsContext.ts
+++ b/src/contexts/LinkedAccountsContext/LinkedAccountsContext.ts
@@ -4,17 +4,12 @@ import { type useLinkedAccounts } from '@hooks/legacy/useLinkedAccounts'
 
 export type LinkedAccountsContextType = ReturnType<typeof useLinkedAccounts>
 export const LinkedAccountsContext = createContext<LinkedAccountsContextType>({
-  data: undefined,
-  isLoading: false,
-  loadingStatus: 'initial',
-  isValidating: false,
   isLinking: false,
-  error: undefined,
   isHostedLinkError: false,
   addConnection: () => Promise.resolve(),
   removeConnection: () => Promise.resolve(),
   repairConnection: () => Promise.resolve(),
-  refetchAccounts: () => Promise.resolve(),
+  refetchAccountsAndTransactions: () => Promise.resolve(),
   unlinkBankAccount: () => Promise.resolve(),
   excludeAccount: () => Promise.resolve(),
   confirmAccount: () => Promise.resolve(),

--- a/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
@@ -1,8 +1,10 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
+import useSWR, { type SWRConfiguration } from 'swr'
 
+import { type LoadedStatus } from '@internal-types/general'
 import { type BankAccount, BankAccountSchema } from '@schemas/bankAccounts/bankAccount'
 import { get } from '@utils/api/authenticatedHttp'
+import { isAnyBankAccountSyncing } from '@utils/bankAccount'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
@@ -52,9 +54,23 @@ export class ListBankAccountsSWRResponse extends SWRQueryResult<BankAccount[]> {
   get disconnectedAccountsRequiringNotification() {
     return (this.data ?? []).filter(requiresNotification).length
   }
+
+  get isSyncing() {
+    return isAnyBankAccountSyncing(this.data ?? [])
+  }
+
+  get loadingStatus(): LoadedStatus {
+    if (this.isLoading) {
+      return 'loading'
+    }
+
+    return this.data !== undefined || this.isError ? 'complete' : 'initial'
+  }
 }
 
-export function useListBankAccounts(): ListBankAccountsSWRResponse {
+export function useListBankAccounts(
+  config?: SWRConfiguration<BankAccount[]>,
+): ListBankAccountsSWRResponse {
   const { businessId } = useLayerContext()
   const { apiUrl } = useEnvironment()
   const { data: auth } = useAuth()
@@ -75,6 +91,7 @@ export function useListBankAccounts(): ListBankAccountsSWRResponse {
     )()
       .then(Schema.decodeUnknownPromise(ListBankAccountsResponseSchema))
       .then(({ data }) => [...data]),
+    config,
   )
 
   return new ListBankAccountsSWRResponse(swrResponse)

--- a/src/hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount.ts
@@ -1,10 +1,8 @@
-import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
@@ -47,7 +45,6 @@ export function useUnlinkBankAccount() {
   const { businessId } = useLayerContext()
   const { apiUrl } = useEnvironment()
   const { data: auth } = useAuth()
-  const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
@@ -64,27 +61,5 @@ export function useUnlinkBankAccount() {
     },
   )
 
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
-
-  const { trigger: originalTrigger } = mutationResponse
-
-  const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const triggerResult = await originalTrigger(...triggerParameters)
-      void forceReloadBankTransactions()
-      return triggerResult
-    },
-    [originalTrigger, forceReloadBankTransactions],
-  )
-
-  return new Proxy(mutationResponse, {
-    get(target, prop) {
-      if (prop === 'trigger') {
-        return stableProxiedTrigger
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return Reflect.get(target, prop)
-    },
-  })
+  return new SWRMutationResult(rawMutationResponse)
 }

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/useCategorizeBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/useCategorizeBankTransaction.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import { useSWRConfig } from 'swr'
 import type { SWRInfiniteKeyedMutator } from 'swr/infinite'
 import useSWRMutation from 'swr/mutation'
 
@@ -9,8 +8,6 @@ import { type CategoryUpdate, type CategoryUpdateEncoded, encodeCategoryUpdate }
 import { put } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
-import { BANK_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
 import { type GetBankTransactionsReturn } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
@@ -69,7 +66,6 @@ export function useCategorizeBankTransaction() {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
-  const { mutate } = useSWRConfig()
 
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
   const { useBankTransactionsOptions } = useBankTransactionsContext()
@@ -111,18 +107,13 @@ export function useCategorizeBankTransaction() {
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
-      void mutate(key => withSWRKeyTags(
-        key,
-        ({ tags }) => tags.includes(BANK_ACCOUNTS_TAG_KEY),
-      ))
-
       void forceReloadBackgroundBankTransactions(useBankTransactionsOptions)
 
       void debouncedInvalidateProfitAndLoss()
 
       return triggerResult
     },
-    [originalTrigger, mutate, forceReloadBackgroundBankTransactions, useBankTransactionsOptions, debouncedInvalidateProfitAndLoss],
+    [originalTrigger, forceReloadBackgroundBankTransactions, useBankTransactionsOptions, debouncedInvalidateProfitAndLoss],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/match/useMatchBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/match/useMatchBankTransaction.ts
@@ -1,14 +1,11 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import { useSWRConfig } from 'swr'
 import useSWRMutation from 'swr/mutation'
 
 import { MatchSchema } from '@schemas/bankTransactions/match'
 import { put } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
-import { BANK_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -65,7 +62,6 @@ export function useMatchBankTransaction() {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
-  const { mutate } = useSWRConfig()
 
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
   const { useBankTransactionsOptions } = useBankTransactionsContext()
@@ -107,20 +103,13 @@ export function useMatchBankTransaction() {
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
-      void mutate(key => withSWRKeyTags(
-        key,
-        ({ tags }) => (
-          tags.includes(BANK_ACCOUNTS_TAG_KEY)
-        ),
-      ))
-
       void forceReloadBackgroundBankTransactions(useBankTransactionsOptions)
 
       void debouncedInvalidateProfitAndLoss()
 
       return triggerResult
     },
-    [originalTrigger, mutate, forceReloadBackgroundBankTransactions, useBankTransactionsOptions, debouncedInvalidateProfitAndLoss],
+    [originalTrigger, forceReloadBackgroundBankTransactions, useBankTransactionsOptions, debouncedInvalidateProfitAndLoss],
   )
 
   return new Proxy(mutationResponse, {

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { Schema } from 'effect'
 import { debounce } from 'lodash-es'
-import useSWRInfinite from 'swr/infinite'
+import useSWRInfinite, { type SWRInfiniteConfiguration } from 'swr/infinite'
 
 import type { BankTransaction } from '@internal-types/bankTransactions'
 import { PaginatedResponseMetaSchema } from '@internal-types/utility/pagination'
@@ -147,7 +147,7 @@ export function useBankTransactions({
   startDate,
   endDate,
   tagFilterQueryString,
-}: UseBankTransactionsOptions) {
+}: UseBankTransactionsOptions, config?: SWRInfiniteConfiguration<GetBankTransactionsReturn>) {
   const withLocale = useLocalizedKey()
   const { data } = useAuth()
   const { businessId } = useLayerContext()
@@ -200,6 +200,7 @@ export function useBankTransactions({
       keepPreviousData: true,
       revalidateFirstPage: false,
       initialSize: 1,
+      ...config,
     },
   )
 

--- a/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/unlink.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/unlink.ts
@@ -1,10 +1,8 @@
-import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
@@ -42,7 +40,6 @@ export function useUnlinkPlaidItem() {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
-  const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
@@ -61,27 +58,5 @@ export function useUnlinkPlaidItem() {
     },
   )
 
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
-
-  const { trigger: originalTrigger } = mutationResponse
-
-  const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const triggerResult = await originalTrigger(...triggerParameters)
-      void forceReloadBankTransactions()
-      return triggerResult
-    },
-    [originalTrigger, forceReloadBankTransactions],
-  )
-
-  return new Proxy(mutationResponse, {
-    get(target, prop) {
-      if (prop === 'trigger') {
-        return stableProxiedTrigger
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return Reflect.get(target, prop)
-    },
-  })
+  return new SWRMutationResult(rawMutationResponse)
 }

--- a/src/hooks/api/businesses/[business-id]/plaid/link/exchange.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/link/exchange.ts
@@ -1,11 +1,9 @@
-import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import type { PublicToken } from '@internal-types/linkedAccounts'
 import { post } from '@utils/api/authenticatedHttp'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
@@ -40,7 +38,6 @@ export function useExchangePlaidPublicToken() {
   const withLocale = useLocalizedKey()
   const { data: auth } = useAuth()
   const { businessId } = useLayerContext()
-  const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
@@ -64,27 +61,5 @@ export function useExchangePlaidPublicToken() {
     },
   )
 
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
-
-  const { trigger: originalTrigger } = mutationResponse
-
-  const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const triggerResult = await originalTrigger(...triggerParameters)
-      void forceReloadBankTransactions()
-      return triggerResult
-    },
-    [originalTrigger, forceReloadBankTransactions],
-  )
-
-  return new Proxy(mutationResponse, {
-    get(target, prop) {
-      if (prop === 'trigger') {
-        return stableProxiedTrigger
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return Reflect.get(target, prop)
-    },
-  })
+  return new SWRMutationResult(rawMutationResponse)
 }

--- a/src/hooks/features/bankTransactions/useAugmentedBankTransactions.tsx
+++ b/src/hooks/features/bankTransactions/useAugmentedBankTransactions.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 
 import {
   type BankTransaction,
@@ -6,16 +6,11 @@ import {
 } from '@internal-types/bankTransactions'
 import { Direction } from '@internal-types/general'
 import { type TagFilterInput } from '@internal-types/tags'
-import { isAnyBankAccountSyncing } from '@utils/bankAccount'
 import { type BankTransactionFilters } from '@utils/bankTransactions/shared'
 import { useBankTransactions, type UseBankTransactionsOptions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useFilterBankTransactions } from '@hooks/features/bankTransactions/useFilterBankTransactions'
-import { useLinkedAccounts } from '@hooks/legacy/useLinkedAccounts'
+import { usePollBankTransactions } from '@hooks/features/bankTransactions/usePollBankTransactions'
 import { CategorizationRulesContext } from '@contexts/CategorizationRulesContext/CategorizationRulesContext'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
-
-const INITIAL_POLL_INTERVAL_MS = 1000
-const POLL_INTERVAL_AFTER_TXNS_RECEIVED_MS = 5000
 
 const tagFilterToQueryString = (tagFilter: TagFilterInput): string => {
   if (tagFilter != 'None' && tagFilter.tagValues.length > 0) {
@@ -24,25 +19,6 @@ const tagFilterToQueryString = (tagFilter: TagFilterInput): string => {
     )}&`
   }
   return ''
-}
-
-function useTriggerOnChange(
-  data: BankTransaction[] | undefined,
-  anyAccountSyncing: boolean,
-  callback: (data: BankTransaction[] | undefined) => void,
-) {
-  const prevDataRef = useRef<BankTransaction[]>()
-
-  useEffect(() => {
-    if (
-      anyAccountSyncing
-      && prevDataRef.current !== undefined
-      && prevDataRef.current !== data
-    ) {
-      callback(data)
-    }
-    prevDataRef.current = data
-  }, [data, anyAccountSyncing, callback])
 }
 
 export function bankTransactionFiltersToHookOptions(
@@ -73,8 +49,6 @@ export type UseAugmentedBankTransactionsWithFiltersParams = {
 export const useAugmentedBankTransactions = (
   params: UseAugmentedBankTransactionsWithFiltersParams,
 ) => {
-  const { eventCallbacks } = useLayerContext()
-
   const { setRuleSuggestion } = useContext(CategorizationRulesContext)
 
   const { filters } = params
@@ -88,13 +62,14 @@ export const useAugmentedBankTransactions = (
   const {
     data: rawResponseData,
     isLoading,
-    isValidating,
     isError,
     mutate,
     size,
     setSize,
     hasMore,
   } = useBankTransactions(useBankTransactionsOptions)
+
+  usePollBankTransactions({ mutate, useBankTransactionsOptions })
 
   const data: BankTransaction[] | undefined = useMemo(() => {
     if (rawResponseData && rawResponseData.length > 0) {
@@ -148,66 +123,9 @@ export const useAugmentedBankTransactions = (
     }
   }, [hasMore, setSize, size])
 
-  const { data: linkedAccounts, refetchAccounts } = useLinkedAccounts()
-  const anyAccountSyncing = useMemo(
-    () => isAnyBankAccountSyncing(linkedAccounts ?? []),
-    [linkedAccounts],
-  )
-
-  const [pollIntervalMs, setPollIntervalMs] = useState(
-    INITIAL_POLL_INTERVAL_MS,
-  )
-
-  const transactionsNotSynced = useMemo(
-    () =>
-      isLoading === false
-      && anyAccountSyncing
-      && (!data || data?.length === 0),
-    [data, anyAccountSyncing, isLoading],
-  )
-
-  const intervalIdRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined)
-
-  // calling `void mutate()` directly in the `setInterval` didn't trigger actual request to API.
-  // But it works when called from `useEffect`
-  const [refreshTrigger, setRefreshTrigger] = useState(-1)
-  useEffect(() => {
-    if (refreshTrigger !== -1) {
-      void mutate()
-      void refetchAccounts()
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshTrigger])
-
-  useEffect(() => {
-    if (anyAccountSyncing) {
-      intervalIdRef.current = setInterval(() => {
-        setRefreshTrigger(Math.random())
-      }, pollIntervalMs)
-    }
-    else {
-      if (intervalIdRef.current) {
-        clearInterval(intervalIdRef.current)
-      }
-    }
-
-    return () => {
-      if (intervalIdRef.current) {
-        clearInterval(intervalIdRef.current)
-      }
-    }
-  }, [anyAccountSyncing, transactionsNotSynced, pollIntervalMs])
-
-  useTriggerOnChange(data, anyAccountSyncing, (_) => {
-    clearInterval(intervalIdRef.current)
-    setPollIntervalMs(POLL_INTERVAL_AFTER_TXNS_RECEIVED_MS)
-    eventCallbacks?.onTransactionsFetched?.()
-  })
-
   return useMemo(() => ({
     data: filteredData,
     isLoading,
-    isValidating,
     isError,
     updateLocalBankTransactions,
     shouldHideAfterCategorize,
@@ -220,7 +138,6 @@ export const useAugmentedBankTransactions = (
   }), [
     filteredData,
     isLoading,
-    isValidating,
     isError,
     updateLocalBankTransactions,
     shouldHideAfterCategorize,

--- a/src/hooks/features/bankTransactions/useAugmentedBankTransactions.tsx
+++ b/src/hooks/features/bankTransactions/useAugmentedBankTransactions.tsx
@@ -10,6 +10,7 @@ import { type BankTransactionFilters } from '@utils/bankTransactions/shared'
 import { useBankTransactions, type UseBankTransactionsOptions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useFilterBankTransactions } from '@hooks/features/bankTransactions/useFilterBankTransactions'
 import { usePollBankTransactions } from '@hooks/features/bankTransactions/usePollBankTransactions'
+import { useBankTransactionsFiltersContext } from '@contexts/BankTransactionsFiltersContext/BankTransactionsFiltersContext'
 import { CategorizationRulesContext } from '@contexts/CategorizationRulesContext/CategorizationRulesContext'
 
 const tagFilterToQueryString = (tagFilter: TagFilterInput): string => {
@@ -42,25 +43,20 @@ export function bankTransactionFiltersToHookOptions(
   }
 }
 
-export type UseAugmentedBankTransactionsWithFiltersParams = {
-  filters: BankTransactionFilters
-}
-
-export const useAugmentedBankTransactions = (
-  params: UseAugmentedBankTransactionsWithFiltersParams,
-) => {
+export const useAugmentedBankTransactions = () => {
   const { setRuleSuggestion } = useContext(CategorizationRulesContext)
-
-  const { filters } = params
+  const { filters } = useBankTransactionsFiltersContext()
 
   const display = filters?.categorizationStatus ?? DisplayState.categorized
+  const shouldHideAfterCategorize = display === DisplayState.review
+
   const useBankTransactionsOptions = useMemo(
     () => bankTransactionFiltersToHookOptions(filters),
     [filters],
   )
 
   const {
-    data: rawResponseData,
+    data,
     isLoading,
     isError,
     mutate,
@@ -69,20 +65,14 @@ export const useAugmentedBankTransactions = (
     hasMore,
   } = useBankTransactions(useBankTransactionsOptions)
 
-  usePollBankTransactions({ mutate, useBankTransactionsOptions })
+  usePollBankTransactions({ data, mutate, useBankTransactionsOptions })
 
-  const data: BankTransaction[] | undefined = useMemo(() => {
-    if (rawResponseData && rawResponseData.length > 0) {
-      return rawResponseData
-        ?.map(x => x?.data)
-        .flat()
-        .filter(x => !!x)
-    }
+  const bankTransactions: BankTransaction[] | undefined = useMemo(
+    () => data?.flatMap(({ data }) => data),
+    [data],
+  )
 
-    return undefined
-  }, [rawResponseData])
-
-  const filteredData = useFilterBankTransactions({ data, filters })
+  const filteredBankTransactions = useFilterBankTransactions({ data: bankTransactions, filters })
 
   const updateLocalBankTransactions = useCallback((newBankTransactions: BankTransaction[]) => {
     const transactionsById = new Map(
@@ -95,7 +85,7 @@ export const useAugmentedBankTransactions = (
       }
     }
 
-    const updatedData = rawResponseData?.map(page => ({
+    const updatedData = data?.map(page => ({
       ...page,
       data: page.data?.map(bt =>
         transactionsById.get(bt.id) ?? bt,
@@ -103,19 +93,17 @@ export const useAugmentedBankTransactions = (
     }))
 
     void mutate(updatedData, { revalidate: false })
-  }, [rawResponseData, mutate, setRuleSuggestion])
-
-  const shouldHideAfterCategorize = filters?.categorizationStatus === DisplayState.review
+  }, [data, mutate, setRuleSuggestion])
 
   const removeAfterCategorize = useCallback((transactionIds: string[]) => {
     if (shouldHideAfterCategorize) {
-      const updatedData = rawResponseData?.map(page => ({
+      const updatedData = data?.map(page => ({
         ...page,
         data: page.data?.filter(bt => !transactionIds.includes(bt.id)),
       }))
       void mutate(updatedData, { revalidate: false })
     }
-  }, [shouldHideAfterCategorize, rawResponseData, mutate])
+  }, [shouldHideAfterCategorize, data, mutate])
 
   const fetchMore = useCallback(() => {
     if (hasMore) {
@@ -124,7 +112,7 @@ export const useAugmentedBankTransactions = (
   }, [hasMore, setSize, size])
 
   return useMemo(() => ({
-    data: filteredData,
+    data: filteredBankTransactions,
     isLoading,
     isError,
     updateLocalBankTransactions,
@@ -136,7 +124,7 @@ export const useAugmentedBankTransactions = (
     hasMore,
     mutate,
   }), [
-    filteredData,
+    filteredBankTransactions,
     isLoading,
     isError,
     updateLocalBankTransactions,

--- a/src/hooks/features/bankTransactions/usePollBankTransactions.ts
+++ b/src/hooks/features/bankTransactions/usePollBankTransactions.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useRef } from 'react'
+import useSWR from 'swr'
+import { type SWRInfiniteKeyedMutator } from 'swr/infinite'
+
+import { type GetBankTransactionsReturn, useBankTransactionsGlobalCacheActions, type UseBankTransactionsOptions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
+import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+
+const INITIAL_POLL_INTERVAL_MS = 1000
+const POLL_INTERVAL_AFTER_TXNS_RECEIVED_MS = 5000
+const BANK_TRANSACTIONS_SYNC_POLL_KEY = 'bank-transactions-sync-poll'
+
+type UsePollBankTransactionsParams = {
+  mutate: SWRInfiniteKeyedMutator<Array<GetBankTransactionsReturn>>
+  useBankTransactionsOptions: UseBankTransactionsOptions
+}
+
+export function usePollBankTransactions({
+  mutate,
+  useBankTransactionsOptions,
+}: UsePollBankTransactionsParams) {
+  const { eventCallbacks } = useLayerContext()
+  const onTransactionsFetched = eventCallbacks?.onTransactionsFetched
+  const { isSyncing } = useBankAccountsContext()
+  const { forceReloadBackgroundBankTransactions } = useBankTransactionsGlobalCacheActions()
+
+  const wasSyncingRef = useRef(isSyncing)
+  const hasReceivedTransactionsRef = useRef(false)
+
+  const intervalMs = useCallback(() =>
+    hasReceivedTransactionsRef.current
+      ? POLL_INTERVAL_AFTER_TXNS_RECEIVED_MS
+      : INITIAL_POLL_INTERVAL_MS,
+  [])
+
+  const onPoll = useCallback(async () => {
+    await mutate()
+
+    hasReceivedTransactionsRef.current = true
+    onTransactionsFetched?.()
+
+    return Date.now()
+  }, [mutate, onTransactionsFetched])
+
+  useSWR(
+    isSyncing ? [BANK_TRANSACTIONS_SYNC_POLL_KEY, useBankTransactionsOptions] : null,
+    onPoll,
+    {
+      refreshInterval: intervalMs,
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnMount: false,
+      revalidateOnReconnect: false,
+      shouldRetryOnError: false,
+    },
+  )
+
+  useEffect(() => {
+    if (wasSyncingRef.current && !isSyncing) {
+      hasReceivedTransactionsRef.current = false
+      void mutate()
+      void forceReloadBackgroundBankTransactions(useBankTransactionsOptions)
+    }
+
+    wasSyncingRef.current = isSyncing
+  }, [
+    forceReloadBackgroundBankTransactions,
+    isSyncing,
+    mutate,
+    useBankTransactionsOptions,
+  ])
+}

--- a/src/hooks/features/bankTransactions/usePollBankTransactions.ts
+++ b/src/hooks/features/bankTransactions/usePollBankTransactions.ts
@@ -2,13 +2,15 @@ import { useCallback, useEffect, useRef } from 'react'
 import useSWR from 'swr'
 import { type SWRInfiniteKeyedMutator } from 'swr/infinite'
 
+import { hasNewSyncingAccounts } from '@utils/bankAccount'
 import { type GetBankTransactionsReturn, useBankTransactionsGlobalCacheActions, type UseBankTransactionsOptions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useTriggerOnChange } from '@hooks/utils/useTriggerOnChange'
 import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
-const INITIAL_POLL_INTERVAL_MS = 1000
+const INITIAL_POLL_INTERVAL_MS = 2000
 const POLL_INTERVAL_AFTER_TXNS_RECEIVED_MS = 5000
+const MAX_POLL_STALL_MS = 15 * 60 * 1000
 const BANK_TRANSACTIONS_SYNC_POLL_KEY = 'bank-transactions-sync-poll'
 
 type UsePollBankTransactionsParams = {
@@ -25,17 +27,23 @@ export function usePollBankTransactions({
   const { eventCallbacks } = useLayerContext()
   const onTransactionsFetched = eventCallbacks?.onTransactionsFetched
 
-  const { isSyncing } = useBankAccountsContext()
+  const { isSyncing, data: bankAccounts } = useBankAccountsContext()
   const { forceReloadBackgroundBankTransactions } = useBankTransactionsGlobalCacheActions()
 
   const wasSyncingRef = useRef(isSyncing)
+  const previousBankAccountsRef = useRef(bankAccounts)
   const hasReceivedTransactionsRef = useRef(false)
+  const stallDeadlineRef = useRef(isSyncing ? Date.now() + MAX_POLL_STALL_MS : null)
 
-  const intervalMs = useCallback(() =>
-    hasReceivedTransactionsRef.current
+  const intervalMs = useCallback(() => {
+    if (stallDeadlineRef.current != null && Date.now() >= stallDeadlineRef.current) {
+      return 0
+    }
+
+    return hasReceivedTransactionsRef.current
       ? POLL_INTERVAL_AFTER_TXNS_RECEIVED_MS
-      : INITIAL_POLL_INTERVAL_MS,
-  [])
+      : INITIAL_POLL_INTERVAL_MS
+  }, [])
 
   const onPoll = useCallback(async () => {
     await mutate()
@@ -48,6 +56,13 @@ export function usePollBankTransactions({
     onTransactionsFetched?.()
   })
 
+  /*
+   * useBankTransactions disables revalidateFirstPage so page changes do not
+   * refetch already-loaded pages. That also means a refreshInterval on the
+   * infinite query would not refresh transactions, so this separate SWR key
+   * owns the sync polling timer and explicitly triggers the invalidation of
+   * stale transactions to force a refresh.
+   */
   useSWR(
     isSyncing ? [BANK_TRANSACTIONS_SYNC_POLL_KEY, useBankTransactionsOptions] : null,
     onPoll,
@@ -62,14 +77,21 @@ export function usePollBankTransactions({
   )
 
   useEffect(() => {
+    if (hasNewSyncingAccounts(previousBankAccountsRef.current, bankAccounts)) {
+      stallDeadlineRef.current = Date.now() + MAX_POLL_STALL_MS
+    }
+
     if (wasSyncingRef.current && !isSyncing) {
+      stallDeadlineRef.current = null
       hasReceivedTransactionsRef.current = false
       void mutate()
       void forceReloadBackgroundBankTransactions(useBankTransactionsOptions)
     }
 
     wasSyncingRef.current = isSyncing
+    previousBankAccountsRef.current = bankAccounts
   }, [
+    bankAccounts,
     forceReloadBackgroundBankTransactions,
     isSyncing,
     mutate,

--- a/src/hooks/features/bankTransactions/usePollBankTransactions.ts
+++ b/src/hooks/features/bankTransactions/usePollBankTransactions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import useSWR from 'swr'
 import { type SWRInfiniteKeyedMutator } from 'swr/infinite'
 
@@ -34,6 +34,9 @@ export function usePollBankTransactions({
   const previousBankAccountsRef = useRef(bankAccounts)
   const hasReceivedTransactionsRef = useRef(false)
   const stallDeadlineRef = useRef(isSyncing ? Date.now() + MAX_POLL_STALL_MS : null)
+  // Part of the SWR key: bumping it restarts the poll after the stall deadline
+  // stopped it, since refreshInterval alone won't resume a halted SWR loop.
+  const [restartNonce, setRestartNonce] = useState(0)
 
   const intervalMs = useCallback(() => {
     if (stallDeadlineRef.current != null && Date.now() >= stallDeadlineRef.current) {
@@ -64,7 +67,7 @@ export function usePollBankTransactions({
    * stale transactions to force a refresh.
    */
   useSWR(
-    isSyncing ? [BANK_TRANSACTIONS_SYNC_POLL_KEY, useBankTransactionsOptions] : null,
+    isSyncing ? [BANK_TRANSACTIONS_SYNC_POLL_KEY, useBankTransactionsOptions, restartNonce] : null,
     onPoll,
     {
       refreshInterval: intervalMs,
@@ -78,7 +81,14 @@ export function usePollBankTransactions({
 
   useEffect(() => {
     if (hasNewSyncingAccounts(previousBankAccountsRef.current, bankAccounts)) {
+      // If the stall deadline already lapsed, refreshInterval returned 0 and the
+      // poll stopped; bump the key's nonce to restart it. Otherwise it's still
+      // polling, so just extend the deadline.
+      const wasStalled = stallDeadlineRef.current != null && Date.now() >= stallDeadlineRef.current
+
       stallDeadlineRef.current = Date.now() + MAX_POLL_STALL_MS
+
+      if (wasStalled) setRestartNonce(nonce => nonce + 1)
     }
 
     if (wasSyncingRef.current && !isSyncing) {

--- a/src/hooks/features/bankTransactions/usePollBankTransactions.ts
+++ b/src/hooks/features/bankTransactions/usePollBankTransactions.ts
@@ -3,6 +3,7 @@ import useSWR from 'swr'
 import { type SWRInfiniteKeyedMutator } from 'swr/infinite'
 
 import { type GetBankTransactionsReturn, useBankTransactionsGlobalCacheActions, type UseBankTransactionsOptions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
+import { useTriggerOnChange } from '@hooks/utils/useTriggerOnChange'
 import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
@@ -11,16 +12,19 @@ const POLL_INTERVAL_AFTER_TXNS_RECEIVED_MS = 5000
 const BANK_TRANSACTIONS_SYNC_POLL_KEY = 'bank-transactions-sync-poll'
 
 type UsePollBankTransactionsParams = {
+  data: Array<GetBankTransactionsReturn> | undefined
   mutate: SWRInfiniteKeyedMutator<Array<GetBankTransactionsReturn>>
   useBankTransactionsOptions: UseBankTransactionsOptions
 }
 
 export function usePollBankTransactions({
+  data,
   mutate,
   useBankTransactionsOptions,
 }: UsePollBankTransactionsParams) {
   const { eventCallbacks } = useLayerContext()
   const onTransactionsFetched = eventCallbacks?.onTransactionsFetched
+
   const { isSyncing } = useBankAccountsContext()
   const { forceReloadBackgroundBankTransactions } = useBankTransactionsGlobalCacheActions()
 
@@ -36,11 +40,13 @@ export function usePollBankTransactions({
   const onPoll = useCallback(async () => {
     await mutate()
 
+    return Date.now()
+  }, [mutate])
+
+  useTriggerOnChange(data, isSyncing, () => {
     hasReceivedTransactionsRef.current = true
     onTransactionsFetched?.()
-
-    return Date.now()
-  }, [mutate, onTransactionsFetched])
+  })
 
   useSWR(
     isSyncing ? [BANK_TRANSACTIONS_SYNC_POLL_KEY, useBankTransactionsOptions] : null,

--- a/src/hooks/features/bankTransactions/usePollBankTransactions.ts
+++ b/src/hooks/features/bankTransactions/usePollBankTransactions.ts
@@ -11,7 +11,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 const INITIAL_POLL_INTERVAL_MS = 2000
 const POLL_INTERVAL_AFTER_TXNS_RECEIVED_MS = 5000
 const MAX_POLL_STALL_MS = 15 * 60 * 1000
-const BANK_TRANSACTIONS_SYNC_POLL_KEY = 'bank-transactions-sync-poll'
+const BANK_TRANSACTIONS_SYNC_POLL_KEY = '#bank-transactions-sync-poll'
 
 type UsePollBankTransactionsParams = {
   data: Array<GetBankTransactionsReturn> | undefined

--- a/src/hooks/features/linkedAccounts/usePollPlaidHostedLinkStatus.ts
+++ b/src/hooks/features/linkedAccounts/usePollPlaidHostedLinkStatus.ts
@@ -47,7 +47,7 @@ export function usePollPlaidHostedLinkStatus({ onSuccess, enabled }: UsePollPlai
 
   // Clear a previous session's cached status; polling fetches the current one.
   useEffect(() => {
-    void mutate(undefined, { revalidate: false })
+    void mutate(undefined, { revalidate: true })
   }, [mutate])
 
   return {

--- a/src/hooks/features/linkedAccounts/usePollPlaidHostedLinkStatus.ts
+++ b/src/hooks/features/linkedAccounts/usePollPlaidHostedLinkStatus.ts
@@ -1,14 +1,10 @@
-import { useCallback, useEffect, useRef } from 'react'
-import { type SWRConfiguration } from 'swr'
+import { useCallback, useEffect } from 'react'
 
 import type { Awaitable } from '@internal-types/utility/promises'
 import { type ApiPlaidHostedLinkStatus, PlaidHostedLinkState } from '@schemas/linkedAccounts/plaid'
 import { APIError } from '@utils/api/apiError'
 import { usePlaidHostedLinkStatus } from '@hooks/api/businesses/[business-id]/plaid/hosted-link'
-
-const POLL_INTERVAL_MS = 2000
-const MAX_POLL_DURATION_MS = 2 * 60 * 1000
-const MAX_ERROR_RETRIES = 3
+import { usePollingConfig } from '@hooks/utils/swr/usePollingConfig'
 
 const TERMINAL_STATES: ReadonlySet<PlaidHostedLinkState> = new Set([
   PlaidHostedLinkState.NOT_STARTED,
@@ -30,56 +26,24 @@ type UsePollPlaidHostedLinkStatusOptions = {
 }
 
 export function usePollPlaidHostedLinkStatus({ onSuccess, enabled }: UsePollPlaidHostedLinkStatusOptions) {
-  const hasStoppedPollingRef = useRef(false)
-  const pollingEndTimestampRef = useRef(Date.now() + MAX_POLL_DURATION_MS)
-  const hasFiredOnSuccessRef = useRef(false)
-
-  const getRefreshInterval = useCallback(() => {
-    if (hasStoppedPollingRef.current || Date.now() >= pollingEndTimestampRef.current) {
-      hasStoppedPollingRef.current = true
-      return 0
-    }
-
-    return POLL_INTERVAL_MS
-  }, [])
-
-  const onErrorRetry = useCallback<NonNullable<SWRConfiguration<ApiPlaidHostedLinkStatus>['onErrorRetry']>>(
-    (error, _key, _config, revalidate, { retryCount }) => {
-      if (hasStoppedPollingRef.current) return
-
-      const isAtMaxRetries = retryCount >= MAX_ERROR_RETRIES
-      const isPastPollingDeadline = Date.now() >= pollingEndTimestampRef.current
-
-      if (isFatalError(error) || isAtMaxRetries || isPastPollingDeadline) {
-        hasStoppedPollingRef.current = true
-        return
-      }
-
-      setTimeout(() => {
-        void revalidate({ retryCount })
-      }, POLL_INTERVAL_MS)
-    },
+  const shouldContinue = useCallback(
+    (latestData?: ApiPlaidHostedLinkStatus) => !isTerminal(latestData?.state),
     [],
   )
 
-  const onPollSuccess = useCallback((latestData?: ApiPlaidHostedLinkStatus) => {
-    const state = latestData?.state
-
-    if (isTerminal(state)) {
-      hasStoppedPollingRef.current = true
-    }
-
-    if (state === PlaidHostedLinkState.SUCCEEDED && !hasFiredOnSuccessRef.current) {
-      void Promise.resolve(onSuccess()).then(() => {
-        hasFiredOnSuccessRef.current = true
-      })
+  const onComplete = useCallback((latestData: ApiPlaidHostedLinkStatus) => {
+    if (latestData.state === PlaidHostedLinkState.SUCCEEDED) {
+      return onSuccess()
     }
   }, [onSuccess])
 
-  const { data, mutate } = usePlaidHostedLinkStatus(
-    { refreshInterval: getRefreshInterval, onErrorRetry, onSuccess: onPollSuccess },
-    enabled,
-  )
+  const pollingConfig = usePollingConfig<ApiPlaidHostedLinkStatus>({
+    shouldContinue,
+    onComplete,
+    isFatalError,
+  })
+
+  const { data, mutate } = usePlaidHostedLinkStatus(pollingConfig, enabled)
 
   // Clear a previous session's cached status; polling fetches the current one.
   useEffect(() => {

--- a/src/hooks/features/linkedAccounts/usePollPlaidHostedLinkStatus.ts
+++ b/src/hooks/features/linkedAccounts/usePollPlaidHostedLinkStatus.ts
@@ -31,15 +31,15 @@ export function usePollPlaidHostedLinkStatus({ onSuccess, enabled }: UsePollPlai
     [],
   )
 
-  const onComplete = useCallback((latestData: ApiPlaidHostedLinkStatus) => {
-    if (latestData.state === PlaidHostedLinkState.SUCCEEDED) {
-      return onSuccess()
-    }
-  }, [onSuccess])
+  const shouldComplete = useCallback(
+    (latestData: ApiPlaidHostedLinkStatus) => latestData.state === PlaidHostedLinkState.SUCCEEDED,
+    [],
+  )
 
   const pollingConfig = usePollingConfig<ApiPlaidHostedLinkStatus>({
     shouldContinue,
-    onComplete,
+    shouldComplete,
+    onComplete: onSuccess,
     isFatalError,
   })
 

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -1,12 +1,10 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { type LoadedStatus } from '@internal-types/general'
 import { type AccountSource } from '@internal-types/linkedAccounts'
-import { type BankAccount } from '@schemas/bankAccounts/bankAccount'
 import { type PlaidHostedLinkConfig, toCreatePlaidLinkParams } from '@schemas/linkedAccounts/plaid'
-import { useListBankAccounts } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
 import { useUnlinkBankAccount } from '@hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount'
+import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useConfirmExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm'
 import { useExcludeExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude'
 import { useBreakPlaidItemConnection } from '@hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/sandbox-reset-item-login'
@@ -15,6 +13,7 @@ import { useCreatePlaidLink } from '@hooks/api/businesses/[business-id]/plaid/li
 import { useCreatePlaidUpdateModeLink } from '@hooks/api/businesses/[business-id]/plaid/update-mode-link'
 import { type LinkMode, usePlaidLinkModal } from '@hooks/features/linkedAccounts/usePlaidLinkModal'
 import { usePollPlaidHostedLinkStatus } from '@hooks/features/linkedAccounts/usePollPlaidHostedLinkStatus'
+import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 type UseLinkedAccountsOptions = {
@@ -22,17 +21,12 @@ type UseLinkedAccountsOptions = {
 }
 
 type UseLinkedAccounts = (options?: UseLinkedAccountsOptions) => {
-  data?: BankAccount[]
-  isLoading: boolean
-  loadingStatus: LoadedStatus
-  isValidating: boolean
   isLinking: boolean
-  error: unknown
   isHostedLinkError: boolean
   addConnection: (source: AccountSource) => Promise<void>
   removeConnection: (source: AccountSource, sourceId: string) => Promise<void>
   repairConnection: (source: AccountSource, sourceId: string) => Promise<void>
-  refetchAccounts: () => Promise<void>
+  refetchAccountsAndTransactions: () => Promise<void>
   unlinkBankAccount: (bankAccountId: string) => Promise<void>
   confirmAccount: (source: AccountSource, accountId: string) => Promise<void>
   excludeAccount: (source: AccountSource, accountId: string) => Promise<void>
@@ -66,16 +60,9 @@ export const useLinkedAccounts: UseLinkedAccounts = ({ plaidHostedLinkConfig } =
   const { t } = useTranslation()
 
   const [linkToken, setLinkToken] = useState<string | null>(null)
-  const [loadingStatus, setLoadingStatus] = useState<LoadedStatus>('initial')
   const [linkMode, setLinkMode] = useState<LinkMode>('add')
 
-  const {
-    data: bankAccounts,
-    isLoading,
-    isValidating,
-    error: responseError,
-    mutate,
-  } = useListBankAccounts()
+  const { refetch } = useBankAccountsContext()
   const { trigger: triggerUnlinkBankAccount } = useUnlinkBankAccount()
   const { trigger: triggerCreatePlaidLink } = useCreatePlaidLink()
   const { trigger: triggerCreatePlaidUpdateModeLink } = useCreatePlaidUpdateModeLink()
@@ -84,55 +71,42 @@ export const useLinkedAccounts: UseLinkedAccounts = ({ plaidHostedLinkConfig } =
   const { trigger: triggerUnlinkPlaidItem } = useUnlinkPlaidItem()
   const { trigger: triggerBreakPlaidItemConnection } = useBreakPlaidItemConnection()
 
-  useEffect(() => {
-    if (!isLoading && bankAccounts) {
-      setLoadingStatus('complete')
-      return
-    }
+  const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
 
-    if (isLoading && loadingStatus === 'initial') {
-      setLoadingStatus('loading')
-      return
-    }
-
-    if (!isLoading && loadingStatus === 'loading') {
-      setLoadingStatus('complete')
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading])
-
-  const refetchAccounts = useCallback(async () => {
-    await mutate()
-  }, [mutate])
+  const refetchAccountsAndTransactions = useCallback(async () => {
+    await Promise.all([
+      refetch(),
+      forceReloadBankTransactions(),
+    ])
+  }, [refetch, forceReloadBankTransactions])
 
   const { isLinking } = usePlaidLinkModal({
     linkToken,
     linkMode,
     setLinkMode,
-    onSuccess: refetchAccounts,
+    onSuccess: refetchAccountsAndTransactions,
   })
 
   const { isFailed: isHostedLinkError } = usePollPlaidHostedLinkStatus({
-    onSuccess: refetchAccounts,
     enabled: plaidHostedLinkConfig != null,
+    onSuccess: refetchAccountsAndTransactions,
   })
 
   /**
-   * Runs a mutation, refreshing the account list on success and surfacing an
-   * error toast on failure. A failed refresh is not reported as a mutation
-   * failure, since the mutation itself succeeded.
+   * Runs a mutation, refetching accounts and transactions on success and showing
+   * an error toast on failure
    *
    * Note: this swallows rejections (the failure becomes a toast and the returned
    * promise resolves), so it must not back an `onConfirm`/submit handler whose
    * caller relies on a rejection to show errors — e.g. BaseConfirmationModal.
    */
-  const mutateAndRefetchAccountsWithToast = useCallback(
+  const mutateAndRefetchWithToast = useCallback(
     (mutation: () => Promise<unknown>, errorMessage: string) =>
       mutation().then(
-        () => refetchAccounts(),
+        () => refetchAccountsAndTransactions(),
         () => addToast({ content: errorMessage, type: 'error' }),
       ),
-    [refetchAccounts, addToast],
+    [refetchAccountsAndTransactions, addToast],
   )
 
   /**
@@ -198,38 +172,38 @@ export const useLinkedAccounts: UseLinkedAccounts = ({ plaidHostedLinkConfig } =
   const repairConnection = usePlaidOnlyAction('Repairing a connection', fetchPlaidUpdateModeLinkToken)
 
   const handleRemoveConnection = useCallback(
-    (connectionExternalId: string) => mutateAndRefetchAccountsWithToast(
+    (connectionExternalId: string) => mutateAndRefetchWithToast(
       () => triggerUnlinkPlaidItem({ plaidItemId: connectionExternalId }),
       t('linkedAccounts:error.remove_connection', 'We couldn’t remove this connection. Please try again.'),
     ),
-    [mutateAndRefetchAccountsWithToast, triggerUnlinkPlaidItem, t],
+    [mutateAndRefetchWithToast, triggerUnlinkPlaidItem, t],
   )
   const removeConnection = usePlaidOnlyAction('Removing a connection', handleRemoveConnection)
 
   const handleConfirmAccount = useCallback(
-    (accountId: string) => mutateAndRefetchAccountsWithToast(
+    (accountId: string) => mutateAndRefetchWithToast(
       () => triggerConfirmExternalAccount({ accountId }),
       t('linkedAccounts:error.confirm_account', 'We couldn’t confirm your account. Please try again.'),
     ),
-    [mutateAndRefetchAccountsWithToast, triggerConfirmExternalAccount, t],
+    [mutateAndRefetchWithToast, triggerConfirmExternalAccount, t],
   )
   const confirmAccount = usePlaidOnlyAction('Confirming an account', handleConfirmAccount)
 
   const handleExcludeAccount = useCallback(
-    (accountId: string) => mutateAndRefetchAccountsWithToast(
+    (accountId: string) => mutateAndRefetchWithToast(
       () => triggerExcludeExternalAccount({ accountId, body: { is_duplicate: true } }),
       t('linkedAccounts:error.exclude_account', 'We couldn’t exclude your account. Please try again.'),
     ),
-    [mutateAndRefetchAccountsWithToast, triggerExcludeExternalAccount, t],
+    [mutateAndRefetchWithToast, triggerExcludeExternalAccount, t],
   )
   const excludeAccount = usePlaidOnlyAction('Excluding an account', handleExcludeAccount)
 
   const handleBreakConnection = useCallback(
-    (connectionExternalId: string) => mutateAndRefetchAccountsWithToast(
+    (connectionExternalId: string) => mutateAndRefetchWithToast(
       () => triggerBreakPlaidItemConnection({ plaidItemId: connectionExternalId }),
       t('linkedAccounts:error.break_connection', 'We couldn’t reset this connection. Please try again.'),
     ),
-    [mutateAndRefetchAccountsWithToast, triggerBreakPlaidItemConnection, t],
+    [mutateAndRefetchWithToast, triggerBreakPlaidItemConnection, t],
   )
   /**
    * Test utility that puts a connection into a broken state; only works in non-production
@@ -237,26 +211,23 @@ export const useLinkedAccounts: UseLinkedAccounts = ({ plaidHostedLinkConfig } =
    */
   const breakConnection = usePlaidOnlyAction('Breaking a sandbox connection', handleBreakConnection)
 
+  // Not `mutateAndRefetchWithToast`: this backs a BaseConfirmationModal that
+  // needs the promise to reject on failure (the helper swallows rejections).
   const unlinkBankAccount = useCallback(
     async (bankAccountId: string) => {
       await triggerUnlinkBankAccount(bankAccountId)
-      await refetchAccounts()
+      await refetchAccountsAndTransactions()
     },
-    [triggerUnlinkBankAccount, refetchAccounts],
+    [triggerUnlinkBankAccount, refetchAccountsAndTransactions],
   )
 
   return {
-    data: bankAccounts ?? [],
-    isLoading,
-    loadingStatus,
-    isValidating,
     isLinking,
-    error: responseError,
     isHostedLinkError,
     addConnection,
     removeConnection,
     repairConnection,
-    refetchAccounts,
+    refetchAccountsAndTransactions,
     unlinkBankAccount,
     confirmAccount,
     excludeAccount,

--- a/src/hooks/utils/swr/pollingPhase.ts
+++ b/src/hooks/utils/swr/pollingPhase.ts
@@ -2,16 +2,18 @@ import { type MutableRefObject } from 'react'
 
 export enum PollingPhase {
   /**
-   * Not polling. Entered whenever `shouldContinue` is false (a natural pause).
-   * The next time `shouldContinue` is true, a fresh session starts.
+   * Not polling because `shouldContinue` is false (a natural pause, or the initial
+   * state). Restarts as soon as `shouldContinue` is true again — at mount via
+   * `refreshInterval`, or once the loop has died via `onSuccess`.
    */
   Idle = 'idle',
   /** Actively polling on the configured interval. */
   Active = 'active',
   /**
-   * Halted by the max-duration deadline, the error-retry max count, or a fatal error,
-   * while `shouldContinue` still wants to continue. No restart until `shouldContinue`
-   * goes false, returning the phase to `Idle`.
+   * Halted by the max-duration/error cap while `shouldContinue` was still true. Stays
+   * here until a poll reports fresh progress (`shouldRestartPolling`, defaulting to a
+   * `shouldContinue` rising edge); a session that merely still wants to continue does
+   * not revive it, so the cap holds for a genuinely stuck poll.
    */
   Stopped = 'stopped',
 }

--- a/src/hooks/utils/swr/pollingPhase.ts
+++ b/src/hooks/utils/swr/pollingPhase.ts
@@ -1,0 +1,23 @@
+import { type MutableRefObject } from 'react'
+
+export enum PollingPhase {
+  /**
+   * Not polling. Entered whenever `shouldContinue` is false (a natural pause).
+   * The next time `shouldContinue` is true, a fresh session starts.
+   */
+  Idle = 'idle',
+  /** Actively polling on the configured interval. */
+  Active = 'active',
+  /**
+   * Halted by the max-duration deadline, the error-retry max count, or a fatal error,
+   * while `shouldContinue` still wants to continue. No restart until `shouldContinue`
+   * goes false, returning the phase to `Idle`.
+   */
+  Stopped = 'stopped',
+}
+
+export type PollingPhaseRef = MutableRefObject<PollingPhase>
+
+export const isIdle = (phaseRef: PollingPhaseRef) => phaseRef.current === PollingPhase.Idle
+export const isActive = (phaseRef: PollingPhaseRef) => phaseRef.current === PollingPhase.Active
+export const isStopped = (phaseRef: PollingPhaseRef) => phaseRef.current === PollingPhase.Stopped

--- a/src/hooks/utils/swr/usePollingConfig.ts
+++ b/src/hooks/utils/swr/usePollingConfig.ts
@@ -1,0 +1,84 @@
+import { useCallback, useMemo, useRef } from 'react'
+import { type SWRConfiguration } from 'swr'
+
+import type { Awaitable } from '@internal-types/utility/promises'
+
+const DEFAULT_POLL_INTERVAL_MS = 2000
+const DEFAULT_MAX_POLL_DURATION_MS = 2 * 60 * 1000
+const DEFAULT_MAX_ERROR_RETRIES = 3
+
+type UsePollingConfigOptions<Data> = {
+  shouldContinue: (latestData: Data | undefined) => boolean
+  onPoll?: (latestData: Data) => Awaitable<void>
+  onComplete?: (latestData: Data) => Awaitable<void>
+  isFatalError?: (error: unknown) => boolean
+  intervalMs?: number | (() => number)
+  maxDurationMs?: number
+  maxErrorRetries?: number
+}
+
+export function usePollingConfig<Data>({
+  shouldContinue,
+  onPoll,
+  onComplete,
+  isFatalError,
+  intervalMs = DEFAULT_POLL_INTERVAL_MS,
+  maxDurationMs = DEFAULT_MAX_POLL_DURATION_MS,
+  maxErrorRetries = DEFAULT_MAX_ERROR_RETRIES,
+}: UsePollingConfigOptions<Data>): Pick<
+    SWRConfiguration<Data>,
+  'refreshInterval' | 'onErrorRetry' | 'onSuccess'
+  > {
+  const hasStoppedPollingRef = useRef(false)
+  const hasCompletedRef = useRef(false)
+  const pollingEndTimestampRef = useRef(Date.now() + maxDurationMs)
+
+  const getInterval = useCallback(
+    () => (typeof intervalMs === 'function' ? intervalMs() : intervalMs),
+    [intervalMs],
+  )
+
+  const refreshInterval = useCallback((latestData?: Data) => {
+    if (hasStoppedPollingRef.current) return 0
+
+    if (Date.now() >= pollingEndTimestampRef.current) {
+      hasStoppedPollingRef.current = true
+      return 0
+    }
+
+    return shouldContinue(latestData) ? getInterval() : 0
+  }, [getInterval, shouldContinue])
+
+  const onErrorRetry = useCallback<NonNullable<SWRConfiguration<Data>['onErrorRetry']>>(
+    (error, _key, _config, revalidate, { retryCount }) => {
+      if (hasStoppedPollingRef.current) return
+
+      const isAtMaxRetries = retryCount >= maxErrorRetries
+      const isPastPollingDeadline = Date.now() >= pollingEndTimestampRef.current
+
+      if (isFatalError?.(error) || isAtMaxRetries || isPastPollingDeadline) {
+        hasStoppedPollingRef.current = true
+        return
+      }
+
+      setTimeout(() => {
+        void revalidate({ retryCount })
+      }, getInterval())
+    },
+    [getInterval, isFatalError, maxErrorRetries],
+  )
+
+  const onSuccess = useCallback((latestData: Data) => {
+    void onPoll?.(latestData)
+
+    if (!hasCompletedRef.current && !shouldContinue(latestData)) {
+      hasCompletedRef.current = true
+      void onComplete?.(latestData)
+    }
+  }, [onPoll, onComplete, shouldContinue])
+
+  return useMemo(
+    () => ({ refreshInterval, onErrorRetry, onSuccess }),
+    [onErrorRetry, onSuccess, refreshInterval],
+  )
+}

--- a/src/hooks/utils/swr/usePollingConfig.ts
+++ b/src/hooks/utils/swr/usePollingConfig.ts
@@ -2,35 +2,43 @@ import { useCallback, useMemo, useRef } from 'react'
 import { type SWRConfiguration } from 'swr'
 
 import type { Awaitable } from '@internal-types/utility/promises'
+import { isActive, isIdle, isStopped, PollingPhase } from '@hooks/utils/swr/pollingPhase'
 
 const DEFAULT_POLL_INTERVAL_MS = 2000
 const DEFAULT_MAX_POLL_DURATION_MS = 2 * 60 * 1000
 const DEFAULT_MAX_ERROR_RETRIES = 3
 
-type UsePollingConfigOptions<Data> = {
-  shouldContinue: (latestData: Data | undefined) => boolean
-  onPoll?: (latestData: Data) => Awaitable<void>
-  onComplete?: (latestData: Data) => Awaitable<void>
+type UsePollingConfigOptions<TData> = {
+  shouldContinue: (nextData: TData | undefined) => boolean
+  /** Gates the one-shot `onComplete`. Defaults to `!shouldContinue`. */
+  shouldComplete?: (nextData: TData) => boolean
+  /** Resets the `maxDurationMs` deadline when true, turning it into a stall timeout. */
+  shouldResetPollingDeadline?: (previousTData: TData | undefined, nextData: TData) => boolean
+  onPoll?: (nextData: TData) => Awaitable<void>
+  onComplete?: (nextData: TData) => Awaitable<void>
   isFatalError?: (error: unknown) => boolean
   intervalMs?: number | (() => number)
   maxDurationMs?: number
   maxErrorRetries?: number
 }
 
-export function usePollingConfig<Data>({
+export function usePollingConfig<TData>({
   shouldContinue,
+  shouldComplete,
+  shouldResetPollingDeadline,
   onPoll,
   onComplete,
   isFatalError,
   intervalMs = DEFAULT_POLL_INTERVAL_MS,
   maxDurationMs = DEFAULT_MAX_POLL_DURATION_MS,
   maxErrorRetries = DEFAULT_MAX_ERROR_RETRIES,
-}: UsePollingConfigOptions<Data>): Pick<
-    SWRConfiguration<Data>,
+}: UsePollingConfigOptions<TData>): Pick<
+    SWRConfiguration<TData>,
   'refreshInterval' | 'onErrorRetry' | 'onSuccess'
   > {
-  const hasStoppedPollingRef = useRef(false)
+  const phaseRef = useRef<PollingPhase>(PollingPhase.Idle)
   const hasCompletedRef = useRef(false)
+  const previousDataRef = useRef<TData>()
   const pollingEndTimestampRef = useRef(Date.now() + maxDurationMs)
 
   const getInterval = useCallback(
@@ -38,26 +46,40 @@ export function usePollingConfig<Data>({
     [intervalMs],
   )
 
-  const refreshInterval = useCallback((latestData?: Data) => {
-    if (hasStoppedPollingRef.current) return 0
+  const restartPolling = useCallback(() => {
+    phaseRef.current = PollingPhase.Active
+    hasCompletedRef.current = false
+    previousDataRef.current = undefined
+    pollingEndTimestampRef.current = Date.now() + maxDurationMs
+  }, [maxDurationMs])
 
-    if (Date.now() >= pollingEndTimestampRef.current) {
-      hasStoppedPollingRef.current = true
+  const refreshInterval = useCallback((nextData?: TData) => {
+    if (!shouldContinue(nextData)) {
+      phaseRef.current = PollingPhase.Idle
       return 0
     }
 
-    return shouldContinue(latestData) ? getInterval() : 0
-  }, [getInterval, shouldContinue])
+    if (isIdle(phaseRef)) restartPolling()
 
-  const onErrorRetry = useCallback<NonNullable<SWRConfiguration<Data>['onErrorRetry']>>(
+    if (isStopped(phaseRef)) return 0
+
+    if (Date.now() >= pollingEndTimestampRef.current) {
+      phaseRef.current = PollingPhase.Stopped
+      return 0
+    }
+
+    return getInterval()
+  }, [getInterval, restartPolling, shouldContinue])
+
+  const onErrorRetry = useCallback<NonNullable<SWRConfiguration<TData>['onErrorRetry']>>(
     (error, _key, _config, revalidate, { retryCount }) => {
-      if (hasStoppedPollingRef.current) return
+      if (isStopped(phaseRef)) return
 
       const isAtMaxRetries = retryCount >= maxErrorRetries
       const isPastPollingDeadline = Date.now() >= pollingEndTimestampRef.current
 
       if (isFatalError?.(error) || isAtMaxRetries || isPastPollingDeadline) {
-        hasStoppedPollingRef.current = true
+        phaseRef.current = PollingPhase.Stopped
         return
       }
 
@@ -68,14 +90,21 @@ export function usePollingConfig<Data>({
     [getInterval, isFatalError, maxErrorRetries],
   )
 
-  const onSuccess = useCallback((latestData: Data) => {
-    void onPoll?.(latestData)
+  const onSuccess = useCallback((nextData: TData) => {
+    void onPoll?.(nextData)
 
-    if (!hasCompletedRef.current && !shouldContinue(latestData)) {
-      hasCompletedRef.current = true
-      void onComplete?.(latestData)
+    if (isActive(phaseRef) && shouldResetPollingDeadline?.(previousDataRef.current, nextData)) {
+      pollingEndTimestampRef.current = Date.now() + maxDurationMs
     }
-  }, [onPoll, onComplete, shouldContinue])
+
+    previousDataRef.current = nextData
+
+    const completed = shouldComplete ? shouldComplete(nextData) : !shouldContinue(nextData)
+    if (!hasCompletedRef.current && completed) {
+      hasCompletedRef.current = true
+      void onComplete?.(nextData)
+    }
+  }, [onPoll, onComplete, shouldContinue, shouldComplete, shouldResetPollingDeadline, maxDurationMs])
 
   return useMemo(
     () => ({ refreshInterval, onErrorRetry, onSuccess }),

--- a/src/hooks/utils/swr/usePollingConfig.ts
+++ b/src/hooks/utils/swr/usePollingConfig.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { type SWRConfiguration } from 'swr'
 
 import type { Awaitable } from '@internal-types/utility/promises'
@@ -10,10 +10,8 @@ const DEFAULT_MAX_ERROR_RETRIES = 3
 
 type UsePollingConfigOptions<TData> = {
   shouldContinue: (nextData: TData | undefined) => boolean
-  /** Gates the one-shot `onComplete`. Defaults to `!shouldContinue`. */
   shouldComplete?: (nextData: TData) => boolean
-  /** Resets the `maxDurationMs` deadline when true, turning it into a stall timeout. */
-  shouldResetPollingDeadline?: (previousTData: TData | undefined, nextData: TData) => boolean
+  shouldRestartPolling?: (previousData: TData | undefined, nextData: TData) => boolean
   onPoll?: (nextData: TData) => Awaitable<void>
   onComplete?: (nextData: TData) => Awaitable<void>
   isFatalError?: (error: unknown) => boolean
@@ -25,7 +23,7 @@ type UsePollingConfigOptions<TData> = {
 export function usePollingConfig<TData>({
   shouldContinue,
   shouldComplete,
-  shouldResetPollingDeadline,
+  shouldRestartPolling,
   onPoll,
   onComplete,
   isFatalError,
@@ -40,6 +38,14 @@ export function usePollingConfig<TData>({
   const hasCompletedRef = useRef(false)
   const previousDataRef = useRef<TData>()
   const pollingEndTimestampRef = useRef(Date.now() + maxDurationMs)
+  /*
+   * SWR's polling loop, once `refreshInterval` returns 0, only restarts when the
+   * polling effect re-runs — i.e. when `refreshInterval`'s identity changes (its
+   * deps are [refreshInterval, ...], not the fetched data). This nonce is a
+   * dependency of `refreshInterval`, so bumping it forces that re-run to revive a
+   * halted session (see onSuccess).
+   */
+  const [restartNonce, setRestartNonce] = useState(0)
 
   const getInterval = useCallback(
     () => (typeof intervalMs === 'function' ? intervalMs() : intervalMs),
@@ -49,11 +55,13 @@ export function usePollingConfig<TData>({
   const restartPolling = useCallback(() => {
     phaseRef.current = PollingPhase.Active
     hasCompletedRef.current = false
-    previousDataRef.current = undefined
     pollingEndTimestampRef.current = Date.now() + maxDurationMs
   }, [maxDurationMs])
 
   const refreshInterval = useCallback((nextData?: TData) => {
+    // Read so this callback's identity tracks restartNonce (see its declaration).
+    void restartNonce
+
     if (!shouldContinue(nextData)) {
       phaseRef.current = PollingPhase.Idle
       return 0
@@ -69,7 +77,7 @@ export function usePollingConfig<TData>({
     }
 
     return getInterval()
-  }, [getInterval, restartPolling, shouldContinue])
+  }, [getInterval, restartPolling, shouldContinue, restartNonce])
 
   const onErrorRetry = useCallback<NonNullable<SWRConfiguration<TData>['onErrorRetry']>>(
     (error, _key, _config, revalidate, { retryCount }) => {
@@ -93,7 +101,17 @@ export function usePollingConfig<TData>({
   const onSuccess = useCallback((nextData: TData) => {
     void onPoll?.(nextData)
 
-    if (isActive(phaseRef) && shouldResetPollingDeadline?.(previousDataRef.current, nextData)) {
+    const hasProgress = shouldRestartPolling
+      ? shouldRestartPolling(previousDataRef.current, nextData)
+      : !shouldContinue(previousDataRef.current) && shouldContinue(nextData)
+
+    const shouldRestart = (isIdle(phaseRef) && shouldContinue(nextData)) || (isStopped(phaseRef) && hasProgress)
+
+    if (shouldRestart) {
+      restartPolling()
+      setRestartNonce(nonce => nonce + 1)
+    }
+    else if (isActive(phaseRef) && hasProgress) {
       pollingEndTimestampRef.current = Date.now() + maxDurationMs
     }
 
@@ -104,7 +122,7 @@ export function usePollingConfig<TData>({
       hasCompletedRef.current = true
       void onComplete?.(nextData)
     }
-  }, [onPoll, onComplete, shouldContinue, shouldComplete, shouldResetPollingDeadline, maxDurationMs])
+  }, [onPoll, onComplete, restartPolling, shouldContinue, shouldComplete, shouldRestartPolling, maxDurationMs])
 
   return useMemo(
     () => ({ refreshInterval, onErrorRetry, onSuccess }),

--- a/src/hooks/utils/useTriggerOnChange.ts
+++ b/src/hooks/utils/useTriggerOnChange.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react'
+
+export function useTriggerOnChange<T>(
+  value: T | undefined,
+  isEnabled: boolean,
+  callback: (data: T | undefined) => void,
+) {
+  const prevDataRef = useRef<T>()
+
+  useEffect(() => {
+    if (
+      isEnabled
+      && prevDataRef.current !== undefined
+      && prevDataRef.current !== value
+    ) {
+      callback(value)
+    }
+
+    prevDataRef.current = value
+  }, [value, isEnabled, callback])
+}

--- a/src/providers/BankTransactionsPaginationProvider/BankTransactionsProvider.tsx
+++ b/src/providers/BankTransactionsPaginationProvider/BankTransactionsProvider.tsx
@@ -1,20 +1,10 @@
-import { type ReactNode } from 'react'
+import { type PropsWithChildren } from 'react'
 
 import { useAugmentedBankTransactions } from '@hooks/features/bankTransactions/useAugmentedBankTransactions'
 import { BankTransactionsContext } from '@contexts/BankTransactionsContext/BankTransactionsContext'
-import { useBankTransactionsFiltersContext } from '@contexts/BankTransactionsFiltersContext/BankTransactionsFiltersContext'
 
-interface BankTransactionsProviderProps {
-  children: ReactNode
-}
-
-export const BankTransactionsProvider = ({
-  children,
-}: BankTransactionsProviderProps) => {
-  const { filters } = useBankTransactionsFiltersContext()
-
-  const bankTransactionsData = useAugmentedBankTransactions({ filters })
-
+export const BankTransactionsProvider = ({ children }: PropsWithChildren) => {
+  const bankTransactionsData = useAugmentedBankTransactions()
   return (
     <BankTransactionsContext.Provider value={bankTransactionsData}>
       {children}

--- a/src/providers/BusinessProvider/BusinessProvider.tsx
+++ b/src/providers/BusinessProvider/BusinessProvider.tsx
@@ -15,6 +15,7 @@ import { useBusiness } from '@hooks/api/businesses/[business-id]/useBusiness'
 import { useGlobalDateRange, useGlobalDateRangeActions } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 import { type LayerEvent } from '@providers/LayerProvider/layerEvents'
 import { type LayerProviderProps } from '@providers/LayerProvider/LayerProvider'
+import { BankAccountsProvider } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { LayerContext } from '@contexts/LayerContext/LayerContext'
 import { type ToastProps, ToastsContainer } from '@components/Toast/Toast'
 
@@ -225,7 +226,9 @@ export const BusinessProvider = ({
         dateRange,
       }}
     >
-      {children}
+      <BankAccountsProvider>
+        {children}
+      </BankAccountsProvider>
       <ToastsContainer />
     </LayerContext.Provider>
   )

--- a/src/providers/BusinessProvider/BusinessProvider.tsx
+++ b/src/providers/BusinessProvider/BusinessProvider.tsx
@@ -15,7 +15,6 @@ import { useBusiness } from '@hooks/api/businesses/[business-id]/useBusiness'
 import { useGlobalDateRange, useGlobalDateRangeActions } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
 import { type LayerEvent } from '@providers/LayerProvider/layerEvents'
 import { type LayerProviderProps } from '@providers/LayerProvider/LayerProvider'
-import { BankAccountsProvider } from '@contexts/BankAccountsContext/BankAccountsContext'
 import { LayerContext } from '@contexts/LayerContext/LayerContext'
 import { type ToastProps, ToastsContainer } from '@components/Toast/Toast'
 
@@ -226,9 +225,7 @@ export const BusinessProvider = ({
         dateRange,
       }}
     >
-      <BankAccountsProvider>
-        {children}
-      </BankAccountsProvider>
+      {children}
       <ToastsContainer />
     </LayerContext.Provider>
   )

--- a/src/providers/LayerProvider/LayerProvider.tsx
+++ b/src/providers/LayerProvider/LayerProvider.tsx
@@ -14,6 +14,7 @@ import { GlobalDateStoreProvider } from '@providers/GlobalDateStore/GlobalDateSt
 import { LayerI18nProvider } from '@providers/I18nProvider/LayerI18nProvider'
 import { StaleLocaleCacheInvalidator } from '@providers/I18nProvider/StaleLocaleCacheInvalidator'
 import type { LayerEvent } from '@providers/LayerProvider/layerEvents'
+import { BankAccountsProvider } from '@contexts/BankAccountsContext/BankAccountsContext'
 
 export type EventCallbacks = {
   onEvent?: (event: LayerEvent) => void
@@ -78,7 +79,9 @@ export const LayerProvider = ({
             businessAccessToken={businessAccessToken}
           >
             <GlobalDateStoreProvider>
-              <BusinessProvider {...restProps} />
+              <BankAccountsProvider>
+                <BusinessProvider {...restProps} />
+              </BankAccountsProvider>
             </GlobalDateStoreProvider>
           </AuthInputProvider>
         </EnvironmentInputProvider>

--- a/src/providers/LayerProvider/LayerProvider.tsx
+++ b/src/providers/LayerProvider/LayerProvider.tsx
@@ -14,7 +14,6 @@ import { GlobalDateStoreProvider } from '@providers/GlobalDateStore/GlobalDateSt
 import { LayerI18nProvider } from '@providers/I18nProvider/LayerI18nProvider'
 import { StaleLocaleCacheInvalidator } from '@providers/I18nProvider/StaleLocaleCacheInvalidator'
 import type { LayerEvent } from '@providers/LayerProvider/layerEvents'
-import { BankAccountsProvider } from '@contexts/BankAccountsContext/BankAccountsContext'
 
 export type EventCallbacks = {
   onEvent?: (event: LayerEvent) => void
@@ -79,9 +78,7 @@ export const LayerProvider = ({
             businessAccessToken={businessAccessToken}
           >
             <GlobalDateStoreProvider>
-              <BankAccountsProvider>
-                <BusinessProvider {...restProps} />
-              </BankAccountsProvider>
+              <BusinessProvider {...restProps} />
             </GlobalDateStoreProvider>
           </AuthInputProvider>
         </EnvironmentInputProvider>

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -18,16 +18,6 @@ export interface S3PresignedUrl {
 
 export type LoadedStatus = 'initial' | 'loading' | 'complete'
 
-export interface FormError {
-  field: string
-  message: string
-}
-
-export interface FormErrorWithId extends FormError {
-  id: number
-}
-// Only Date and string (ISO8601 formatted) make sense here
-
 export type DateRange<T = Date> = {
   startDate: T
   endDate: T

--- a/src/utils/bankAccount.ts
+++ b/src/utils/bankAccount.ts
@@ -28,6 +28,32 @@ export function isAnyBankAccountSyncing(bankAccounts: ReadonlyArray<BankAccount>
   return bankAccounts.some(isBankAccountSyncing)
 }
 
+export function getSyncingExternalAccountIds(bankAccounts: ReadonlyArray<BankAccount> | undefined): Set<string> {
+  const ids = new Set<string>()
+
+  for (const account of bankAccounts ?? []) {
+    for (const external of account.externalAccounts) {
+      if (external.isSyncing) ids.add(external.id)
+    }
+  }
+
+  return ids
+}
+
+export function hasNewSyncingAccounts(
+  prevAccounts: ReadonlyArray<BankAccount> | undefined,
+  newAccounts: ReadonlyArray<BankAccount> | undefined,
+): boolean {
+  const prevIds = getSyncingExternalAccountIds(prevAccounts)
+  const newIds = getSyncingExternalAccountIds(newAccounts)
+
+  for (const id of newIds) {
+    if (!prevIds.has(id)) return true
+  }
+
+  return false
+}
+
 export function isAllExternalAccountsUserCreatedCustom(bankAccount: BankAccount): boolean {
   return bankAccount.externalAccounts.length > 0
     && bankAccount.externalAccounts.every(ea => ea.externalAccountSource === 'CUSTOM' && ea.userCreated)


### PR DESCRIPTION
## Description

Fixes account-sync polling so syncing bank accounts refresh reliably, and separates bank-account *reads* from Plaid/linking *actions*.

Previously, sync-driven refresh was bolted onto `useAugmentedBankTransactions` (a raw `setInterval` plus inline account refetches), and account data was entangled with `LinkedAccountsContext`'s linking/mutation concerns. This made polling fragile and cache invalidation hard to reason about.

## Changes

**New `BankAccountsProvider` / `useBankAccountsContext`** (mounted on `BusinessProvider`)
- Single source of truth for account-list reads, backed by `useListBankAccounts`.
- Exposes `isSyncing`, `loadingStatus`, `refetch`, and disconnected-account counts.
- Polls syncing accounts via the shared `usePollingConfig` helper (polls while any account `is_syncing`).

**Consumers migrated to `useBankAccountsContext`** for account data: bank transactions header, P&L chart/header, linked accounts, link-accounts wizard, tasks panel, and onboarding banner.

**`LinkedAccountsContext` / `useLinkedAccounts` slimmed down** to linking, hosted-link errors, and mutations. `refetchAccounts` → `refetchAccountsAndTransactions` (refetches accounts + `forceReloadBankTransactions`).

**Bank-transaction sync refresh extracted** into `usePollBankTransactions`:
- Removes the `setInterval` + inline account refetch from `useAugmentedBankTransactions`.
- Polls the infinite list with SWR while `isSyncing`, fires `onTransactionsFetched` on change, and reloads background caches when sync ends.

**Shared polling helpers**
- `usePollingConfig` — reused by account polling and Plaid hosted-link status polling.
- `useTriggerOnChange` — new utility for firing callbacks on value changes.

**Tighter cache invalidation**
- categorize/match no longer invalidate `#bank-accounts`.
- unlink / Plaid exchange mutations no longer auto-reload all bank transactions; those refreshes now come from `refetchAccountsAndTransactions` after link flows.

## How this has been tested?

- Verified syncing accounts poll and update without manual refresh.
- Verified link/unlink/exchange flows refresh accounts and transactions via `refetchAccountsAndTransactions`.
- Verified categorize/match no longer trigger unnecessary bank-account refetches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync/link refresh paths and SWR invalidation across bank accounts and transactions; incorrect polling or refetch timing could leave stale UI after link/unlink or long syncs.
> 
> **Overview**
> Introduces **`BankAccountsProvider`** on `BusinessProvider` as the shared read layer for bank accounts (list data, `isSyncing`, `loadingStatus`, `refetch`, disconnected counts), with **SWR polling via `usePollingConfig`** while any account is syncing.
> 
> **UI and hooks** that previously used `useLinkedAccounts` / `LinkedAccountsContext` for list state now call **`useBankAccountsContext`**; **`LinkedAccountsContext`** is narrowed to Plaid/linking actions and **`refetchAccountsAndTransactions`** (accounts + full transaction reload after link flows).
> 
> **Bank transaction refresh during sync** moves out of `useAugmentedBankTransactions` (removed `setInterval` and inline account refetch) into **`usePollBankTransactions`**, which polls via a dedicated SWR key, respects stall/restart when new syncing accounts appear, and reloads background transaction caches when sync ends.
> 
> Adds shared **`usePollingConfig`**, **`useTriggerOnChange`**, and **`hasNewSyncingAccounts`** helpers; **Plaid hosted-link polling** adopts the same config. **Cache side effects** are trimmed: categorize/match no longer invalidate `#bank-accounts`; unlink/Plaid exchange/unlink mutations no longer auto-`forceReloadBankTransactions`—those refreshes are expected from link-flow refetch helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d3a4a7e76d6fcff6945795d327df43e149097f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->