### PR TITLE
refactor: add createBuildKey helper and migrate API hooks off hand-written buildKey functions

### DIFF
--- a/src/hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration.tsx
+++ b/src/hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration.tsx
@@ -3,6 +3,7 @@ import useSWR from 'swr'
 
 import { AccountingConfigurationSchema, type AccountingConfigurationSchemaType } from '@schemas/accountingConfiguration'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
@@ -13,24 +14,7 @@ type GetAccountingConfigurationParams = {
   businessId: string
 }
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tag: [ACCOUNTING_CONFIGURATION_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([ACCOUNTING_CONFIGURATION_TAG_KEY])
 
 const getAccountingConfiguration = get<{ data: AccountingConfigurationSchemaType }, GetAccountingConfigurationParams>(
   ({ businessId }) => {

--- a/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
@@ -5,6 +5,7 @@ import { type LoadedStatus } from '@internal-types/general'
 import { type BankAccount, BankAccountSchema } from '@schemas/bankAccounts/bankAccount'
 import { get } from '@utils/api/authenticatedHttp'
 import { isAnyBankAccountSyncing } from '@utils/bankAccount'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
@@ -26,24 +27,7 @@ const listBankAccounts = get<
   }
 >(({ businessId }) => `/v1/businesses/${businessId}/bank-accounts`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [BANK_ACCOUNTS_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([BANK_ACCOUNTS_TAG_KEY])
 
 export class ListBankAccountsSWRResponse extends SWRQueryResult<BankAccount[]> {
   get error(): unknown {

--- a/src/hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount.ts
@@ -1,6 +1,7 @@
 import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -21,24 +22,7 @@ const unlinkBankAccount = del<
     `/v1/businesses/${businessId}/bank-accounts/${bankAccountId}`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [UNLINK_BANK_ACCOUNT_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([UNLINK_BANK_ACCOUNT_TAG_KEY])
 
 export function useUnlinkBankAccount() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/useCategorizeBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/useCategorizeBankTransaction.ts
@@ -6,6 +6,7 @@ import useSWRMutation from 'swr/mutation'
 import { BankTransactionSchema } from '@schemas/bankTransactions/bankTransaction'
 import { type CategoryUpdate, type CategoryUpdateEncoded, encodeCategoryUpdate } from '@schemas/bankTransactions/categoryUpdate'
 import { put } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -34,24 +35,7 @@ const categorizeBankTransaction = put<
     `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/categorize`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [CATEGORIZE_BANK_TRANSACTION_TAG],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([CATEGORIZE_BANK_TRANSACTION_TAG])
 
 type CategorizeBankTransactionArgs = CategoryUpdate & {
   bankTransactionId: string

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/match/useMatchBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/match/useMatchBankTransaction.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { MatchSchema } from '@schemas/bankTransactions/match'
 import { put } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -36,24 +37,7 @@ const matchBankTransaction = put<
 
 const MATCH_BANK_TRANSACTION_TAG = '#match-bank-transaction'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [MATCH_BANK_TRANSACTION_TAG],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([MATCH_BANK_TRANSACTION_TAG])
 
 type MatchBankTransactionArgs = MatchBankTransactionBody & {
   bankTransactionId: string

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useBankTransactionsMetadata.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useBankTransactionsMetadata.ts
@@ -2,6 +2,7 @@ import useSWR from 'swr'
 
 import { type BankTransaction, type BankTransactionMetadata } from '@internal-types/bankTransactions'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
@@ -16,27 +17,7 @@ const getBankTransactionMetadata = get<{
 
 export const GET_BANK_TRANSACTION_METADATA_TAG_KEY = '#bank-transaction-metadata'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  bankTransactionId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  bankTransactionId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      bankTransactionId,
-      tags: [GET_BANK_TRANSACTION_METADATA_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, bankTransactionId: string }>([GET_BANK_TRANSACTION_METADATA_TAG_KEY])
 
 export function useBankTransactionMetadata({ bankTransactionId }: { bankTransactionId: BankTransaction['id'] }) {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useSetMetadataOnBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useSetMetadataOnBankTransaction.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 import { type CustomerSchema } from '@schemas/customer'
 import { type VendorSchema } from '@schemas/vendor'
 import { patch } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
@@ -13,27 +14,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const SET_METADATA_ON_BANK_TRANSACTION_TAG_KEY = '#set-metadata-on-bank-transaction'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  bankTransactionId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  bankTransactionId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      bankTransactionId,
-      tags: [SET_METADATA_ON_BANK_TRANSACTION_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, bankTransactionId: string }>([SET_METADATA_ON_BANK_TRANSACTION_TAG_KEY])
 
 type SetMetadataOnBankTransactionBody = {
   vendor_id: string | null

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useUpdateBankTransactionMetadata.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useUpdateBankTransactionMetadata.ts
@@ -5,6 +5,7 @@ import useSWRMutation from 'swr/mutation'
 import type { BankTransactionMetadata } from '@internal-types/bankTransactions'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { put } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -25,27 +26,7 @@ export type UpdateBankTransactionMetadataBody = { memo: string }
 
 const UPDATE_BANK_TRANSACTION_METADATA_TAG_KEY = '#update-bank-transaction-metadata'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  bankTransactionId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  bankTransactionId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      bankTransactionId,
-      tags: [UPDATE_BANK_TRANSACTION_METADATA_TAG_KEY],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, bankTransactionId: string }>([UPDATE_BANK_TRANSACTION_METADATA_TAG_KEY])
 
 export function useUpdateBankTransactionMetadata({ bankTransactionId, onSuccess }: { bankTransactionId: string, onSuccess?: () => Awaitable<unknown> }) {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-categorize/useBulkCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-categorize/useBulkCategorize.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { CategoryUpdateSchema } from '@schemas/bankTransactions/categoryUpdate'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
@@ -33,24 +34,7 @@ const bulkCategorize = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/bank-transactions/bulk-categorize`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [BULK_CATEGORIZE_BANK_TRANSACTIONS_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([BULK_CATEGORIZE_BANK_TRANSACTIONS_TAG_KEY])
 
 export const useBulkCategorize = () => {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -5,6 +5,7 @@ import useSWRMutation from 'swr/mutation'
 import { type Split } from '@internal-types/bankTransactions'
 import { CategoryUpdateSchema } from '@schemas/bankTransactions/categoryUpdate'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
@@ -139,24 +140,7 @@ const bulkMatchOrCategorize = post<
   },
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [BULK_MATCH_OR_CATEGORIZE_TAG],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([BULK_MATCH_OR_CATEGORIZE_TAG])
 
 export const useBulkMatchOrCategorize = () => {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-uncategorize/useBulkUncategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-uncategorize/useBulkUncategorize.ts
@@ -3,6 +3,7 @@ import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
@@ -27,24 +28,7 @@ const bulkUncategorize = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/bank-transactions/bulk-uncategorize`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [BULK_UNCATEGORIZE_BANK_TRANSACTIONS_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([BULK_UNCATEGORIZE_BANK_TRANSACTIONS_TAG_KEY])
 
 export const useBulkUncategorize = () => {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/tags/useRemoveTagFromBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/tags/useRemoveTagFromBankTransaction.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
@@ -20,27 +21,7 @@ const removeTagFromBankTransaction = del<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/bank-transactions/tags`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  bankTransactionId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  bankTransactionId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      bankTransactionId,
-      tags: [REMOVE_TAG_FROM_BANK_TRANSACTION_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, bankTransactionId: string }>([REMOVE_TAG_FROM_BANK_TRANSACTION_TAG_KEY])
 
 type RemoveTagFromBankTransactionArg = {
   tagId: string

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/tags/useTagBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/tags/useTagBankTransaction.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import type { TransactionTagEncoded } from '@schemas/tag'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import {
@@ -37,27 +38,7 @@ const tagBankTransaction = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/bank-transactions/tags`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  bankTransactionId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  bankTransactionId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      bankTransactionId,
-      tags: [TAG_BANK_TRANSACTION_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, bankTransactionId: string }>([TAG_BANK_TRANSACTION_TAG_KEY])
 
 type TagBankTransactionArg = {
   key: string

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions.ts
@@ -8,6 +8,7 @@ import { BankTransactionSchema } from '@schemas/bankTransactions/bankTransaction
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { createKeyMatcher } from '@utils/swr/createKeyMatcher'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -69,6 +70,20 @@ const getBankTransactions = get<
 
 export const BANK_TRANSACTIONS_TAG_KEY = '#bank-transactions'
 
+export type UseBankTransactionsOptions = {
+  categorized?: boolean
+  direction?: 'INFLOW' | 'OUTFLOW'
+  query?: string
+  startDate?: Date
+  endDate?: Date
+  tagFilterQueryString?: string
+}
+
+const keyLoader = createInfiniteKeyLoader<
+  UseBankTransactionsOptions & { businessId: string },
+  GetBankTransactionsReturn
+>([BANK_TRANSACTIONS_TAG_KEY])
+
 export type BankTransactionsKey = NonNullable<ReturnType<typeof keyLoader>>
 
 const compareDates = (a: unknown, b: unknown) =>
@@ -82,50 +97,6 @@ const keyMatchesParams = createKeyMatcher<BankTransactionsKey, UseBankTransactio
   { key: 'endDate', compare: compareDates },
   { key: 'tagFilterQueryString' },
 ])
-
-export type UseBankTransactionsOptions = {
-  categorized?: boolean
-  direction?: 'INFLOW' | 'OUTFLOW'
-  query?: string
-  startDate?: Date
-  endDate?: Date
-  tagFilterQueryString?: string
-}
-
-function keyLoader(
-  previousPageData: GetBankTransactionsReturn | null,
-  {
-    access_token: accessToken,
-    apiUrl,
-    businessId,
-    categorized,
-    direction,
-    query,
-    startDate,
-    endDate,
-    tagFilterQueryString,
-  }: UseBankTransactionsOptions & {
-    access_token?: string
-    apiUrl?: string
-    businessId: string
-  },
-) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      categorized,
-      cursor: previousPageData?.meta?.pagination.cursor ?? undefined,
-      direction,
-      query,
-      startDate,
-      endDate,
-      tagFilterQueryString,
-      tags: [BANK_TRANSACTIONS_TAG_KEY],
-    } as const
-  }
-}
 
 export function useBankTransactions({
   categorized,

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration.tsx
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration.tsx
@@ -8,6 +8,7 @@ import {
   TransactionTaggingStrategy,
 } from '@schemas/bookkeepingConfiguration'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -23,24 +24,7 @@ type GetBookkeepingConfigurationParams = {
   businessId: string
 }
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tag: [BOOKKEEPING_CONFIGURATION_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([BOOKKEEPING_CONFIGURATION_TAG_KEY])
 
 const getBookkeepingConfiguration = get<
   Record<string, unknown>,

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods.ts
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods.ts
@@ -7,6 +7,7 @@ import { get } from '@utils/api/authenticatedHttp'
 import { isActiveOrPausedBookkeepingStatus } from '@utils/bookkeeping/bookkeepingStatusFilters'
 import { isActiveBookkeepingPeriod } from '@utils/bookkeeping/periods/getFilteredBookkeepingPeriods'
 import { getUserVisibleTasks } from '@utils/bookkeeping/tasks/bookkeepingTasksFilters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import {
   BOOKKEEPING_TAG_KEY,
@@ -69,26 +70,7 @@ const getBookkeepingPeriods = get<
 
 export const BOOKKEEPING_PERIODS_TAG_KEY = '#bookkeeping-periods'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  isActiveOrPaused,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  isActiveOrPaused: boolean
-}) {
-  if (accessToken && apiUrl && isActiveOrPaused) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [BOOKKEEPING_TAG_KEY, BOOKKEEPING_PERIODS_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([BOOKKEEPING_TAG_KEY, BOOKKEEPING_PERIODS_TAG_KEY])
 
 export function useBookkeepingPeriods() {
   const withLocale = useLocalizedKey()
@@ -102,7 +84,7 @@ export function useBookkeepingPeriods() {
     () => withLocale(buildKey({
       ...auth,
       businessId,
-      isActiveOrPaused,
+      isEnabled: isActiveOrPaused,
     })),
     ({ accessToken, apiUrl, businessId }) => getBookkeepingPeriods(
       apiUrl,

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus.ts
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus.ts
@@ -4,6 +4,7 @@ import useSWR from 'swr'
 
 import { BookkeepingStatus, BookkeepingStatusResponseSchema } from '@schemas/bookkeepingStatus'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useLegacyMode } from '@providers/LegacyModeProvider/LegacyModeProvider'
@@ -21,24 +22,7 @@ const getBookkeepingStatus = get<
 export const BOOKKEEPING_TAG_KEY = '#bookkeeping'
 export const BOOKKEEPING_STATUS_TAG_KEY = '#bookkeeping-status'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [BOOKKEEPING_TAG_KEY, BOOKKEEPING_STATUS_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([BOOKKEEPING_TAG_KEY, BOOKKEEPING_STATUS_TAG_KEY])
 
 export function useBookkeepingStatus() {
   const { data: auth } = useAuth()

--- a/src/hooks/api/businesses/[business-id]/call-bookings/useCallBookings.tsx
+++ b/src/hooks/api/businesses/[business-id]/call-bookings/useCallBookings.tsx
@@ -15,6 +15,7 @@ import {
 } from '@schemas/callBooking'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
@@ -44,31 +45,12 @@ const listCallBookings = get<
   return `/v1/businesses/${businessId}/call-bookings?${parameters}`
 })
 
-function keyLoader(
-  previousPageData: ListCallBookingsResponse | null,
-  {
-    access_token: accessToken,
-    apiUrl,
-    businessId,
-    limit,
-  }: {
-    access_token?: string
-    apiUrl?: string
-    businessId: string
-    limit?: number
-  },
-) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      cursor: previousPageData?.meta?.pagination.cursor ?? undefined,
-      limit,
-      tags: [CALL_BOOKINGS_TAG_KEY],
-    } as const
-  }
-}
+export const CALL_BOOKINGS_TAG_KEY = '#call-bookings'
+
+const keyLoader = createInfiniteKeyLoader<
+  { businessId: string, limit?: number },
+  ListCallBookingsResponse
+>([CALL_BOOKINGS_TAG_KEY])
 
 export function useCallBookings({ limit }: { limit?: number } = {}) {
   const withLocale = useLocalizedKey()
@@ -106,8 +88,6 @@ export function useCallBookings({ limit }: { limit?: number } = {}) {
 
   return useSWRInfiniteResult(swrResponse)
 }
-
-export const CALL_BOOKINGS_TAG_KEY = '#call-bookings'
 
 export function useCallBookingsGlobalCacheActions() {
   const { forceReload } = useGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/call-bookings/useCreateCallBooking.tsx
+++ b/src/hooks/api/businesses/[business-id]/call-bookings/useCreateCallBooking.tsx
@@ -8,6 +8,7 @@ import {
   type CreateCallBookingBodyEncoded,
 } from '@schemas/callBooking'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -23,24 +24,7 @@ const createCallBooking = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/call-bookings`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [CREATE_CALL_BOOKING_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([CREATE_CALL_BOOKING_TAG_KEY])
 
 export function useCreateCallBooking() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useArchiveCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useArchiveCatalogService.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { CatalogServiceSchema } from '@schemas/catalogService'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -26,27 +27,7 @@ const archiveCatalogService = post<ArchiveCatalogServiceResponse>(
     `/v1/businesses/${businessId}/catalog/services/${serviceId}/archive`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  serviceId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  serviceId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      serviceId,
-      tags: [ARCHIVE_CATALOG_SERVICE_TAG_KEY, CATALOG_SERVICES_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, serviceId: string }>([ARCHIVE_CATALOG_SERVICE_TAG_KEY, CATALOG_SERVICES_TAG_KEY])
 
 type UseArchiveCatalogServiceProps = {
   serviceId: string

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useGetCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useGetCatalogService.ts
@@ -4,6 +4,7 @@ import useSWR from 'swr'
 import { type CatalogService, CatalogServiceSchema } from '@schemas/catalogService'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { CATALOG_SERVICES_TAG_KEY } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
@@ -26,36 +27,11 @@ const getCatalogService = get<
   return query ? `${baseUrl}?${query}` : baseUrl
 })
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  serviceId,
-  allowArchived,
-  isEnabled,
-}: {
-  access_token?: string
-  apiUrl?: string
+const buildKey = createBuildKey<{
   businessId: string
   serviceId: string
   allowArchived?: boolean
-  isEnabled: boolean
-}) {
-  if (!isEnabled) {
-    return
-  }
-
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      serviceId,
-      allowArchived,
-      tags: [GET_CATALOG_SERVICE_TAG_KEY, CATALOG_SERVICES_TAG_KEY],
-    } as const
-  }
-}
+}>([GET_CATALOG_SERVICE_TAG_KEY, CATALOG_SERVICES_TAG_KEY])
 
 type UseGetCatalogServiceParameters = {
   serviceId: string

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useReactivateCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useReactivateCatalogService.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { CatalogServiceSchema } from '@schemas/catalogService'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -26,27 +27,7 @@ const reactivateCatalogService = post<ReactivateCatalogServiceResponse>(
     `/v1/businesses/${businessId}/catalog/services/${serviceId}/reactivate`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  serviceId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  serviceId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      serviceId,
-      tags: [REACTIVATE_CATALOG_SERVICE_TAG_KEY, CATALOG_SERVICES_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, serviceId: string }>([REACTIVATE_CATALOG_SERVICE_TAG_KEY, CATALOG_SERVICES_TAG_KEY])
 
 type UseReactivateCatalogServiceProps = {
   serviceId: string

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useUpdateCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useUpdateCatalogService.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { CatalogServiceSchema, type UpdateCatalogServiceEncoded } from '@schemas/catalogService'
 import { patch } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -29,27 +30,7 @@ const updateCatalogService = patch<
   { businessId: string, serviceId: string }
 >(({ businessId, serviceId }) => `/v1/businesses/${businessId}/catalog/services/${serviceId}`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  serviceId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  serviceId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      serviceId,
-      tags: [UPDATE_CATALOG_SERVICE_TAG_KEY, CATALOG_SERVICES_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, serviceId: string }>([UPDATE_CATALOG_SERVICE_TAG_KEY, CATALOG_SERVICES_TAG_KEY])
 
 type UseUpdateCatalogServiceProps = {
   serviceId: string

--- a/src/hooks/api/businesses/[business-id]/catalog/services/useCreateCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/useCreateCatalogService.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { CatalogServiceSchema, type CreateCatalogServiceEncoded } from '@schemas/catalogService'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -29,24 +30,7 @@ const createCatalogService = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/catalog/services`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [CREATE_CATALOG_SERVICE_TAG_KEY, CATALOG_SERVICES_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([CREATE_CATALOG_SERVICE_TAG_KEY, CATALOG_SERVICES_TAG_KEY])
 
 export function useCreateCatalogService() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
@@ -5,6 +5,7 @@ import useSWR from 'swr'
 import { type CatalogService, CatalogServiceSchema } from '@schemas/catalogService'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -19,33 +20,7 @@ const ListCatalogServicesResponseSchema = Schema.Struct({
 })
 type ListCatalogServicesResponse = typeof ListCatalogServicesResponseSchema.Type
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  allowArchived,
-  isEnabled = true,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  allowArchived?: boolean
-  isEnabled?: boolean
-}) {
-  if (!isEnabled) {
-    return
-  }
-
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      allowArchived,
-      tags: [CATALOG_SERVICES_TAG_KEY, LIST_CATALOG_SERVICES_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, allowArchived?: boolean }>([CATALOG_SERVICES_TAG_KEY, LIST_CATALOG_SERVICES_TAG_KEY])
 
 const listCatalogServices = get<
   typeof ListCatalogServicesResponseSchema.Encoded,

--- a/src/hooks/api/businesses/[business-id]/categories/useCategories.ts
+++ b/src/hooks/api/businesses/[business-id]/categories/useCategories.ts
@@ -4,33 +4,14 @@ import useSWR from 'swr'
 import { type CategoriesListMode, CategoryListSchema, type NestedCategorization } from '@schemas/categorization'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export const CATEGORIES_TAG_KEY = '#categories'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  mode,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  mode?: CategoriesListMode
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      mode,
-      tags: [CATEGORIES_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, mode?: CategoriesListMode }>([CATEGORIES_TAG_KEY])
 
 export const getCategories = get<
   {

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/[categorization-rule-id]/archive/useArchiveCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/[categorization-rule-id]/archive/useArchiveCategorizationRule.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { CategorizationRuleSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCategorizationRulesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules'
@@ -12,24 +13,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const ARCHIVE_CATEGORIZATION_RULE_TAG = '#archive-categorization-rule'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [ARCHIVE_CATEGORIZATION_RULE_TAG],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([ARCHIVE_CATEGORIZATION_RULE_TAG])
 
 const ArchiveCategorizationRuleReturnSchema = Schema.Struct({
   data: CategorizationRuleSchema,

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/suggestions/useRejectCategorizationRulesUpdateSuggestion.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/suggestions/useRejectCategorizationRulesUpdateSuggestion.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -9,24 +10,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const REJECT_CATEGORIZATION_RULE_SUGGESTION_TAG = '#reject-categorization-rule-suggestion'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [REJECT_CATEGORIZATION_RULE_SUGGESTION_TAG],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([REJECT_CATEGORIZATION_RULE_SUGGESTION_TAG])
 
 export const rejectCategorizationRulesUpdateSuggestion = del<never>(
   ({ businessId, suggestionId }) =>

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useCreateCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useCreateCategorizationRule.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { CategorizationRuleSchema, type CreateCategorizationRuleSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
@@ -14,24 +15,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const CREATE_CATEGORIZATION_RULE_TAG = '#create-categorization-rule'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [CREATE_CATEGORIZATION_RULE_TAG],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([CREATE_CATEGORIZATION_RULE_TAG])
 
 const CreateCategorizationRuleReturnSchema = Schema.Struct({
   data: CategorizationRuleSchema,

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules.ts
@@ -7,6 +7,7 @@ import { type CategorizationRule, CategorizationRuleSchema } from '@schemas/bank
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
@@ -56,39 +57,7 @@ export const listCategorizationRules = get<
   return parameters ? `${baseUrl}?${parameters}` : baseUrl
 })
 
-function keyLoader(
-  previousPageData: ListCategorizationRulesReturn | null,
-  {
-    access_token: accessToken,
-    apiUrl,
-    businessId,
-    externalIds,
-    includeArchived,
-    sortBy,
-    sortOrder,
-    limit,
-    showTotalCount,
-  }: {
-    access_token?: string
-    apiUrl?: string
-  } & Omit<ListCategorizationRulesParams, 'cursor'>,
-) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      externalIds,
-      includeArchived,
-      cursor: previousPageData?.meta?.pagination.cursor,
-      sortBy,
-      sortOrder,
-      limit,
-      showTotalCount,
-      tags: [LIST_CATEGORIZATION_RULES_TAG_KEY],
-    } as const
-  }
-}
+const keyLoader = createInfiniteKeyLoader<Omit<ListCategorizationRulesParams, 'cursor'>, ListCategorizationRulesReturn>([LIST_CATEGORIZATION_RULES_TAG_KEY])
 
 export function useListCategorizationRules({
   externalIds,

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule.ts
@@ -8,6 +8,7 @@ import {
   type PatchCategorizationRuleSchema,
 } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { patch, post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
@@ -18,24 +19,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const UPSERT_CATEGORIZATION_RULE_TAG = '#upsert-categorization-rule'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [UPSERT_CATEGORIZATION_RULE_TAG],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([UPSERT_CATEGORIZATION_RULE_TAG])
 
 const UpsertCategorizationRuleReturnSchema = Schema.Struct({
   data: CategorizationRuleSchema,

--- a/src/hooks/api/businesses/[business-id]/counterparties/useListCounterparties.ts
+++ b/src/hooks/api/businesses/[business-id]/counterparties/useListCounterparties.ts
@@ -6,6 +6,7 @@ import { BankTransactionCounterpartySchema } from '@schemas/bankTransactions/bas
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
@@ -54,39 +55,7 @@ export const listCounterparties = get<
   return parameters ? `${baseUrl}?${parameters}` : baseUrl
 })
 
-function keyLoader(
-  previousPageData: ListCounterpartiesReturn | null,
-  {
-    access_token: accessToken,
-    apiUrl,
-    businessId,
-    externalIds,
-    q,
-    sortBy,
-    sortOrder,
-    limit,
-    showTotalCount,
-  }: {
-    access_token?: string
-    apiUrl?: string
-  } & Omit<ListCounterpartiesParams, 'cursor'>,
-) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      externalIds,
-      q,
-      cursor: previousPageData?.meta?.pagination.cursor,
-      sortBy,
-      sortOrder,
-      limit,
-      showTotalCount,
-      tags: [LIST_COUNTERPARTIES_TAG_KEY],
-    } as const
-  }
-}
+const keyLoader = createInfiniteKeyLoader<Omit<ListCounterpartiesParams, 'cursor'>, ListCounterpartiesReturn>([LIST_COUNTERPARTIES_TAG_KEY])
 
 export function useListCounterparties({
   externalIds,

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/parse-csv/useCustomAccountParseCsv.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/parse-csv/useCustomAccountParseCsv.ts
@@ -5,6 +5,7 @@ import { PreviewCellSchema, type PreviewCsv, PreviewRowSchema } from '@schemas/c
 import type { CustomAccountTransactionRow, RawCustomTransaction } from '@schemas/customAccounts'
 import { type APIError } from '@utils/api/apiError'
 import { postWithFormData } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { CUSTOM_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -69,24 +70,7 @@ export type CustomAccountParseCsvResponse = {
   totalTransactionsCount: number
 }
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [`${CUSTOM_ACCOUNTS_TAG_KEY}:parse-csv`],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([`${CUSTOM_ACCOUNTS_TAG_KEY}:parse-csv`])
 
 const parseCsv = (baseUrl: string, accessToken: string, {
   businessId,

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/transactions/useCreateCustomAccountTransactions.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/transactions/useCreateCustomAccountTransactions.ts
@@ -5,6 +5,7 @@ import { BankTransactionDataOnlySchema } from '@schemas/bankTransactions/bankTra
 import type { RawCustomTransaction } from '@schemas/customAccounts'
 import { type APIError } from '@utils/api/apiError'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { CUSTOM_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -32,24 +33,7 @@ const createCustomAccountTransactions = post<
   `/v1/businesses/${businessId}/custom-accounts/${customAccountId}/transactions`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [`${CUSTOM_ACCOUNTS_TAG_KEY}:create-transactions`],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([`${CUSTOM_ACCOUNTS_TAG_KEY}:create-transactions`])
 
 export function useCreateCustomAccountTransactions() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/useCreateCustomAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/useCreateCustomAccount.ts
@@ -5,6 +5,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { CustomAccountSchema, type RawCustomAccount } from '@schemas/customAccounts'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
@@ -34,24 +35,7 @@ const createCustomAccount = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/custom-accounts`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [`${CUSTOM_ACCOUNTS_TAG_KEY}:create`],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([`${CUSTOM_ACCOUNTS_TAG_KEY}:create`])
 
 export function useCreateCustomAccount() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts.ts
@@ -3,6 +3,7 @@ import useSWR from 'swr'
 
 import { CustomAccountSchema } from '@schemas/customAccounts'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
@@ -20,27 +21,7 @@ const GetCustomAccountsResponseSchema = Schema.Struct({
 
 type GetCustomAccountsResponseEncoded = typeof GetCustomAccountsResponseSchema.Encoded
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  userCreated,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  userCreated?: boolean
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      userCreated,
-      tags: [CUSTOM_ACCOUNTS_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, userCreated?: boolean }>([CUSTOM_ACCOUNTS_TAG_KEY])
 
 const getCustomAccounts = get<
   GetCustomAccountsResponseEncoded,

--- a/src/hooks/api/businesses/[business-id]/customers/useListCustomers.ts
+++ b/src/hooks/api/businesses/[business-id]/customers/useListCustomers.ts
@@ -6,6 +6,7 @@ import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { type Customer, CustomerSchema } from '@schemas/customer'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
@@ -47,37 +48,10 @@ const listCustomers = get<
 
 export const CUSTOMERS_TAG_KEY = '#customers'
 
-function keyLoader(
-  previousPageData: ListCustomersRawResult | null,
-  {
-    access_token: accessToken,
-    apiUrl,
-    businessId,
-    query,
-    isEnabled,
-  }: {
-    access_token?: string
-    apiUrl?: string
-    businessId: string
-    query?: string
-    isEnabled?: boolean
-  },
-) {
-  if (!isEnabled) {
-    return
-  }
-
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      cursor: previousPageData?.meta?.pagination.cursor ?? undefined,
-      query,
-      tags: [CUSTOMERS_TAG_KEY],
-    } as const
-  }
-}
+const keyLoader = createInfiniteKeyLoader<
+  { businessId: string, query?: string },
+  ListCustomersRawResult
+>([CUSTOMERS_TAG_KEY])
 
 type UseListCustomersParams = {
   query?: string

--- a/src/hooks/api/businesses/[business-id]/customers/useUpsertCustomer.tsx
+++ b/src/hooks/api/businesses/[business-id]/customers/useUpsertCustomer.tsx
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { CustomerSchema, type UpsertCustomerEncoded } from '@schemas/customer'
 import { patch, post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -33,27 +34,7 @@ const updateCustomer = patch<
   { businessId: string, customerId: string }
 >(({ businessId, customerId }) => `/v1/businesses/${businessId}/customers/${customerId}`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  customerId = undefined,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  customerId?: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      customerId,
-      tags: [UPSERT_CUSTOMER_TAG_KEY, CUSTOMERS_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, customerId?: string }>([UPSERT_CUSTOMER_TAG_KEY, CUSTOMERS_TAG_KEY])
 
 const UpsertCustomerReturnSchema = Schema.Struct({
   data: CustomerSchema,

--- a/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm.ts
+++ b/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm.ts
@@ -3,6 +3,7 @@ import useSWRMutation from 'swr/mutation'
 
 import type { OneOf } from '@internal-types/utility/oneOf'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -30,24 +31,7 @@ type ConfirmExternalAccountArg = {
   body?: ConfirmAccountBodyStrict
 }
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [CONFIRM_EXTERNAL_ACCOUNT_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([CONFIRM_EXTERNAL_ACCOUNT_TAG_KEY])
 
 export function useConfirmExternalAccount() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude.ts
+++ b/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude.ts
@@ -3,6 +3,7 @@ import useSWRMutation from 'swr/mutation'
 
 import type { OneOf } from '@internal-types/utility/oneOf'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -30,24 +31,7 @@ type ExcludeExternalAccountArg = {
   body?: ExcludeAccountBodyStrict
 }
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [EXCLUDE_EXTERNAL_ACCOUNT_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([EXCLUDE_EXTERNAL_ACCOUNT_TAG_KEY])
 
 export function useExcludeExternalAccount() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/external-accounts/update-connection-status.ts
+++ b/src/hooks/api/businesses/[business-id]/external-accounts/update-connection-status.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -19,24 +20,7 @@ const updateConnectionStatus = post<
     `/v1/businesses/${businessId}/external-accounts/update-connection-status`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [UPDATE_CONNECTION_STATUS_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([UPDATE_CONNECTION_STATUS_TAG_KEY])
 
 export function useUpdateConnectionStatus() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/finalize-invoice/useFinalizeInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/finalize-invoice/useFinalizeInvoice.tsx
@@ -6,6 +6,7 @@ import useSWRMutation from 'swr/mutation'
 import { InvoiceSchema } from '@schemas/invoices/invoice'
 import { InvoicePaymentMethodsSchema } from '@schemas/invoices/invoicePaymentMethod'
 import { put } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -47,27 +48,7 @@ export const finalizeInvoice = put<
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/finalize-invoice`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  invoiceId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  invoiceId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      invoiceId,
-      tags: [FINALIZE_INVOICE_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([FINALIZE_INVOICE_TAG_KEY])
 
 type UseFinalizeInvoiceProps = {
   invoiceId: string

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/html/useInvoicePreview.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/html/useInvoicePreview.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import useSWR from 'swr'
 
 import { getText } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -10,27 +11,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export const INVOICE_PREVIEW_TAG_KEY = '#invoices-preview'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  invoiceId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  invoiceId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      invoiceId,
-      tags: [INVOICE_PREVIEW_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([INVOICE_PREVIEW_TAG_KEY])
 
 const getInvoicePreview = getText<{ businessId: string, invoiceId: string }>(
   ({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/html`,

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment-methods/useInvoicePaymentMethods.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment-methods/useInvoicePaymentMethods.tsx
@@ -6,6 +6,7 @@ import {
   InvoicePaymentMethodsResponseSchema,
 } from '@schemas/invoices/invoicePaymentMethod'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -13,33 +14,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export const INVOICE_PAYMENT_METHODS_TAG_KEY = '#invoice-payment-methods'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  isEnabled,
-  invoiceId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  isEnabled: boolean
-  invoiceId: string | null
-}) {
-  if (!isEnabled) {
-    return
-  }
-
-  if (accessToken && apiUrl && invoiceId) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      invoiceId,
-      tags: [INVOICE_PAYMENT_METHODS_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([INVOICE_PAYMENT_METHODS_TAG_KEY])
 
 const getInvoicePaymentMethods = get<
   InvoicePaymentMethodsResponse,
@@ -63,8 +38,8 @@ export function useInvoicePaymentMethods({
     () => withLocale(buildKey({
       ...data,
       businessId,
-      isEnabled,
       invoiceId,
+      isEnabled: isEnabled && Boolean(invoiceId),
     })),
     ({ accessToken, apiUrl, businessId, invoiceId }) => getInvoicePaymentMethods(
       apiUrl,

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment/useUpsertDedicatedInvoicePayment.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment/useUpsertDedicatedInvoicePayment.tsx
@@ -5,6 +5,7 @@ import useSWRMutation from 'swr/mutation'
 import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { type InvoicePayment, InvoicePaymentSchema, type UpsertDedicatedInvoicePaymentSchema } from '@schemas/invoices/invoicePayment'
 import { post, put } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -34,30 +35,7 @@ const updateDedicatedInvoicePayment = put<
   { businessId: string, invoiceId: string, invoicePaymentId: string }
 >(({ businessId, invoiceId, invoicePaymentId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/payment/${invoicePaymentId}`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  invoiceId,
-  invoicePaymentId = undefined,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  invoiceId: string
-  invoicePaymentId?: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      invoiceId,
-      invoicePaymentId,
-      tags: [UPSERT_INVOICE_PAYMENT_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, invoiceId: string, invoicePaymentId?: string }>([UPSERT_INVOICE_PAYMENT_TAG_KEY])
 
 const UpsertDedicatedInvoicePaymentReturnSchema = Schema.Struct({
   data: InvoicePaymentSchema,

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/pdf/useInvoicePdfDownload.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/pdf/useInvoicePdfDownload.tsx
@@ -5,6 +5,7 @@ import useSWRMutation from 'swr/mutation'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -24,27 +25,7 @@ const InvoicePdfReturnSchema = Schema.Struct({
   data: S3PresignedUrlSchema,
 })
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  invoiceId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  invoiceId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      invoiceId,
-      tags: [DOWNLOAD_INVOICE_PDF_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([DOWNLOAD_INVOICE_PDF_TAG_KEY])
 
 type UseInvoicePdfDownloadProps = {
   invoiceId: string

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/refund/useRefundInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/refund/useRefundInvoice.tsx
@@ -5,6 +5,7 @@ import useSWRMutation from 'swr/mutation'
 import { type CreateCustomerRefundSchema, CustomerRefundSchema } from '@schemas/invoices/customerRefund'
 import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -29,27 +30,7 @@ const refundInvoice = post<
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/refund`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  invoiceId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  invoiceId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      invoiceId,
-      tags: [REFUND_INVOICE_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([REFUND_INVOICE_TAG_KEY])
 
 export const updateInvoiceWithRefund = (invoice: Invoice): Invoice => {
   return { ...invoice, status: InvoiceStatus.Refunded }

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/reset/useResetInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/reset/useResetInvoice.tsx
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { InvoiceSchema } from '@schemas/invoices/invoice'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -26,27 +27,7 @@ const resetInvoice = post<
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/reset`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  invoiceId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  invoiceId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      invoiceId,
-      tags: [RESET_INVOICE_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([RESET_INVOICE_TAG_KEY])
 
 type UseResetInvoiceProps = { invoiceId: string }
 

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/void/useVoidInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/void/useVoidInvoice.tsx
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { InvoiceSchema } from '@schemas/invoices/invoice'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -26,27 +27,7 @@ const voidInvoice = post<
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/void`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  invoiceId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  invoiceId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      invoiceId,
-      tags: [VOID_INVOICE_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([VOID_INVOICE_TAG_KEY])
 
 type UseVoidInvoiceProps = { invoiceId: string }
 

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/write-off/useWriteoffInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/write-off/useWriteoffInvoice.tsx
@@ -5,6 +5,7 @@ import useSWRMutation from 'swr/mutation'
 import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { type CreateInvoiceWriteoff, CreateInvoiceWriteoffSchema, InvoiceWriteoffSchema } from '@schemas/invoices/invoiceWriteoff'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -21,30 +22,7 @@ const writeoffInvoice = post<
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/write-off`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  invoiceId,
-  invoiceWriteoffId = undefined,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  invoiceId: string
-  invoiceWriteoffId?: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      invoiceId,
-      invoiceWriteoffId,
-      tags: [CREATE_INVOICE_WRITEOFF_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, invoiceId: string, invoiceWriteoffId?: string }>([CREATE_INVOICE_WRITEOFF_TAG_KEY])
 
 const WriteoffInvoiceReturnSchema = Schema.Struct({
   data: InvoiceWriteoffSchema,

--- a/src/hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats.tsx
@@ -4,6 +4,7 @@ import useSWR from 'swr'
 
 import { type InvoiceSummaryStatsResponse, InvoiceSummaryStatsResponseSchema } from '@schemas/invoices/invoice'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -12,24 +13,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export const INVOICE_SUMMARY_STATS_TAG_KEY = '#invoices-summary-stats'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [INVOICE_SUMMARY_STATS_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([INVOICE_SUMMARY_STATS_TAG_KEY])
 
 const getInvoiceSummaryStats = get<
   { data: InvoiceSummaryStatsResponse },

--- a/src/hooks/api/businesses/[business-id]/invoices/useListInvoices.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/useListInvoices.tsx
@@ -7,6 +7,7 @@ import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { type Invoice, InvoiceSchema, type InvoiceStatus } from '@schemas/invoices/invoice'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
@@ -62,45 +63,10 @@ export const listInvoices = get<
   return parameters ? `${baseUrl}?${parameters}` : baseUrl
 })
 
-function keyLoader(
-  previousPageData: ListInvoicesReturn | null,
-  {
-    access_token: accessToken,
-    apiUrl,
-    businessId,
-    showSalesReceipts,
-    status,
-    query,
-    dueAtStart,
-    dueAtEnd,
-    sortBy,
-    sortOrder,
-    limit,
-    showTotalCount,
-  }: {
-    access_token?: string
-    apiUrl?: string
-  } & Omit<ListInvoicesParams, 'cursor'>,
-) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      showSalesReceipts,
-      status,
-      query,
-      dueAtStart,
-      dueAtEnd,
-      cursor: previousPageData?.meta?.pagination.cursor,
-      sortBy,
-      sortOrder,
-      limit,
-      showTotalCount,
-      tags: [LIST_INVOICES_TAG_KEY],
-    } as const
-  }
-}
+const keyLoader = createInfiniteKeyLoader<
+  Omit<ListInvoicesParams, 'cursor'>,
+  ListInvoicesReturn
+>([LIST_INVOICES_TAG_KEY])
 
 export function useListInvoices({
   status,

--- a/src/hooks/api/businesses/[business-id]/invoices/useUpsertInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/useUpsertInvoice.tsx
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { InvoiceSchema, type UpsertInvoiceSchema } from '@schemas/invoices/invoice'
 import { patch, post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -33,27 +34,7 @@ const updateInvoice = patch<
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  invoiceId = undefined,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  invoiceId?: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      invoiceId,
-      tags: [UPSERT_INVOICE_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, invoiceId?: string }>([UPSERT_INVOICE_TAG_KEY])
 
 const UpsertInvoiceReturnSchema = Schema.Struct({
   data: InvoiceSchema,

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/lines/useListLedgerAccountLines.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/lines/useListLedgerAccountLines.ts
@@ -7,6 +7,7 @@ import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { type LedgerAccountLineItem, LedgerAccountLineItemSchema } from '@schemas/generalLedger/ledgerEntry'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
@@ -66,55 +67,10 @@ export const listLedgerAccountLines = get<
   return `/v1/businesses/${businessId}/ledger/accounts/${accountId}/lines?${parameters}`
 })
 
-function keyLoader(
-  previousPageData: ListLedgerAccountLinesReturn | null,
-  {
-    access_token: accessToken,
-    apiUrl,
-    businessId,
-    accountId,
-    include_entries_before_activation,
-    include_child_account_lines,
-    start_date,
-    end_date,
-    sort_by,
-    sort_order,
-    limit,
-    show_total_count,
-  }: {
-    access_token?: string
-    apiUrl?: string
-    businessId: string
-    accountId: string
-    include_entries_before_activation?: boolean
-    include_child_account_lines?: boolean
-    start_date?: string
-    end_date?: string
-    sort_by?: 'entry_at' | 'entry_number' | 'created_at'
-    sort_order?: 'ASC' | 'ASCENDING' | 'DESC' | 'DESCENDING' | 'DES'
-    limit?: number
-    show_total_count?: boolean
-  },
-) {
-  if (accessToken && apiUrl && accountId) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      accountId,
-      cursor: previousPageData?.meta?.pagination.cursor ?? undefined,
-      include_entries_before_activation,
-      include_child_account_lines,
-      start_date,
-      end_date,
-      sort_by,
-      sort_order,
-      limit,
-      show_total_count,
-      tags: [LIST_LEDGER_ACCOUNT_LINES_TAG_KEY],
-    } as const
-  }
-}
+const keyLoader = createInfiniteKeyLoader<
+  UseListLedgerAccountLinesOptions & { businessId: string },
+  ListLedgerAccountLinesReturn
+>([LIST_LEDGER_ACCOUNT_LINES_TAG_KEY])
 
 export type UseListLedgerAccountLinesOptions = {
   accountId: string
@@ -160,6 +116,7 @@ export function useListLedgerAccountLines({
         sort_order,
         limit,
         show_total_count,
+        isEnabled: Boolean(accountId),
       },
     )),
     ({

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/useDeleteLedgerAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/useDeleteLedgerAccount.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useLedgerBalancesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances'
@@ -14,24 +15,7 @@ const deleteAccountFromLedger = del<
   { accountId: string, businessId: string }
 >(({ businessId, accountId }) => `/v1/businesses/${businessId}/ledger/accounts/${accountId}`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: ['#delete-account-from-ledger'],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>(['#delete-account-from-ledger'])
 
 export function useDeleteAccountFromLedger() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/useUpsertLedgerAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/useUpsertLedgerAccount.ts
@@ -5,6 +5,7 @@ import useSWRMutation from 'swr/mutation'
 import { SingleChartAccountSchema } from '@schemas/generalLedger/ledgerAccount'
 import { type UpsertLedgerAccountSchema } from '@schemas/generalLedger/upsertLedgerAccount'
 import { post, put } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -34,27 +35,7 @@ const updateLedgerAccount = put<
   { businessId: string, accountId: string }
 >(({ businessId, accountId }) => `/v1/businesses/${businessId}/ledger/accounts/${accountId}`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  accountId = undefined,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  accountId?: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      accountId,
-      tags: [UPSERT_LEDGER_ACCOUNT_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, accountId?: string }>([UPSERT_LEDGER_ACCOUNT_TAG_KEY])
 
 const UpsertLedgerAccountReturnSchema = Schema.Struct({
   data: SingleChartAccountSchema,

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
@@ -3,6 +3,7 @@ import useSWRMutation from 'swr/mutation'
 import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
@@ -11,30 +12,7 @@ const getLedgerAccountBalancesCSV = get<{ data: S3PresignedUrl }>(
   ({ businessId }) => `/v1/businesses/${businessId}/ledger/balances/exports/csv`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  startCutoff,
-  endCutoff,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  startCutoff?: Date
-  endCutoff?: Date
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      startCutoff,
-      endCutoff,
-      tags: ['#account-balances', '#exports', '#csv'],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, startCutoff?: Date, endCutoff?: Date }>(['#account-balances', '#exports', '#csv'])
 
 type UseAccountBalancesDownloadOptions = {
   startCutoff?: Date

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances.tsx
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances.tsx
@@ -5,6 +5,7 @@ import useSWR from 'swr'
 import { LedgerBalancesSchema, type LedgerBalancesSchemaType } from '@schemas/generalLedger/ledgerAccount'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -27,30 +28,7 @@ const getLedgerAccountBalances = get<{ data: LedgerBalancesSchemaType }, GetLedg
   },
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  startDate,
-  endDate,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  startDate?: Date
-  endDate?: Date
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      startDate,
-      endDate,
-      tags: [LEDGER_BALANCES_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, startDate?: Date, endDate?: Date }>([LEDGER_BALANCES_TAG_KEY])
 
 export function useLedgerBalances(withDates?: boolean, startDate?: Date, endDate?: Date) {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/reverse/useReverseJournalEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/reverse/useReverseJournalEntry.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -17,24 +18,7 @@ const reverseJournalEntry = post<Record<never, never>>(
     `/v1/businesses/${businessId}/ledger/entries/${entryId}/reverse`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [REVERSE_JOURNAL_ENTRY_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([REVERSE_JOURNAL_ENTRY_TAG_KEY])
 
 export const useReverseJournalEntry = () => {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/useLedgerAccountsEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/useLedgerAccountsEntry.ts
@@ -3,6 +3,7 @@ import useSWR from 'swr'
 
 import { LedgerEntrySchema } from '@schemas/generalLedger/ledgerEntry'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -18,27 +19,7 @@ const getLedgerAccountsEntry = get<typeof LedgerAccountsEntryResponseSchema.Enco
     `/v1/businesses/${businessId}/ledger/entries/${entryId}`,
 )
 
-function buildKey({
-  accessToken,
-  apiUrl,
-  businessId,
-  entryId,
-}: {
-  accessToken?: string
-  apiUrl: string
-  businessId: string
-  entryId?: string
-}) {
-  if (!accessToken || !entryId) return null
-
-  return {
-    accessToken,
-    apiUrl,
-    businessId,
-    entryId,
-    tags: [LEDGER_ACCOUNTS_ENTRY_TAG_KEY],
-  } as const
-}
+const buildKey = createBuildKey<{ businessId: string, entryId?: string }>([LEDGER_ACCOUNTS_ENTRY_TAG_KEY])
 
 export function useLedgerAccountsEntry({ entryId }: { entryId?: string }) {
   const withLocale = useLocalizedKey()
@@ -48,10 +29,11 @@ export function useLedgerAccountsEntry({ entryId }: { entryId?: string }) {
 
   const swrResponse = useSWR(() =>
     withLocale(buildKey({
-      accessToken: auth?.access_token,
+      ...auth,
       apiUrl,
       businessId,
       entryId,
+      isEnabled: Boolean(entryId),
     })),
   ({ accessToken, apiUrl, businessId, entryId }) =>
     getLedgerAccountsEntry(apiUrl, accessToken, {

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
@@ -4,6 +4,7 @@ import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { type APIError } from '@utils/api/apiError'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
@@ -12,30 +13,7 @@ const getJournalEntriesCSV = get<{ data: S3PresignedUrl }>(
   ({ businessId }) => `/v1/businesses/${businessId}/ledger/entries/exports/csv`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  startCutoff,
-  endCutoff,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  startCutoff?: Date
-  endCutoff?: Date
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      startCutoff,
-      endCutoff,
-      tags: ['#journal-entries', '#exports', '#csv'],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, startCutoff?: Date, endCutoff?: Date }>(['#journal-entries', '#exports', '#csv'])
 
 type UseJournalEntriesDownloadOptions = {
   startCutoff?: Date
@@ -47,8 +25,8 @@ type MutationParams = () => {
   accessToken: string
   apiUrl: string
   businessId: string
-  startCutoff: Date | undefined
-  endCutoff: Date | undefined
+  startCutoff?: Date
+  endCutoff?: Date
 } | undefined
 
 export function useJournalEntriesDownload({

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries.ts
@@ -7,6 +7,7 @@ import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { LedgerEntrySchema } from '@schemas/generalLedger/ledgerEntry'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
@@ -51,40 +52,10 @@ export const listLedgerEntries = get<
   return `/v1/businesses/${businessId}/ledger/entries?${parameters}`
 })
 
-function keyLoader(
-  previousPageData: ListLedgerEntriesReturn | null,
-  {
-    access_token: accessToken,
-    apiUrl,
-    businessId,
-    sortBy,
-    sortOrder,
-    limit,
-    showTotalCount,
-  }: {
-    access_token?: string
-    apiUrl?: string
-    businessId: string
-    sortBy?: LedgerEntriesSortBy
-    sortOrder?: SortOrder
-    limit?: number
-    showTotalCount?: boolean
-  },
-) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      cursor: previousPageData?.meta?.pagination.cursor ?? undefined,
-      sortBy,
-      sortOrder,
-      limit,
-      showTotalCount,
-      tags: [LIST_LEDGER_ENTRIES_TAG_KEY],
-    } as const
-  }
-}
+const keyLoader = createInfiniteKeyLoader<
+  UseListLedgerEntriesOptions & { businessId: string },
+  ListLedgerEntriesReturn
+>([LIST_LEDGER_ENTRIES_TAG_KEY])
 
 export type UseListLedgerEntriesOptions = {
   sortBy?: LedgerEntriesSortBy

--- a/src/hooks/api/businesses/[business-id]/ledger/journal-entries/useUpsertJournalEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/journal-entries/useUpsertJournalEntry.ts
@@ -3,6 +3,7 @@ import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { useLedgerEntriesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries'
@@ -28,24 +29,7 @@ const createJournalEntry = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/ledger/journal-entries`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [UPSERT_JOURNAL_ENTRY_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([UPSERT_JOURNAL_ENTRY_TAG_KEY])
 
 type UseUpsertJournalEntryProps =
   | { mode: UpsertJournalEntryMode.Create }

--- a/src/hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary.tsx
@@ -4,6 +4,7 @@ import useSWR from 'swr'
 
 import { type MileageSummary, MileageSummarySchema } from '@schemas/mileage'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -12,24 +13,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export const MILEAGE_SUMMARY_TAG_KEY = '#mileage-summary'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [MILEAGE_SUMMARY_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([MILEAGE_SUMMARY_TAG_KEY])
 
 const getMileageSummary = get<
   { data: MileageSummary },

--- a/src/hooks/api/businesses/[business-id]/mileage/trips/[trip-id]/useDeleteTrip.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/trips/[trip-id]/useDeleteTrip.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -18,27 +19,7 @@ const deleteTrip = del<
   { businessId: string, tripId: string }
 >(({ businessId, tripId }) => `/v1/businesses/${businessId}/mileage/trips/${tripId}`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  tripId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  tripId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tripId,
-      tags: [DELETE_TRIP_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, tripId: string }>([DELETE_TRIP_TAG_KEY])
 
 type UseDeleteTripProps = {
   tripId: string

--- a/src/hooks/api/businesses/[business-id]/mileage/trips/useListTrips.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/trips/useListTrips.tsx
@@ -6,6 +6,7 @@ import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { type Trip, TripSchema } from '@schemas/trip'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
@@ -25,40 +26,10 @@ export type ListTripsFilterParams = {
 const ListTripsResponseSchema = PaginatedResponseSchema(TripSchema)
 type ListTripsResponse = typeof ListTripsResponseSchema.Type
 
-function keyLoader(
-  previousPageData: ListTripsResponse | null,
-  {
-    access_token: accessToken,
-    apiUrl,
-    businessId,
-    query,
-    vehicleId,
-    purpose,
-    year,
-  }: {
-    access_token?: string
-    apiUrl?: string
-    businessId: string
-    query?: string
-    vehicleId?: string
-    purpose?: string
-    year?: number
-  },
-) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      cursor: previousPageData?.meta?.pagination.cursor ?? undefined,
-      query,
-      vehicleId,
-      purpose,
-      year,
-      tags: [LIST_TRIPS_TAG_KEY],
-    } as const
-  }
-}
+const keyLoader = createInfiniteKeyLoader<
+  ListTripsFilterParams & { businessId: string },
+  ListTripsResponse
+>([LIST_TRIPS_TAG_KEY])
 
 const listTrips = get<
   typeof ListTripsResponseSchema.Encoded,

--- a/src/hooks/api/businesses/[business-id]/mileage/trips/useUpsertTrip.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/trips/useUpsertTrip.tsx
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { TripSchema, type UpsertTripEncoded } from '@schemas/trip'
 import { patch, post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -34,27 +35,7 @@ const updateTrip = patch<
   { businessId: string, tripId: string }
 >(({ businessId, tripId }) => `/v1/businesses/${businessId}/mileage/trips/${tripId}`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  tripId = undefined,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  tripId?: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tripId,
-      tags: [UPSERT_TRIP_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, tripId?: string }>([UPSERT_TRIP_TAG_KEY])
 
 const UpsertTripReturnSchema = Schema.Struct({
   data: TripSchema,

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/reactivate/useReactivateVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/reactivate/useReactivateVehicle.tsx
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { VehicleSchema } from '@schemas/vehicle'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -25,27 +26,7 @@ const reactivateVehicle = post<
   { businessId: string, vehicleId: string }
 >(({ businessId, vehicleId }) => `/v1/businesses/${businessId}/mileage/vehicles/${vehicleId}/reactivate`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  vehicleId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  vehicleId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      vehicleId,
-      tags: [REACTIVATE_VEHICLE_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, vehicleId: string }>([REACTIVATE_VEHICLE_TAG_KEY])
 
 type UseReactivateVehicleProps = {
   vehicleId: string

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useArchiveVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useArchiveVehicle.tsx
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { VehicleSchema } from '@schemas/vehicle'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -25,27 +26,7 @@ const archiveVehicle = post<
   { businessId: string, vehicleId: string }
 >(({ businessId, vehicleId }) => `/v1/businesses/${businessId}/mileage/vehicles/${vehicleId}/archive`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  vehicleId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  vehicleId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      vehicleId,
-      tags: [ARCHIVE_VEHICLE_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, vehicleId: string }>([ARCHIVE_VEHICLE_TAG_KEY])
 
 type UseArchiveVehicleProps = {
   vehicleId: string

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useDeleteVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useDeleteVehicle.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -16,27 +17,7 @@ const deleteVehicle = del<
   { businessId: string, vehicleId: string }
 >(({ businessId, vehicleId }) => `/v1/businesses/${businessId}/mileage/vehicles/${vehicleId}`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  vehicleId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  vehicleId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      vehicleId,
-      tags: [DELETE_VEHICLE_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, vehicleId: string }>([DELETE_VEHICLE_TAG_KEY])
 
 type UseDeleteVehicleProps = {
   vehicleId: string

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
@@ -5,6 +5,7 @@ import useSWR from 'swr'
 import { type Vehicle, VehicleSchema } from '@schemas/vehicle'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -33,27 +34,7 @@ const listVehicles = get<
 
 export const VEHICLES_TAG_KEY = '#list-vehicles'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  allowArchived,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  allowArchived?: boolean
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      allowArchived,
-      tags: [VEHICLES_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, allowArchived?: boolean }>([VEHICLES_TAG_KEY])
 
 class ListVehiclesSWRResponse extends SWRQueryResult<ListVehiclesResponse> {
   // @ts-expect-error override narrows return type to unwrap nested data

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/useUpsertVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/useUpsertVehicle.tsx
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { type UpsertVehicleEncoded, VehicleSchema } from '@schemas/vehicle'
 import { patch, post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -33,27 +34,7 @@ const updateVehicle = patch<
   { businessId: string, vehicleId: string }
 >(({ businessId, vehicleId }) => `/v1/businesses/${businessId}/mileage/vehicles/${vehicleId}`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  vehicleId = undefined,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  vehicleId?: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      vehicleId,
-      tags: [UPSERT_VEHICLE_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, vehicleId?: string }>([UPSERT_VEHICLE_TAG_KEY])
 
 const UpsertVehicleReturnSchema = Schema.Struct({
   data: VehicleSchema,

--- a/src/hooks/api/businesses/[business-id]/plaid/hosted-link.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/hosted-link.ts
@@ -6,6 +6,7 @@ import {
   ApiPlaidHostedLinkStatusSchema,
 } from '@schemas/linkedAccounts/plaid'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
@@ -22,26 +23,7 @@ const getPlaidHostedLinkStatus = get<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/plaid/hosted-link`)
 
-function buildKey({
-  accessToken,
-  apiUrl,
-  businessId,
-  enabled,
-}: {
-  accessToken?: string
-  apiUrl: string
-  businessId: string
-  enabled: boolean
-}) {
-  if (!enabled || !accessToken) return null
-
-  return {
-    accessToken,
-    apiUrl,
-    businessId,
-    tags: [PLAID_HOSTED_LINK_TAG_KEY],
-  } as const
-}
+const buildKey = createBuildKey<{ businessId: string }>([PLAID_HOSTED_LINK_TAG_KEY])
 
 export function usePlaidHostedLinkStatus(
   config?: SWRConfiguration<ApiPlaidHostedLinkStatus>,
@@ -52,7 +34,7 @@ export function usePlaidHostedLinkStatus(
   const { businessId } = useLayerContext()
 
   const swrResponse = useSWR(
-    () => buildKey({ accessToken: auth?.access_token, apiUrl, businessId, enabled }),
+    () => buildKey({ ...auth, apiUrl, businessId, isEnabled: enabled }),
     ({ accessToken, apiUrl, businessId }) =>
       getPlaidHostedLinkStatus(apiUrl, accessToken, { params: { businessId } })()
         .then(Schema.decodeUnknownPromise(PlaidHostedLinkStatusResponseSchema))

--- a/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/sandbox-reset-item-login.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/sandbox-reset-item-login.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -23,24 +24,7 @@ const breakPlaidItemConnection = post<
     `/v1/businesses/${businessId}/plaid/items/${plaidItemId}/sandbox-reset-item-login`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [BREAK_PLAID_ITEM_CONNECTION_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([BREAK_PLAID_ITEM_CONNECTION_TAG_KEY])
 
 export function useBreakPlaidItemConnection() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/unlink.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/unlink.ts
@@ -1,6 +1,7 @@
 import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -17,24 +18,7 @@ const unlinkPlaidItem = post<
     `/v1/businesses/${businessId}/plaid/items/${plaidItemId}/unlink`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [UNLINK_PLAID_ITEM_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([UNLINK_PLAID_ITEM_TAG_KEY])
 
 export function useUnlinkPlaidItem() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/plaid/link/exchange.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/link/exchange.ts
@@ -2,6 +2,7 @@ import useSWRMutation from 'swr/mutation'
 
 import type { PublicToken } from '@internal-types/linkedAccounts'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -15,24 +16,7 @@ const exchangePlaidPublicToken = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/plaid/link/exchange`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [EXCHANGE_PLAID_PUBLIC_TOKEN_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([EXCHANGE_PLAID_PUBLIC_TOKEN_TAG_KEY])
 
 export function useExchangePlaidPublicToken() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/plaid/link/index.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/link/index.ts
@@ -9,6 +9,7 @@ import {
   encodeCreatePlaidLinkParams,
 } from '@schemas/linkedAccounts/plaid'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -28,24 +29,7 @@ const createPlaidLink = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/plaid/link`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [CREATE_PLAID_LINK_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([CREATE_PLAID_LINK_TAG_KEY])
 
 export function useCreatePlaidLink() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/plaid/update-mode-link.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/update-mode-link.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { ApiLinkTokenSchema } from '@schemas/linkedAccounts/plaid'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -27,24 +28,7 @@ const createPlaidUpdateModeLink = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/plaid/update-mode-link`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [CREATE_PLAID_UPDATE_MODE_LINK_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([CREATE_PLAID_UPDATE_MODE_LINK_TAG_KEY])
 
 export function useCreatePlaidUpdateModeLink() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/reports/balance-sheet/exports/excel/useBalanceSheetDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/balance-sheet/exports/excel/useBalanceSheetDownload.ts
@@ -4,6 +4,7 @@ import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import type { GetBalanceSheetParams } from '@hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -22,27 +23,7 @@ const getBalanceSheetExcel = get<
 
 const DOWNLOAD_BALANCE_SHEET_TAG_KEY = '#download-balance-sheet'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  effectiveDate,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  effectiveDate: Date
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      effectiveDate,
-      tags: [DOWNLOAD_BALANCE_SHEET_TAG_KEY],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, effectiveDate: Date }>([DOWNLOAD_BALANCE_SHEET_TAG_KEY])
 
 type UseBalanceSheetOptions = {
   effectiveDate: Date

--- a/src/hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet.ts
@@ -4,6 +4,7 @@ import useSWR from 'swr'
 import type { BalanceSheet } from '@internal-types/balanceSheet'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -26,27 +27,7 @@ const getBalanceSheet = get<
   },
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  effectiveDate,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  effectiveDate: Date
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      effectiveDate,
-      tags: ['#balance-sheet'],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, effectiveDate: Date }>(['#balance-sheet'])
 
 export function useBalanceSheet({
   effectiveDate = endOfDay(new Date()),

--- a/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/exports/csv/useCashflowStatementDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/exports/csv/useCashflowStatementDownload.ts
@@ -4,6 +4,7 @@ import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import type { GetStatementOfCashFlowParams } from '@hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -22,30 +23,7 @@ const getCashflowStatementCSV = get<
 
 const DOWNLOAD_CASHFLOW_STATEMENT_TAG_KEY = '#download-cashflow-statement'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  startDate,
-  endDate,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  startDate: Date
-  endDate: Date
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      startDate,
-      endDate,
-      tags: [DOWNLOAD_CASHFLOW_STATEMENT_TAG_KEY],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, startDate: Date, endDate: Date }>([DOWNLOAD_CASHFLOW_STATEMENT_TAG_KEY])
 
 type UseCashflowStatementDownloadOptions = {
   startDate: Date

--- a/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow.tsx
@@ -4,6 +4,7 @@ import useSWR from 'swr'
 import type { StatementOfCashFlow } from '@internal-types/statementOfCashFlow'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -27,30 +28,7 @@ const getStatementOfCashFlow = get<
   },
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  startDate,
-  endDate,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  startDate: Date
-  endDate: Date
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      startDate,
-      endDate,
-      tags: ['#statement-of-cash-flow'],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, startDate: Date, endDate: Date }>(['#statement-of-cash-flow'])
 
 export function useStatementOfCashFlow({
   startDate = startOfMonth(new Date()),

--- a/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
@@ -3,6 +3,7 @@ import useSWR from 'swr'
 
 import { type ReportConfigResponse, ReportConfigResponseSchema } from '@schemas/reports/reportConfig'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -18,24 +19,7 @@ const getReportConfig = get<ReportConfigResponse, GetReportConfigParams>(
   ({ businessId }) => `/v1/businesses/${businessId}/reports/config`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [REPORT_CONFIG_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([REPORT_CONFIG_TAG_KEY])
 
 export function useReportConfig() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
@@ -4,6 +4,7 @@ import useSWR from 'swr'
 import { type ReportingBasis } from '@internal-types/general'
 import { type ProfitAndLossComparison, type ProfitAndLossComparisonRequestBody } from '@internal-types/profitAndLoss'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -20,29 +21,7 @@ type ProfitAndLossComparisonRequestParams = {
   reportingBasis?: ReportingBasis
 }
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  periods,
-  tagFilters,
-  reportingBasis,
-}: {
-  access_token?: string
-  apiUrl?: string
-} & ProfitAndLossComparisonRequestParams) {
-  if (accessToken && apiUrl && periods) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      periods,
-      tagFilters,
-      reportingBasis,
-      tags: [PNL_COMPARISON_REPORT_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<ProfitAndLossComparisonRequestParams>([PNL_COMPARISON_REPORT_TAG_KEY])
 
 const compareProfitAndLoss = post<
   { data?: ProfitAndLossComparison },
@@ -72,6 +51,7 @@ export function useProfitAndLossComparisonReport({
       periods,
       tagFilters,
       reportingBasis,
+      isEnabled: Boolean(periods),
     })),
     ({ accessToken, apiUrl, businessId }) => compareProfitAndLoss(
       apiUrl,

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-summaries/useProfitAndLossSummaries.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-summaries/useProfitAndLossSummaries.tsx
@@ -5,6 +5,7 @@ import useSWR from 'swr'
 import { type ProfitAndLossSummaries, type ProfitAndLossSummariesRequestParams, ProfitAndLossSummariesSchema } from '@schemas/reports/profitAndLoss'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -13,37 +14,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export const PNL_SUMMARIES_TAG_KEY = '#profit-and-loss-summaries'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  startMonth,
-  startYear,
-  endMonth,
-  endYear,
-  tagKey,
-  tagValues,
-  reportingBasis,
-}: {
-  access_token?: string
-  apiUrl?: string
-} & ProfitAndLossSummariesRequestParams) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      startMonth,
-      startYear,
-      endMonth,
-      endYear,
-      tagKey,
-      tagValues,
-      reportingBasis,
-      tags: [PNL_SUMMARIES_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<ProfitAndLossSummariesRequestParams>([PNL_SUMMARIES_TAG_KEY])
 
 const getProfitAndLossSummaries = get<
   { data: ProfitAndLossSummaries },

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
@@ -4,6 +4,7 @@ import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { type GetProfitAndLossDetailLinesParams, type PnlDetailLinesBaseParams, type PnlDetailLinesFilterParams } from '@hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -30,36 +31,7 @@ const getProfitAndLossDetailLinesExcel = (apiUrl: string, accessToken: string | 
   )(apiUrl, accessToken, { params: { businessId } })
 }
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  startDate,
-  endDate,
-  pnlStructureLineItemName,
-  tagFilter,
-  reportingBasis,
-  pnlStructure,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-} & PnlDetailLinesBaseParams & PnlDetailLinesFilterParams) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      startDate,
-      endDate,
-      pnlStructureLineItemName,
-      tagFilter,
-      reportingBasis,
-      pnlStructure,
-      tags: ['#pnl-detail-lines', '#exports', '#excel'],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string } & PnlDetailLinesBaseParams & PnlDetailLinesFilterParams>(['#pnl-detail-lines', '#exports', '#excel'])
 
 type UseProfitAndLossDetailLinesExportOptions = PnlDetailLinesBaseParams & PnlDetailLinesFilterParams & {
   onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
@@ -6,6 +6,7 @@ import { type ReportingBasis } from '@internal-types/general'
 import { type PnlDetailLineSchema, PnlDetailLinesDataSchema } from '@schemas/reports/profitAndLoss'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -38,38 +39,7 @@ type PnlDetailLinesParams = PnlDetailLinesBaseParams & PnlDetailLinesFilterParam
 export type PnlDetailLine = typeof PnlDetailLineSchema.Type
 export type PnlDetailLinesReturn = typeof PnlDetailLinesDataSchema.Type
 
-function keyLoader(
-  {
-    access_token: accessToken,
-    apiUrl,
-    businessId,
-    startDate,
-    endDate,
-    pnlStructureLineItemName,
-    tagFilter,
-    reportingBasis,
-    pnlStructure,
-  }: {
-    access_token?: string
-    apiUrl?: string
-  } & PnlDetailLinesParams,
-) {
-  if (accessToken && apiUrl && businessId && startDate && endDate && pnlStructureLineItemName) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      startDate,
-      endDate,
-      pnlStructureLineItemName,
-      tagFilter,
-      reportingBasis,
-      pnlStructure,
-      tags: [LIST_PNL_DETAIL_LINES_TAG_KEY],
-    } as const
-  }
-  return null
-}
+const keyLoader = createBuildKey<PnlDetailLinesParams>([LIST_PNL_DETAIL_LINES_TAG_KEY])
 
 export function useProfitAndLossDetailLines({
   startDate,
@@ -95,6 +65,7 @@ export function useProfitAndLossDetailLines({
       tagFilter,
       reportingBasis,
       pnlStructure,
+      isEnabled: Boolean(startDate && endDate && pnlStructureLineItemName),
     })),
     ({
       accessToken,

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/useProfitAndLossReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/useProfitAndLossReport.tsx
@@ -5,6 +5,7 @@ import useSWR from 'swr'
 import { type ProfitAndLoss, type ProfitAndLossReportRequestParams, ProfitAndLossReportSchema } from '@schemas/reports/profitAndLoss'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -13,35 +14,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export const PNL_REPORT_TAG_KEY = '#profit-and-loss-report'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  startDate,
-  endDate,
-  tagKey,
-  tagValues,
-  reportingBasis,
-  includeUncategorized,
-}: {
-  access_token?: string
-  apiUrl?: string
-} & ProfitAndLossReportRequestParams) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      startDate,
-      endDate,
-      tagKey,
-      tagValues,
-      reportingBasis,
-      includeUncategorized,
-      tags: [PNL_REPORT_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<ProfitAndLossReportRequestParams>([PNL_REPORT_TAG_KEY])
 
 const getProfitAndLoss = get<
   { data: ProfitAndLoss },

--- a/src/hooks/api/businesses/[business-id]/reports/transactions/exports/excel/useBankTransactionsDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/transactions/exports/excel/useBankTransactionsDownload.ts
@@ -4,6 +4,7 @@ import type { S3PresignedUrl } from '@internal-types/general'
 import { type APIError } from '@utils/api/apiError'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import type { UseBankTransactionsOptions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -47,25 +48,7 @@ const getBankTransactionsExcel = get<
   return `/v1/businesses/${businessId}/reports/transactions/exports/excel?${parameters}`
 })
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-},
-) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: ['#bank-transactions-download-excel'],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>(['#bank-transactions-download-excel'])
 
 type UseBankTransactionsDownloadOptions = UseBankTransactionsOptions
 

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
 import { get } from '@utils/api/authenticatedHttp'
 import { type QueryParams, toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -35,28 +36,6 @@ const UnifiedReportExcelReturnSchema = Schema.Struct({
   data: S3PresignedUrlSchema,
 })
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  params,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  params: UnifiedReportParams | null
-}) {
-  if (!params || !accessToken || !apiUrl) return
-
-  return {
-    accessToken,
-    apiUrl,
-    businessId,
-    ...params,
-    tags: [getTag(params.route)],
-  }
-}
-
 type UseUnifiedReportExcelOptions = {
   onSuccess?: (url: S3PresignedUrlSchemaType) => Promise<void> | void
 }
@@ -68,13 +47,14 @@ export function useUnifiedReportExcel({ onSuccess }: UseUnifiedReportExcelOption
   const { businessId } = useLayerContext()
   const params = useUnifiedReportParams()
 
+  const buildKey = createBuildKey<{ businessId: string } & UnifiedReportParams>(
+    params ? [getTag(params.route)] : [],
+  )
+
   const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      apiUrl,
-      businessId,
-      params,
-    })),
+    () => params
+      ? withLocale(buildKey({ ...auth, apiUrl, businessId, ...params }))
+      : null,
     ({ accessToken, apiUrl, businessId, tags, ...restParams }) =>
       getUnifiedReportExcel(apiUrl, accessToken, {
         params: { businessId, ...restParams },

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
@@ -4,6 +4,7 @@ import useSWR from 'swr'
 import { UnifiedReportSchema } from '@schemas/reports/unifiedReport'
 import { get } from '@utils/api/authenticatedHttp'
 import { type QueryParams, toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -12,28 +13,6 @@ import { type UnifiedReportControlParams, type UnifiedReportParams, useUnifiedRe
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const getTag = (report: string) => `#unified-${report}-report`
-
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  params,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  params: UnifiedReportParams | null
-}) {
-  if (!params || !accessToken || !apiUrl) return
-
-  return {
-    accessToken,
-    apiUrl,
-    businessId,
-    ...params,
-    tags: [getTag(params.route)],
-  } as const
-}
 
 const getUnifiedReport = get<
   { data: unknown },
@@ -51,13 +30,14 @@ export function useUnifiedReport() {
   const { businessId } = useLayerContext()
   const params = useUnifiedReportParams()
 
+  const buildKey = createBuildKey<{ businessId: string } & UnifiedReportParams>(
+    params ? [getTag(params.route)] : [],
+  )
+
   const swrResponse = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      apiUrl,
-      businessId,
-      params,
-    })),
+    () => params
+      ? withLocale(buildKey({ ...auth, apiUrl, businessId, ...params }))
+      : null,
     ({ accessToken, apiUrl, businessId, tags, ...restParams }) => getUnifiedReport(apiUrl, accessToken, {
       params: { businessId, ...restParams },
     })().then(({ data }) => Schema.decodeUnknownPromise(UnifiedReportSchema)(data)),

--- a/src/hooks/api/businesses/[business-id]/stripe/connect-account-link/useStripeConnectAccountLink.tsx
+++ b/src/hooks/api/businesses/[business-id]/stripe/connect-account-link/useStripeConnectAccountLink.tsx
@@ -2,6 +2,7 @@ import { pipe, Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -37,24 +38,7 @@ const createStripeConnectAccountLink = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/stripe/connect-account-link`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [STRIPE_CONNECT_ACCOUNT_LINK_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([STRIPE_CONNECT_ACCOUNT_LINK_TAG_KEY])
 
 export function useStripeConnectAccountLink() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus.tsx
+++ b/src/hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus.tsx
@@ -3,6 +3,7 @@ import useSWR from 'swr'
 
 import { type StripeAccountStatusResponse, StripeAccountStatusResponseSchema } from '@schemas/stripeAccountStatus'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -11,24 +12,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export const STRIPE_ACCOUNT_STATUS_TAG_KEY = '#stripe-account-status'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [STRIPE_ACCOUNT_STATUS_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([STRIPE_ACCOUNT_STATUS_TAG_KEY])
 
 const getStripeAccountStatus = get<
   { data: StripeAccountStatusResponse },

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/[dimension-id]/values/useCreateTagValueDefinition.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/[dimension-id]/values/useCreateTagValueDefinition.ts
@@ -3,6 +3,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { type TagValueDefinitionSchema } from '@schemas/tag'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -13,24 +14,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const CREATE_TAG_VALUE_DEFINITION_TAG_KEY = '#create-tag-value-definition'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [CREATE_TAG_VALUE_DEFINITION_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([CREATE_TAG_VALUE_DEFINITION_TAG_KEY])
 
 const createTagValueDefinition = post<
   { data: typeof TagValueDefinitionSchema.Encoded },

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/key/[dimension-key]/useTagDimensionByKey.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/key/[dimension-key]/useTagDimensionByKey.ts
@@ -3,6 +3,7 @@ import useSWR from 'swr'
 
 import { TagDimensionSchema } from '@schemas/tag'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -11,33 +12,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export const TAG_DIMENSION_BY_KEY_TAG_KEY = '#tag-dimension-by-key'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  isEnabled,
-  dimensionKey,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  isEnabled: boolean
-  dimensionKey: string
-}) {
-  if (!isEnabled) {
-    return
-  }
-
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      dimensionKey,
-      tags: [TAG_DIMENSION_BY_KEY_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, dimensionKey: string }>([TAG_DIMENSION_BY_KEY_TAG_KEY])
 
 const getTagDimensionByKey = get<
   { data: unknown },

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/useCreateTagDimension.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/useCreateTagDimension.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { type TagDimensionSchema, TagDimensionStrictnessSchema } from '@schemas/tag'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -14,24 +15,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const CREATE_TAG_DIMENSION_TAG_KEY = '#create-tag-dimension'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [CREATE_TAG_DIMENSION_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([CREATE_TAG_DIMENSION_TAG_KEY])
 
 const CreateTagDimensionBodySchema = Schema.Struct({
   key: Schema.NonEmptyTrimmedString,

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
@@ -3,6 +3,7 @@ import useSWR from 'swr'
 
 import { TagDimensionSchema } from '@schemas/tag'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -11,30 +12,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export const TAG_DIMENSIONS_TAG_KEY = '#tag-dimensions'
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  isEnabled,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  isEnabled: boolean
-}) {
-  if (!isEnabled) {
-    return
-  }
-
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [TAG_DIMENSIONS_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([TAG_DIMENSIONS_TAG_KEY])
 
 const getTagDimensions = get<
   { data: unknown },
@@ -54,12 +32,7 @@ export function useTagDimensions({ isEnabled = true }: UseTagDimensionsParameter
   const { businessId } = useLayerContext()
 
   const swrResponse = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      apiUrl,
-      businessId,
-      isEnabled,
-    })),
+    () => withLocale(buildKey({ ...auth, apiUrl, businessId, isEnabled })),
     ({ accessToken, apiUrl, businessId }) => getTagDimensions(
       apiUrl,
       accessToken,

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/delete/useDeleteUploadsOnTask.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/delete/useDeleteUploadsOnTask.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import type { BusinessTaskEncoded } from '@schemas/businessTasks/businessTask'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
@@ -23,24 +24,7 @@ const deleteUploadsOnTask = post<
     `/v1/businesses/${businessId}/tasks/${taskId}/upload/delete`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: ['#delete-uploads-on-task'],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>(['#delete-uploads-on-task'])
 
 type UseDeleteUploadsOnTaskArg = {
   taskId: string

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/useUpdateTaskUploadDescription.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/useUpdateTaskUploadDescription.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import type { BusinessTaskEncoded } from '@schemas/businessTasks/businessTask'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
@@ -28,24 +29,7 @@ const updateTaskUploadsDescription = post<
     `/v1/businesses/${businessId}/tasks/${taskId}/upload/update-description`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: ['#update-task-upload-description'],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>(['#update-task-upload-description'])
 
 type UseUpdateTaskUploadDescriptionArg = {
   taskId: string

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/useUploadDocumentsForTask.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/useUploadDocumentsForTask.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import type { FileMetadata } from '@internal-types/fileUpload'
 import { postWithFormData } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
@@ -41,24 +42,7 @@ function completeTaskWithUpload(
   )
 }
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: ['#use-upload-documents-for-task'],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>(['#use-upload-documents-for-task'])
 
 type UseUploadDocumentsForTaskArg = {
   taskId: string

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/user-response/useSubmitResponseForTask.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/user-response/useSubmitResponseForTask.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import type { BusinessTaskEncoded } from '@schemas/businessTasks/businessTask'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
@@ -27,24 +28,7 @@ const submitUserResponseForTask = post<
   ({ businessId, taskId }) => `/v1/businesses/${businessId}/tasks/${taskId}/user-response`,
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: ['#submit-user-response-for-task'],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>(['#submit-user-response-for-task'])
 
 type UseSubmitUserResponseForTaskArg = {
   taskId: string

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner.ts
@@ -6,6 +6,7 @@ import type { ReportingBasis } from '@internal-types/general'
 import { type TaxEstimatesBannerResponse, TaxEstimatesBannerResponseSchema } from '@schemas/taxEstimates/banner'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -36,33 +37,12 @@ const getTaxEstimatesBanner = get<TaxEstimatesBannerResponse, GetTaxEstimatesBan
   },
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  year,
-  reportingBasis,
-  fullYearProjection,
-}: {
-  access_token?: string
-  apiUrl?: string
+const buildKey = createBuildKey<{
   businessId: string
   year: number
   reportingBasis?: TaxReportingBasis
   fullYearProjection?: boolean
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      year,
-      reportingBasis,
-      fullYearProjection,
-      tags: [TAX_ESTIMATES_BANNER_TAG_KEY],
-    } as const
-  }
-}
+}>([TAX_ESTIMATES_BANNER_TAG_KEY])
 
 export function useTaxEstimatesBanner({ year, reportingBasis, fullYearProjection }: UseTaxEstimatesBannerOptions) {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails.ts
@@ -6,6 +6,7 @@ import type { ReportingBasis } from '@internal-types/general'
 import { type TaxDetailsResponse, TaxDetailsResponseSchema } from '@schemas/taxEstimates/details'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -32,33 +33,12 @@ const getTaxDetails = get<TaxDetailsResponse, GetTaxDetailsParams>(
   },
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  year,
-  reportingBasis,
-  fullYearProjection,
-}: {
-  access_token?: string
-  apiUrl?: string
+const buildKey = createBuildKey<{
   businessId: string
   year: number
   reportingBasis?: TaxReportingBasis
   fullYearProjection?: boolean
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      year,
-      reportingBasis,
-      fullYearProjection,
-      tags: [TAX_DETAILS_TAG_KEY],
-    } as const
-  }
-}
+}>([TAX_DETAILS_TAG_KEY])
 
 export function useTaxDetails({ year, reportingBasis, fullYearProjection }: UseTaxDetailsOptions) {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
@@ -5,6 +5,7 @@ import type { ReportingBasis } from '@internal-types/general'
 import { type TaxOverviewApiResponse, TaxOverviewApiResponseSchema } from '@schemas/taxEstimates/overview'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
@@ -35,39 +36,12 @@ const getTaxOverview = get<TaxOverviewApiResponse, GetTaxOverviewParams>(
   },
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  year,
-  reportingBasis,
-  fullYearProjection,
-  enabled = true,
-}: {
-  access_token?: string
-  apiUrl?: string
+const buildKey = createBuildKey<{
   businessId: string
   year: number
   reportingBasis?: TaxReportingBasis
   fullYearProjection?: boolean
-  enabled?: boolean
-}) {
-  if (!enabled) {
-    return
-  }
-
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      year,
-      reportingBasis,
-      fullYearProjection,
-      tags: [TAX_OVERVIEW_TAG_KEY],
-    } as const
-  }
-}
+}>([TAX_OVERVIEW_TAG_KEY])
 
 export function useTaxOverview({ year, reportingBasis, fullYearProjection, enabled = true }: UseTaxOverviewOptions) {
   const withLocale = useLocalizedKey()
@@ -81,7 +55,7 @@ export function useTaxOverview({ year, reportingBasis, fullYearProjection, enabl
       year,
       reportingBasis,
       fullYearProjection,
-      enabled,
+      isEnabled: enabled,
     })),
     async ({ accessToken, apiUrl, businessId, year, reportingBasis, fullYearProjection }) => {
       return getTaxOverview(

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments.ts
@@ -6,6 +6,7 @@ import type { ReportingBasis } from '@internal-types/general'
 import { type TaxPaymentsResponse, TaxPaymentsResponseSchema } from '@schemas/taxEstimates/payments'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -32,33 +33,12 @@ const getTaxPayments = get<TaxPaymentsResponse, GetTaxPaymentsParams>(
   },
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  year,
-  reportingBasis,
-  fullYearProjection,
-}: {
-  access_token?: string
-  apiUrl?: string
+const buildKey = createBuildKey<{
   businessId: string
   year: number
   reportingBasis?: TaxReportingBasis
   fullYearProjection?: boolean
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      year,
-      reportingBasis,
-      fullYearProjection,
-      tags: [TAX_PAYMENTS_TAG_KEY],
-    } as const
-  }
-}
+}>([TAX_PAYMENTS_TAG_KEY])
 
 export function useTaxPayments({ year, reportingBasis, fullYearProjection }: UseTaxPaymentsOptions) {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile.ts
@@ -4,6 +4,7 @@ import useSWR from 'swr'
 
 import { type TaxProfile, type TaxProfileResponse, TaxProfileResponseSchema } from '@schemas/taxEstimates/profile'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -18,24 +19,7 @@ export const getTaxProfile = get<TaxProfileResponse, { businessId: string }>(
   },
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [TAX_PROFILE_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([TAX_PROFILE_TAG_KEY])
 
 export function useTaxProfile() {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useUpsertTaxProfile.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useUpsertTaxProfile.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { type TaxProfileRequest, type TaxProfileResponse, TaxProfileResponseSchema } from '@schemas/taxEstimates/profile'
 import { patch, post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -32,24 +33,7 @@ export const updateTaxProfile = patch<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/profile`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [UPSERT_TAX_PROFILE_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([UPSERT_TAX_PROFILE_TAG_KEY])
 
 function getRequestFn(mode: UpsertTaxProfileMode) {
   return mode === UpsertTaxProfileMode.Update ? updateTaxProfile : createTaxProfile

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
@@ -6,6 +6,7 @@ import type { ReportingBasis } from '@internal-types/general'
 import { type TaxSummaryResponse, TaxSummaryResponseSchema } from '@schemas/taxEstimates/summary'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -33,39 +34,12 @@ const getTaxSummary = get<TaxSummaryResponse, GetTaxSummaryParams>(
   },
 )
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  year,
-  reportingBasis,
-  fullYearProjection,
-  enabled = true,
-}: {
-  access_token?: string
-  apiUrl?: string
+const buildKey = createBuildKey<{
   businessId: string
   year: number
   reportingBasis?: TaxReportingBasis
   fullYearProjection?: boolean
-  enabled?: boolean
-}) {
-  if (!enabled) {
-    return
-  }
-
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      year,
-      reportingBasis,
-      fullYearProjection,
-      tags: [TAX_SUMMARY_TAG_KEY],
-    } as const
-  }
-}
+}>([TAX_SUMMARY_TAG_KEY])
 
 export function useTaxSummary({ year, reportingBasis, fullYearProjection, enabled = true }: UseTaxSummaryOptions) {
   const withLocale = useLocalizedKey()
@@ -79,7 +53,7 @@ export function useTaxSummary({ year, reportingBasis, fullYearProjection, enable
       year,
       reportingBasis,
       fullYearProjection,
-      enabled,
+      isEnabled: enabled,
     })),
     async ({ accessToken, apiUrl, businessId, year, reportingBasis, fullYearProjection }) => {
       return getTaxSummary(

--- a/src/hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary.ts
@@ -1,11 +1,11 @@
 import { useCallback } from 'react'
-import { formatISO } from 'date-fns'
 import { Schema } from 'effect'
 import useSWR from 'swr'
 
 import { TimeEntrySummarySchema } from '@schemas/timeTracking'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -25,36 +25,11 @@ export type TimeTrackingSummaryFilterParams = {
   endDate?: Date
 }
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  customerId,
-  serviceId,
-  startDate,
-  endDate,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-} & TimeTrackingSummaryFilterParams) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      customerId,
-      serviceId,
-      startDate: startDate ? formatISO(startDate, { representation: 'date' }) : undefined,
-      endDate: endDate ? formatISO(endDate, { representation: 'date' }) : undefined,
-      tags: [TIME_TRACKING_SUMMARY_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string } & TimeTrackingSummaryFilterParams>([TIME_TRACKING_SUMMARY_TAG_KEY])
 
 const getTimeTrackingSummary = get<
   typeof TimeTrackingSummaryResponseSchema.Encoded,
-  { businessId: string, customerId?: string, serviceId?: string, startDate?: string, endDate?: string }
+  { businessId: string } & TimeTrackingSummaryFilterParams
 >(({ businessId, customerId, serviceId, startDate, endDate }) => {
   const parameters = toDefinedSearchParameters({
     customerId,

--- a/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/[time-entry-id]/useDeleteTimeEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/[time-entry-id]/useDeleteTimeEntry.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -18,27 +19,7 @@ const deleteTimeEntry = del<
   { businessId: string, timeEntryId: string }
 >(({ businessId, timeEntryId }) => `/v1/businesses/${businessId}/time-tracking/time-entries/${timeEntryId}`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  timeEntryId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  timeEntryId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      timeEntryId,
-      tags: [DELETE_TIME_ENTRY_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, timeEntryId: string }>([DELETE_TIME_ENTRY_TAG_KEY])
 
 type UseDeleteTimeEntryProps = {
   timeEntryId: string | undefined

--- a/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useListTimeEntries.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useListTimeEntries.ts
@@ -1,5 +1,4 @@
 import { useCallback } from 'react'
-import { formatISO } from 'date-fns'
 import { Schema } from 'effect'
 import useSWRInfinite from 'swr/infinite'
 
@@ -7,6 +6,7 @@ import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { type TimeEntry, TimeEntrySchema } from '@schemas/timeTracking'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
@@ -32,58 +32,10 @@ export type ListTimeEntriesFilterParams = {
 const ListTimeEntriesResponseSchema = PaginatedResponseSchema(TimeEntrySchema)
 type ListTimeEntriesResponse = typeof ListTimeEntriesResponseSchema.Type
 
-function keyLoader(
-  previousPageData: ListTimeEntriesResponse | null,
-  {
-    access_token: accessToken,
-    apiUrl,
-    businessId,
-    customerId,
-    serviceId,
-    startDate,
-    endDate,
-    includeDeleted,
-    status,
-    billable,
-    hasCustomer,
-    sortBy,
-    sortOrder,
-  }: {
-    access_token?: string
-    apiUrl?: string
-    businessId: string
-    customerId?: string
-    serviceId?: string
-    startDate?: Date
-    endDate?: Date
-    includeDeleted?: boolean
-    status?: 'ACTIVE' | 'COMPLETED' | 'RECORDED'
-    billable?: boolean
-    hasCustomer?: boolean
-    sortBy?: string
-    sortOrder?: 'ASC' | 'DESC'
-  },
-) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      cursor: previousPageData?.meta?.pagination.cursor,
-      customerId,
-      serviceId,
-      startDate: startDate ? formatISO(startDate, { representation: 'date' }) : undefined,
-      endDate: endDate ? formatISO(endDate, { representation: 'date' }) : undefined,
-      includeDeleted,
-      status,
-      billable,
-      hasCustomer,
-      sortBy,
-      sortOrder,
-      tags: [LIST_TIME_ENTRIES_TAG_KEY],
-    } as const
-  }
-}
+const keyLoader = createInfiniteKeyLoader<
+  { businessId: string } & ListTimeEntriesFilterParams,
+  ListTimeEntriesResponse
+>([LIST_TIME_ENTRIES_TAG_KEY])
 
 const listTimeEntries = get<
   typeof ListTimeEntriesResponseSchema.Encoded,
@@ -93,8 +45,8 @@ const listTimeEntries = get<
     limit?: number
     customerId?: string
     serviceId?: string
-    startDate?: string
-    endDate?: string
+    startDate?: Date
+    endDate?: Date
     includeDeleted?: boolean
     status?: 'ACTIVE' | 'COMPLETED' | 'RECORDED'
     billable?: boolean

--- a/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useUpsertTimeEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useUpsertTimeEntry.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { TimeEntrySchema, type UpsertTimeEntryEncoded } from '@schemas/timeTracking'
 import { patch, post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -35,27 +36,7 @@ const updateTimeEntry = patch<
   { businessId: string, timeEntryId: string }
 >(({ businessId, timeEntryId }) => `/v1/businesses/${businessId}/time-tracking/time-entries/${timeEntryId}`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  timeEntryId = undefined,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  timeEntryId?: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      timeEntryId,
-      tags: [UPSERT_TIME_ENTRY_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, timeEntryId?: string }>([UPSERT_TIME_ENTRY_TAG_KEY])
 
 const UpsertTimeEntryReturnSchema = Schema.Struct({
   data: TimeEntrySchema,

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker.ts
@@ -4,6 +4,7 @@ import useSWR from 'swr'
 
 import { type TimeEntry, TimeEntrySchema } from '@schemas/timeTracking'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
@@ -26,24 +27,7 @@ const getActiveTimeTracker = get<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/time-tracking/tracker/active`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [ACTIVE_TIME_TRACKER_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([ACTIVE_TIME_TRACKER_TAG_KEY])
 
 export class ActiveTimeTrackerSWRResponse extends SWRQueryResult<TimeEntry | null> {
   get error(): unknown {

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStartTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStartTimeTracker.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { type StartTrackerEncoded, TimeEntrySchema } from '@schemas/timeTracking'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -27,24 +28,7 @@ const startTimeTracker = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/time-tracking/tracker/start`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [START_TIME_TRACKER_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([START_TIME_TRACKER_TAG_KEY])
 
 export const useStartTimeTracker = () => {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStopTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStopTimeTracker.ts
@@ -4,6 +4,7 @@ import useSWRMutation from 'swr/mutation'
 
 import { type StopTrackerEncoded } from '@schemas/timeTracking'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -30,24 +31,7 @@ const stopTimeTracker = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/time-tracking/tracker/stop`)
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: [STOP_TIME_TRACKER_TAG_KEY],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>([STOP_TIME_TRACKER_TAG_KEY])
 
 export const useStopTimeTracker = () => {
   const withLocale = useLocalizedKey()

--- a/src/hooks/api/businesses/[business-id]/useBusiness.ts
+++ b/src/hooks/api/businesses/[business-id]/useBusiness.ts
@@ -3,6 +3,7 @@ import useSWR from 'swr'
 
 import { type Business, BusinessResponseSchema } from '@schemas/business'
 import { get } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
@@ -13,31 +14,14 @@ const getBusiness = get<{ data: Business }>(
   ({ businessId }) => `/v1/businesses/${businessId}`,
 )
 
-function buildKey({
-  accessToken,
-  apiUrl,
-  businessId,
-}: {
-  accessToken?: string
-  apiUrl: string
-  businessId: string
-}) {
-  if (!accessToken) return null
-
-  return {
-    accessToken,
-    apiUrl,
-    businessId,
-    tags: [BUSINESS_TAG_KEY],
-  } as const
-}
+const buildKey = createBuildKey<{ businessId: string }>([BUSINESS_TAG_KEY])
 
 export function useBusiness({ businessId }: { businessId: string }) {
   const { apiUrl } = useEnvironment()
   const { data: auth } = useAuth()
 
   const swrResponse = useSWR(
-    () => buildKey({ accessToken: auth?.access_token, apiUrl, businessId }),
+    () => buildKey({ ...auth, apiUrl, businessId }),
     ({ accessToken, apiUrl, businessId }) =>
       getBusiness(apiUrl, accessToken, { params: { businessId } })()
         .then(Schema.decodeUnknownPromise(BusinessResponseSchema)),

--- a/src/hooks/api/businesses/[business-id]/vendors/useListVendors.ts
+++ b/src/hooks/api/businesses/[business-id]/vendors/useListVendors.ts
@@ -5,6 +5,7 @@ import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { VendorSchema } from '@schemas/vendor'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
@@ -44,37 +45,10 @@ const listVendors = get<
 
 export const VENDORS_TAG_KEY = '#vendors'
 
-function keyLoader(
-  previousPageData: ListVendorsRawResult | null,
-  {
-    access_token: accessToken,
-    apiUrl,
-    businessId,
-    query,
-    isEnabled,
-  }: {
-    access_token?: string
-    apiUrl?: string
-    businessId: string
-    query?: string
-    isEnabled?: boolean
-  },
-) {
-  if (!isEnabled) {
-    return
-  }
-
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      cursor: previousPageData?.meta?.pagination.cursor ?? undefined,
-      query,
-      tags: [VENDORS_TAG_KEY],
-    } as const
-  }
-}
+const keyLoader = createInfiniteKeyLoader<
+  { businessId: string, query?: string },
+  ListVendorsRawResult
+>([VENDORS_TAG_KEY])
 
 type UseListVendorsParameters = {
   query?: string

--- a/src/hooks/features/bankAccounts/useConfirmAndExcludeMultiple.ts
+++ b/src/hooks/features/bankAccounts/useConfirmAndExcludeMultiple.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import useSWRMutation from 'swr/mutation'
 
 import type { Awaitable } from '@internal-types/utility/promises'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -12,24 +13,7 @@ import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export type AccountConfirmExcludeFormState = Record<string, boolean>
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      tags: ['#bulk-confirm', '#bulk-exclude'],
-    }
-  }
-}
+const buildKey = createBuildKey<{ businessId: string }>(['#bulk-confirm', '#bulk-exclude'])
 
 export function useConfirmAndExcludeMultiple({ onSuccess }: { onSuccess?: () => Awaitable<unknown> }) {
   const withLocale = useLocalizedKey()

--- a/src/hooks/legacy/useUpdateOpeningBalanceAndDate.ts
+++ b/src/hooks/legacy/useUpdateOpeningBalanceAndDate.ts
@@ -2,6 +2,7 @@ import useSWRMutation from 'swr/mutation'
 
 import type { Awaitable } from '@internal-types/utility/promises'
 import { post } from '@utils/api/authenticatedHttp'
+import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
@@ -53,27 +54,7 @@ export type OpeningBalanceAPIResponseResult =
   | OpeningBalanceAPIResponseValidationError
   | OpeningBalanceAPIResponseError
 
-function buildKey({
-  access_token: accessToken,
-  apiUrl,
-  businessId,
-  data,
-}: {
-  access_token?: string
-  apiUrl?: string
-  businessId: string
-  data: OpeningBalanceData[]
-}) {
-  if (accessToken && apiUrl) {
-    return {
-      accessToken,
-      apiUrl,
-      businessId,
-      data,
-      tags: ['#update-opening-balance'],
-    } as const
-  }
-}
+const buildKey = createBuildKey<{ businessId: string, data: OpeningBalanceData[] }>(['#update-opening-balance'])
 
 function setOpeningBalanceOnBankAccount({
   apiUrl,

--- a/src/utils/swr/createBuildKey.ts
+++ b/src/utils/swr/createBuildKey.ts
@@ -1,20 +1,12 @@
 import type { OAuthResponse } from '@internal-types/authentication'
 import type { PaginatedResponse } from '@schemas/common/pagination'
 
-// Auth fields from `useAuth()`. `access_token`/`apiUrl` become part of the key;
-// the rest (`token_type`, `expires_in`) are destructured out so callers can spread
-// `...auth` without leaking auth metadata into cache identity.
 type AuthKeyInput = Partial<OAuthResponse> & { apiUrl?: string }
 
 type BuildKeyParams = Record<string, unknown>
 
 type EnablementInput = { isEnabled?: boolean }
 
-/**
- * Builds the `buildKey` used by most API hooks: renames `access_token` -> `accessToken`,
- * returns `undefined` when disabled or auth is incomplete, copies passthrough params, and
- * attaches cache `tags`.
- */
 export function createBuildKey<TParams extends BuildKeyParams>(tags: ReadonlyArray<string>) {
   return ({
     access_token: accessToken,
@@ -37,10 +29,6 @@ export function createBuildKey<TParams extends BuildKeyParams>(tags: ReadonlyArr
   }
 }
 
-/**
- * `useSWRInfinite` variant of {@link createBuildKey} that also derives `cursor` from the
- * previous page (defaults to the standard {@link PaginatedResponse} shape).
- */
 export function createInfiniteKeyLoader<
   TParams extends BuildKeyParams,
   TPage extends PaginatedResponse<unknown> = PaginatedResponse<unknown>,

--- a/src/utils/swr/createBuildKey.ts
+++ b/src/utils/swr/createBuildKey.ts
@@ -1,0 +1,115 @@
+import type { PaginatedResponse } from '@schemas/common/pagination'
+
+/**
+ * Auth fields as they arrive from `useAuth()` (`{ access_token, ... }`), which is
+ * typically spread into a `buildKey` call as `buildKey({ ...auth, businessId })`.
+ */
+type AuthKeyInput = {
+  access_token?: string
+  apiUrl?: string
+}
+
+/**
+ * Extra parameters a caller threads through the key untouched (e.g. `businessId`,
+ * path params like `serviceId`, or query params like `allowArchived`). Every
+ * passthrough field is copied verbatim into the returned key object.
+ */
+type BuildKeyParams = Record<string, unknown>
+
+/**
+ * Optional enablement gate. When `isEnabled` is explicitly `false`, `buildKey`
+ * returns `undefined` so SWR treats the request as disabled. Defaults to enabled.
+ */
+type EnablementInput = {
+  isEnabled?: boolean
+}
+
+/**
+ * Generates the `buildKey` function that nearly every API hook under
+ * `src/hooks/api` declares by hand.
+ *
+ * The generated function:
+ *   - renames `access_token` -> `accessToken` (so callers can spread `...auth`),
+ *   - returns `undefined` when `isEnabled === false` or auth is incomplete
+ *     (matching the ubiquitous `if (accessToken && apiUrl)` guard), so SWR skips
+ *     the request until it can actually run,
+ *   - copies every remaining param (`businessId`, path/query params, ...) into
+ *     the key untouched,
+ *   - attaches the provided cache `tags`.
+ *
+ * @example
+ * const buildKey = createBuildKey<{ businessId: string, allowArchived?: boolean }>(
+ *   [CATALOG_SERVICES_TAG_KEY, LIST_CATALOG_SERVICES_TAG_KEY],
+ * )
+ * // in the hook:
+ * useSWR(() => withLocale(buildKey({ ...auth, businessId, allowArchived, isEnabled })), fetcher)
+ */
+export function createBuildKey<TParams extends BuildKeyParams>(tags: ReadonlyArray<string>) {
+  return ({
+    access_token: accessToken,
+    apiUrl,
+    isEnabled = true,
+    ...params
+  }: AuthKeyInput & EnablementInput & TParams) => {
+    if (!isEnabled) return
+
+    if (accessToken && apiUrl) {
+      return {
+        accessToken,
+        apiUrl,
+        ...params as TParams,
+        tags,
+      } as const
+    }
+  }
+}
+
+/**
+ * `useSWRInfinite` variant of {@link createBuildKey}. Produces the `keyLoader`
+ * that infinite-list hooks declare by hand: same auth/enablement/tags handling,
+ * plus a `cursor` derived from the previous page.
+ *
+ * The default cursor extractor reads `previousPageData?.meta?.pagination.cursor`
+ * (the standard {@link PaginatedResponse} shape); pass `getCursor` for responses
+ * that page differently.
+ *
+ * @example
+ * const keyLoader = createInfiniteKeyLoader<Omit<ListInvoicesParams, 'cursor'>, ListInvoicesReturn>(
+ *   [LIST_INVOICES_TAG_KEY],
+ * )
+ * // in the hook:
+ * useSWRInfinite(
+ *   (_index, previousPageData) => withLocale(keyLoader(previousPageData, { ...auth, businessId, ...params })),
+ *   fetcher,
+ * )
+ */
+export function createInfiniteKeyLoader<
+  TParams extends BuildKeyParams,
+  TPage extends PaginatedResponse<unknown> = PaginatedResponse<unknown>,
+>(
+  tags: ReadonlyArray<string>,
+  getCursor: (previousPageData: TPage | null) => string | undefined =
+  previousPageData => previousPageData?.meta?.pagination.cursor ?? undefined,
+) {
+  return (
+    previousPageData: TPage | null,
+    {
+      access_token: accessToken,
+      apiUrl,
+      isEnabled = true,
+      ...params
+    }: AuthKeyInput & EnablementInput & TParams,
+  ) => {
+    if (!isEnabled) return
+
+    if (accessToken && apiUrl) {
+      return {
+        accessToken,
+        apiUrl,
+        ...(params as TParams),
+        cursor: getCursor(previousPageData),
+        tags,
+      } as const
+    }
+  }
+}

--- a/src/utils/swr/createBuildKey.ts
+++ b/src/utils/swr/createBuildKey.ts
@@ -1,53 +1,26 @@
+import type { OAuthResponse } from '@internal-types/authentication'
 import type { PaginatedResponse } from '@schemas/common/pagination'
 
-/**
- * Auth fields as they arrive from `useAuth()` (`{ access_token, ... }`), which is
- * typically spread into a `buildKey` call as `buildKey({ ...auth, businessId })`.
- */
-type AuthKeyInput = {
-  access_token?: string
-  apiUrl?: string
-}
+// Auth fields from `useAuth()`. `access_token`/`apiUrl` become part of the key;
+// the rest (`token_type`, `expires_in`) are destructured out so callers can spread
+// `...auth` without leaking auth metadata into cache identity.
+type AuthKeyInput = Partial<OAuthResponse> & { apiUrl?: string }
 
-/**
- * Extra parameters a caller threads through the key untouched (e.g. `businessId`,
- * path params like `serviceId`, or query params like `allowArchived`). Every
- * passthrough field is copied verbatim into the returned key object.
- */
 type BuildKeyParams = Record<string, unknown>
 
-/**
- * Optional enablement gate. When `isEnabled` is explicitly `false`, `buildKey`
- * returns `undefined` so SWR treats the request as disabled. Defaults to enabled.
- */
-type EnablementInput = {
-  isEnabled?: boolean
-}
+type EnablementInput = { isEnabled?: boolean }
 
 /**
- * Generates the `buildKey` function that nearly every API hook under
- * `src/hooks/api` declares by hand.
- *
- * The generated function:
- *   - renames `access_token` -> `accessToken` (so callers can spread `...auth`),
- *   - returns `undefined` when `isEnabled === false` or auth is incomplete
- *     (matching the ubiquitous `if (accessToken && apiUrl)` guard), so SWR skips
- *     the request until it can actually run,
- *   - copies every remaining param (`businessId`, path/query params, ...) into
- *     the key untouched,
- *   - attaches the provided cache `tags`.
- *
- * @example
- * const buildKey = createBuildKey<{ businessId: string, allowArchived?: boolean }>(
- *   [CATALOG_SERVICES_TAG_KEY, LIST_CATALOG_SERVICES_TAG_KEY],
- * )
- * // in the hook:
- * useSWR(() => withLocale(buildKey({ ...auth, businessId, allowArchived, isEnabled })), fetcher)
+ * Builds the `buildKey` used by most API hooks: renames `access_token` -> `accessToken`,
+ * returns `undefined` when disabled or auth is incomplete, copies passthrough params, and
+ * attaches cache `tags`.
  */
 export function createBuildKey<TParams extends BuildKeyParams>(tags: ReadonlyArray<string>) {
   return ({
     access_token: accessToken,
     apiUrl,
+    token_type,
+    expires_in,
     isEnabled = true,
     ...params
   }: AuthKeyInput & EnablementInput & TParams) => {
@@ -65,23 +38,8 @@ export function createBuildKey<TParams extends BuildKeyParams>(tags: ReadonlyArr
 }
 
 /**
- * `useSWRInfinite` variant of {@link createBuildKey}. Produces the `keyLoader`
- * that infinite-list hooks declare by hand: same auth/enablement/tags handling,
- * plus a `cursor` derived from the previous page.
- *
- * The default cursor extractor reads `previousPageData?.meta?.pagination.cursor`
- * (the standard {@link PaginatedResponse} shape); pass `getCursor` for responses
- * that page differently.
- *
- * @example
- * const keyLoader = createInfiniteKeyLoader<Omit<ListInvoicesParams, 'cursor'>, ListInvoicesReturn>(
- *   [LIST_INVOICES_TAG_KEY],
- * )
- * // in the hook:
- * useSWRInfinite(
- *   (_index, previousPageData) => withLocale(keyLoader(previousPageData, { ...auth, businessId, ...params })),
- *   fetcher,
- * )
+ * `useSWRInfinite` variant of {@link createBuildKey} that also derives `cursor` from the
+ * previous page (defaults to the standard {@link PaginatedResponse} shape).
  */
 export function createInfiniteKeyLoader<
   TParams extends BuildKeyParams,
@@ -96,6 +54,8 @@ export function createInfiniteKeyLoader<
     {
       access_token: accessToken,
       apiUrl,
+      token_type,
+      expires_in,
       isEnabled = true,
       ...params
     }: AuthKeyInput & EnablementInput & TParams,
@@ -106,7 +66,7 @@ export function createInfiniteKeyLoader<
       return {
         accessToken,
         apiUrl,
-        ...(params as TParams),
+        ...params as TParams,
         cursor: getCursor(previousPageData),
         tags,
       } as const


### PR DESCRIPTION
## Scope

Introduces `createBuildKey` / `createInfiniteKeyLoader` in `src/utils/swr/createBuildKey.ts` to eliminate the hand-written `buildKey`/`keyLoader` boilerplate that was duplicated across ~120 API hooks.

The helpers:
- rename `access_token` → `accessToken` (so callers keep spreading `...auth`),
- apply the ubiquitous `if (!isEnabled) return` + `if (accessToken && apiUrl)` guards (returns `undefined` → SWR skips the request),
- copy passthrough params (`businessId`, path/query params) into the key verbatim,
- attach cache `tags`,
- `createInfiniteKeyLoader` additionally derives `cursor` from the previous page (normalized to `string | undefined`).

**119 hooks migrated; net −2249 lines.**

### Edge cases folded in
- **Extra guard conditions** (`&& invoiceId`, `&& periods`, `&& accountId`, `isActiveOrPaused`, …) → moved to the call site as `isEnabled: <cond>`. Behavior identical.
- **`tag` (singular) → `tags`** for `useAccountingConfiguration` / `useBookkeepingConfiguration` (the singular keys were dead — nothing matched them).
- **`plaid/hosted-link`** — renamed `accessToken`/`enabled` to the helper's `access_token`/`isEnabled`.
- **Unified reports** — computed tag in the hook (`createBuildKey(params ? [getTag(params.route)] : [])`).
- **Date filters standardized** — `Date` stays in the key (`stableHash` serializes via `.toJSON()`); the fetcher formats via `toDefinedSearchParameters` (which already does `formatISO(..., { representation: 'date' })`). Removed all manual `formatISO`-into-key formatting.

### Left as-is
- `utils/auth/useAuth.ts` — it *produces* the auth data and returns two different shapes by mode; not a standard cache key.

## Verification
- `tsc --noEmit`: no new errors (only 2 pre-existing `Chart/*` errors on the base, untouched).
- ESLint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide-touch refactor across fetch/mutation cache keys; mistakes could skip requests or break tag-based invalidation, though intent is behavior-preserving with a few deliberate tag fixes.
> 
> **Overview**
> Adds shared **`createBuildKey`** and **`createInfiniteKeyLoader`** utilities so SWR cache keys no longer repeat auth/`apiUrl` guards, `access_token` → `accessToken` mapping, optional **`isEnabled`** skipping, and **`tags`** attachment.
> 
> Roughly **~120 business API hooks** drop local `buildKey` / `keyLoader` implementations in favor of the helpers (including infinite lists for bank transactions, invoices, ledger, customers, etc.). Hooks that previously gated fetches with extra conditions now pass those as **`isEnabled`** at the call site (e.g. bookkeeping periods when status is active, P&amp;L comparison when `periods` exist, ledger lines when `accountId` is set).
> 
> Notable behavior-aligned tweaks bundled in the migration: accounting/bookkeeping config keys use **`tags`** (plural) for invalidation; unified report hooks build tag arrays from the current route when params exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a67ca12169f2c621eb8918f7f00d42625cba4d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->