### PR TITLE
refactor: add useBuildKeyInputs hook and migrate all SWR key-input callsites

### DIFF
--- a/src/components/ProfitAndLossDownloadButton/ProfitAndLossFullReportDownloadButton.tsx
+++ b/src/components/ProfitAndLossDownloadButton/ProfitAndLossFullReportDownloadButton.tsx
@@ -26,7 +26,7 @@ export const ProfitAndLossFullReportDownloadButton = ({
     ProfitAndLossComparisonContext,
   )
 
-  const { businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { businessId, auth } = useBuildKeyInputs()
 
   const [requestFailed, setRequestFailed] = useState(false)
   const [isDownloading, setIsDownloading] = useState(false)
@@ -40,10 +40,11 @@ export const ProfitAndLossFullReportDownloadButton = ({
     : undefined
 
   const handleClick = async () => {
+    if (!auth) return
     setIsDownloading(true)
     const getProfitAndLossExcelCall = getProfitAndLossExcel(
-      apiUrl,
-      auth?.access_token,
+      auth.apiUrl,
+      auth.access_token,
       {
         businessId,
         moneyFormat,

--- a/src/components/ProfitAndLossDownloadButton/ProfitAndLossFullReportDownloadButton.tsx
+++ b/src/components/ProfitAndLossDownloadButton/ProfitAndLossFullReportDownloadButton.tsx
@@ -3,9 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { type MoneyFormat } from '@internal-types/general'
 import { getProfitAndLossExcel } from '@hooks/legacy/useDownloadProfitAndLoss'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { ProfitAndLossComparisonContext } from '@contexts/ProfitAndLossComparisonContext/ProfitAndLossComparisonContext'
 import { ProfitAndLossContext } from '@contexts/ProfitAndLossContext/ProfitAndLossContext'
 import { DownloadButton as DownloadButtonComponent } from '@ui/Button/DownloadButton'
@@ -28,9 +26,7 @@ export const ProfitAndLossFullReportDownloadButton = ({
     ProfitAndLossComparisonContext,
   )
 
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const [requestFailed, setRequestFailed] = useState(false)
   const [isDownloading, setIsDownloading] = useState(false)

--- a/src/hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration.tsx
+++ b/src/hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration.tsx
@@ -5,7 +5,7 @@ import { AccountingConfigurationSchema, type AccountingConfigurationSchemaType }
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { useAuth } from '@hooks/utils/auth/useAuth'
 
 export const ACCOUNTING_CONFIGURATION_TAG_KEY = '#accounting-configuration'
 
@@ -22,7 +22,7 @@ const getAccountingConfiguration = get<{ data: AccountingConfigurationSchemaType
 )
 
 export function useAccountingConfiguration({ businessId }: GetAccountingConfigurationParams) {
-  const { auth } = useBuildKeyInputs()
+  const { data: auth } = useAuth()
 
   const queryKey = buildKey({
     ...auth,

--- a/src/hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration.tsx
+++ b/src/hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration.tsx
@@ -22,11 +22,10 @@ const getAccountingConfiguration = get<{ data: AccountingConfigurationSchemaType
 )
 
 export function useAccountingConfiguration({ businessId }: GetAccountingConfigurationParams) {
-  const { apiUrl, auth } = useBuildKeyInputs()
+  const { auth } = useBuildKeyInputs()
 
   const queryKey = buildKey({
     ...auth,
-    apiUrl,
     businessId,
   })
 

--- a/src/hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration.tsx
+++ b/src/hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration.tsx
@@ -5,8 +5,7 @@ import { AccountingConfigurationSchema, type AccountingConfigurationSchemaType }
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const ACCOUNTING_CONFIGURATION_TAG_KEY = '#accounting-configuration'
 
@@ -23,8 +22,7 @@ const getAccountingConfiguration = get<{ data: AccountingConfigurationSchemaType
 )
 
 export function useAccountingConfiguration({ businessId }: GetAccountingConfigurationParams) {
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { apiUrl, auth } = useBuildKeyInputs()
 
   const queryKey = buildKey({
     ...auth,

--- a/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
@@ -48,13 +48,12 @@ export class ListBankAccountsSWRResponse extends SWRQueryResult<BankAccount[]> {
 export function useListBankAccounts(
   config?: SWRConfiguration<BankAccount[]>,
 ): ListBankAccountsSWRResponse {
-  const { businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () =>
       buildKey({
         ...auth,
-        apiUrl,
         businessId,
       }),
     ({ accessToken, apiUrl, businessId }) => listBankAccounts(

--- a/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
@@ -7,9 +7,7 @@ import { get } from '@utils/api/authenticatedHttp'
 import { isAnyBankAccountSyncing } from '@utils/bankAccount'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const BANK_ACCOUNTS_TAG_KEY = '#bank-accounts'
 
@@ -50,9 +48,7 @@ export class ListBankAccountsSWRResponse extends SWRQueryResult<BankAccount[]> {
 export function useListBankAccounts(
   config?: SWRConfiguration<BankAccount[]>,
 ): ListBankAccountsSWRResponse {
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () =>

--- a/src/hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount.ts
@@ -22,12 +22,11 @@ const unlinkBankAccount = del<
 const buildKey = createBuildKey<{ businessId: string }>([UNLINK_BANK_ACCOUNT_TAG_KEY])
 
 export function useUnlinkBankAccount() {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl,
+      ...auth,
       businessId,
     })),
     ({ accessToken, apiUrl, businessId }, { arg: bankAccountId }: { arg: string }) =>

--- a/src/hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount.ts
@@ -2,11 +2,8 @@ import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UNLINK_BANK_ACCOUNT_TAG_KEY = '#unlink-bank-account'
 
@@ -25,10 +22,7 @@ const unlinkBankAccount = del<
 const buildKey = createBuildKey<{ businessId: string }>([UNLINK_BANK_ACCOUNT_TAG_KEY])
 
 export function useUnlinkBankAccount() {
-  const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/useCategorizeBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/useCategorizeBankTransaction.ts
@@ -7,15 +7,13 @@ import { BankTransactionSchema } from '@schemas/bankTransactions/bankTransaction
 import { type CategoryUpdate, type CategoryUpdateEncoded, encodeCategoryUpdate } from '@schemas/bankTransactions/categoryUpdate'
 import { put } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { type GetBankTransactionsReturn } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useAuth } from '@hooks/utils/auth/useAuth'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { useBankTransactionsContext } from '@contexts/BankTransactionsContext/BankTransactionsContext'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const CATEGORIZE_BANK_TRANSACTION_TAG = '#categorize-bank-transaction'
 
@@ -48,9 +46,7 @@ export type UseCategorizeBankTransactionOptions = {
 }
 
 export function useCategorizeBankTransaction() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
   const { useBankTransactionsOptions } = useBankTransactionsContext()

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/match/useMatchBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/match/useMatchBankTransaction.ts
@@ -5,14 +5,12 @@ import useSWRMutation from 'swr/mutation'
 import { MatchSchema } from '@schemas/bankTransactions/match'
 import { put } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useAuth } from '@hooks/utils/auth/useAuth'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { useBankTransactionsContext } from '@contexts/BankTransactionsContext/BankTransactionsContext'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export type MatchBankTransactionBody = {
   match_id: string
@@ -44,9 +42,7 @@ type MatchBankTransactionArgs = MatchBankTransactionBody & {
 }
 
 export function useMatchBankTransaction() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
   const { useBankTransactionsOptions } = useBankTransactionsContext()

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useBankTransactionsMetadata.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useBankTransactionsMetadata.ts
@@ -3,9 +3,7 @@ import useSWR from 'swr'
 import { type BankTransaction, type BankTransactionMetadata } from '@internal-types/bankTransactions'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const getBankTransactionMetadata = get<{
   data: BankTransactionMetadata
@@ -20,9 +18,7 @@ export const GET_BANK_TRANSACTION_METADATA_TAG_KEY = '#bank-transaction-metadata
 const buildKey = createBuildKey<{ businessId: string, bankTransactionId: string }>([GET_BANK_TRANSACTION_METADATA_TAG_KEY])
 
 export function useBankTransactionMetadata({ bankTransactionId }: { bankTransactionId: BankTransaction['id'] }) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   return useSWR(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useSetMetadataOnBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useSetMetadataOnBankTransaction.ts
@@ -5,12 +5,10 @@ import { type CustomerSchema } from '@schemas/customer'
 import { type VendorSchema } from '@schemas/vendor'
 import { patch } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
-import { useAuth } from '@hooks/utils/auth/useAuth'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { useMinMutatingMutation } from '@hooks/utils/swr/useMinMutatingMutation'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const SET_METADATA_ON_BANK_TRANSACTION_TAG_KEY = '#set-metadata-on-bank-transaction'
 
@@ -45,13 +43,11 @@ type UseSetMetadataOnBankTransactionParameters = {
 export function useSetMetadataOnBankTransaction({
   bankTransactionId,
 }: UseSetMetadataOnBankTransactionParameters) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       bankTransactionId,
     })),

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useUpdateBankTransactionMetadata.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useUpdateBankTransactionMetadata.ts
@@ -6,13 +6,11 @@ import type { BankTransactionMetadata } from '@internal-types/bankTransactions'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { put } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { GET_BANK_TRANSACTION_METADATA_TAG_KEY } from '@hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useBankTransactionsMetadata'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const updateBankTransactionMetadata = put<
   { data: BankTransactionMetadata, errors: unknown },
@@ -29,9 +27,7 @@ const UPDATE_BANK_TRANSACTION_METADATA_TAG_KEY = '#update-bank-transaction-metad
 const buildKey = createBuildKey<{ businessId: string, bankTransactionId: string }>([UPDATE_BANK_TRANSACTION_METADATA_TAG_KEY])
 
 export function useUpdateBankTransactionMetadata({ bankTransactionId, onSuccess }: { bankTransactionId: string, onSuccess?: () => Awaitable<unknown> }) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
   const rawMutationResponse = useSWRMutation(

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-categorize/useBulkCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-categorize/useBulkCategorize.ts
@@ -5,11 +5,10 @@ import useSWRMutation from 'swr/mutation'
 import { CategoryUpdateSchema } from '@schemas/bankTransactions/categoryUpdate'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useAuth } from '@hooks/utils/auth/useAuth'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const BULK_CATEGORIZE_BANK_TRANSACTIONS_TAG_KEY = '#bulk-categorize-bank-transactions'
@@ -37,16 +36,15 @@ const bulkCategorize = post<
 const buildKey = createBuildKey<{ businessId: string }>([BULK_CATEGORIZE_BANK_TRANSACTIONS_TAG_KEY])
 
 export const useBulkCategorize = () => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId, eventCallbacks } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
+  const { eventCallbacks } = useLayerContext()
 
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     (

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -6,11 +6,10 @@ import { type Split } from '@internal-types/bankTransactions'
 import { CategoryUpdateSchema } from '@schemas/bankTransactions/categoryUpdate'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useAuth } from '@hooks/utils/auth/useAuth'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { type BankTransactionCategorization, BankTransactionSelectionVariant, DEFAULT_CATEGORIZATION, useGetAllBankTransactionsCategorizations } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useSelectedIds } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
@@ -143,9 +142,8 @@ const bulkMatchOrCategorize = post<
 const buildKey = createBuildKey<{ businessId: string }>([BULK_MATCH_OR_CATEGORIZE_TAG])
 
 export const useBulkMatchOrCategorize = () => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId, eventCallbacks } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
+  const { eventCallbacks } = useLayerContext()
   const { selectedIds } = useSelectedIds()
   const { categorizations } = useGetAllBankTransactionsCategorizations()
 
@@ -159,7 +157,7 @@ export const useBulkMatchOrCategorize = () => {
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     (

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-uncategorize/useBulkUncategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-uncategorize/useBulkUncategorize.ts
@@ -4,11 +4,10 @@ import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useAuth } from '@hooks/utils/auth/useAuth'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const BULK_UNCATEGORIZE_BANK_TRANSACTIONS_TAG_KEY = '#bulk-uncategorize-bank-transactions'
@@ -31,16 +30,15 @@ const bulkUncategorize = post<
 const buildKey = createBuildKey<{ businessId: string }>([BULK_UNCATEGORIZE_BANK_TRANSACTIONS_TAG_KEY])
 
 export const useBulkUncategorize = () => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId, eventCallbacks } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
+  const { eventCallbacks } = useLayerContext()
 
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     (

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/tags/useRemoveTagFromBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/tags/useRemoveTagFromBankTransaction.ts
@@ -3,11 +3,9 @@ import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const REMOVE_TAG_FROM_BANK_TRANSACTION_TAG_KEY = '#remove-tag-from-bank-transaction'
 
@@ -32,13 +30,11 @@ type RemoveTagFromBankTransactionOptions = {
 }
 
 export function useRemoveTagFromBankTransaction({ bankTransactionId }: RemoveTagFromBankTransactionOptions) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       bankTransactionId,
     })),

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/tags/useTagBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/tags/useTagBankTransaction.ts
@@ -5,13 +5,11 @@ import { v4 as uuidv4 } from 'uuid'
 import type { TransactionTagEncoded } from '@schemas/tag'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import {
   useBankTransactionsGlobalCacheActions,
 } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const TAG_BANK_TRANSACTION_TAG_KEY = '#tag-bank-transaction'
 
@@ -52,13 +50,11 @@ type TagBankTransactionOptions = {
 }
 
 export function useTagBankTransaction({ bankTransactionId }: TagBankTransactionOptions) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       bankTransactionId,
     })),

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions.ts
@@ -11,12 +11,10 @@ import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParamet
 import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createKeyMatcher } from '@utils/swr/createKeyMatcher'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const GetBankTransactionsResponseSchema = PaginatedResponseSchema(BankTransactionSchema)
 
@@ -107,15 +105,13 @@ export function useBankTransactions({
   endDate,
   tagFilterQueryString,
 }: UseBankTransactionsOptions, config?: SWRInfiniteConfiguration<GetBankTransactionsReturn>) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: GetBankTransactionsReturn | null) => withLocale(keyLoader(
       previousPageData,
       {
-        ...data,
+        ...auth,
         businessId,
         categorized,
         direction,

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration.tsx
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration.tsx
@@ -31,11 +31,10 @@ const getBookkeepingConfiguration = get<
 })
 
 export function useBookkeepingConfiguration() {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const queryKey = withLocale(buildKey({
     ...auth,
-    apiUrl,
     businessId,
   }))
 

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration.tsx
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration.tsx
@@ -9,11 +9,8 @@ import {
 } from '@schemas/bookkeepingConfiguration'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export type { BookkeepingConfiguration }
 export { BookkeepingStatus, TransactionTaggingStrategy }
@@ -34,10 +31,7 @@ const getBookkeepingConfiguration = get<
 })
 
 export function useBookkeepingConfiguration() {
-  const withLocale = useLocalizedKey()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const queryKey = withLocale(buildKey({
     ...auth,

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods.ts
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods.ts
@@ -8,13 +8,11 @@ import { isActiveOrPausedBookkeepingStatus } from '@utils/bookkeeping/bookkeepin
 import { isActiveBookkeepingPeriod } from '@utils/bookkeeping/periods/getFilteredBookkeepingPeriods'
 import { getUserVisibleTasks } from '@utils/bookkeeping/tasks/bookkeepingTasksFilters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import {
   BOOKKEEPING_TAG_KEY,
   useBookkeepingStatus,
 } from '@hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export enum BookkeepingPeriodStatus {
   BOOKKEEPING_NOT_ACTIVE = 'BOOKKEEPING_NOT_ACTIVE',
@@ -73,9 +71,7 @@ export const BOOKKEEPING_PERIODS_TAG_KEY = '#bookkeeping-periods'
 const buildKey = createBuildKey<{ businessId: string }>([BOOKKEEPING_TAG_KEY, BOOKKEEPING_PERIODS_TAG_KEY])
 
 export function useBookkeepingPeriods() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const { data, isLoading: isLoadingBookkeepingStatus } = useBookkeepingStatus()
   const isActiveOrPaused = data ? isActiveOrPausedBookkeepingStatus(data.status) : false

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus.ts
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus.ts
@@ -5,9 +5,8 @@ import { BookkeepingStatus, type BookkeepingStatusData, BookkeepingStatusRespons
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useAuth } from '@hooks/utils/auth/useAuth'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { useLegacyMode } from '@providers/LegacyModeProvider/LegacyModeProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export { BookkeepingStatus }
 
@@ -24,8 +23,7 @@ export const BOOKKEEPING_STATUS_TAG_KEY = '#bookkeeping-status'
 const buildKey = createBuildKey<{ businessId: string }>([BOOKKEEPING_TAG_KEY, BOOKKEEPING_STATUS_TAG_KEY])
 
 export function useBookkeepingStatus() {
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { businessId, auth } = useBuildKeyInputs()
 
   return useSWR(
     () => buildKey({

--- a/src/hooks/api/businesses/[business-id]/call-bookings/useCallBookings.tsx
+++ b/src/hooks/api/businesses/[business-id]/call-bookings/useCallBookings.tsx
@@ -16,11 +16,9 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export type { CallBooking, CreateCallBookingBody }
 export { CallBookingPurpose, CallBookingState, CallBookingType }
@@ -52,9 +50,7 @@ const keyLoader = createInfiniteKeyLoader<
 >([CALL_BOOKINGS_TAG_KEY])
 
 export function useCallBookings({ limit }: { limit?: number } = {}) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListCallBookingsResponse | null) => withLocale(keyLoader(

--- a/src/hooks/api/businesses/[business-id]/call-bookings/useCreateCallBooking.tsx
+++ b/src/hooks/api/businesses/[business-id]/call-bookings/useCreateCallBooking.tsx
@@ -9,12 +9,10 @@ import {
 } from '@schemas/callBooking'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCallBookingsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/call-bookings/useCallBookings'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const CREATE_CALL_BOOKING_TAG_KEY = '#create-call-booking'
 
@@ -27,14 +25,12 @@ const createCallBooking = post<
 const buildKey = createBuildKey<{ businessId: string }>([CREATE_CALL_BOOKING_TAG_KEY])
 
 export function useCreateCallBooking() {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReload: forceReloadCallBookings } = useCallBookingsGlobalCacheActions()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     (

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useArchiveCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useArchiveCatalogService.ts
@@ -5,12 +5,10 @@ import useSWRMutation from 'swr/mutation'
 import { CatalogServiceSchema } from '@schemas/catalogService'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCatalogServicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const ARCHIVE_CATALOG_SERVICE_TAG_KEY = '#archive-catalog-service'
 
@@ -31,14 +29,12 @@ type UseArchiveCatalogServiceProps = {
 }
 
 export function useArchiveCatalogService({ serviceId }: UseArchiveCatalogServiceProps) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReload: forceReloadCatalogServices } = useCatalogServicesGlobalCacheActions()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       serviceId,
     })),

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useReactivateCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useReactivateCatalogService.ts
@@ -5,12 +5,10 @@ import useSWRMutation from 'swr/mutation'
 import { CatalogServiceSchema } from '@schemas/catalogService'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCatalogServicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const REACTIVATE_CATALOG_SERVICE_TAG_KEY = '#reactivate-catalog-service'
 
@@ -31,14 +29,12 @@ type UseReactivateCatalogServiceProps = {
 }
 
 export function useReactivateCatalogService({ serviceId }: UseReactivateCatalogServiceProps) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReload: forceReloadCatalogServices } = useCatalogServicesGlobalCacheActions()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       serviceId,
     })),

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useUpdateCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useUpdateCatalogService.ts
@@ -5,12 +5,10 @@ import useSWRMutation from 'swr/mutation'
 import { CatalogServiceSchema, type UpdateCatalogServiceEncoded } from '@schemas/catalogService'
 import { patch } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCatalogServicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UPDATE_CATALOG_SERVICE_TAG_KEY = '#update-catalog-service'
 
@@ -34,14 +32,12 @@ type UseUpdateCatalogServiceProps = {
 }
 
 export function useUpdateCatalogService({ serviceId }: UseUpdateCatalogServiceProps) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { patchByKey: patchCatalogServiceByKey } = useCatalogServicesGlobalCacheActions()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       serviceId,
     })),

--- a/src/hooks/api/businesses/[business-id]/catalog/services/useCreateCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/useCreateCatalogService.ts
@@ -5,12 +5,10 @@ import useSWRMutation from 'swr/mutation'
 import { CatalogServiceSchema, type CreateCatalogServiceEncoded } from '@schemas/catalogService'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCatalogServicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const CREATE_CATALOG_SERVICE_TAG_KEY = '#create-catalog-service'
 
@@ -30,14 +28,12 @@ const createCatalogService = post<
 const buildKey = createBuildKey<{ businessId: string }>([CREATE_CATALOG_SERVICE_TAG_KEY])
 
 export function useCreateCatalogService() {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReload: forceReloadCatalogServices } = useCatalogServicesGlobalCacheActions()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     (

--- a/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
@@ -6,10 +6,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const LIST_CATALOG_SERVICES_TAG_KEY = '#list-catalog-services'
 
@@ -37,13 +35,11 @@ export function useListCatalogServices({
   allowArchived,
   isEnabled = true,
 }: UseListCatalogServicesOptions = {}): SWRQueryResult<ListCatalogServicesResponse> {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       allowArchived,
       isEnabled,

--- a/src/hooks/api/businesses/[business-id]/categories/useCategories.ts
+++ b/src/hooks/api/businesses/[business-id]/categories/useCategories.ts
@@ -5,9 +5,7 @@ import { type CategoriesListMode, CategoryListSchema, type NestedCategorization 
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const CATEGORIES_TAG_KEY = '#categories'
 
@@ -35,9 +33,7 @@ type UseCategoriesOptions = {
 }
 
 export function useCategories({ mode }: UseCategoriesOptions = {}) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   return useSWR(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/[categorization-rule-id]/archive/useArchiveCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/[categorization-rule-id]/archive/useArchiveCategorizationRule.ts
@@ -5,11 +5,9 @@ import useSWRMutation from 'swr/mutation'
 import { CategorizationRuleSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCategorizationRulesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const ARCHIVE_CATEGORIZATION_RULE_TAG = '#archive-categorization-rule'
 
@@ -27,9 +25,7 @@ export const archiveCategorizationRule = post<ArchiveCategorizationRuleReturn>(
 )
 
 export function useArchiveCategorizationRule() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReload: forceReloadCategorizationRules } = useCategorizationRulesGlobalCacheActions()
 
   const mutationResponse = useSWRMutation(

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/suggestions/useRejectCategorizationRulesUpdateSuggestion.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/suggestions/useRejectCategorizationRulesUpdateSuggestion.ts
@@ -3,10 +3,8 @@ import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const REJECT_CATEGORIZATION_RULE_SUGGESTION_TAG = '#reject-categorization-rule-suggestion'
 
@@ -18,9 +16,7 @@ export const rejectCategorizationRulesUpdateSuggestion = del<never>(
 )
 
 export function useRejectCategorizationRulesUpdateSuggestion() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useCreateCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useCreateCategorizationRule.ts
@@ -5,13 +5,11 @@ import useSWRMutation from 'swr/mutation'
 import { CategorizationRuleSchema, type CreateCategorizationRuleSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useCategorizationRulesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const CREATE_CATEGORIZATION_RULE_TAG = '#create-categorization-rule'
 
@@ -30,9 +28,7 @@ const createCategorizationRule = post<CreateCategorizationRuleReturn, CreateCate
 )
 
 export function useCreateCategorizationRule() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
 
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules.ts
@@ -63,14 +63,13 @@ export function useListCategorizationRules({
   limit,
   showTotalCount = true,
 }: ListCategorizationRulesOptions = {}) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListCategorizationRulesReturn | null) => withLocale(keyLoader(
       previousPageData,
       {
         ...auth,
-        apiUrl,
         businessId,
         externalIds,
         includeArchived,

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules.ts
@@ -8,12 +8,9 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const LIST_CATEGORIZATION_RULES_TAG_KEY = '#list-categorization-rules'
 
@@ -66,10 +63,7 @@ export function useListCategorizationRules({
   limit,
   showTotalCount = true,
 }: ListCategorizationRulesOptions = {}) {
-  const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListCategorizationRulesReturn | null) => withLocale(keyLoader(

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule.ts
@@ -9,13 +9,11 @@ import {
 } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useCategorizationRulesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UPSERT_CATEGORIZATION_RULE_TAG = '#upsert-categorization-rule'
 
@@ -44,9 +42,7 @@ const updateCategorizationRule = patch<UpsertCategorizationRuleReturn, PatchCate
 )
 
 export function useUpsertCategorizationRule() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
   const { forceReload: forceReloadCategorizationRules, patchByKey: patchCategorizationRuleByKey } = useCategorizationRulesGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/counterparties/useListCounterparties.ts
+++ b/src/hooks/api/businesses/[business-id]/counterparties/useListCounterparties.ts
@@ -7,12 +7,9 @@ import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const LIST_COUNTERPARTIES_TAG_KEY = '#list-counterparties'
 
@@ -65,10 +62,7 @@ export function useListCounterparties({
   limit,
   showTotalCount = true,
 }: ListCounterpartiesOptions = {}) {
-  const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListCounterpartiesReturn | null) => withLocale(keyLoader(

--- a/src/hooks/api/businesses/[business-id]/counterparties/useListCounterparties.ts
+++ b/src/hooks/api/businesses/[business-id]/counterparties/useListCounterparties.ts
@@ -62,14 +62,13 @@ export function useListCounterparties({
   limit,
   showTotalCount = true,
 }: ListCounterpartiesOptions = {}) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListCounterpartiesReturn | null) => withLocale(keyLoader(
       previousPageData,
       {
         ...auth,
-        apiUrl,
         businessId,
         externalIds,
         q,

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/parse-csv/useCustomAccountParseCsv.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/parse-csv/useCustomAccountParseCsv.ts
@@ -6,10 +6,8 @@ import type { CustomAccountTransactionRow, RawCustomTransaction } from '@schemas
 import { type APIError } from '@utils/api/apiError'
 import { postWithFormData } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { CUSTOM_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 type CustomAccountParseCsvArgs = {
   file: File
@@ -96,9 +94,7 @@ const parseCsv = (baseUrl: string, accessToken: string, {
 }
 
 export function useCustomAccountParseCsv() {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   return useSWRMutation<
     CustomAccountParseCsvResponse,
@@ -108,7 +104,7 @@ export function useCustomAccountParseCsv() {
   >
       (
       () => withLocale(buildKey({
-        ...data,
+        ...auth,
         businessId,
       })),
       (

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/transactions/useCreateCustomAccountTransactions.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/transactions/useCreateCustomAccountTransactions.ts
@@ -6,10 +6,8 @@ import type { RawCustomTransaction } from '@schemas/customAccounts'
 import { type APIError } from '@utils/api/apiError'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { CUSTOM_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 type CreateCustomAccountTransactionsBody = {
   transactions: RawCustomTransaction[]
@@ -36,9 +34,7 @@ const createCustomAccountTransactions = post<
 const buildKey = createBuildKey<{ businessId: string }>([`${CUSTOM_ACCOUNTS_TAG_KEY}:create-transactions`])
 
 export function useCreateCustomAccountTransactions() {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   return useSWRMutation<
     CreateCustomAccountTransactionsResponse['data'],
@@ -46,7 +42,7 @@ export function useCreateCustomAccountTransactions() {
     () => ReturnType<typeof buildKey>,
     CreateCustomAccountTransactionsArgs>(
       () => withLocale(buildKey({
-        ...data,
+        ...auth,
         businessId,
       })),
       (

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/useCreateCustomAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/useCreateCustomAccount.ts
@@ -6,13 +6,11 @@ import useSWRMutation from 'swr/mutation'
 import { CustomAccountSchema, type RawCustomAccount } from '@schemas/customAccounts'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { BANK_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
 import { CUSTOM_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 type CreateCustomAccountBody = Pick<
   RawCustomAccount,
@@ -38,14 +36,12 @@ const createCustomAccount = post<
 const buildKey = createBuildKey<{ businessId: string }>([`${CUSTOM_ACCOUNTS_TAG_KEY}:create`])
 
 export function useCreateCustomAccount() {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     (

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts.ts
@@ -4,9 +4,7 @@ import useSWR from 'swr'
 import { CustomAccountSchema } from '@schemas/customAccounts'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const CUSTOM_ACCOUNTS_TAG_KEY = '#custom-accounts'
 
@@ -42,13 +40,11 @@ type useCustomAccountsParams = {
   userCreated?: boolean
 }
 export function useCustomAccounts({ userCreated }: useCustomAccountsParams = {}) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   return useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       userCreated,
     })),

--- a/src/hooks/api/businesses/[business-id]/customers/useListCustomers.ts
+++ b/src/hooks/api/businesses/[business-id]/customers/useListCustomers.ts
@@ -7,11 +7,9 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const ListCustomersRawResultSchema = PaginatedResponseSchema(CustomerSchema)
 type ListCustomersRawResult = typeof ListCustomersRawResultSchema.Type
@@ -58,15 +56,13 @@ type UseListCustomersParams = {
 }
 
 export function useListCustomers({ query, isEnabled = true }: UseListCustomersParams = {}) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListCustomersRawResult | null) => withLocale(keyLoader(
       previousPageData,
       {
-        ...data,
+        ...auth,
         businessId,
         query,
         isEnabled,

--- a/src/hooks/api/businesses/[business-id]/customers/useUpsertCustomer.tsx
+++ b/src/hooks/api/businesses/[business-id]/customers/useUpsertCustomer.tsx
@@ -5,13 +5,11 @@ import useSWRMutation from 'swr/mutation'
 import { CustomerSchema, type UpsertCustomerEncoded } from '@schemas/customer'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { CUSTOMERS_TAG_KEY, useCustomersGlobalCacheActions } from '@hooks/api/businesses/[business-id]/customers/useListCustomers'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UPSERT_CUSTOMER_TAG_KEY = '#upsert-customer'
 
@@ -106,16 +104,14 @@ type UseUpsertCustomerProps =
   | { mode: UpsertCustomerMode.Update, customerId: string }
 
 export const useUpsertCustomer = (props: UseUpsertCustomerProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const { mode } = props
   const customerId = mode === UpsertCustomerMode.Update ? props.customerId : undefined
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       customerId,
     })),

--- a/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm.ts
+++ b/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm.ts
@@ -4,11 +4,9 @@ import useSWRMutation from 'swr/mutation'
 import type { OneOf } from '@internal-types/utility/oneOf'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const CONFIRM_EXTERNAL_ACCOUNT_TAG_KEY = '#confirm-external-account'
 
@@ -34,9 +32,7 @@ type ConfirmExternalAccountArg = {
 const buildKey = createBuildKey<{ businessId: string }>([CONFIRM_EXTERNAL_ACCOUNT_TAG_KEY])
 
 export function useConfirmExternalAccount() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude.ts
+++ b/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude.ts
@@ -4,11 +4,9 @@ import useSWRMutation from 'swr/mutation'
 import type { OneOf } from '@internal-types/utility/oneOf'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const EXCLUDE_EXTERNAL_ACCOUNT_TAG_KEY = '#exclude-external-account'
 
@@ -34,9 +32,7 @@ type ExcludeExternalAccountArg = {
 const buildKey = createBuildKey<{ businessId: string }>([EXCLUDE_EXTERNAL_ACCOUNT_TAG_KEY])
 
 export function useExcludeExternalAccount() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/external-accounts/update-connection-status.ts
+++ b/src/hooks/api/businesses/[business-id]/external-accounts/update-connection-status.ts
@@ -3,11 +3,9 @@ import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UPDATE_CONNECTION_STATUS_TAG_KEY = '#update-connection-status'
 
@@ -23,9 +21,7 @@ const updateConnectionStatus = post<
 const buildKey = createBuildKey<{ businessId: string }>([UPDATE_CONNECTION_STATUS_TAG_KEY])
 
 export function useUpdateConnectionStatus() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/finalize-invoice/useFinalizeInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/finalize-invoice/useFinalizeInvoice.tsx
@@ -7,15 +7,13 @@ import { InvoiceSchema } from '@schemas/invoices/invoice'
 import { InvoicePaymentMethodsSchema } from '@schemas/invoices/invoicePaymentMethod'
 import { put } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { INVOICE_PAYMENT_METHODS_TAG_KEY } from '@hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment-methods/useInvoicePaymentMethods'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const FINALIZE_INVOICE_TAG_KEY = '#finalize-invoice'
 
@@ -55,14 +53,12 @@ type UseFinalizeInvoiceProps = {
 }
 
 export function useFinalizeInvoice({ invoiceId }: UseFinalizeInvoiceProps) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       invoiceId,
     })),

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/html/useInvoicePreview.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/html/useInvoicePreview.tsx
@@ -2,10 +2,8 @@ import useSWR from 'swr'
 
 import { getText } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const INVOICE_PREVIEW_TAG_KEY = '#invoices-preview'
 
@@ -19,13 +17,11 @@ type UseInvoicePreviewProps = {
   invoiceId: string
 }
 export function useInvoicePreview({ invoiceId }: UseInvoicePreviewProps) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       invoiceId,
     })),

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment-methods/useInvoicePaymentMethods.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment-methods/useInvoicePaymentMethods.tsx
@@ -7,10 +7,8 @@ import {
 } from '@schemas/invoices/invoicePaymentMethod'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const INVOICE_PAYMENT_METHODS_TAG_KEY = '#invoice-payment-methods'
 
@@ -30,13 +28,11 @@ export function useInvoicePaymentMethods({
   invoiceId,
   isEnabled = true,
 }: UseInvoicePaymentMethodsProps) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       invoiceId,
       isEnabled: isEnabled && Boolean(invoiceId),

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment/useUpsertDedicatedInvoicePayment.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment/useUpsertDedicatedInvoicePayment.tsx
@@ -6,13 +6,11 @@ import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { type InvoicePayment, InvoicePaymentSchema, type UpsertDedicatedInvoicePaymentSchema } from '@schemas/invoices/invoicePayment'
 import { post, put } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UPSERT_INVOICE_PAYMENT_TAG_KEY = '#upsert-dedicated-invoice-payment'
 
@@ -116,9 +114,7 @@ type UseUpsertDedicatedInvoicePaymentProps =
   | { mode: UpsertDedicatedInvoicePaymentMode.Update, invoiceId: string, invoicePaymentId: string }
 
 export const useUpsertDedicatedInvoicePayment = (props: UseUpsertDedicatedInvoicePaymentProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const { mode, invoiceId } = props
   const invoicePaymentId = mode === UpsertDedicatedInvoicePaymentMode.Update ? props.invoicePaymentId : undefined
@@ -131,7 +127,7 @@ export const useUpsertDedicatedInvoicePayment = (props: UseUpsertDedicatedInvoic
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       invoiceId,
       invoicePaymentId,

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/pdf/useInvoicePdfDownload.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/pdf/useInvoicePdfDownload.tsx
@@ -6,11 +6,9 @@ import type { Awaitable } from '@internal-types/utility/promises'
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const getInvoicePdf = get<
   { data: S3PresignedUrlSchemaType },
@@ -38,13 +36,11 @@ export function useInvoicePdfDownload({
   onSuccess,
   onError,
 }: UseInvoicePdfDownloadProps) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       invoiceId,
     })),

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/refund/useRefundInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/refund/useRefundInvoice.tsx
@@ -6,13 +6,11 @@ import { type CreateCustomerRefundSchema, CustomerRefundSchema } from '@schemas/
 import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const REFUND_INVOICE_TAG_KEY = '#refund-invoice'
 
@@ -38,9 +36,7 @@ export const updateInvoiceWithRefund = (invoice: Invoice): Invoice => {
 
 type UseRefundInvoiceProps = { invoiceId: string }
 export const useRefundInvoice = ({ invoiceId }: UseRefundInvoiceProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const applyRefundToInvoice = useCallback(() =>
     (invoice: Invoice) => {
@@ -50,7 +46,7 @@ export const useRefundInvoice = ({ invoiceId }: UseRefundInvoiceProps) => {
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       invoiceId,
     })),

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/reset/useResetInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/reset/useResetInvoice.tsx
@@ -5,13 +5,11 @@ import useSWRMutation from 'swr/mutation'
 import { InvoiceSchema } from '@schemas/invoices/invoice'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const RESET_INVOICE_TAG_KEY = '#reset-invoice'
 
@@ -32,13 +30,11 @@ const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([RESE
 type UseResetInvoiceProps = { invoiceId: string }
 
 export const useResetInvoice = ({ invoiceId }: UseResetInvoiceProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       invoiceId,
     })),

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/void/useVoidInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/void/useVoidInvoice.tsx
@@ -5,13 +5,11 @@ import useSWRMutation from 'swr/mutation'
 import { InvoiceSchema } from '@schemas/invoices/invoice'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const VOID_INVOICE_TAG_KEY = '#void-invoice'
 
@@ -32,13 +30,11 @@ const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([VOID
 type UseVoidInvoiceProps = { invoiceId: string }
 
 export const useVoidInvoice = ({ invoiceId }: UseVoidInvoiceProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       invoiceId,
     })),

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/write-off/useWriteoffInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/write-off/useWriteoffInvoice.tsx
@@ -6,13 +6,11 @@ import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { type CreateInvoiceWriteoff, CreateInvoiceWriteoffSchema, InvoiceWriteoffSchema } from '@schemas/invoices/invoiceWriteoff'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const CREATE_INVOICE_WRITEOFF_TAG_KEY = '#writeoff-invoice'
 
@@ -38,9 +36,7 @@ export const updateInvoiceWithWriteoff = (invoice: Invoice): Invoice => {
 
 type UseWriteoffInvoiceProps = { invoiceId: string }
 export const useWriteoffInvoice = ({ invoiceId }: UseWriteoffInvoiceProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const applyWriteoffToInvoice = useCallback(() =>
     (invoice: Invoice) => {
@@ -50,7 +46,7 @@ export const useWriteoffInvoice = ({ invoiceId }: UseWriteoffInvoiceProps) => {
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       invoiceId,
     })),

--- a/src/hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats.tsx
@@ -5,10 +5,8 @@ import { type InvoiceSummaryStatsResponse, InvoiceSummaryStatsResponseSchema } f
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const INVOICE_SUMMARY_STATS_TAG_KEY = '#invoices-summary-stats'
 
@@ -20,13 +18,11 @@ const getInvoiceSummaryStats = get<
 >(({ businessId }) => `/v1/businesses/${businessId}/invoices/summary-stats`)
 
 export function useInvoiceSummaryStats() {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     ({ accessToken, apiUrl, businessId }) => getInvoiceSummaryStats(

--- a/src/hooks/api/businesses/[business-id]/invoices/useListInvoices.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/useListInvoices.tsx
@@ -75,14 +75,13 @@ export function useListInvoices({
   limit,
   showTotalCount = true,
 }: ListInvoicesOptions = {}) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListInvoicesReturn | null) => withLocale(keyLoader(
       previousPageData,
       {
         ...auth,
-        apiUrl,
         businessId,
         showSalesReceipts,
         status,

--- a/src/hooks/api/businesses/[business-id]/invoices/useListInvoices.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/useListInvoices.tsx
@@ -8,12 +8,9 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const LIST_INVOICES_TAG_KEY = '#list-invoices'
 
@@ -78,10 +75,7 @@ export function useListInvoices({
   limit,
   showTotalCount = true,
 }: ListInvoicesOptions = {}) {
-  const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListInvoicesReturn | null) => withLocale(keyLoader(

--- a/src/hooks/api/businesses/[business-id]/invoices/useUpsertInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/useUpsertInvoice.tsx
@@ -5,13 +5,11 @@ import useSWRMutation from 'swr/mutation'
 import { InvoiceSchema, type UpsertInvoiceSchema } from '@schemas/invoices/invoice'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UPSERT_INVOICE_TAG_KEY = '#upsert-invoice'
 
@@ -106,16 +104,14 @@ type UseUpsertInvoiceProps =
   | { mode: UpsertInvoiceMode.Update, invoiceId: string }
 
 export const useUpsertInvoice = (props: UseUpsertInvoiceProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const { mode } = props
   const invoiceId = mode === UpsertInvoiceMode.Update ? props.invoiceId : undefined
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       invoiceId,
     })),

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/lines/useListLedgerAccountLines.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/lines/useListLedgerAccountLines.ts
@@ -6,12 +6,9 @@ import { LedgerAccountLineItemSchema } from '@schemas/generalLedger/ledgerEntry'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const LIST_LEDGER_ACCOUNT_LINES_TAG_KEY = '#list-ledger-account-lines'
 
@@ -92,10 +89,7 @@ export function useListLedgerAccountLines({
   limit,
   show_total_count,
 }: UseListLedgerAccountLinesOptions) {
-  const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListLedgerAccountLinesReturn | null) => withLocale(keyLoader(

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/lines/useListLedgerAccountLines.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/lines/useListLedgerAccountLines.ts
@@ -89,14 +89,13 @@ export function useListLedgerAccountLines({
   limit,
   show_total_count,
 }: UseListLedgerAccountLinesOptions) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListLedgerAccountLinesReturn | null) => withLocale(keyLoader(
       previousPageData,
       {
         ...auth,
-        apiUrl,
         businessId,
         accountId,
         include_entries_before_activation,

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/useDeleteLedgerAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/useDeleteLedgerAccount.ts
@@ -3,12 +3,10 @@ import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useLedgerBalancesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances'
 import { useLedgerEntriesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const deleteAccountFromLedger = del<
   Record<string, never>,
@@ -18,13 +16,11 @@ const deleteAccountFromLedger = del<
 const buildKey = createBuildKey<{ businessId: string }>(['#delete-account-from-ledger'])
 
 export function useDeleteAccountFromLedger() {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     (

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/useUpsertLedgerAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/useUpsertLedgerAccount.ts
@@ -6,13 +6,11 @@ import { SingleChartAccountSchema } from '@schemas/generalLedger/ledgerAccount'
 import { type UpsertLedgerAccountSchema } from '@schemas/generalLedger/upsertLedgerAccount'
 import { post, put } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useLedgerBalancesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances'
 import { useLedgerEntriesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UPSERT_LEDGER_ACCOUNT_TAG_KEY = '#upsert-ledger-account'
 
@@ -48,16 +46,14 @@ type UseUpsertLedgerAccountProps =
   | { mode: UpsertLedgerAccountMode.Update, accountId: string }
 
 export const useUpsertLedgerAccount = (props: UseUpsertLedgerAccountProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const { mode } = props
   const accountId = mode === UpsertLedgerAccountMode.Update ? props.accountId : undefined
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       accountId,
     })),

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
@@ -4,9 +4,7 @@ import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const getLedgerAccountBalancesCSV = get<{ data: S3PresignedUrl }>(
   ({ businessId }) => `/v1/businesses/${businessId}/ledger/balances/exports/csv`,
@@ -25,9 +23,7 @@ export function useAccountBalancesDownload({
   endCutoff,
   onSuccess,
 }: UseAccountBalancesDownloadOptions) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   return useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances.tsx
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances.tsx
@@ -6,10 +6,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const LEDGER_BALANCES_TAG_KEY = '#ledger-balances'
 
@@ -30,12 +28,10 @@ const getLedgerAccountBalances = get<{ data: LedgerBalancesSchemaType }, GetLedg
 const buildKey = createBuildKey<{ businessId: string, startDate?: Date, endDate?: Date }>([LEDGER_BALANCES_TAG_KEY])
 
 export function useLedgerBalances(withDates?: boolean, startDate?: Date, endDate?: Date) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       startDate: withDates ? startDate : undefined,
       endDate: withDates ? endDate : undefined,

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/reverse/useReverseJournalEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/reverse/useReverseJournalEntry.ts
@@ -3,14 +3,12 @@ import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useLedgerEntriesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries'
 import { useBalanceSheetGlobalCacheActions } from '@hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet'
 import { useStatementOfCashFlowGlobalCacheActions } from '@hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const REVERSE_JOURNAL_ENTRY_TAG_KEY = '#reverse-journal-entry'
 
@@ -22,9 +20,7 @@ const reverseJournalEntry = post<Record<never, never>>(
 const buildKey = createBuildKey<{ businessId: string }>([REVERSE_JOURNAL_ENTRY_TAG_KEY])
 
 export const useReverseJournalEntry = () => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const { forceReload: forceReloadLedgerEntries } = useLedgerEntriesCacheActions()
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
@@ -33,7 +29,7 @@ export const useReverseJournalEntry = () => {
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     (

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/useLedgerAccountsEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/useLedgerAccountsEntry.ts
@@ -4,11 +4,8 @@ import useSWR from 'swr'
 import { LedgerEntrySchema } from '@schemas/generalLedger/ledgerEntry'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const LEDGER_ACCOUNTS_ENTRY_TAG_KEY = '#ledger-accounts-entry'
 
@@ -22,10 +19,7 @@ const getLedgerAccountsEntry = get<typeof LedgerAccountsEntryResponseSchema.Enco
 const buildKey = createBuildKey<{ businessId: string, entryId?: string }>([LEDGER_ACCOUNTS_ENTRY_TAG_KEY])
 
 export function useLedgerAccountsEntry({ entryId }: { entryId?: string }) {
-  const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(() =>
     withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/useLedgerAccountsEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/useLedgerAccountsEntry.ts
@@ -19,12 +19,11 @@ const getLedgerAccountsEntry = get<typeof LedgerAccountsEntryResponseSchema.Enco
 const buildKey = createBuildKey<{ businessId: string, entryId?: string }>([LEDGER_ACCOUNTS_ENTRY_TAG_KEY])
 
 export function useLedgerAccountsEntry({ entryId }: { entryId?: string }) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(() =>
     withLocale(buildKey({
       ...auth,
-      apiUrl,
       businessId,
       entryId,
       isEnabled: Boolean(entryId),

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
@@ -5,9 +5,7 @@ import type { Awaitable } from '@internal-types/utility/promises'
 import { type APIError } from '@utils/api/apiError'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const getJournalEntriesCSV = get<{ data: S3PresignedUrl }>(
   ({ businessId }) => `/v1/businesses/${businessId}/ledger/entries/exports/csv`,
@@ -34,9 +32,7 @@ export function useJournalEntriesDownload({
   endCutoff,
   onSuccess,
 }: UseJournalEntriesDownloadOptions) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   return useSWRMutation<
     unknown,

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries.ts
@@ -8,12 +8,9 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const LIST_LEDGER_ENTRIES_TAG_KEY = '#list-ledger-entries'
 
@@ -69,10 +66,7 @@ export function useListLedgerEntries({
   limit,
   showTotalCount,
 }: UseListLedgerEntriesOptions = {}) {
-  const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListLedgerEntriesReturn | null) => withLocale(keyLoader(

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries.ts
@@ -66,14 +66,13 @@ export function useListLedgerEntries({
   limit,
   showTotalCount,
 }: UseListLedgerEntriesOptions = {}) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListLedgerEntriesReturn | null) => withLocale(keyLoader(
       previousPageData,
       {
         ...auth,
-        apiUrl,
         businessId,
         sortBy,
         sortOrder,

--- a/src/hooks/api/businesses/[business-id]/ledger/journal-entries/useUpsertJournalEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/journal-entries/useUpsertJournalEntry.ts
@@ -4,13 +4,11 @@ import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useLedgerEntriesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries'
 import { useBalanceSheetGlobalCacheActions } from '@hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet'
 import { useStatementOfCashFlowGlobalCacheActions } from '@hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { type JournalEntryReturn, JournalEntryReturnSchema, type UpsertJournalEntrySchema } from '@components/Journal/JournalEntryForm/journalEntryFormSchemas'
 
 const UPSERT_JOURNAL_ENTRY_TAG_KEY = '#upsert-journal-entry'
@@ -37,9 +35,7 @@ type UseUpsertJournalEntryProps =
   | { mode: UpsertJournalEntryMode.Update, journalEntryId: string }
 
 export const useUpsertJournalEntry = (props: UseUpsertJournalEntryProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const { mode } = props
   // For now, we only support create mode since the API doesn't have an update endpoint
@@ -55,7 +51,7 @@ export const useUpsertJournalEntry = (props: UseUpsertJournalEntryProps) => {
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     (

--- a/src/hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary.tsx
@@ -5,10 +5,8 @@ import { type MileageSummary, MileageSummarySchema } from '@schemas/mileage'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const MILEAGE_SUMMARY_TAG_KEY = '#mileage-summary'
 
@@ -20,13 +18,11 @@ const getMileageSummary = get<
 >(({ businessId }) => `/v1/businesses/${businessId}/mileage/summary`)
 
 export function useMileageSummary() {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     ({ accessToken, apiUrl, businessId }) => getMileageSummary(

--- a/src/hooks/api/businesses/[business-id]/mileage/trips/[trip-id]/useDeleteTrip.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/trips/[trip-id]/useDeleteTrip.tsx
@@ -3,14 +3,12 @@ import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useMileageSummaryGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary'
 import { useTripsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/trips/useListTrips'
 import { useVehiclesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const DELETE_TRIP_TAG_KEY = '#delete-trip'
 
@@ -26,13 +24,11 @@ type UseDeleteTripProps = {
 }
 
 export const useDeleteTrip = ({ tripId }: UseDeleteTripProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       tripId,
     })),

--- a/src/hooks/api/businesses/[business-id]/mileage/trips/useListTrips.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/trips/useListTrips.tsx
@@ -7,11 +7,9 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const LIST_TRIPS_TAG_KEY = '#list-trips'
 
@@ -47,15 +45,13 @@ const listTrips = get<
 })
 
 export function useListTrips(filterParams: ListTripsFilterParams = {}) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListTripsResponse | null) => withLocale(keyLoader(
       previousPageData,
       {
-        ...data,
+        ...auth,
         businessId,
         ...filterParams,
       },

--- a/src/hooks/api/businesses/[business-id]/mileage/trips/useUpsertTrip.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/trips/useUpsertTrip.tsx
@@ -5,14 +5,12 @@ import useSWRMutation from 'swr/mutation'
 import { TripSchema, type UpsertTripEncoded } from '@schemas/trip'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useMileageSummaryGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary'
 import { useTripsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/trips/useListTrips'
 import { useVehiclesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UPSERT_TRIP_TAG_KEY = '#upsert-trip'
 
@@ -107,16 +105,14 @@ type UseUpsertTripProps =
   | { mode: UpsertTripMode.Update, tripId: string }
 
 export const useUpsertTrip = (props: UseUpsertTripProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const { mode } = props
   const tripId = mode === UpsertTripMode.Update ? props.tripId : undefined
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       tripId,
     })),

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/reactivate/useReactivateVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/reactivate/useReactivateVehicle.tsx
@@ -5,12 +5,10 @@ import useSWRMutation from 'swr/mutation'
 import { VehicleSchema } from '@schemas/vehicle'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useVehiclesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const REACTIVATE_VEHICLE_TAG_KEY = '#reactivate-vehicle'
 
@@ -33,13 +31,11 @@ type UseReactivateVehicleProps = {
 }
 
 export const useReactivateVehicle = ({ vehicleId }: UseReactivateVehicleProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       vehicleId,
     })),

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useArchiveVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useArchiveVehicle.tsx
@@ -5,12 +5,10 @@ import useSWRMutation from 'swr/mutation'
 import { VehicleSchema } from '@schemas/vehicle'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useVehiclesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const ARCHIVE_VEHICLE_TAG_KEY = '#archive-vehicle'
 
@@ -33,13 +31,11 @@ type UseArchiveVehicleProps = {
 }
 
 export const useArchiveVehicle = ({ vehicleId }: UseArchiveVehicleProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       vehicleId,
     })),

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useDeleteVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useDeleteVehicle.tsx
@@ -3,12 +3,10 @@ import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useVehiclesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const DELETE_VEHICLE_TAG_KEY = '#delete-vehicle'
 
@@ -24,13 +22,11 @@ type UseDeleteVehicleProps = {
 }
 
 export const useDeleteVehicle = ({ vehicleId }: UseDeleteVehicleProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       vehicleId,
     })),

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
@@ -6,10 +6,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 type ListVehiclesParams = {
   businessId: string
@@ -43,13 +41,11 @@ class ListVehiclesSWRResponse extends SWRQueryResult<ListVehiclesResponse> {
 }
 
 export function useListVehicles({ allowArchived }: { allowArchived?: boolean } = {}) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       allowArchived,
     })),

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/useUpsertVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/useUpsertVehicle.tsx
@@ -5,13 +5,11 @@ import useSWRMutation from 'swr/mutation'
 import { type UpsertVehicleEncoded, VehicleSchema } from '@schemas/vehicle'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTripsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/trips/useListTrips'
 import { useVehiclesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UPSERT_VEHICLE_TAG_KEY = '#upsert-vehicle'
 
@@ -106,16 +104,14 @@ type UseUpsertVehicleProps =
   | { mode: UpsertVehicleMode.Update, vehicleId: string }
 
 export const useUpsertVehicle = (props: UseUpsertVehicleProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const { mode } = props
   const vehicleId = mode === UpsertVehicleMode.Update ? props.vehicleId : undefined
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       vehicleId,
     })),

--- a/src/hooks/api/businesses/[business-id]/plaid/hosted-link.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/hosted-link.ts
@@ -27,10 +27,10 @@ export function usePlaidHostedLinkStatus(
   config?: SWRConfiguration<ApiPlaidHostedLinkStatus>,
   enabled = false,
 ) {
-  const { businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
-    () => buildKey({ ...auth, apiUrl, businessId, isEnabled: enabled }),
+    () => buildKey({ ...auth, businessId, isEnabled: enabled }),
     ({ accessToken, apiUrl, businessId }) =>
       getPlaidHostedLinkStatus(apiUrl, accessToken, { params: { businessId } })()
         .then(Schema.decodeUnknownPromise(PlaidHostedLinkStatusResponseSchema))

--- a/src/hooks/api/businesses/[business-id]/plaid/hosted-link.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/hosted-link.ts
@@ -8,9 +8,7 @@ import {
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const PLAID_HOSTED_LINK_TAG_KEY = '#plaid-hosted-link'
 
@@ -29,9 +27,7 @@ export function usePlaidHostedLinkStatus(
   config?: SWRConfiguration<ApiPlaidHostedLinkStatus>,
   enabled = false,
 ) {
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => buildKey({ ...auth, apiUrl, businessId, isEnabled: enabled }),

--- a/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/sandbox-reset-item-login.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/sandbox-reset-item-login.ts
@@ -3,11 +3,9 @@ import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const BREAK_PLAID_ITEM_CONNECTION_TAG_KEY = '#break-plaid-item-connection'
 
@@ -27,9 +25,7 @@ const breakPlaidItemConnection = post<
 const buildKey = createBuildKey<{ businessId: string }>([BREAK_PLAID_ITEM_CONNECTION_TAG_KEY])
 
 export function useBreakPlaidItemConnection() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/unlink.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/unlink.ts
@@ -2,10 +2,8 @@ import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UNLINK_PLAID_ITEM_TAG_KEY = '#unlink-plaid-item'
 
@@ -21,9 +19,7 @@ const unlinkPlaidItem = post<
 const buildKey = createBuildKey<{ businessId: string }>([UNLINK_PLAID_ITEM_TAG_KEY])
 
 export function useUnlinkPlaidItem() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/plaid/link/exchange.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/link/exchange.ts
@@ -3,10 +3,8 @@ import useSWRMutation from 'swr/mutation'
 import type { PublicToken } from '@internal-types/linkedAccounts'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const EXCHANGE_PLAID_PUBLIC_TOKEN_TAG_KEY = '#exchange-plaid-public-token'
 
@@ -19,9 +17,7 @@ const exchangePlaidPublicToken = post<
 const buildKey = createBuildKey<{ businessId: string }>([EXCHANGE_PLAID_PUBLIC_TOKEN_TAG_KEY])
 
 export function useExchangePlaidPublicToken() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/plaid/link/index.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/link/index.ts
@@ -10,11 +10,9 @@ import {
 } from '@schemas/linkedAccounts/plaid'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const CREATE_PLAID_LINK_TAG_KEY = '#create-plaid-link'
 
@@ -32,9 +30,7 @@ const createPlaidLink = post<
 const buildKey = createBuildKey<{ businessId: string }>([CREATE_PLAID_LINK_TAG_KEY])
 
 export function useCreatePlaidLink() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/plaid/update-mode-link.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/update-mode-link.ts
@@ -5,11 +5,9 @@ import useSWRMutation from 'swr/mutation'
 import { ApiLinkTokenSchema } from '@schemas/linkedAccounts/plaid'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const CREATE_PLAID_UPDATE_MODE_LINK_TAG_KEY = '#create-plaid-update-mode-link'
 
@@ -31,9 +29,7 @@ const createPlaidUpdateModeLink = post<
 const buildKey = createBuildKey<{ businessId: string }>([CREATE_PLAID_UPDATE_MODE_LINK_TAG_KEY])
 
 export function useCreatePlaidUpdateModeLink() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/reports/balance-sheet/exports/excel/useBalanceSheetDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/balance-sheet/exports/excel/useBalanceSheetDownload.ts
@@ -5,10 +5,8 @@ import type { Awaitable } from '@internal-types/utility/promises'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import type { GetBalanceSheetParams } from '@hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const getBalanceSheetExcel = get<
   { data: S3PresignedUrl },
@@ -34,9 +32,7 @@ export function useBalanceSheetDownload({
   effectiveDate,
   onSuccess,
 }: UseBalanceSheetOptions) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   return useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet.ts
@@ -6,11 +6,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export type GetBalanceSheetParams = {
   businessId: string
@@ -37,10 +34,7 @@ export function useBalanceSheet({
 }: {
   effectiveDate?: Date
 }) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { apiUrl } = useEnvironment()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet.ts
@@ -34,12 +34,11 @@ export function useBalanceSheet({
 }: {
   effectiveDate?: Date
 }) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
       ...auth,
-      apiUrl,
       businessId,
       effectiveDate,
     })),

--- a/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/exports/csv/useCashflowStatementDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/exports/csv/useCashflowStatementDownload.ts
@@ -5,10 +5,8 @@ import type { Awaitable } from '@internal-types/utility/promises'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import type { GetStatementOfCashFlowParams } from '@hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const getCashflowStatementCSV = get<
   { data: S3PresignedUrl },
@@ -36,9 +34,7 @@ export function useCashflowStatementDownload({
   endDate,
   onSuccess,
 }: UseCashflowStatementDownloadOptions) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   return useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow.tsx
@@ -37,12 +37,11 @@ export function useStatementOfCashFlow({
   startDate?: Date
   endDate?: Date
 }) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     withLocale(buildKey({
       ...auth,
-      apiUrl,
       businessId,
       startDate,
       endDate,

--- a/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow.tsx
@@ -6,11 +6,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export type GetStatementOfCashFlowParams = {
   businessId: string
@@ -40,10 +37,7 @@ export function useStatementOfCashFlow({
   startDate?: Date
   endDate?: Date
 }) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { apiUrl } = useEnvironment()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
@@ -4,10 +4,8 @@ import useSWR from 'swr'
 import { type ReportConfigResponse, ReportConfigResponseSchema } from '@schemas/reports/reportConfig'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const REPORT_CONFIG_TAG_KEY = '#report-config'
 
@@ -22,9 +20,7 @@ const getReportConfig = get<ReportConfigResponse, GetReportConfigParams>(
 const buildKey = createBuildKey<{ businessId: string }>([REPORT_CONFIG_TAG_KEY])
 
 export function useReportConfig() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
@@ -5,11 +5,8 @@ import { type ProfitAndLossComparison, type ProfitAndLossComparisonRequestBody }
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const PNL_COMPARISON_REPORT_TAG_KEY = '#profit-and-loss-comparison-report'
 
@@ -37,14 +34,11 @@ export function useProfitAndLossComparisonReport({
   tagFilters,
   reportingBasis,
 }: UseProfitAndLossComparisonReportProps) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       apiUrl,
       businessId,
       periods,

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
@@ -34,12 +34,11 @@ export function useProfitAndLossComparisonReport({
   tagFilters,
   reportingBasis,
 }: UseProfitAndLossComparisonReportProps) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
       ...auth,
-      apiUrl,
       businessId,
       periods,
       tagFilters,

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-summaries/useProfitAndLossSummaries.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-summaries/useProfitAndLossSummaries.tsx
@@ -6,10 +6,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const PNL_SUMMARIES_TAG_KEY = '#profit-and-loss-summaries'
 
@@ -46,13 +44,11 @@ export function useProfitAndLossSummaries({
   reportingBasis,
   keepPreviousData,
 }: UseProfitAndLossSummariesProps) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       startYear,
       startMonth,

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
@@ -5,11 +5,8 @@ import type { Awaitable } from '@internal-types/utility/promises'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { type GetProfitAndLossDetailLinesParams, type PnlDetailLinesBaseParams, type PnlDetailLinesFilterParams } from '@hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const getProfitAndLossDetailLinesExcel = (apiUrl: string, accessToken: string | undefined, params: GetProfitAndLossDetailLinesParams) => {
   const { businessId, startDate, endDate, pnlStructureLineItemName, tagKey, tagValues, reportingBasis, pnlStructure } = params
@@ -46,10 +43,7 @@ export function useProfitAndLossDetailLinesExport({
   pnlStructure,
   onSuccess,
 }: UseProfitAndLossDetailLinesExportOptions) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   return useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
@@ -43,12 +43,11 @@ export function useProfitAndLossDetailLinesExport({
   pnlStructure,
   onSuccess,
 }: UseProfitAndLossDetailLinesExportOptions) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   return useSWRMutation(
     () => withLocale(buildKey({
       ...auth,
-      apiUrl,
       businessId,
       startDate,
       endDate,

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
@@ -7,11 +7,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const LIST_PNL_DETAIL_LINES_TAG_KEY = '#list-pnl-detail-lines'
 
@@ -48,10 +45,7 @@ export function useProfitAndLossDetailLines({
   reportingBasis,
   pnlStructure,
 }: PnlDetailLinesBaseParams & PnlDetailLinesFilterParams) {
-  const withLocale = useLocalizedKey()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => withLocale(keyLoader({

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
@@ -45,12 +45,11 @@ export function useProfitAndLossDetailLines({
   reportingBasis,
   pnlStructure,
 }: PnlDetailLinesBaseParams & PnlDetailLinesFilterParams) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => withLocale(keyLoader({
       ...auth,
-      apiUrl,
       businessId,
       startDate,
       endDate,

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/useProfitAndLossReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/useProfitAndLossReport.tsx
@@ -6,10 +6,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const PNL_REPORT_TAG_KEY = '#profit-and-loss-report'
 
@@ -34,13 +32,11 @@ const getProfitAndLoss = get<
 
 type UseProfitAndLossReportProps = Omit<ProfitAndLossReportRequestParams, 'businessId'>
 export function useProfitAndLossReport({ startDate, endDate, tagKey, tagValues, reportingBasis, includeUncategorized }: UseProfitAndLossReportProps) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       startDate,
       endDate,

--- a/src/hooks/api/businesses/[business-id]/reports/transactions/exports/excel/useBankTransactionsDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/transactions/exports/excel/useBankTransactionsDownload.ts
@@ -5,10 +5,8 @@ import { type APIError } from '@utils/api/apiError'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import type { UseBankTransactionsOptions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 type GetBankTransactionsExportParams = {
   businessId: string
@@ -53,9 +51,7 @@ const buildKey = createBuildKey<{ businessId: string }>(['#bank-transactions-dow
 type UseBankTransactionsDownloadOptions = UseBankTransactionsOptions
 
 export function useBankTransactionsDownload() {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   return useSWRMutation<
     S3PresignedUrl,
@@ -63,7 +59,7 @@ export function useBankTransactionsDownload() {
     () => ReturnType<typeof buildKey>,
     UseBankTransactionsDownloadOptions>(
       () => withLocale(buildKey({
-        ...data,
+        ...auth,
         businessId,
       })),
       (

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
@@ -5,16 +5,13 @@ import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/co
 import { get } from '@utils/api/authenticatedHttp'
 import { type QueryParams, toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import {
   type UnifiedReportControlParams,
   type UnifiedReportParams,
   useUnifiedReportParams,
 } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 type GetUnifiedReportExcelParams = {
   businessId: string
@@ -41,10 +38,7 @@ type UseUnifiedReportExcelOptions = {
 }
 
 export function useUnifiedReportExcel({ onSuccess }: UseUnifiedReportExcelOptions = {}) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { apiUrl } = useEnvironment()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
   const params = useUnifiedReportParams()
 
   const buildKey = createBuildKey<{ businessId: string } & UnifiedReportParams>(

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
@@ -38,7 +38,7 @@ type UseUnifiedReportExcelOptions = {
 }
 
 export function useUnifiedReportExcel({ onSuccess }: UseUnifiedReportExcelOptions = {}) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const params = useUnifiedReportParams()
 
   const buildKey = createBuildKey<{ businessId: string } & UnifiedReportParams>(
@@ -47,7 +47,7 @@ export function useUnifiedReportExcel({ onSuccess }: UseUnifiedReportExcelOption
 
   const rawMutationResponse = useSWRMutation(
     () => params
-      ? withLocale(buildKey({ ...auth, apiUrl, businessId, ...params }))
+      ? withLocale(buildKey({ ...auth, businessId, ...params }))
       : null,
     ({ accessToken, apiUrl, businessId, tags, ...restParams }) =>
       getUnifiedReportExcel(apiUrl, accessToken, {

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
@@ -21,7 +21,7 @@ const getUnifiedReport = get<
 })
 
 export function useUnifiedReport() {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const params = useUnifiedReportParams()
 
   const buildKey = createBuildKey<{ businessId: string } & UnifiedReportParams>(
@@ -30,7 +30,7 @@ export function useUnifiedReport() {
 
   const swrResponse = useSWR(
     () => params
-      ? withLocale(buildKey({ ...auth, apiUrl, businessId, ...params }))
+      ? withLocale(buildKey({ ...auth, businessId, ...params }))
       : null,
     ({ accessToken, apiUrl, businessId, tags, ...restParams }) => getUnifiedReport(apiUrl, accessToken, {
       params: { businessId, ...restParams },

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
@@ -5,12 +5,9 @@ import { UnifiedReportSchema } from '@schemas/reports/unifiedReport'
 import { get } from '@utils/api/authenticatedHttp'
 import { type QueryParams, toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { type UnifiedReportControlParams, type UnifiedReportParams, useUnifiedReportParams } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const getTag = (report: string) => `#unified-${report}-report`
 
@@ -24,10 +21,7 @@ const getUnifiedReport = get<
 })
 
 export function useUnifiedReport() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { apiUrl } = useEnvironment()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
   const params = useUnifiedReportParams()
 
   const buildKey = createBuildKey<{ businessId: string } & UnifiedReportParams>(

--- a/src/hooks/api/businesses/[business-id]/stripe/connect-account-link/useStripeConnectAccountLink.tsx
+++ b/src/hooks/api/businesses/[business-id]/stripe/connect-account-link/useStripeConnectAccountLink.tsx
@@ -3,11 +3,8 @@ import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const STRIPE_CONNECT_ACCOUNT_LINK_TAG_KEY = '#stripe-connect-account-link'
 
@@ -41,14 +38,11 @@ const createStripeConnectAccountLink = post<
 const buildKey = createBuildKey<{ businessId: string }>([STRIPE_CONNECT_ACCOUNT_LINK_TAG_KEY])
 
 export function useStripeConnectAccountLink() {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       apiUrl,
       businessId,
     })),

--- a/src/hooks/api/businesses/[business-id]/stripe/connect-account-link/useStripeConnectAccountLink.tsx
+++ b/src/hooks/api/businesses/[business-id]/stripe/connect-account-link/useStripeConnectAccountLink.tsx
@@ -38,12 +38,11 @@ const createStripeConnectAccountLink = post<
 const buildKey = createBuildKey<{ businessId: string }>([STRIPE_CONNECT_ACCOUNT_LINK_TAG_KEY])
 
 export function useStripeConnectAccountLink() {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
       ...auth,
-      apiUrl,
       businessId,
     })),
     ({ accessToken, apiUrl, businessId }) => {

--- a/src/hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus.tsx
+++ b/src/hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus.tsx
@@ -17,12 +17,11 @@ const getStripeAccountStatus = get<
 >(({ businessId }) => `/v1/businesses/${businessId}/stripe/status`)
 
 export function useStripeAccountStatus() {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
       ...auth,
-      apiUrl,
       businessId,
     })),
     ({ accessToken, apiUrl, businessId }) => getStripeAccountStatus(

--- a/src/hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus.tsx
+++ b/src/hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus.tsx
@@ -4,11 +4,8 @@ import useSWR from 'swr'
 import { type StripeAccountStatusResponse, StripeAccountStatusResponseSchema } from '@schemas/stripeAccountStatus'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const STRIPE_ACCOUNT_STATUS_TAG_KEY = '#stripe-account-status'
 
@@ -20,14 +17,11 @@ const getStripeAccountStatus = get<
 >(({ businessId }) => `/v1/businesses/${businessId}/stripe/status`)
 
 export function useStripeAccountStatus() {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       apiUrl,
       businessId,
     })),

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/[dimension-id]/values/useCreateTagValueDefinition.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/[dimension-id]/values/useCreateTagValueDefinition.ts
@@ -4,12 +4,9 @@ import useSWRMutation from 'swr/mutation'
 import { type TagValueDefinitionSchema } from '@schemas/tag'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTagDimensionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const CREATE_TAG_VALUE_DEFINITION_TAG_KEY = '#create-tag-value-definition'
 
@@ -25,10 +22,7 @@ const createTagValueDefinition = post<
 >(({ businessId, dimensionId }) => `/v1/businesses/${businessId}/tags/dimensions/${dimensionId}/values`)
 
 export function useCreateTagDimension() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { apiUrl } = useEnvironment()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/[dimension-id]/values/useCreateTagValueDefinition.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/[dimension-id]/values/useCreateTagValueDefinition.ts
@@ -22,12 +22,11 @@ const createTagValueDefinition = post<
 >(({ businessId, dimensionId }) => `/v1/businesses/${businessId}/tags/dimensions/${dimensionId}/values`)
 
 export function useCreateTagDimension() {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({
       ...auth,
-      apiUrl,
       businessId,
     })),
     (

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/key/[dimension-key]/useTagDimensionByKey.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/key/[dimension-key]/useTagDimensionByKey.ts
@@ -22,12 +22,11 @@ type UseTagDimensionByKeyParameters = {
 }
 
 export function useTagDimensionByKey({ isEnabled = true, dimensionKey }: UseTagDimensionByKeyParameters) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => withLocale(buildKey({
       ...auth,
-      apiUrl,
       isEnabled,
       businessId,
       dimensionKey,

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/key/[dimension-key]/useTagDimensionByKey.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/key/[dimension-key]/useTagDimensionByKey.ts
@@ -4,11 +4,8 @@ import useSWR from 'swr'
 import { TagDimensionSchema } from '@schemas/tag'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const TAG_DIMENSION_BY_KEY_TAG_KEY = '#tag-dimension-by-key'
 
@@ -25,10 +22,7 @@ type UseTagDimensionByKeyParameters = {
 }
 
 export function useTagDimensionByKey({ isEnabled = true, dimensionKey }: UseTagDimensionByKeyParameters) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { apiUrl } = useEnvironment()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/useCreateTagDimension.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/useCreateTagDimension.ts
@@ -5,12 +5,9 @@ import useSWRMutation from 'swr/mutation'
 import { type TagDimensionSchema, TagDimensionStrictnessSchema } from '@schemas/tag'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTagDimensionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const CREATE_TAG_DIMENSION_TAG_KEY = '#create-tag-dimension'
 
@@ -31,10 +28,7 @@ const createTagDimension = post<
 >(({ businessId }) => `/v1/businesses/${businessId}/tags/dimensions`)
 
 export function useCreateTagDimension() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { apiUrl } = useEnvironment()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/useCreateTagDimension.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/useCreateTagDimension.ts
@@ -28,12 +28,11 @@ const createTagDimension = post<
 >(({ businessId }) => `/v1/businesses/${businessId}/tags/dimensions`)
 
 export function useCreateTagDimension() {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const mutationResponse = useSWRMutation(
     () => withLocale(buildKey({
       ...auth,
-      apiUrl,
       businessId,
     })),
     (

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
@@ -24,10 +24,10 @@ type UseTagDimensionsParameters = {
 }
 
 export function useTagDimensions({ isEnabled = true }: UseTagDimensionsParameters = {}) {
-  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
-    () => withLocale(buildKey({ ...auth, apiUrl, businessId, isEnabled })),
+    () => withLocale(buildKey({ ...auth, businessId, isEnabled })),
     ({ accessToken, apiUrl, businessId }) => getTagDimensions(
       apiUrl,
       accessToken,

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
@@ -5,11 +5,8 @@ import { type TagDimension, TagDimensionSchema } from '@schemas/tag'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const TAG_DIMENSIONS_TAG_KEY = '#tag-dimensions'
 
@@ -27,10 +24,7 @@ type UseTagDimensionsParameters = {
 }
 
 export function useTagDimensions({ isEnabled = true }: UseTagDimensionsParameters = {}) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { apiUrl } = useEnvironment()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => withLocale(buildKey({ ...auth, apiUrl, businessId, isEnabled })),

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/delete/useDeleteUploadsOnTask.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/delete/useDeleteUploadsOnTask.ts
@@ -5,12 +5,10 @@ import useSWRMutation from 'swr/mutation'
 import type { BusinessTaskEncoded } from '@schemas/businessTasks/businessTask'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { BOOKKEEPING_PERIODS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const deleteUploadsOnTask = post<
   { data: BusinessTaskEncoded },
@@ -31,9 +29,7 @@ type UseDeleteUploadsOnTaskArg = {
 }
 
 export function useDeleteUploadsOnTask() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
   const mutationResponse = useSWRMutation(

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/useUpdateTaskUploadDescription.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/useUpdateTaskUploadDescription.ts
@@ -5,12 +5,10 @@ import useSWRMutation from 'swr/mutation'
 import type { BusinessTaskEncoded } from '@schemas/businessTasks/businessTask'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { BOOKKEEPING_PERIODS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 type UpdateTaskUploadsDescriptionBody = {
   type: 'FreeResponse'
@@ -37,9 +35,7 @@ type UseUpdateTaskUploadDescriptionArg = {
 }
 
 export function useUpdateTaskUploadDescription() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
   const mutationResponse = useSWRMutation(

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/useUploadDocumentsForTask.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/useUploadDocumentsForTask.ts
@@ -5,12 +5,10 @@ import useSWRMutation from 'swr/mutation'
 import type { FileMetadata } from '@internal-types/fileUpload'
 import { postWithFormData } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { BOOKKEEPING_PERIODS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 function completeTaskWithUpload(
   baseUrl: string,
@@ -51,9 +49,7 @@ type UseUploadDocumentsForTaskArg = {
 }
 
 export function useUploadDocumentsForTask() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
   const mutationResponse = useSWRMutation(

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/user-response/useSubmitResponseForTask.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/user-response/useSubmitResponseForTask.ts
@@ -5,12 +5,10 @@ import useSWRMutation from 'swr/mutation'
 import type { BusinessTaskEncoded } from '@schemas/businessTasks/businessTask'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { BOOKKEEPING_PERIODS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 type SubmitUserResponseForTaskBody = {
   type: 'FreeResponse'
@@ -36,9 +34,7 @@ type UseSubmitUserResponseForTaskArg = {
 }
 
 export function useSubmitUserResponseForTask() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
   const mutationResponse = useSWRMutation(

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner.ts
@@ -7,10 +7,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const TAX_ESTIMATES_BANNER_TAG_KEY = '#tax-estimates-banner'
 type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
@@ -44,9 +42,7 @@ const buildKey = createBuildKey<{
 }>([TAX_ESTIMATES_BANNER_TAG_KEY])
 
 export function useTaxEstimatesBanner({ year, reportingBasis, fullYearProjection }: UseTaxEstimatesBannerOptions) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails.ts
@@ -7,10 +7,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const TAX_DETAILS_TAG_KEY = '#tax-details'
 type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
@@ -40,9 +38,7 @@ const buildKey = createBuildKey<{
 }>([TAX_DETAILS_TAG_KEY])
 
 export function useTaxDetails({ year, reportingBasis, fullYearProjection }: UseTaxDetailsOptions) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
@@ -6,10 +6,8 @@ import { type TaxOverviewApiResponse, TaxOverviewApiResponseSchema } from '@sche
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const TAX_OVERVIEW_TAG_KEY = '#tax-overview'
 type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
@@ -44,9 +42,7 @@ const buildKey = createBuildKey<{
 }>([TAX_OVERVIEW_TAG_KEY])
 
 export function useTaxOverview({ year, reportingBasis, fullYearProjection, enabled = true }: UseTaxOverviewOptions) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments.ts
@@ -7,10 +7,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const TAX_PAYMENTS_TAG_KEY = '#tax-payments'
 type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
@@ -40,9 +38,7 @@ const buildKey = createBuildKey<{
 }>([TAX_PAYMENTS_TAG_KEY])
 
 export function useTaxPayments({ year, reportingBasis, fullYearProjection }: UseTaxPaymentsOptions) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile.ts
@@ -5,10 +5,8 @@ import { type TaxProfile, type TaxProfileResponse, TaxProfileResponseSchema } fr
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const TAX_PROFILE_TAG_KEY = '#tax-profile'
 
@@ -21,9 +19,7 @@ export const getTaxProfile = get<TaxProfileResponse, { businessId: string }>(
 const buildKey = createBuildKey<{ businessId: string }>([TAX_PROFILE_TAG_KEY])
 
 export function useTaxProfile() {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => withLocale(buildKey({ ...auth, businessId })),

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useUpsertTaxProfile.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useUpsertTaxProfile.ts
@@ -5,14 +5,12 @@ import useSWRMutation from 'swr/mutation'
 import { type TaxProfileRequest, type TaxProfileResponse, TaxProfileResponseSchema } from '@schemas/taxEstimates/profile'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTaxDetailsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails'
 import { useTaxPaymentsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments'
 import { useTaxProfileGlobalCacheActions } from '@hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UPSERT_TAX_PROFILE_TAG_KEY = '#upsert-tax-profile'
 
@@ -43,9 +41,7 @@ type UseUpsertTaxProfileProps = {
   mode: UpsertTaxProfileMode
 }
 export function useUpsertTaxProfile({ mode }: UseUpsertTaxProfileProps) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { overwriteCache: overwriteTaxProfile } = useTaxProfileGlobalCacheActions()
   const { forceReload: forceReloadTaxPayments } = useTaxPaymentsGlobalCacheActions()
   const { forceReload: forceReloadTaxDetails } = useTaxDetailsGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
@@ -7,10 +7,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const TAX_SUMMARY_TAG_KEY = '#tax-summary'
 type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
@@ -41,9 +39,7 @@ const buildKey = createBuildKey<{
 }>([TAX_SUMMARY_TAG_KEY])
 
 export function useTaxSummary({ year, reportingBasis, fullYearProjection, enabled = true }: UseTaxSummaryOptions) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => withLocale(buildKey({

--- a/src/hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary.ts
@@ -6,10 +6,8 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const TimeTrackingSummaryResponseSchema = Schema.Struct({
   data: TimeEntrySummarySchema,
@@ -41,13 +39,11 @@ const getTimeTrackingSummary = get<
 })
 
 export function useTimeTrackingSummary(filterParams: TimeTrackingSummaryFilterParams = {}) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       ...filterParams,
     })),

--- a/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/[time-entry-id]/useDeleteTimeEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/[time-entry-id]/useDeleteTimeEntry.ts
@@ -3,13 +3,11 @@ import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTimeTrackingSummaryGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary'
 import { useTimeEntriesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/time-entries/useListTimeEntries'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const DELETE_TIME_ENTRY_TAG_KEY = '#delete-time-entry'
 
@@ -26,9 +24,7 @@ type UseDeleteTimeEntryProps = {
 }
 
 export const useDeleteTimeEntry = ({ timeEntryId }: UseDeleteTimeEntryProps) => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => {
@@ -37,7 +33,7 @@ export const useDeleteTimeEntry = ({ timeEntryId }: UseDeleteTimeEntryProps) => 
       }
 
       return withLocale(buildKey({
-        ...data,
+        ...auth,
         businessId,
         timeEntryId,
       }))

--- a/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useListTimeEntries.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useListTimeEntries.ts
@@ -7,11 +7,9 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const LIST_TIME_ENTRIES_TAG_KEY = '#list-time-entries'
 
@@ -74,15 +72,13 @@ const listTimeEntries = get<
 })
 
 export function useListTimeEntries(filterParams: ListTimeEntriesFilterParams = {}) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListTimeEntriesResponse | null) => withLocale(keyLoader(
       previousPageData,
       {
-        ...data,
+        ...auth,
         businessId,
         ...filterParams,
       },

--- a/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useUpsertTimeEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useUpsertTimeEntry.ts
@@ -5,13 +5,11 @@ import useSWRMutation from 'swr/mutation'
 import { TimeEntrySchema, type UpsertTimeEntryEncoded } from '@schemas/timeTracking'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTimeTrackingSummaryGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary'
 import { useTimeEntriesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/time-entries/useListTimeEntries'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const UPSERT_TIME_ENTRY_TAG_KEY = '#upsert-time-entry'
 
@@ -52,16 +50,14 @@ export function useUpsertTimeEntry(props: UseUpsertTimeEntryCreateProps): SWRMut
 export function useUpsertTimeEntry(props: UseUpsertTimeEntryUpdateProps): SWRMutationResult<UpsertTimeEntryReturn, UpdateTimeEntryBody>
 export function useUpsertTimeEntry(props: UseUpsertTimeEntryProps): SWRMutationResult<UpsertTimeEntryReturn, UpsertTimeEntryBody>
 export function useUpsertTimeEntry(props: UseUpsertTimeEntryProps) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const { mode } = props
   const timeEntryId = mode === UpsertTimeEntryMode.Update ? props.timeEntryId : undefined
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
       timeEntryId,
     })),

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker.ts
@@ -5,10 +5,8 @@ import { type TimeEntry, TimeEntrySchema } from '@schemas/timeTracking'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const ACTIVE_TIME_TRACKER_TAG_KEY = '#active-time-tracker'
 
@@ -29,13 +27,11 @@ const getActiveTimeTracker = get<
 const buildKey = createBuildKey<{ businessId: string }>([ACTIVE_TIME_TRACKER_TAG_KEY])
 
 export function useActiveTimeTracker(): SWRQueryResult<TimeEntry | null> {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const response = useSWR(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     ({ accessToken, apiUrl, businessId }) => getActiveTimeTracker(

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStartTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStartTimeTracker.ts
@@ -5,12 +5,10 @@ import useSWRMutation from 'swr/mutation'
 import { type StartTrackerEncoded, TimeEntrySchema } from '@schemas/timeTracking'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useActiveTimeTrackerGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const START_TIME_TRACKER_TAG_KEY = '#start-time-tracker'
 
@@ -31,14 +29,12 @@ const startTimeTracker = post<
 const buildKey = createBuildKey<{ businessId: string }>([START_TIME_TRACKER_TAG_KEY])
 
 export const useStartTimeTracker = () => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { invalidate: invalidateActiveTimeTracker } = useActiveTimeTrackerGlobalCacheActions()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     (

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStopTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStopTimeTracker.ts
@@ -5,14 +5,12 @@ import useSWRMutation from 'swr/mutation'
 import { type StopTrackerEncoded } from '@schemas/timeTracking'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTimeTrackingSummaryGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary'
 import { useTimeEntriesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/time-entries/useListTimeEntries'
 import { useActiveTimeTrackerGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const STOP_TIME_TRACKER_TAG_KEY = '#stop-time-tracker'
 
@@ -34,16 +32,14 @@ const stopTimeTracker = post<
 const buildKey = createBuildKey<{ businessId: string }>([STOP_TIME_TRACKER_TAG_KEY])
 
 export const useStopTimeTracker = () => {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReload: forceReloadTimeEntries } = useTimeEntriesGlobalCacheActions()
   const { invalidate: invalidateTimeTrackingSummary } = useTimeTrackingSummaryGlobalCacheActions()
   const { invalidate: invalidateActiveTimeTracker } = useActiveTimeTrackerGlobalCacheActions()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({
-      ...data,
+      ...auth,
       businessId,
     })),
     ({ accessToken, apiUrl, businessId }, { arg: body }: { arg: StopTimeTrackerBody }) => stopTimeTracker(

--- a/src/hooks/api/businesses/[business-id]/useBusiness.ts
+++ b/src/hooks/api/businesses/[business-id]/useBusiness.ts
@@ -5,7 +5,7 @@ import { type Business, BusinessResponseSchema } from '@schemas/business'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { useAuth } from '@hooks/utils/auth/useAuth'
 
 export const BUSINESS_TAG_KEY = '#business'
 
@@ -16,7 +16,7 @@ const getBusiness = get<{ data: Business }>(
 const buildKey = createBuildKey<{ businessId: string }>([BUSINESS_TAG_KEY])
 
 export function useBusiness({ businessId }: { businessId: string }) {
-  const { auth } = useBuildKeyInputs()
+  const { data: auth } = useAuth()
 
   const swrResponse = useSWR(
     () => buildKey({ ...auth, businessId }),

--- a/src/hooks/api/businesses/[business-id]/useBusiness.ts
+++ b/src/hooks/api/businesses/[business-id]/useBusiness.ts
@@ -5,8 +5,7 @@ import { type Business, BusinessResponseSchema } from '@schemas/business'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const BUSINESS_TAG_KEY = '#business'
 
@@ -17,8 +16,7 @@ const getBusiness = get<{ data: Business }>(
 const buildKey = createBuildKey<{ businessId: string }>([BUSINESS_TAG_KEY])
 
 export function useBusiness({ businessId }: { businessId: string }) {
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { apiUrl, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
     () => buildKey({ ...auth, apiUrl, businessId }),

--- a/src/hooks/api/businesses/[business-id]/useBusiness.ts
+++ b/src/hooks/api/businesses/[business-id]/useBusiness.ts
@@ -16,10 +16,10 @@ const getBusiness = get<{ data: Business }>(
 const buildKey = createBuildKey<{ businessId: string }>([BUSINESS_TAG_KEY])
 
 export function useBusiness({ businessId }: { businessId: string }) {
-  const { apiUrl, auth } = useBuildKeyInputs()
+  const { auth } = useBuildKeyInputs()
 
   const swrResponse = useSWR(
-    () => buildKey({ ...auth, apiUrl, businessId }),
+    () => buildKey({ ...auth, businessId }),
     ({ accessToken, apiUrl, businessId }) =>
       getBusiness(apiUrl, accessToken, { params: { businessId } })()
         .then(Schema.decodeUnknownPromise(BusinessResponseSchema)),

--- a/src/hooks/api/businesses/[business-id]/vendors/useListVendors.ts
+++ b/src/hooks/api/businesses/[business-id]/vendors/useListVendors.ts
@@ -6,11 +6,9 @@ import { VendorSchema } from '@schemas/vendor'
 import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
 import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 const ListVendorsRawResultSchema = PaginatedResponseSchema(VendorSchema)
 type ListVendorsRawResult = typeof ListVendorsRawResultSchema.Type
@@ -56,15 +54,13 @@ type UseListVendorsParameters = {
 }
 
 export function useListVendors({ query, isEnabled = true }: UseListVendorsParameters = {}) {
-  const withLocale = useLocalizedKey()
-  const { data } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const swrResponse = useSWRInfinite(
     (_index, previousPageData: ListVendorsRawResult | null) => withLocale(keyLoader(
       previousPageData,
       {
-        ...data,
+        ...auth,
         businessId,
         query,
         isEnabled,

--- a/src/hooks/features/bankAccounts/useConfirmAndExcludeMultiple.ts
+++ b/src/hooks/features/bankAccounts/useConfirmAndExcludeMultiple.ts
@@ -3,22 +3,18 @@ import useSWRMutation from 'swr/mutation'
 
 import type { Awaitable } from '@internal-types/utility/promises'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { confirmExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm'
 import { excludeExternalAccount } from '@hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export type AccountConfirmExcludeFormState = Record<string, boolean>
 
 const buildKey = createBuildKey<{ businessId: string }>(['#bulk-confirm', '#bulk-exclude'])
 
 export function useConfirmAndExcludeMultiple({ onSuccess }: { onSuccess?: () => Awaitable<unknown> }) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const rawMutationResponse = useSWRMutation(
     () => withLocale(buildKey({

--- a/src/hooks/features/profitAndLoss/useProfitAndLossComparison.tsx
+++ b/src/hooks/features/profitAndLoss/useProfitAndLossComparison.tsx
@@ -213,7 +213,7 @@ export function useProfitAndLossComparison({
     }
   }
 
-  const { businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { businessId, auth } = useBuildKeyInputs()
 
   const periods = compareModeActive
     ? preparePeriodsBody(dateRange, comparePeriods, comparisonPeriodMode)
@@ -232,9 +232,11 @@ export function useProfitAndLossComparison({
     dateRange: DateRange,
     moneyFormat?: MoneyFormat,
   ) => {
+    if (!auth) return Promise.resolve<{ data?: S3PresignedUrl, error?: unknown }>({})
+
     const periods = preparePeriodsBody(dateRange, comparePeriods, comparisonPeriodMode)
     const tagFilters = prepareFiltersBody(selectedCompareOptions)
-    return profitAndLossComparisonCsv(apiUrl, auth?.access_token, {
+    return profitAndLossComparisonCsv(auth.apiUrl, auth.access_token, {
       params: {
         businessId,
         moneyFormat,

--- a/src/hooks/features/profitAndLoss/useProfitAndLossComparison.tsx
+++ b/src/hooks/features/profitAndLoss/useProfitAndLossComparison.tsx
@@ -13,10 +13,8 @@ import { type ReadonlyArrayWithAtLeastOne } from '@utils/array/getArrayWithAtLea
 import { range } from '@utils/array/range'
 import { toLocalDateString } from '@utils/time/timeUtils'
 import { useProfitAndLossComparisonReport } from '@hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { useGlobalDateRange } from '@providers/GlobalDateStore/GlobalDateStoreProvider'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { ProfitAndLossContext } from '@contexts/ProfitAndLossContext/ProfitAndLossContext'
 
 function prepareFiltersBody(compareOptions: TagComparisonOption[]): ReadonlyArrayWithAtLeastOne<ProfitAndLossComparisonTags> | undefined {
@@ -215,9 +213,7 @@ export function useProfitAndLossComparison({
     }
   }
 
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { businessId, apiUrl, auth } = useBuildKeyInputs()
 
   const periods = compareModeActive
     ? preparePeriodsBody(dateRange, comparePeriods, comparisonPeriodMode)

--- a/src/hooks/legacy/useReceipts.ts
+++ b/src/hooks/legacy/useReceipts.ts
@@ -113,7 +113,7 @@ export const useReceipts: UseReceipts = ({
 }: UseReceiptsProps) => {
   const { t } = useTranslation()
   const { formatDate } = useIntlFormatter()
-  const { businessId, apiUrl, auth } = useBuildKeyInputs()
+  const { businessId, auth } = useBuildKeyInputs()
   const { updateLocalBankTransactions } = useBankTransactionsContext()
   const emitLayerEvent = useEmitLayerEvent(LayerEventComponent.BankTransactions)
 
@@ -129,9 +129,11 @@ export const useReceipts: UseReceipts = ({
   }, [isActive])
 
   const fetchDocuments = async () => {
+    if (!auth) return
+
     const listBankTransactionDocumentsCall = listBankTransactionDocuments(
-      apiUrl,
-      auth?.access_token,
+      auth.apiUrl,
+      auth.access_token,
       {
         params: {
           businessId: businessId,
@@ -153,6 +155,8 @@ export const useReceipts: UseReceipts = ({
   }
 
   const uploadReceipt = async (file: File) => {
+    if (!auth) return
+
     emitLayerEvent({
       type: LayerEventType.TransactionReceiptUploadClicked,
       version: 1,
@@ -200,8 +204,8 @@ export const useReceipts: UseReceipts = ({
     try {
       setReceiptUrls(prev => [...prev, newReceipt])
       const uploadDocument = uploadBankTransactionDocument(
-        apiUrl,
-        auth?.access_token,
+        auth.apiUrl,
+        auth.access_token,
       )
       const result = await uploadDocument({
         businessId: businessId,
@@ -242,7 +246,7 @@ export const useReceipts: UseReceipts = ({
   }
 
   const archiveDocument = async (document: DocumentWithStatus) => {
-    if (!document.id) return
+    if (!document.id || !auth) return
 
     try {
       if (document.error) {
@@ -261,7 +265,7 @@ export const useReceipts: UseReceipts = ({
             return url
           }),
         )
-        await archiveBankTransactionDocument(apiUrl, auth?.access_token, {
+        await archiveBankTransactionDocument(auth.apiUrl, auth.access_token, {
           params: {
             businessId: businessId,
             bankTransactionId: bankTransaction.id,

--- a/src/hooks/legacy/useReceipts.ts
+++ b/src/hooks/legacy/useReceipts.ts
@@ -8,12 +8,10 @@ import { type Awaitable } from '@internal-types/utility/promises'
 import { get, post, postWithFormData } from '@utils/api/authenticatedHttp'
 import { hasReceipts } from '@utils/bankTransactions/shared'
 import { useEmitLayerEvent } from '@hooks/useEmitLayerEvent'
-import { useAuth } from '@hooks/utils/auth/useAuth'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { LayerEventComponent, LayerEventType } from '@providers/LayerProvider/layerEvents'
 import { useBankTransactionsContext } from '@contexts/BankTransactionsContext/BankTransactionsContext'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { type DocumentWithStatus } from '@components/BankTransactionReceipts/BankTransactionReceipts'
 
 const listBankTransactionDocuments = get<{
@@ -115,9 +113,7 @@ export const useReceipts: UseReceipts = ({
 }: UseReceiptsProps) => {
   const { t } = useTranslation()
   const { formatDate } = useIntlFormatter()
-  const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
-  const { data: auth } = useAuth()
+  const { businessId, apiUrl, auth } = useBuildKeyInputs()
   const { updateLocalBankTransactions } = useBankTransactionsContext()
   const emitLayerEvent = useEmitLayerEvent(LayerEventComponent.BankTransactions)
 

--- a/src/hooks/legacy/useUpdateOpeningBalanceAndDate.ts
+++ b/src/hooks/legacy/useUpdateOpeningBalanceAndDate.ts
@@ -3,9 +3,7 @@ import useSWRMutation from 'swr/mutation'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { post } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
-import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 type UpdateBankAccountOpeningBalanceBody = {
   effective_at: string
@@ -91,9 +89,7 @@ export function useBulkSetOpeningBalanceAndDate(
   data: OpeningBalanceData[],
   { onSuccess }: { onSuccess: (results: OpeningBalanceAPIResponseResult[]) => Awaitable<void> },
 ) {
-  const withLocale = useLocalizedKey()
-  const { data: auth } = useAuth()
-  const { businessId } = useLayerContext()
+  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
   const validate = ({ openingBalance, openingDate, isDateInvalid }: OpeningBalanceData) => {
     const errors: string[] = []

--- a/src/hooks/utils/swr/useBuildKeyInputs.ts
+++ b/src/hooks/utils/swr/useBuildKeyInputs.ts
@@ -1,13 +1,11 @@
 import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
 import { useAuth } from '@hooks/utils/auth/useAuth'
-import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 export function useBuildKeyInputs() {
   const withLocale = useLocalizedKey()
   const { businessId } = useLayerContext()
-  const { apiUrl } = useEnvironment()
   const { data: auth } = useAuth()
 
-  return { withLocale, businessId, apiUrl, auth }
+  return { withLocale, businessId, auth }
 }

--- a/src/hooks/utils/swr/useBuildKeyInputs.ts
+++ b/src/hooks/utils/swr/useBuildKeyInputs.ts
@@ -1,0 +1,13 @@
+import { useLocalizedKey } from '@utils/swr/localeKeyMiddleware'
+import { useAuth } from '@hooks/utils/auth/useAuth'
+import { useEnvironment } from '@providers/Environment/EnvironmentInputProvider'
+import { useLayerContext } from '@contexts/LayerContext/LayerContext'
+
+export function useBuildKeyInputs() {
+  const withLocale = useLocalizedKey()
+  const { businessId } = useLayerContext()
+  const { apiUrl } = useEnvironment()
+  const { data: auth } = useAuth()
+
+  return { withLocale, businessId, apiUrl, auth }
+}


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide mechanical change across most data-fetching hooks; incorrect auth/key shape could alter SWR cache keys or skip requests until auth loads.
> 
> **Overview**
> Introduces **`useBuildKeyInputs`**, which bundles `withLocale`, `businessId`, and auth from `useLocalizedKey`, `useLayerContext`, and `useAuth`, and migrates business API hooks, report hooks, Plaid/Stripe hooks, and the P&amp;L full-report download button to use it instead of wiring those three (and often `useEnvironment` for `apiUrl`) separately.
> 
> SWR/mutation **`buildKey` / `keyLoader` calls** now spread `...auth` and drop redundant `apiUrl` on the key object, since `apiUrl` already lives on the auth payload from `useAuth`. Bulk mutation hooks that still need `eventCallbacks` keep **`useLayerContext`** only for that slice.
> 
> The P&amp;L download button adds an early **`if (!auth) return`** before downloads and reads **`auth.apiUrl`** / **`auth.access_token`** from the consolidated auth object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b9311aa77f54d335b2cfeedcb066d48070beef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->