### PR TITLE
feat: create factories for all API hooks

### DIFF
--- a/src/components/BalanceSheet/download/BalanceSheetDownloadButton.tsx
+++ b/src/components/BalanceSheet/download/BalanceSheetDownloadButton.tsx
@@ -12,10 +12,11 @@ export function BalanceSheetDownloadButton({
   icon,
 }: BalanceSheetDownloadButtonProps) {
   const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const { trigger, isMutating, error } = useBalanceSheetDownload({
+  const { trigger, isMutating, isError } = useBalanceSheetDownload({
     effectiveDate,
-    onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
+    swrOptions: {
+      onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
+    },
   })
 
   return (
@@ -24,7 +25,7 @@ export function BalanceSheetDownloadButton({
         icon={icon}
         onPress={() => { void trigger() }}
         isPending={isMutating}
-        requestFailed={Boolean(error)}
+        requestFailed={isError}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />
     </>

--- a/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsConfirmAllModal.tsx
+++ b/src/components/BankTransactions/BankTransactionsBulkActions/BankTransactionsConfirmAllModal.tsx
@@ -20,7 +20,7 @@ export const BankTransactionsConfirmAllModal = ({ isOpen, onOpenChange, isMobile
   const { formatNumber } = useIntlFormatter()
   const { count } = useCountSelectedIds()
   const { clearSelection } = useBulkSelectionActions()
-  const { trigger, buildTransactionsPayload } = useBulkMatchOrCategorize()
+  const { response: { trigger }, buildTransactionsPayload } = useBulkMatchOrCategorize()
   const payload = buildTransactionsPayload()
 
   const { actionableCount, skippedCount } = useMemo(() => {

--- a/src/components/CategorizationRules/CategorizationRuleForm/useCategorizationRuleForm.ts
+++ b/src/components/CategorizationRules/CategorizationRuleForm/useCategorizationRuleForm.ts
@@ -46,7 +46,7 @@ export const useCategorizationRuleForm = ({ formState, onSuccess }: UseCategoriz
         })
 
       setSubmitError(undefined)
-      onSuccess(result.data)
+      onSuccess(result)
     }
     catch (e) {
       console.error(e)

--- a/src/components/CategorizationRules/CategorizationRuleForm/useCategorizationRuleForm.ts
+++ b/src/components/CategorizationRules/CategorizationRuleForm/useCategorizationRuleForm.ts
@@ -3,7 +3,7 @@ import { revalidateLogic } from '@tanstack/react-form'
 import { useTranslation } from 'react-i18next'
 
 import type { CategorizationRule } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
-import { useUpsertCategorizationRule } from '@hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule'
+import { UpsertCategorizationRuleMode, useUpsertCategorizationRule } from '@hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule'
 import { useAppForm } from '@hooks/features/forms/useForm'
 import {
   type CategorizationRuleFormState,
@@ -22,7 +22,11 @@ type UseCategorizationRuleFormProps = {
 export const useCategorizationRuleForm = ({ formState, onSuccess }: UseCategorizationRuleFormProps) => {
   const { t } = useTranslation()
   const [submitError, setSubmitError] = useState<string | undefined>(undefined)
-  const { trigger: upsertCategorizationRule } = useUpsertCategorizationRule()
+  const { trigger: upsertCategorizationRule } = useUpsertCategorizationRule(
+    formState.mode === 'edit'
+      ? { mode: UpsertCategorizationRuleMode.Update, categorizationRuleId: formState.rule.id }
+      : { mode: UpsertCategorizationRuleMode.Create },
+  )
 
   const formDefaults = useMemo(
     () => getCategorizationRuleFormDefaultValues(formState),
@@ -35,15 +39,8 @@ export const useCategorizationRuleForm = ({ formState, onSuccess }: UseCategoriz
   const onSubmit = useCallback(async ({ value }: { value: CategorizationRuleFormValues }) => {
     try {
       const result = formState.mode === 'edit'
-        ? await upsertCategorizationRule({
-          mode: 'update',
-          categorizationRuleId: formState.rule.id,
-          body: convertFormToPatchBody(value),
-        })
-        : await upsertCategorizationRule({
-          mode: 'create',
-          body: convertFormToCreateBody(value),
-        })
+        ? await upsertCategorizationRule(convertFormToPatchBody(value))
+        : await upsertCategorizationRule(convertFormToCreateBody(value))
 
       setSubmitError(undefined)
       onSuccess(result)

--- a/src/components/ChartOfAccounts/download/AccountBalancesDownloadButton.tsx
+++ b/src/components/ChartOfAccounts/download/AccountBalancesDownloadButton.tsx
@@ -5,22 +5,22 @@ import { DownloadButton } from '@ui/Button/DownloadButton'
 import InvisibleDownload, { useInvisibleDownload } from '@components/utility/InvisibleDownload'
 
 type AccountBalancesDownloadButtonProps = {
-  startCutoff?: Date
-  endCutoff?: Date
+  startDate?: Date
+  endDate?: Date
   icon?: boolean
 }
 
 export function AccountBalancesDownloadButton({
-  startCutoff,
-  endCutoff,
+  startDate,
+  endDate,
   icon,
 }: AccountBalancesDownloadButtonProps) {
   const { t } = useTranslation()
   const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
   const { trigger, isMutating, error } = useAccountBalancesDownload({
-    startCutoff,
-    endCutoff,
+    startDate,
+    endDate,
     onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
   })
 

--- a/src/components/ChartOfAccounts/download/AccountBalancesDownloadButton.tsx
+++ b/src/components/ChartOfAccounts/download/AccountBalancesDownloadButton.tsx
@@ -21,7 +21,9 @@ export function AccountBalancesDownloadButton({
   const { trigger, isMutating, error } = useAccountBalancesDownload({
     startDate,
     endDate,
-    onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
+    swrOptions: {
+      onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
+    },
   })
 
   return (

--- a/src/components/CustomerForm/useCustomerForm.ts
+++ b/src/components/CustomerForm/useCustomerForm.ts
@@ -43,7 +43,7 @@ export const useCustomerForm = (props: UseCustomerFormProps) => {
       const result = await upsertCustomer(upsertCustomerRequest)
 
       setSubmitError(undefined)
-      onSuccess(result.data)
+      onSuccess(result)
     }
     catch (e) {
       console.error(e)

--- a/src/components/Invoices/InvoiceForm/useInvoiceForm.ts
+++ b/src/components/Invoices/InvoiceForm/useInvoiceForm.ts
@@ -48,7 +48,7 @@ export const useInvoiceForm = (props: UseInvoiceFormProps) => {
         const upsertInvoiceParams = convertInvoiceFormToParams(value)
         const upsertInvoiceRequest = Schema.encodeUnknownSync(UpsertInvoiceSchema)(upsertInvoiceParams)
 
-        const { data: upsertedInvoice } = await upsertInvoice(upsertInvoiceRequest)
+        const upsertedInvoice = await upsertInvoice(upsertInvoiceRequest)
 
         setSubmitError(undefined)
         onSuccess(upsertedInvoice)

--- a/src/components/Invoices/InvoicePaymentForm/useInvoicePaymentForm.ts
+++ b/src/components/Invoices/InvoicePaymentForm/useInvoicePaymentForm.ts
@@ -36,7 +36,7 @@ export const useInvoicePaymentForm = (props: UseInvoicePaymentFormProps) => {
       const upsertDedicatedInvoicePaymentParams = convertInvoicePaymentFormToParams(value)
       const upsertDedicatedInvoicePaymentRequest = Schema.encodeUnknownSync(UpsertDedicatedInvoicePaymentSchema)(upsertDedicatedInvoicePaymentParams)
 
-      const { data: invoicePayment } = await upsertDedicatedInvoicePayment(upsertDedicatedInvoicePaymentRequest)
+      const invoicePayment = await upsertDedicatedInvoicePayment(upsertDedicatedInvoicePaymentRequest)
 
       setSubmitError(undefined)
       onSuccess(invoicePayment)

--- a/src/components/Invoices/InvoicePreview/InvoiceFinalizeForm/useInvoiceFinalizeForm.ts
+++ b/src/components/Invoices/InvoicePreview/InvoiceFinalizeForm/useInvoiceFinalizeForm.ts
@@ -45,9 +45,9 @@ export const useInvoiceFinalizeForm = ({
           FinalizeInvoiceBodySchema,
         )(finalizeInvoiceParams)
 
-        const { data } = await finalizeInvoice(finalizeInvoiceRequest)
+        const { invoice: finalizedInvoice } = await finalizeInvoice(finalizeInvoiceRequest)
         setSubmitError(undefined)
-        onSuccess(data.invoice)
+        onSuccess(finalizedInvoice)
       }
       catch (e) {
         console.error(e)

--- a/src/components/Invoices/InvoiceRefundForm/useInvoiceRefundForm.ts
+++ b/src/components/Invoices/InvoiceRefundForm/useInvoiceRefundForm.ts
@@ -35,7 +35,7 @@ export const useInvoiceRefundForm = ({ onSuccess, invoice }: UseInvoiceRefundFor
       const customerRefundParams = convertInvoiceRefundFormToParams(value)
       const refundInvoiceRequest = Schema.encodeUnknownSync(CreateCustomerRefundSchema)(customerRefundParams)
 
-      const { data: refund } = await refundInvoice(refundInvoiceRequest)
+      const refund = await refundInvoice(refundInvoiceRequest)
 
       setSubmitError(undefined)
       onSuccess(refund)

--- a/src/components/Invoices/modals/InvoiceResetModal.tsx
+++ b/src/components/Invoices/modals/InvoiceResetModal.tsx
@@ -16,7 +16,7 @@ export function InvoiceResetModal({ isOpen, onOpenChange, invoice, onSuccess }: 
   const { trigger: resetInvoice } = useResetInvoice({ invoiceId: invoice.id })
 
   const onConfirm = useCallback(async () => {
-    const { data: updatedInvoice } = await resetInvoice()
+    const updatedInvoice = await resetInvoice()
     onSuccess(updatedInvoice)
   }, [onSuccess, resetInvoice])
 

--- a/src/components/Invoices/modals/InvoiceVoidModal.tsx
+++ b/src/components/Invoices/modals/InvoiceVoidModal.tsx
@@ -16,7 +16,7 @@ export function InvoiceVoidModal({ isOpen, onOpenChange, invoiceId, onSuccess }:
   const { trigger: voidInvoice } = useVoidInvoice({ invoiceId })
 
   const onConfirm = useCallback(async () => {
-    const { data: invoice } = await voidInvoice()
+    const invoice = await voidInvoice()
     onSuccess(invoice)
   }, [onSuccess, voidInvoice])
 

--- a/src/components/Journal/download/JournalEntriesDownloadButton.tsx
+++ b/src/components/Journal/download/JournalEntriesDownloadButton.tsx
@@ -5,21 +5,21 @@ import { DownloadButton } from '@ui/Button/DownloadButton'
 import InvisibleDownload, { useInvisibleDownload } from '@components/utility/InvisibleDownload'
 
 type JournalEntriesDownloadButtonProps = {
-  startCutoff?: Date
-  endCutoff?: Date
+  startDate?: Date
+  endDate?: Date
   icon?: boolean
 }
 
 export function JournalEntriesDownloadButton({
-  startCutoff,
-  endCutoff,
+  startDate,
+  endDate,
   icon,
 }: JournalEntriesDownloadButtonProps) {
   const { t } = useTranslation()
   const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
   const { trigger, isMutating, error } = useJournalEntriesDownload({
-    startCutoff,
-    endCutoff,
+    startDate,
+    endDate,
     onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
   })
 

--- a/src/components/Journal/download/JournalEntriesDownloadButton.tsx
+++ b/src/components/Journal/download/JournalEntriesDownloadButton.tsx
@@ -20,7 +20,9 @@ export function JournalEntriesDownloadButton({
   const { trigger, isMutating, error } = useJournalEntriesDownload({
     startDate,
     endDate,
-    onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
+    swrOptions: {
+      onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
+    },
   })
 
   return (

--- a/src/components/ProfitAndLossDetailReport/ProfitAndLossDetailReport.tsx
+++ b/src/components/ProfitAndLossDetailReport/ProfitAndLossDetailReport.tsx
@@ -9,7 +9,6 @@ import type { PnlDetailLine } from '@hooks/api/businesses/[business-id]/reports/
 import { useProfitAndLossDetailLines } from '@hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useInAppLinkContext } from '@contexts/InAppLinkContext'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { ProfitAndLossContext } from '@contexts/ProfitAndLossContext/ProfitAndLossContext'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
@@ -91,7 +90,6 @@ export const ProfitAndLossDetailReport = ({
 }: ProfitAndLossDetailReportProps) => {
   const { t } = useTranslation()
   const { formatDateRange } = useIntlFormatter()
-  const { businessId } = useLayerContext()
   const { tagFilter, dateRange } = useContext(ProfitAndLossContext)
   const [selectedSource, setSelectedSource] = useState<LedgerEntrySourceType | null>(null)
 
@@ -111,11 +109,11 @@ export const ProfitAndLossDetailReport = ({
   }, [breadcrumbPath, lineItemName])
 
   const { data, isLoading, isError } = useProfitAndLossDetailLines({
-    businessId,
     startDate: dateRange.startDate,
     endDate: dateRange.endDate,
     pnlStructureLineItemName: lineItemName,
     tagFilter,
+    isEnabled: Boolean(dateRange.startDate && dateRange.endDate && lineItemName),
   })
 
   const handleSourceClick = useCallback((source: LedgerEntrySourceType) => {

--- a/src/components/ProfitAndLossDownloadButton/ProfitAndLossDetailLinesDownloadButton.tsx
+++ b/src/components/ProfitAndLossDownloadButton/ProfitAndLossDetailLinesDownloadButton.tsx
@@ -1,9 +1,7 @@
 import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import type { S3PresignedUrl } from '@internal-types/general'
 import { useProfitAndLossDetailLinesExport } from '@hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport'
-import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { ProfitAndLossContext } from '@contexts/ProfitAndLossContext/ProfitAndLossContext'
 import { DownloadButton } from '@ui/Button/DownloadButton'
 import type { ProfitAndLossDownloadButtonStringOverrides } from '@components/ProfitAndLossDownloadButton/types'
@@ -21,21 +19,20 @@ export function ProfitAndLossDetailLinesDownloadButton({
   icon,
 }: ProfitAndLossDetailLinesDownloadButtonProps) {
   const { t } = useTranslation()
-  const { businessId } = useLayerContext()
   const { tagFilter, dateRange } = useContext(ProfitAndLossContext)
   const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const { trigger, isMutating, error } = useProfitAndLossDetailLinesExport({
-    businessId,
+  const { trigger, isMutating, isError } = useProfitAndLossDetailLinesExport({
     startDate: dateRange.startDate,
     endDate: dateRange.endDate,
     pnlStructureLineItemName,
     tagFilter,
-    onSuccess: (data: S3PresignedUrl) => {
-      if (data?.presignedUrl) {
-        triggerInvisibleDownload({ url: data.presignedUrl })
-      }
+    swrOptions: {
+      onSuccess: (data) => {
+        if (data?.presignedUrl) {
+          triggerInvisibleDownload({ url: data.presignedUrl })
+        }
+      },
     },
   })
 
@@ -45,7 +42,7 @@ export function ProfitAndLossDetailLinesDownloadButton({
         icon={icon}
         onPress={() => { void trigger() }}
         isPending={isMutating}
-        requestFailed={Boolean(error)}
+        requestFailed={isError}
         text={stringOverrides?.downloadButtonText || t('common:action.download_label', 'Download')}
         retryText={stringOverrides?.retryButtonText || t('common:action.retry_label', 'Retry')}
       />

--- a/src/components/StatementOfCashFlow/download/CashflowStatementDownloadButton.tsx
+++ b/src/components/StatementOfCashFlow/download/CashflowStatementDownloadButton.tsx
@@ -14,11 +14,12 @@ export function CashflowStatementDownloadButton({
   icon,
 }: CashflowStatementDownloadButtonProps) {
   const { invisibleDownloadRef, triggerInvisibleDownload } = useInvisibleDownload()
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const { trigger, isMutating, error } = useCashflowStatementDownload({
+  const { trigger, isMutating, isError } = useCashflowStatementDownload({
     startDate,
     endDate,
-    onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
+    swrOptions: {
+      onSuccess: ({ presignedUrl }) => triggerInvisibleDownload({ url: presignedUrl }),
+    },
   })
 
   return (
@@ -27,7 +28,7 @@ export function CashflowStatementDownloadButton({
         icon={icon}
         onPress={() => { void trigger() }}
         isPending={isMutating}
-        requestFailed={Boolean(error)}
+        requestFailed={isError}
       />
       <InvisibleDownload ref={invisibleDownloadRef} />
     </>

--- a/src/components/TaxEstimatesSummaryCard/useTaxEstimatesSummaryCard.ts
+++ b/src/components/TaxEstimatesSummaryCard/useTaxEstimatesSummaryCard.ts
@@ -20,7 +20,7 @@ export const useTaxEstimatesSummaryCard = () => {
   const { fullYearProjection } = useFullYearProjection()
   const { t } = useTranslation()
   const { isDesktop, isMobile } = useSizeClass()
-  const { data: taxSummaryData, isLoading, isError } = useTaxSummary({ year, fullYearProjection, enabled: true })
+  const { data: taxSummaryData, isLoading, isError } = useTaxSummary({ year, fullYearProjection })
 
   const shortenedDisplayName = useCallback((type: TaxSummarySectionType) => {
     if (type === 'federal') return t('taxEstimates:label.federal', 'Federal')

--- a/src/components/TaxOverview/TaxableIncomeCard.tsx
+++ b/src/components/TaxOverview/TaxableIncomeCard.tsx
@@ -38,7 +38,6 @@ export const TaxableIncomeCard = () => {
   const { data: taxOverviewData, isLoading, isError } = useTaxOverview({
     year,
     fullYearProjection,
-    enabled: true,
   })
 
   return (

--- a/src/components/TaxPayments/utils.ts
+++ b/src/components/TaxPayments/utils.ts
@@ -1,7 +1,7 @@
 import { type TaxPaymentsResponse } from '@schemas/taxEstimates/payments'
 
 export interface CommonTaxPaymentsListProps {
-  data: TaxPaymentsResponse['data']['data'] | undefined
+  data: TaxPaymentsResponse['data'] | undefined
   isLoading: boolean
   isError: boolean
   slots: {

--- a/src/components/TaxProfileForm/useTaxProfileForm.ts
+++ b/src/components/TaxProfileForm/useTaxProfileForm.ts
@@ -40,7 +40,7 @@ export const useTaxProfileForm = ({ taxProfile, onSuccess }: UseTaxProfileFormPr
 
       setSubmitError(undefined)
       setSubmitSuccess(t('taxEstimates:label.tax_profile_saved', 'Tax profile saved'))
-      onSuccess?.(result.data)
+      onSuccess?.(result)
     }
     catch (e) {
       console.error(e)

--- a/src/components/TimeEntries/TimeEntryForm/useTimeEntryForm.ts
+++ b/src/components/TimeEntries/TimeEntryForm/useTimeEntryForm.ts
@@ -33,7 +33,7 @@ export const useTimeEntryForm = (props: UseTimeEntryFormProps) => {
       const upsertRequest = Schema.encodeUnknownSync(UpsertTimeEntrySchema)(entryParams)
       const result = await upsertTimeEntry(upsertRequest)
 
-      onSuccess(result.data)
+      onSuccess(result)
     }
     catch {
       setSubmitError(t('common:error.something_went_wrong_please_try_again', 'Something went wrong. Please try again.'))

--- a/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
+++ b/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
@@ -94,7 +94,7 @@ export function TimeEntryServiceSelector({
 }: TimeEntryServiceSelectorProps) {
   const { t } = useTranslation()
 
-  const { data: servicesResponse, isLoading, isError, error } = useListCatalogServices({ allowArchived })
+  const { flattenedData: servicesResponse, isLoading, isError, error } = useListCatalogServices({ allowArchived })
 
   const isLoadingWithoutFallback = isLoading && !servicesResponse
   const shouldHideError = hideSpecifiedIdNotFoundError && isAPIErrorOfType(error, ApiEnumErrorType.SpecifiedIdNotFound)

--- a/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
+++ b/src/components/TimeEntries/TimeEntryServiceSelector/TimeEntryServiceSelector.tsx
@@ -102,7 +102,7 @@ export function TimeEntryServiceSelector({
   const shouldDisableComboBox = isLoadingWithoutFallback || isError
 
   const serviceOptions = useMemo<ServiceAsOption[]>(
-    () => servicesResponse?.data.map(service => new ServiceAsOption(service, t)) ?? [],
+    () => servicesResponse?.map(service => new ServiceAsOption(service, t)) ?? [],
     [servicesResponse, t],
   )
 

--- a/src/components/TimeEntries/TimeTrackingServicesDrawer/TimeTrackingServicesDrawer.tsx
+++ b/src/components/TimeEntries/TimeTrackingServicesDrawer/TimeTrackingServicesDrawer.tsx
@@ -196,7 +196,7 @@ type ArchivedServicesContentProps = {
 
 function ArchivedServicesContent({ isEnabled, formatHourly, onRestore }: ArchivedServicesContentProps) {
   const { t } = useTranslation()
-  const { data, isLoading, isError } = useListCatalogServices({
+  const { flattenedData: data, isLoading, isError } = useListCatalogServices({
     allowArchived: true,
     isEnabled,
   })
@@ -261,7 +261,7 @@ export function TimeTrackingServicesDrawer({
   const { t } = useTranslation()
   const { isMobile } = useSizeClass()
   const formatHourly = useFormatHourly()
-  const { data, isLoading, isError } = useListCatalogServices()
+  const { flattenedData: data, isLoading, isError } = useListCatalogServices()
   const [tab, setTab] = useState<ServicesTab>('active')
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [isAdding, setIsAdding] = useState(false)

--- a/src/components/TimeEntries/TimeTrackingServicesDrawer/TimeTrackingServicesDrawer.tsx
+++ b/src/components/TimeEntries/TimeTrackingServicesDrawer/TimeTrackingServicesDrawer.tsx
@@ -202,7 +202,7 @@ function ArchivedServicesContent({ isEnabled, formatHourly, onRestore }: Archive
   })
 
   const archivedServices = useMemo(
-    () => (data?.data ?? []).filter(s => s.archivedAt != null),
+    () => (data ?? []).filter(s => s.archivedAt != null),
     [data],
   )
 
@@ -302,7 +302,7 @@ export function TimeTrackingServicesDrawer({
     setIsRestoreOpen(true)
   }, [])
 
-  const activeServices = useMemo(() => data?.data ?? [], [data])
+  const activeServices = useMemo(() => data ?? [], [data])
   const showCreateForm = isAdding || (!isLoading && !isError && activeServices.length === 0)
   const showAddButton = !showCreateForm && activeServices.length > 0
 

--- a/src/components/Trips/TripForm/useTripForm.ts
+++ b/src/components/Trips/TripForm/useTripForm.ts
@@ -32,7 +32,7 @@ export const useTripForm = (props: UseTripFormProps) => {
       const result = await upsertTrip(upsertTripRequest)
 
       setSubmitError(undefined)
-      onSuccess(result.data)
+      onSuccess(result)
     }
     catch (e) {
       console.error(e)

--- a/src/components/VehicleManagement/VehicleForm/useVehicleForm.ts
+++ b/src/components/VehicleManagement/VehicleForm/useVehicleForm.ts
@@ -40,7 +40,7 @@ export const useVehicleForm = (props: UseVehicleFormProps) => {
       const result = await upsertVehicle(upsertVehicleRequest)
 
       setSubmitError(undefined)
-      onSuccess(result.data)
+      onSuccess(result)
     }
     catch (e) {
       console.error(e)

--- a/src/contexts/BankAccountsContext/BankAccountsContext.tsx
+++ b/src/contexts/BankAccountsContext/BankAccountsContext.tsx
@@ -1,24 +1,30 @@
 import { createContext, type PropsWithChildren, useCallback, useContext, useMemo } from 'react'
 
+import { type LoadedStatus } from '@internal-types/general'
 import { type BankAccount } from '@schemas/bankAccounts/bankAccount'
 import { hasNewSyncingAccounts, isAnyBankAccountSyncing } from '@utils/bankAccount'
-import { type ListBankAccountsSWRResponse, useListBankAccounts } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
+import { type SWRQueryResult } from '@utils/swr/SWRResponseTypes'
+import { useListBankAccounts } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
 import { usePollingConfig } from '@hooks/utils/swr/usePollingConfig'
 
 type BankAccountsContextValue = Pick<
-  ListBankAccountsSWRResponse,
+  SWRQueryResult<BankAccount[]>,
   | 'data'
-  | 'disconnectedAccountsRequiringNotification'
   | 'isError'
   | 'isLoading'
-  | 'isSyncing'
   | 'isValidating'
-  | 'loadingStatus'
   | 'refetch'
->
+> & {
+  disconnectedAccountsRequiringNotification: number
+  isSyncing: boolean
+  loadingStatus: LoadedStatus
+}
 
 const BANK_ACCOUNTS_POLL_INTERVAL_MS = 5 * 1000
 const BANK_ACCOUNTS_MAX_POLL_STALL_MS = 15 * 60 * 1000
+
+const requiresNotification = (bankAccount: BankAccount): boolean =>
+  bankAccount.isDisconnected && bankAccount.notifyWhenDisconnected
 
 const BankAccountsContext = createContext<BankAccountsContextValue>({
   data: undefined,
@@ -49,31 +55,31 @@ export function BankAccountsProvider({ children }: PropsWithChildren) {
   const pollingConfig = useBankAccountsPollingConfig()
   const {
     data,
-    disconnectedAccountsRequiringNotification,
     isError,
     isLoading,
-    isSyncing,
     isValidating,
-    loadingStatus,
     refetch,
-  } = useListBankAccounts(pollingConfig)
+  } = useListBankAccounts({ swrOptions: pollingConfig })
 
-  const value = useMemo<BankAccountsContextValue>(() => ({
+  const value = useMemo<BankAccountsContextValue>(() => {
+    const loadingStatus: LoadedStatus = isLoading
+      ? 'loading'
+      : data !== undefined || isError ? 'complete' : 'initial'
+
+    return {
+      data,
+      disconnectedAccountsRequiringNotification: (data ?? []).filter(requiresNotification).length,
+      isError,
+      isLoading,
+      isSyncing: isAnyBankAccountSyncing(data ?? []),
+      isValidating,
+      loadingStatus,
+      refetch,
+    }
+  }, [
     data,
-    disconnectedAccountsRequiringNotification,
     isError,
     isLoading,
-    isSyncing,
-    isValidating,
-    loadingStatus,
-    refetch,
-  }), [
-    data,
-    disconnectedAccountsRequiringNotification,
-    isError,
-    isLoading,
-    isSyncing,
-    loadingStatus,
     isValidating,
     refetch,
   ])

--- a/src/hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration.tsx
+++ b/src/hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration.tsx
@@ -1,7 +1,7 @@
-import { Schema } from 'effect'
 import useSWR from 'swr'
 
 import { AccountingConfigurationSchema } from '@schemas/accountingConfiguration'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
@@ -16,9 +16,7 @@ type GetAccountingConfigurationParams = {
 
 const buildKey = createBuildKey<{ businessId: string }>([ACCOUNTING_CONFIGURATION_TAG_KEY])
 
-const GetAccountingConfigurationResponseSchema = Schema.Struct({
-  data: AccountingConfigurationSchema,
-})
+const GetAccountingConfigurationResponseSchema = UnwrappedDataResponseSchema(AccountingConfigurationSchema)
 
 const getAccountingConfiguration = get<
   typeof GetAccountingConfigurationResponseSchema.Encoded,
@@ -31,20 +29,14 @@ const getAccountingConfiguration = get<
 
 const fetchAccountingConfiguration = createKeyedFetcher(
   getAccountingConfiguration,
-  GetAccountingConfigurationResponseSchema.pipe(Schema.pluck('data')),
+  GetAccountingConfigurationResponseSchema,
 )
 
 export function useAccountingConfiguration({ businessId }: GetAccountingConfigurationParams) {
   const { data: auth } = useAuth()
 
-  const queryKey = buildKey({
-    ...auth,
-    businessId,
-  })
+  const queryKey = buildKey({ ...auth, businessId })
+  const response = useSWR(() => queryKey, fetchAccountingConfiguration)
 
-  const response = useSWR(
-    () => queryKey,
-    fetchAccountingConfiguration,
-  )
   return new SWRQueryResult(response)
 }

--- a/src/hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration.tsx
+++ b/src/hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration.tsx
@@ -1,9 +1,10 @@
-import { Schema } from 'effect/index'
+import { Schema } from 'effect'
 import useSWR from 'swr'
 
-import { AccountingConfigurationSchema, type AccountingConfigurationSchemaType } from '@schemas/accountingConfiguration'
+import { AccountingConfigurationSchema } from '@schemas/accountingConfiguration'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 
@@ -15,10 +16,22 @@ type GetAccountingConfigurationParams = {
 
 const buildKey = createBuildKey<{ businessId: string }>([ACCOUNTING_CONFIGURATION_TAG_KEY])
 
-const getAccountingConfiguration = get<{ data: AccountingConfigurationSchemaType }, GetAccountingConfigurationParams>(
+const GetAccountingConfigurationResponseSchema = Schema.Struct({
+  data: AccountingConfigurationSchema,
+})
+
+const getAccountingConfiguration = get<
+  typeof GetAccountingConfigurationResponseSchema.Encoded,
+  GetAccountingConfigurationParams
+>(
   ({ businessId }) => {
     return `/v1/businesses/${businessId}/accounting-config`
   },
+)
+
+const fetchAccountingConfiguration = createKeyedFetcher(
+  getAccountingConfiguration,
+  GetAccountingConfigurationResponseSchema.pipe(Schema.pluck('data')),
 )
 
 export function useAccountingConfiguration({ businessId }: GetAccountingConfigurationParams) {
@@ -31,15 +44,7 @@ export function useAccountingConfiguration({ businessId }: GetAccountingConfigur
 
   const response = useSWR(
     () => queryKey,
-    ({ accessToken, apiUrl, businessId }) => getAccountingConfiguration(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-        },
-      },
-    )().then(({ data }) => Schema.decodeUnknownPromise(AccountingConfigurationSchema)(data)),
+    fetchAccountingConfiguration,
   )
   return new SWRQueryResult(response)
 }

--- a/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
@@ -3,6 +3,7 @@ import { Schema } from 'effect'
 import { type BankAccount, BankAccountSchema } from '@schemas/bankAccounts/bankAccount'
 import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
+import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const BANK_ACCOUNTS_TAG_KEY = '#bank-accounts'
@@ -21,3 +22,6 @@ export const useListBankAccounts = createQueryHook({
   select: (data): BankAccount[] => [...data],
   isLocalized: false,
 })
+
+export const useBankAccountsGlobalCacheActions =
+  createResourceGlobalCacheActions<BankAccount[]>(BANK_ACCOUNTS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
@@ -6,6 +6,7 @@ import { type BankAccount, BankAccountSchema } from '@schemas/bankAccounts/bankA
 import { get } from '@utils/api/authenticatedHttp'
 import { isAnyBankAccountSyncing } from '@utils/bankAccount'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher, type SWRKeyContext } from '@utils/swr/createKeyedFetcher'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
@@ -19,11 +20,13 @@ const requiresNotification = (bankAccount: BankAccount): boolean =>
   bankAccount.isDisconnected && bankAccount.notifyWhenDisconnected
 
 const listBankAccounts = get<
-  Record<string, unknown>,
+  typeof ListBankAccountsResponseSchema.Encoded,
   {
     businessId: string
   }
 >(({ businessId }) => `/v1/businesses/${businessId}/bank-accounts`)
+
+const fetchBankAccounts = createKeyedFetcher(listBankAccounts, ListBankAccountsResponseSchema)
 
 const buildKey = createBuildKey<{ businessId: string }>([BANK_ACCOUNTS_TAG_KEY])
 
@@ -56,15 +59,8 @@ export function useListBankAccounts(
         ...auth,
         businessId,
       }),
-    ({ accessToken, apiUrl, businessId }) => listBankAccounts(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-      },
-    )()
-      .then(Schema.decodeUnknownPromise(ListBankAccountsResponseSchema))
-      .then(({ data }) => [...data]),
+    (key: SWRKeyContext & { businessId: string }) =>
+      fetchBankAccounts(key).then(({ data }) => [...data]),
     config,
   )
 

--- a/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts.ts
@@ -1,68 +1,23 @@
 import { Schema } from 'effect'
-import useSWR, { type SWRConfiguration } from 'swr'
 
-import { type LoadedStatus } from '@internal-types/general'
 import { type BankAccount, BankAccountSchema } from '@schemas/bankAccounts/bankAccount'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
-import { isAnyBankAccountSyncing } from '@utils/bankAccount'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { createKeyedFetcher, type SWRKeyContext } from '@utils/swr/createKeyedFetcher'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const BANK_ACCOUNTS_TAG_KEY = '#bank-accounts'
 
-const ListBankAccountsResponseSchema = Schema.Struct({
-  data: Schema.Array(BankAccountSchema),
-})
-
-const requiresNotification = (bankAccount: BankAccount): boolean =>
-  bankAccount.isDisconnected && bankAccount.notifyWhenDisconnected
+const ListBankAccountsResponseSchema = UnwrappedDataResponseSchema(Schema.Array(BankAccountSchema))
 
 const listBankAccounts = get<
   typeof ListBankAccountsResponseSchema.Encoded,
-  {
-    businessId: string
-  }
+  { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/bank-accounts`)
 
-const fetchBankAccounts = createKeyedFetcher(listBankAccounts, ListBankAccountsResponseSchema)
-
-const buildKey = createBuildKey<{ businessId: string }>([BANK_ACCOUNTS_TAG_KEY])
-
-export class ListBankAccountsSWRResponse extends SWRQueryResult<BankAccount[]> {
-  get disconnectedAccountsRequiringNotification() {
-    return (this.data ?? []).filter(requiresNotification).length
-  }
-
-  get isSyncing() {
-    return isAnyBankAccountSyncing(this.data ?? [])
-  }
-
-  get loadingStatus(): LoadedStatus {
-    if (this.isLoading) {
-      return 'loading'
-    }
-
-    return this.data !== undefined || this.isError ? 'complete' : 'initial'
-  }
-}
-
-export function useListBankAccounts(
-  config?: SWRConfiguration<BankAccount[]>,
-): ListBankAccountsSWRResponse {
-  const { businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(
-    () =>
-      buildKey({
-        ...auth,
-        businessId,
-      }),
-    (key: SWRKeyContext & { businessId: string }) =>
-      fetchBankAccounts(key).then(({ data }) => [...data]),
-    config,
-  )
-
-  return new ListBankAccountsSWRResponse(swrResponse)
-}
+export const useListBankAccounts = createQueryHook({
+  tags: [BANK_ACCOUNTS_TAG_KEY],
+  request: listBankAccounts,
+  schema: ListBankAccountsResponseSchema,
+  select: (data): BankAccount[] => [...data],
+  isLocalized: false,
+})

--- a/src/hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount.ts
@@ -1,9 +1,5 @@
-import useSWRMutation from 'swr/mutation'
-
 import { del } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UNLINK_BANK_ACCOUNT_TAG_KEY = '#unlink-bank-account'
 
@@ -19,24 +15,9 @@ const unlinkBankAccount = del<
     `/v1/businesses/${businessId}/bank-accounts/${bankAccountId}`,
 )
 
-const buildKey = createBuildKey<{ businessId: string }>([UNLINK_BANK_ACCOUNT_TAG_KEY])
-
-export function useUnlinkBankAccount() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    ({ accessToken, apiUrl, businessId }, { arg: bankAccountId }: { arg: string }) =>
-      unlinkBankAccount(apiUrl, accessToken, {
-        params: { businessId, bankAccountId },
-      }),
-    {
-      revalidate: false,
-    },
-  )
-
-  return new SWRMutationResult(rawMutationResponse)
-}
+export const useUnlinkBankAccount = createMutationHook({
+  tags: [UNLINK_BANK_ACCOUNT_TAG_KEY],
+  request: unlinkBankAccount,
+  argToParams: (bankAccountId: string) => ({ bankAccountId }),
+  argToBody: () => undefined,
+})

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/useCategorizeBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/useCategorizeBankTransaction.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 import type { SWRInfiniteKeyedMutator } from 'swr/infinite'
 
 import { BankTransactionSchema } from '@schemas/bankTransactions/bankTransaction'
 import { type CategoryUpdate, type CategoryUpdateEncoded, encodeCategoryUpdate } from '@schemas/bankTransactions/categoryUpdate'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { put } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { type GetBankTransactionsReturn } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
@@ -14,9 +14,7 @@ import { useBankTransactionsContext } from '@contexts/BankTransactionsContext/Ba
 
 const CATEGORIZE_BANK_TRANSACTION_TAG = '#categorize-bank-transaction'
 
-const CategorizeBankTransactionResponseSchema = Schema.Struct({
-  data: BankTransactionSchema,
-})
+const CategorizeBankTransactionResponseSchema = UnwrappedDataResponseSchema(BankTransactionSchema)
 
 const categorizeBankTransaction = put<
   typeof CategorizeBankTransactionResponseSchema.Encoded,
@@ -46,7 +44,7 @@ const useCategorizeBankTransactionMutation = createMutationHook({
   argToParams: ({ bankTransactionId }: CategorizeBankTransactionArgs) => ({ bankTransactionId }),
   argToBody: ({ bankTransactionId: _bankTransactionId, ...rest }: CategorizeBankTransactionArgs) =>
     encodeCategoryUpdate(rest),
-  schema: CategorizeBankTransactionResponseSchema.pipe(Schema.pluck('data')),
+  schema: CategorizeBankTransactionResponseSchema,
   swrOptions: { throwOnError: true },
 })
 

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/useCategorizeBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/useCategorizeBankTransaction.ts
@@ -1,18 +1,15 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
 import type { SWRInfiniteKeyedMutator } from 'swr/infinite'
-import useSWRMutation from 'swr/mutation'
 
 import { BankTransactionSchema } from '@schemas/bankTransactions/bankTransaction'
 import { type CategoryUpdate, type CategoryUpdateEncoded, encodeCategoryUpdate } from '@schemas/bankTransactions/categoryUpdate'
 import { put } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { type GetBankTransactionsReturn } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 import { useBankTransactionsContext } from '@contexts/BankTransactionsContext/BankTransactionsContext'
 
 const CATEGORIZE_BANK_TRANSACTION_TAG = '#categorize-bank-transaction'
@@ -22,7 +19,7 @@ const CategorizeBankTransactionResponseSchema = Schema.Struct({
 })
 
 const categorizeBankTransaction = put<
-  Record<string, unknown>,
+  typeof CategorizeBankTransactionResponseSchema.Encoded,
   CategoryUpdateEncoded,
   {
     businessId: string
@@ -32,8 +29,6 @@ const categorizeBankTransaction = put<
   ({ businessId, bankTransactionId }) =>
     `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/categorize`,
 )
-
-const buildKey = createBuildKey<{ businessId: string }>([CATEGORIZE_BANK_TRANSACTION_TAG])
 
 type CategorizeBankTransactionArgs = CategoryUpdate & {
   bankTransactionId: string
@@ -45,42 +40,22 @@ export type UseCategorizeBankTransactionOptions = {
   >
 }
 
-export function useCategorizeBankTransaction() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
+const useCategorizeBankTransactionMutation = createMutationHook({
+  tags: [CATEGORIZE_BANK_TRANSACTION_TAG],
+  request: categorizeBankTransaction,
+  argToParams: ({ bankTransactionId }: CategorizeBankTransactionArgs) => ({ bankTransactionId }),
+  argToBody: ({ bankTransactionId: _bankTransactionId, ...rest }: CategorizeBankTransactionArgs) =>
+    encodeCategoryUpdate(rest),
+  schema: CategorizeBankTransactionResponseSchema.pipe(Schema.pluck('data')),
+  swrOptions: { throwOnError: true },
+})
 
+export function useCategorizeBankTransaction() {
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
   const { useBankTransactionsOptions } = useBankTransactionsContext()
   const { forceReloadBackgroundBankTransactions } = useBankTransactionsGlobalCacheActions()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { bankTransactionId, ...rest } }: { arg: CategorizeBankTransactionArgs },
-    ) => categorizeBankTransaction(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          bankTransactionId,
-        },
-        body: encodeCategoryUpdate(rest),
-      },
-    )
-      .then(Schema.decodeUnknownPromise(CategorizeBankTransactionResponseSchema))
-      .then(({ data }) => data),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useCategorizeBankTransactionMutation()
 
   const originalTrigger = mutationResponse.trigger
 

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/match/useMatchBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/match/useMatchBankTransaction.ts
@@ -1,15 +1,12 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { MatchSchema } from '@schemas/bankTransactions/match'
 import { put } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 import { useBankTransactionsContext } from '@contexts/BankTransactionsContext/BankTransactionsContext'
 
 export type MatchBankTransactionBody = {
@@ -22,7 +19,7 @@ const MatchBankTransactionResponseSchema = Schema.Struct({
 })
 
 const matchBankTransaction = put<
-  Record<string, unknown>,
+  typeof MatchBankTransactionResponseSchema.Encoded,
   MatchBankTransactionBody,
   {
     businessId: string
@@ -35,48 +32,25 @@ const matchBankTransaction = put<
 
 const MATCH_BANK_TRANSACTION_TAG = '#match-bank-transaction'
 
-const buildKey = createBuildKey<{ businessId: string }>([MATCH_BANK_TRANSACTION_TAG])
-
 type MatchBankTransactionArgs = MatchBankTransactionBody & {
   bankTransactionId: string
 }
 
-export function useMatchBankTransaction() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
+const useMatchBankTransactionMutation = createMutationHook({
+  tags: [MATCH_BANK_TRANSACTION_TAG],
+  request: matchBankTransaction,
+  argToParams: ({ bankTransactionId }: MatchBankTransactionArgs) => ({ bankTransactionId }),
+  argToBody: ({ bankTransactionId: _bankTransactionId, ...body }: MatchBankTransactionArgs) => body,
+  schema: MatchBankTransactionResponseSchema.pipe(Schema.pluck('data')),
+  swrOptions: { throwOnError: true },
+})
 
+export function useMatchBankTransaction() {
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
   const { useBankTransactionsOptions } = useBankTransactionsContext()
   const { forceReloadBackgroundBankTransactions } = useBankTransactionsGlobalCacheActions()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { bankTransactionId, ...body } }: { arg: MatchBankTransactionArgs },
-    ) => matchBankTransaction(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          bankTransactionId,
-        },
-        body,
-      },
-    )
-      .then(Schema.decodeUnknownPromise(MatchBankTransactionResponseSchema))
-      .then(({ data }) => data),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useMatchBankTransactionMutation()
 
   const originalTrigger = mutationResponse.trigger
 

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/match/useMatchBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/match/useMatchBankTransaction.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { MatchSchema } from '@schemas/bankTransactions/match'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { put } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
@@ -14,9 +14,7 @@ export type MatchBankTransactionBody = {
   type: 'Confirm_Match'
 }
 
-const MatchBankTransactionResponseSchema = Schema.Struct({
-  data: MatchSchema,
-})
+const MatchBankTransactionResponseSchema = UnwrappedDataResponseSchema(MatchSchema)
 
 const matchBankTransaction = put<
   typeof MatchBankTransactionResponseSchema.Encoded,
@@ -41,7 +39,7 @@ const useMatchBankTransactionMutation = createMutationHook({
   request: matchBankTransaction,
   argToParams: ({ bankTransactionId }: MatchBankTransactionArgs) => ({ bankTransactionId }),
   argToBody: ({ bankTransactionId: _bankTransactionId, ...body }: MatchBankTransactionArgs) => body,
-  schema: MatchBankTransactionResponseSchema.pipe(Schema.pluck('data')),
+  schema: MatchBankTransactionResponseSchema,
   swrOptions: { throwOnError: true },
 })
 

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useBankTransactionsMetadata.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useBankTransactionsMetadata.ts
@@ -3,15 +3,26 @@ import useSWR from 'swr'
 import { type BankTransaction, type BankTransactionMetadata } from '@internal-types/bankTransactions'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher, type SWRKeyContext } from '@utils/swr/createKeyedFetcher'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
-const getBankTransactionMetadata = get<{
-  data: BankTransactionMetadata
-  errors: unknown
-}>(
+type GetBankTransactionMetadataParams = {
+  businessId: string
+  bankTransactionId: string
+}
+
+const getBankTransactionMetadata = get<
+  {
+    data: BankTransactionMetadata
+    errors: unknown
+  },
+  GetBankTransactionMetadataParams
+>(
   ({ businessId, bankTransactionId }) =>
     `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/metadata`,
 )
+
+const fetchBankTransactionMetadata = createKeyedFetcher(getBankTransactionMetadata)
 
 export const GET_BANK_TRANSACTION_METADATA_TAG_KEY = '#bank-transaction-metadata'
 
@@ -26,10 +37,7 @@ export function useBankTransactionMetadata({ bankTransactionId }: { bankTransact
       businessId,
       bankTransactionId,
     })),
-    ({ accessToken, apiUrl, businessId }) => getBankTransactionMetadata(
-      apiUrl,
-      accessToken,
-      { params: { businessId, bankTransactionId } },
-    )().then(({ data }) => data),
+    (key: SWRKeyContext & GetBankTransactionMetadataParams) =>
+      fetchBankTransactionMetadata(key).then(({ data }) => data),
   )
 }

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useBankTransactionsMetadata.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useBankTransactionsMetadata.ts
@@ -1,43 +1,35 @@
-import useSWR from 'swr'
+import { Schema } from 'effect'
 
-import { type BankTransaction, type BankTransactionMetadata } from '@internal-types/bankTransactions'
+import { type BankTransactionMetadata } from '@internal-types/bankTransactions'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { createKeyedFetcher, type SWRKeyContext } from '@utils/swr/createKeyedFetcher'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
-type GetBankTransactionMetadataParams = {
-  businessId: string
-  bankTransactionId: string
-}
+export const GET_BANK_TRANSACTION_METADATA_TAG_KEY = '#bank-transaction-metadata'
+
+const BankTransactionMetadataSchema = Schema.Struct({
+  memo: Schema.NullishOr(Schema.String),
+})
+
+const GetBankTransactionMetadataResponseSchema = UnwrappedDataResponseSchema(BankTransactionMetadataSchema)
 
 const getBankTransactionMetadata = get<
+  typeof GetBankTransactionMetadataResponseSchema.Encoded,
   {
-    data: BankTransactionMetadata
-    errors: unknown
-  },
-  GetBankTransactionMetadataParams
+    businessId: string
+    bankTransactionId: string
+  }
 >(
   ({ businessId, bankTransactionId }) =>
     `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/metadata`,
 )
 
-const fetchBankTransactionMetadata = createKeyedFetcher(getBankTransactionMetadata)
+export const useBankTransactionMetadata = createQueryHook({
+  tags: [GET_BANK_TRANSACTION_METADATA_TAG_KEY],
+  request: getBankTransactionMetadata,
+  schema: GetBankTransactionMetadataResponseSchema,
+})
 
-export const GET_BANK_TRANSACTION_METADATA_TAG_KEY = '#bank-transaction-metadata'
-
-const buildKey = createBuildKey<{ businessId: string, bankTransactionId: string }>([GET_BANK_TRANSACTION_METADATA_TAG_KEY])
-
-export function useBankTransactionMetadata({ bankTransactionId }: { bankTransactionId: BankTransaction['id'] }) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  return useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      bankTransactionId,
-    })),
-    (key: SWRKeyContext & GetBankTransactionMetadataParams) =>
-      fetchBankTransactionMetadata(key).then(({ data }) => data),
-  )
-}
+export const useBankTransactionMetadataGlobalCacheActions =
+  createResourceGlobalCacheActions<BankTransactionMetadata>(GET_BANK_TRANSACTION_METADATA_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useSetMetadataOnBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useSetMetadataOnBankTransaction.ts
@@ -50,7 +50,8 @@ type UseSetMetadataOnBankTransactionParameters = {
 export function useSetMetadataOnBankTransaction({
   bankTransactionId,
 }: UseSetMetadataOnBankTransactionParameters) {
-  const mutationResponse = useSetMetadataOnBankTransactionMutation({ bankTransactionId })
+  const rawMutationResponse = useSetMetadataOnBankTransactionMutation({ bankTransactionId })
+  const mutationResponse = useMinMutatingMutation({ swrMutationResponse: rawMutationResponse })
 
   const { debouncedInvalidateBankTransactions, optimisticallyUpdateBankTransactions } = useBankTransactionsGlobalCacheActions()
 
@@ -103,7 +104,5 @@ export function useSetMetadataOnBankTransaction({
     ],
   )
 
-  const baseProxiedResponse = withStableTrigger(mutationResponse, stableProxiedTrigger)
-
-  return useMinMutatingMutation({ swrMutationResponse: baseProxiedResponse })
+  return withStableTrigger(mutationResponse, stableProxiedTrigger)
 }

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useSetMetadataOnBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useSetMetadataOnBankTransaction.ts
@@ -1,18 +1,14 @@
 import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
 
 import { type CustomerSchema } from '@schemas/customer'
 import { type VendorSchema } from '@schemas/vendor'
 import { patch } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 import { useMinMutatingMutation } from '@hooks/utils/swr/useMinMutatingMutation'
 
 const SET_METADATA_ON_BANK_TRANSACTION_TAG_KEY = '#set-metadata-on-bank-transaction'
-
-const buildKey = createBuildKey<{ businessId: string, bankTransactionId: string }>([SET_METADATA_ON_BANK_TRANSACTION_TAG_KEY])
 
 type SetMetadataOnBankTransactionBody = {
   vendor_id: string | null
@@ -36,6 +32,17 @@ type SetMetadataOnBankTransactionArg = {
   customer: typeof CustomerSchema.Type | null
 }
 
+const useSetMetadataOnBankTransactionMutation = createMutationHook({
+  tags: [SET_METADATA_ON_BANK_TRANSACTION_TAG_KEY],
+  request: setMetadataOnBankTransaction,
+  keyParams: ['bankTransactionId'],
+  argToBody: ({ vendor, customer }: SetMetadataOnBankTransactionArg) => ({
+    vendor_id: vendor?.id ?? null,
+    customer_id: customer?.id ?? null,
+  }),
+  swrOptions: { throwOnError: false },
+})
+
 type UseSetMetadataOnBankTransactionParameters = {
   bankTransactionId: string
 }
@@ -43,36 +50,7 @@ type UseSetMetadataOnBankTransactionParameters = {
 export function useSetMetadataOnBankTransaction({
   bankTransactionId,
 }: UseSetMetadataOnBankTransactionParameters) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      bankTransactionId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, bankTransactionId },
-      { arg: { vendor, customer } }: { arg: SetMetadataOnBankTransactionArg },
-    ) => setMetadataOnBankTransaction(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          bankTransactionId,
-        },
-        body: {
-          vendor_id: vendor?.id ?? null,
-          customer_id: customer?.id ?? null,
-        },
-      },
-    ),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
+  const mutationResponse = useSetMetadataOnBankTransactionMutation({ bankTransactionId })
 
   const { debouncedInvalidateBankTransactions, optimisticallyUpdateBankTransactions } = useBankTransactionsGlobalCacheActions()
 

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useUpdateBankTransactionMetadata.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useUpdateBankTransactionMetadata.ts
@@ -1,20 +1,18 @@
 import { useCallback } from 'react'
 import { useSWRConfig } from 'swr'
-import useSWRMutation from 'swr/mutation'
 
 import type { BankTransactionMetadata } from '@internal-types/bankTransactions'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { put } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { GET_BANK_TRANSACTION_METADATA_TAG_KEY } from '@hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useBankTransactionsMetadata'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const updateBankTransactionMetadata = put<
   { data: BankTransactionMetadata, errors: unknown },
-  { memo: string }
+  { memo: string },
+  { businessId: string, bankTransactionId: string }
 >(
   ({ businessId, bankTransactionId }) =>
     `/v1/businesses/${businessId}/bank-transactions/${bankTransactionId}/metadata`,
@@ -24,41 +22,22 @@ export type UpdateBankTransactionMetadataBody = { memo: string }
 
 const UPDATE_BANK_TRANSACTION_METADATA_TAG_KEY = '#update-bank-transaction-metadata'
 
-const buildKey = createBuildKey<{ businessId: string, bankTransactionId: string }>([UPDATE_BANK_TRANSACTION_METADATA_TAG_KEY])
+const useUpdateBankTransactionMetadataMutation = createMutationHook({
+  tags: [UPDATE_BANK_TRANSACTION_METADATA_TAG_KEY],
+  request: updateBankTransactionMetadata,
+  keyParams: ['bankTransactionId'],
+  select: ({ data }) => data,
+  swrOptions: { throwOnError: false },
+})
 
 export function useUpdateBankTransactionMetadata({ bankTransactionId, onSuccess }: { bankTransactionId: string, onSuccess?: () => Awaitable<unknown> }) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-      bankTransactionId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: body }: { arg: UpdateBankTransactionMetadataBody },
-    ) => updateBankTransactionMetadata(apiUrl, accessToken,
-      {
-        params: {
-          businessId,
-          bankTransactionId,
-        },
-        body,
-      },
-    ).then(({ data }) => {
-      onSuccess?.()
-      return data
-    }),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
+  const mutationResponse = useUpdateBankTransactionMetadataMutation({
+    bankTransactionId,
+    swrOptions: { onSuccess: () => { void onSuccess?.() } },
+  })
 
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useUpdateBankTransactionMetadata.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useUpdateBankTransactionMetadata.ts
@@ -1,12 +1,10 @@
 import { useCallback } from 'react'
-import { useSWRConfig } from 'swr'
 
 import type { BankTransactionMetadata } from '@internal-types/bankTransactions'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { put } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
-import { GET_BANK_TRANSACTION_METADATA_TAG_KEY } from '@hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useBankTransactionsMetadata'
+import { useBankTransactionMetadataGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/metadata/useBankTransactionsMetadata'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const updateBankTransactionMetadata = put<
@@ -31,7 +29,7 @@ const useUpdateBankTransactionMetadataMutation = createMutationHook({
 })
 
 export function useUpdateBankTransactionMetadata({ bankTransactionId, onSuccess }: { bankTransactionId: string, onSuccess?: () => Awaitable<unknown> }) {
-  const { mutate } = useSWRConfig()
+  const { invalidate: invalidateBankTransactionMetadata } = useBankTransactionMetadataGlobalCacheActions()
 
   const mutationResponse = useUpdateBankTransactionMetadataMutation({
     bankTransactionId,
@@ -44,17 +42,11 @@ export function useUpdateBankTransactionMetadata({ bankTransactionId, onSuccess 
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
-      void mutate(key => withSWRKeyTags(
-        key,
-        ({ tags }) => tags.includes(GET_BANK_TRANSACTION_METADATA_TAG_KEY),
-      ))
+      void invalidateBankTransactionMetadata()
 
       return triggerResult
     },
-    [
-      originalTrigger,
-      mutate,
-    ],
+    [originalTrigger, invalidateBankTransactionMetadata],
   )
 
   return withStableTrigger(mutationResponse, stableProxiedTrigger)

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-categorize/useBulkCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-categorize/useBulkCategorize.ts
@@ -1,14 +1,12 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { CategoryUpdateSchema } from '@schemas/bankTransactions/categoryUpdate'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const BULK_CATEGORIZE_BANK_TRANSACTIONS_TAG_KEY = '#bulk-categorize-bank-transactions'
@@ -33,36 +31,21 @@ const bulkCategorize = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/bank-transactions/bulk-categorize`)
 
-const buildKey = createBuildKey<{ businessId: string }>([BULK_CATEGORIZE_BANK_TRANSACTIONS_TAG_KEY])
+const useBulkCategorizeMutation = createMutationHook({
+  tags: [BULK_CATEGORIZE_BANK_TRANSACTIONS_TAG_KEY],
+  request: bulkCategorize,
+  argToBody: (arg: BulkCategorizeRequest) => Schema.encodeSync(BulkCategorizeRequestSchema)(arg),
+  select: ({ data }) => data,
+  swrOptions: { throwOnError: true },
+})
 
 export const useBulkCategorize = () => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { eventCallbacks } = useLayerContext()
 
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg }: { arg: BulkCategorizeRequest },
-    ) => bulkCategorize(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body: Schema.encodeSync(BulkCategorizeRequestSchema)(arg),
-      },
-    ).then(({ data }) => data),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
+  const mutationResponse = useBulkCategorizeMutation()
 
   const originalTrigger = mutationResponse.trigger
 

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -180,12 +180,7 @@ export const useBulkMatchOrCategorize = () => {
   const proxiedResponse = withStableTrigger(mutationResponse, stableProxiedTrigger)
 
   return {
-    data: proxiedResponse.data,
-    trigger: proxiedResponse.trigger,
-    isMutating: proxiedResponse.isMutating,
-    error: proxiedResponse.error,
-    isError: proxiedResponse.isError,
-    reset: proxiedResponse.reset,
+    ...proxiedResponse,
     buildTransactionsPayload,
   }
 }

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -177,15 +177,10 @@ export const useBulkMatchOrCategorize = () => {
     [originalTrigger, forceReloadBankTransactions, debouncedInvalidateProfitAndLoss, eventCallbacks],
   )
 
-  const proxiedResponse = withStableTrigger(mutationResponse, stableProxiedTrigger)
+  const response = withStableTrigger(mutationResponse, stableProxiedTrigger)
 
   return {
-    data: proxiedResponse.data,
-    trigger: proxiedResponse.trigger,
-    isMutating: proxiedResponse.isMutating,
-    error: proxiedResponse.error,
-    isError: proxiedResponse.isError,
-    reset: proxiedResponse.reset,
+    response,
     buildTransactionsPayload,
   }
 }

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -1,15 +1,13 @@
 import { useCallback } from 'react'
 import { pipe, Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { type Split } from '@internal-types/bankTransactions'
 import { CategoryUpdateSchema } from '@schemas/bankTransactions/categoryUpdate'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 import { type BankTransactionCategorization, BankTransactionSelectionVariant, DEFAULT_CATEGORIZATION, useGetAllBankTransactionsCategorizations } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
 import { useSelectedIds } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
@@ -139,10 +137,15 @@ const bulkMatchOrCategorize = post<
   },
 )
 
-const buildKey = createBuildKey<{ businessId: string }>([BULK_MATCH_OR_CATEGORIZE_TAG])
+const useBulkMatchOrCategorizeMutation = createMutationHook({
+  tags: [BULK_MATCH_OR_CATEGORIZE_TAG],
+  request: bulkMatchOrCategorize,
+  argToBody: (arg: BulkMatchOrCategorizeRequest) => Schema.encodeSync(BulkMatchOrCategorizeRequestSchema)(arg),
+  select: ({ data }) => data,
+  swrOptions: { throwOnError: true },
+})
 
 export const useBulkMatchOrCategorize = () => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { eventCallbacks } = useLayerContext()
   const { selectedIds } = useSelectedIds()
   const { categorizations } = useGetAllBankTransactionsCategorizations()
@@ -155,27 +158,7 @@ export const useBulkMatchOrCategorize = () => {
     return { transactions }
   }, [selectedIds, categorizations])
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg }: { arg: BulkMatchOrCategorizeRequest },
-    ) => bulkMatchOrCategorize(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body: Schema.encodeSync(BulkMatchOrCategorizeRequestSchema)(arg),
-      },
-    ).then(({ data }) => data),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
+  const mutationResponse = useBulkMatchOrCategorizeMutation()
 
   const { trigger: originalTrigger } = mutationResponse
 
@@ -197,7 +180,12 @@ export const useBulkMatchOrCategorize = () => {
   const proxiedResponse = withStableTrigger(mutationResponse, stableProxiedTrigger)
 
   return {
-    ...proxiedResponse,
+    data: proxiedResponse.data,
+    trigger: proxiedResponse.trigger,
+    isMutating: proxiedResponse.isMutating,
+    error: proxiedResponse.error,
+    isError: proxiedResponse.isError,
+    reset: proxiedResponse.reset,
     buildTransactionsPayload,
   }
 }

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-match-or-categorize/useBulkMatchOrCategorize.ts
@@ -180,7 +180,12 @@ export const useBulkMatchOrCategorize = () => {
   const proxiedResponse = withStableTrigger(mutationResponse, stableProxiedTrigger)
 
   return {
-    ...proxiedResponse,
+    data: proxiedResponse.data,
+    trigger: proxiedResponse.trigger,
+    isMutating: proxiedResponse.isMutating,
+    error: proxiedResponse.error,
+    isError: proxiedResponse.isError,
+    reset: proxiedResponse.reset,
     buildTransactionsPayload,
   }
 }

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-uncategorize/useBulkUncategorize.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/bulk-uncategorize/useBulkUncategorize.ts
@@ -1,13 +1,11 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 const BULK_UNCATEGORIZE_BANK_TRANSACTIONS_TAG_KEY = '#bulk-uncategorize-bank-transactions'
@@ -27,36 +25,21 @@ const bulkUncategorize = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/bank-transactions/bulk-uncategorize`)
 
-const buildKey = createBuildKey<{ businessId: string }>([BULK_UNCATEGORIZE_BANK_TRANSACTIONS_TAG_KEY])
+const useBulkUncategorizeMutation = createMutationHook({
+  tags: [BULK_UNCATEGORIZE_BANK_TRANSACTIONS_TAG_KEY],
+  request: bulkUncategorize,
+  argToBody: (arg: BulkUncategorizeRequest) => Schema.encodeSync(BulkUncategorizeRequestSchema)(arg),
+  select: ({ data }) => data,
+  swrOptions: { throwOnError: true },
+})
 
 export const useBulkUncategorize = () => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { eventCallbacks } = useLayerContext()
 
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg }: { arg: BulkUncategorizeRequest },
-    ) => bulkUncategorize(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body: Schema.encodeSync(BulkUncategorizeRequestSchema)(arg),
-      },
-    ).then(({ data }) => data),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
+  const mutationResponse = useBulkUncategorizeMutation()
 
   const originalTrigger = mutationResponse.trigger
 

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/tags/useRemoveTagFromBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/tags/useRemoveTagFromBankTransaction.ts
@@ -1,11 +1,9 @@
 import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const REMOVE_TAG_FROM_BANK_TRANSACTION_TAG_KEY = '#remove-tag-from-bank-transaction'
 
@@ -16,46 +14,29 @@ type RemoveTagFromBankTransactionBody = {
 const removeTagFromBankTransaction = del<
   Record<string, never>,
   RemoveTagFromBankTransactionBody,
-  { businessId: string }
+  { businessId: string, bankTransactionId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/bank-transactions/tags`)
-
-const buildKey = createBuildKey<{ businessId: string, bankTransactionId: string }>([REMOVE_TAG_FROM_BANK_TRANSACTION_TAG_KEY])
 
 type RemoveTagFromBankTransactionArg = {
   tagId: string
 }
+
+const useRemoveTagFromBankTransactionMutation = createMutationHook({
+  tags: [REMOVE_TAG_FROM_BANK_TRANSACTION_TAG_KEY],
+  request: removeTagFromBankTransaction,
+  keyParams: ['bankTransactionId'],
+  argToBody: ({ tagId }: RemoveTagFromBankTransactionArg) => ({
+    tag_ids: [tagId],
+  }),
+  swrOptions: { throwOnError: false },
+})
 
 type RemoveTagFromBankTransactionOptions = {
   bankTransactionId: string
 }
 
 export function useRemoveTagFromBankTransaction({ bankTransactionId }: RemoveTagFromBankTransactionOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      bankTransactionId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { tagId } }: { arg: RemoveTagFromBankTransactionArg },
-    ) => removeTagFromBankTransaction(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body: {
-          tag_ids: [tagId],
-        },
-      },
-    ),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
+  const mutationResponse = useRemoveTagFromBankTransactionMutation({ bankTransactionId })
 
   const { optimisticallyUpdateBankTransactions, debouncedInvalidateBankTransactions } = useBankTransactionsGlobalCacheActions()
 

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/tags/useTagBankTransaction.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/tags/useTagBankTransaction.ts
@@ -1,15 +1,13 @@
 import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
 import { v4 as uuidv4 } from 'uuid'
 
 import type { TransactionTagEncoded } from '@schemas/tag'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import {
   useBankTransactionsGlobalCacheActions,
 } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const TAG_BANK_TRANSACTION_TAG_KEY = '#tag-bank-transaction'
 
@@ -33,10 +31,8 @@ type TagBankTransactionResponse = {
 const tagBankTransaction = post<
   TagBankTransactionResponse,
   TagBankTransactionBody,
-  { businessId: string }
+  { businessId: string, bankTransactionId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/bank-transactions/tags`)
-
-const buildKey = createBuildKey<{ businessId: string, bankTransactionId: string }>([TAG_BANK_TRANSACTION_TAG_KEY])
 
 type TagBankTransactionArg = {
   key: string
@@ -45,38 +41,26 @@ type TagBankTransactionArg = {
   valueDisplayName?: string | null
 }
 
+const useTagBankTransactionMutation = createMutationHook({
+  tags: [TAG_BANK_TRANSACTION_TAG_KEY],
+  request: tagBankTransaction,
+  keyParams: ['bankTransactionId'],
+  argToBody: (
+    { key, value, dimensionDisplayName, valueDisplayName }: TagBankTransactionArg,
+    { bankTransactionId },
+  ) => ({
+    key_values: [{ key, dimension_display_name: dimensionDisplayName, value, value_display_name: valueDisplayName }],
+    transaction_ids: [bankTransactionId],
+  }),
+  swrOptions: { throwOnError: false },
+})
+
 type TagBankTransactionOptions = {
   bankTransactionId: string
 }
 
 export function useTagBankTransaction({ bankTransactionId }: TagBankTransactionOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      bankTransactionId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, bankTransactionId },
-      { arg: { key, value, dimensionDisplayName, valueDisplayName } }: { arg: TagBankTransactionArg },
-    ) => tagBankTransaction(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body: {
-          key_values: [{ key, dimension_display_name: dimensionDisplayName, value, value_display_name: valueDisplayName }],
-          transaction_ids: [bankTransactionId],
-        },
-      },
-    ),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
+  const mutationResponse = useTagBankTransactionMutation({ bankTransactionId })
 
   const { optimisticallyUpdateBankTransactions, debouncedInvalidateBankTransactions } = useBankTransactionsGlobalCacheActions()
 

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions.ts
@@ -1,5 +1,4 @@
 import { useCallback, useMemo } from 'react'
-import { Schema } from 'effect'
 import { debounce } from 'lodash-es'
 import useSWRInfinite, { type SWRInfiniteConfiguration } from 'swr/infinite'
 
@@ -10,6 +9,7 @@ import { get } from '@utils/api/authenticatedHttp'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
 import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import { createKeyMatcher } from '@utils/swr/createKeyMatcher'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
 import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
@@ -35,7 +35,7 @@ type GetBankTransactionsPaginatedParams = {
 }
 
 const getBankTransactions = get<
-  Record<string, unknown>,
+  typeof GetBankTransactionsResponseSchema.Encoded,
   GetBankTransactionsPaginatedParams
 >(
   ({
@@ -79,9 +79,11 @@ export type UseBankTransactionsOptions = {
 }
 
 const keyLoader = createInfiniteKeyLoader<
-  UseBankTransactionsOptions & { businessId: string },
+  UseBankTransactionsOptions & { businessId: string, limit?: number },
   GetBankTransactionsReturn
 >([BANK_TRANSACTIONS_TAG_KEY])
+
+const fetchBankTransactions = createKeyedFetcher(getBankTransactions, GetBankTransactionsResponseSchema)
 
 export type BankTransactionsKey = NonNullable<ReturnType<typeof keyLoader>>
 
@@ -119,38 +121,10 @@ export function useBankTransactions({
         startDate,
         endDate,
         tagFilterQueryString,
+        limit: 200,
       },
     )),
-    ({
-      accessToken,
-      apiUrl,
-      businessId,
-      categorized,
-      cursor,
-      direction,
-      query,
-      startDate,
-      endDate,
-      tagFilterQueryString,
-    }: NonNullable<ReturnType<typeof keyLoader>>) => {
-      return getBankTransactions(
-        apiUrl,
-        accessToken,
-        {
-          params: {
-            businessId,
-            categorized,
-            cursor,
-            direction,
-            limit: 200,
-            query,
-            startDate,
-            endDate,
-            tagFilterQueryString,
-          },
-        },
-      )().then(Schema.decodeUnknownPromise(GetBankTransactionsResponseSchema))
-    },
+    fetchBankTransactions,
     {
       keepPreviousData: true,
       revalidateFirstPage: false,

--- a/src/hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions.ts
+++ b/src/hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions.ts
@@ -1,71 +1,18 @@
 import { useCallback, useMemo } from 'react'
 import { debounce } from 'lodash-es'
-import useSWRInfinite, { type SWRInfiniteConfiguration } from 'swr/infinite'
 
 import type { BankTransaction } from '@internal-types/bankTransactions'
 import { BankTransactionSchema } from '@schemas/bankTransactions/bankTransaction'
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import { createKeyMatcher } from '@utils/swr/createKeyMatcher'
 import { useGlobalCacheActions } from '@utils/swr/useGlobalCacheActions'
-import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
-import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createInfiniteQueryHook } from '@hooks/utils/swr/createInfiniteQueryHook'
 
 const GetBankTransactionsResponseSchema = PaginatedResponseSchema(BankTransactionSchema)
 
 export type GetBankTransactionsReturn = typeof GetBankTransactionsResponseSchema.Type
-
-type GetBankTransactionsPaginatedParams = {
-  businessId: string
-  categorized?: boolean
-  direction?: 'INFLOW' | 'OUTFLOW'
-  query?: string
-  startDate?: Date
-  endDate?: Date
-  tagFilterQueryString?: string
-  sortOrder?: 'ASC' | 'DESC'
-  sortBy?: string
-  cursor?: string
-  limit?: number
-}
-
-const getBankTransactions = get<
-  typeof GetBankTransactionsResponseSchema.Encoded,
-  GetBankTransactionsPaginatedParams
->(
-  ({
-    businessId,
-    cursor,
-    categorized,
-    direction,
-    limit,
-    query,
-    startDate,
-    endDate,
-    sortBy = 'date',
-    sortOrder = 'DESC',
-    tagFilterQueryString,
-  }: GetBankTransactionsPaginatedParams) => {
-    const parameters = toDefinedSearchParameters({
-      cursor,
-      categorized,
-      direction,
-      q: query,
-      startDate,
-      endDate,
-      sortBy,
-      sortOrder,
-      limit,
-    })
-
-    return `/v1/businesses/${businessId}/bank-transactions?${parameters}${tagFilterQueryString ? `&${tagFilterQueryString}` : ''}`
-  },
-)
 
 export const BANK_TRANSACTIONS_TAG_KEY = '#bank-transactions'
 
@@ -75,17 +22,66 @@ export type UseBankTransactionsOptions = {
   query?: string
   startDate?: Date
   endDate?: Date
-  tagFilterQueryString?: string
+  tagKey?: string
+  tagValues?: string
 }
 
-const keyLoader = createInfiniteKeyLoader<
-  UseBankTransactionsOptions & { businessId: string, limit?: number },
-  GetBankTransactionsReturn
->([BANK_TRANSACTIONS_TAG_KEY])
+type GetBankTransactionsPaginatedParams = UseBankTransactionsOptions & {
+  businessId: string
+  sortOrder?: 'ASC' | 'DESC'
+  sortBy?: string
+  cursor?: string
+  limit?: number
+}
 
-const fetchBankTransactions = createKeyedFetcher(getBankTransactions, GetBankTransactionsResponseSchema)
+const getBankTransactions = getWithQuery<
+  typeof GetBankTransactionsResponseSchema.Encoded,
+  GetBankTransactionsPaginatedParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/bank-transactions`,
+  ({
+    cursor,
+    categorized,
+    direction,
+    query,
+    startDate,
+    endDate,
+    sortBy = 'date',
+    sortOrder = 'DESC',
+    limit,
+    tagKey,
+    tagValues,
+  }) => ({
+    cursor,
+    categorized,
+    direction,
+    q: query,
+    startDate,
+    endDate,
+    sortBy,
+    sortOrder,
+    limit,
+    tagKey,
+    tagValues,
+  }),
+)
 
-export type BankTransactionsKey = NonNullable<ReturnType<typeof keyLoader>>
+export const useBankTransactions = createInfiniteQueryHook({
+  tags: [BANK_TRANSACTIONS_TAG_KEY],
+  request: getBankTransactions,
+  schema: GetBankTransactionsResponseSchema,
+  keyDefaults: { limit: 200 },
+})
+
+export type BankTransactionsKey = UseBankTransactionsOptions & {
+  accessToken: string
+  apiUrl: string
+  businessId: string
+  cursor?: string
+  limit?: number
+  tags: ReadonlyArray<string>
+}
 
 const compareDates = (a: unknown, b: unknown) =>
   (a as Date | undefined)?.getTime() === (b as Date | undefined)?.getTime()
@@ -96,47 +92,9 @@ const keyMatchesParams = createKeyMatcher<BankTransactionsKey, UseBankTransactio
   { key: 'query' },
   { key: 'startDate', compare: compareDates },
   { key: 'endDate', compare: compareDates },
-  { key: 'tagFilterQueryString' },
+  { key: 'tagKey' },
+  { key: 'tagValues' },
 ])
-
-export function useBankTransactions({
-  categorized,
-  direction,
-  query,
-  startDate,
-  endDate,
-  tagFilterQueryString,
-}: UseBankTransactionsOptions, config?: SWRInfiniteConfiguration<GetBankTransactionsReturn>) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWRInfinite(
-    (_index, previousPageData: GetBankTransactionsReturn | null) => withLocale(keyLoader(
-      previousPageData,
-      {
-        ...auth,
-        businessId,
-        categorized,
-        direction,
-        query,
-        startDate,
-        endDate,
-        tagFilterQueryString,
-        limit: 200,
-      },
-    )),
-    fetchBankTransactions,
-    {
-      keepPreviousData: true,
-      revalidateFirstPage: false,
-      initialSize: 1,
-      ...config,
-    },
-  )
-
-  usePreserveInfiniteSize(swrResponse)
-
-  return useSWRInfiniteResult(swrResponse)
-}
 
 const INVALIDATION_DEBOUNCE_OPTIONS = {
   wait: 1000,

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration.tsx
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration.tsx
@@ -1,6 +1,3 @@
-import { Schema } from 'effect'
-import useSWR from 'swr'
-
 import {
   type BookkeepingConfiguration,
   BookkeepingConfigurationResponseSchema,
@@ -8,9 +5,7 @@ import {
   TransactionTaggingStrategy,
 } from '@schemas/bookkeepingConfiguration'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export type { BookkeepingConfiguration }
 export { BookkeepingStatus, TransactionTaggingStrategy }
@@ -21,34 +16,16 @@ type GetBookkeepingConfigurationParams = {
   businessId: string
 }
 
-const buildKey = createBuildKey<{ businessId: string }>([BOOKKEEPING_CONFIGURATION_TAG_KEY])
-
 const getBookkeepingConfiguration = get<
-  Record<string, unknown>,
+  typeof BookkeepingConfigurationResponseSchema.Encoded,
   GetBookkeepingConfigurationParams
 >(({ businessId }) => {
   return `/v1/businesses/${businessId}/bookkeeping/config`
 })
 
-export function useBookkeepingConfiguration() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const queryKey = withLocale(buildKey({
-    ...auth,
-    businessId,
-  }))
-
-  const response = useSWR(
-    () => queryKey,
-    ({ accessToken, apiUrl, businessId }) =>
-      getBookkeepingConfiguration(apiUrl, accessToken, {
-        params: {
-          businessId,
-        },
-      })()
-        .then(Schema.decodeUnknownPromise(BookkeepingConfigurationResponseSchema))
-        .then(({ data }) => data),
-  )
-
-  return new SWRQueryResult(response)
-}
+export const useBookkeepingConfiguration = createQueryHook({
+  tags: [BOOKKEEPING_CONFIGURATION_TAG_KEY],
+  request: getBookkeepingConfiguration,
+  schema: BookkeepingConfigurationResponseSchema,
+  select: ({ data }) => data,
+})

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration.tsx
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration.tsx
@@ -1,11 +1,10 @@
-import { Schema } from 'effect'
-
 import {
   type BookkeepingConfiguration,
-  BookkeepingConfigurationResponseSchema,
+  BookkeepingConfigurationSchema,
   BookkeepingStatus,
   TransactionTaggingStrategy,
 } from '@schemas/bookkeepingConfiguration'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
@@ -18,6 +17,8 @@ type GetBookkeepingConfigurationParams = {
   businessId: string
 }
 
+const BookkeepingConfigurationResponseSchema = UnwrappedDataResponseSchema(BookkeepingConfigurationSchema)
+
 const getBookkeepingConfiguration = get<
   typeof BookkeepingConfigurationResponseSchema.Encoded,
   GetBookkeepingConfigurationParams
@@ -28,5 +29,5 @@ const getBookkeepingConfiguration = get<
 export const useBookkeepingConfiguration = createQueryHook({
   tags: [BOOKKEEPING_CONFIGURATION_TAG_KEY],
   request: getBookkeepingConfiguration,
-  schema: BookkeepingConfigurationResponseSchema.pipe(Schema.pluck('data')),
+  schema: BookkeepingConfigurationResponseSchema,
 })

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration.tsx
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration.tsx
@@ -1,3 +1,5 @@
+import { Schema } from 'effect'
+
 import {
   type BookkeepingConfiguration,
   BookkeepingConfigurationResponseSchema,
@@ -26,6 +28,5 @@ const getBookkeepingConfiguration = get<
 export const useBookkeepingConfiguration = createQueryHook({
   tags: [BOOKKEEPING_CONFIGURATION_TAG_KEY],
   request: getBookkeepingConfiguration,
-  schema: BookkeepingConfigurationResponseSchema,
-  select: ({ data }) => data,
+  schema: BookkeepingConfigurationResponseSchema.pipe(Schema.pluck('data')),
 })

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods.ts
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods.ts
@@ -1,19 +1,17 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
 
 import type { EnumWithUnknownValues } from '@internal-types/utility/enumWithUnknownValues'
 import { BusinessTaskSchema } from '@schemas/businessTasks/businessTask'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
 import { isActiveOrPausedBookkeepingStatus } from '@utils/bookkeeping/bookkeepingStatusFilters'
 import { isActiveBookkeepingPeriod } from '@utils/bookkeeping/periods/getFilteredBookkeepingPeriods'
 import { getUserVisibleTasks } from '@utils/bookkeeping/tasks/bookkeepingTasksFilters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import {
   BOOKKEEPING_TAG_KEY,
   useBookkeepingStatus,
 } from '@hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export enum BookkeepingPeriodStatus {
   BOOKKEEPING_NOT_ACTIVE = 'BOOKKEEPING_NOT_ACTIVE',
@@ -54,11 +52,9 @@ const RawBookkeepingPeriodSchema = Schema.Struct({
 })
 type RawBookkeepingPeriod = typeof RawBookkeepingPeriodSchema.Type
 
-const BookkeepingPeriodsResponseSchema = Schema.Struct({
-  data: Schema.Struct({
-    periods: Schema.Array(RawBookkeepingPeriodSchema),
-  }),
-})
+const BookkeepingPeriodsResponseSchema = UnwrappedDataResponseSchema(Schema.Struct({
+  periods: Schema.Array(RawBookkeepingPeriodSchema),
+}))
 
 const getBookkeepingPeriods = get<
   typeof BookkeepingPeriodsResponseSchema.Encoded,
@@ -67,40 +63,32 @@ const getBookkeepingPeriods = get<
   return `/v1/businesses/${businessId}/bookkeeping/periods`
 })
 
-const fetchBookkeepingPeriods = createKeyedFetcher(getBookkeepingPeriods, BookkeepingPeriodsResponseSchema)
-
 export const BOOKKEEPING_PERIODS_TAG_KEY = '#bookkeeping-periods'
 
-const buildKey = createBuildKey<{ businessId: string }>([BOOKKEEPING_TAG_KEY, BOOKKEEPING_PERIODS_TAG_KEY])
+const useBookkeepingPeriodsQuery = createQueryHook({
+  tags: [BOOKKEEPING_TAG_KEY, BOOKKEEPING_PERIODS_TAG_KEY],
+  request: getBookkeepingPeriods,
+  schema: BookkeepingPeriodsResponseSchema,
+  select: ({ periods }) =>
+    periods
+      .map(period => ({
+        ...period,
+        status: constrainToKnownBookkeepingPeriodStatus(period.status),
+        tasks: getUserVisibleTasks(period.tasks),
+      }))
+      .filter(period => isActiveBookkeepingPeriod(period)),
+})
 
 export function useBookkeepingPeriods() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
   const { data, isLoading: isLoadingBookkeepingStatus } = useBookkeepingStatus()
   const isActiveOrPaused = data ? isActiveOrPausedBookkeepingStatus(data.status) : false
 
-  const swrResponse = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      isEnabled: isActiveOrPaused,
-    })),
-    key => fetchBookkeepingPeriods(key).then(
-      ({ data: { periods } }) =>
-        periods
-          .map(period => ({
-            ...period,
-            status: constrainToKnownBookkeepingPeriodStatus(period.status),
-            tasks: getUserVisibleTasks(period.tasks),
-          }))
-          .filter(period => isActiveBookkeepingPeriod(period)),
-    ),
-  )
+  const queryResult = useBookkeepingPeriodsQuery({ isEnabled: isActiveOrPaused })
 
-  return new Proxy(swrResponse, {
+  return new Proxy(queryResult, {
     get(target, prop) {
       if (prop === 'isLoading') {
-        return isLoadingBookkeepingStatus || swrResponse.isLoading
+        return isLoadingBookkeepingStatus || target.isLoading
       }
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods.ts
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods.ts
@@ -8,6 +8,7 @@ import { isActiveOrPausedBookkeepingStatus } from '@utils/bookkeeping/bookkeepin
 import { isActiveBookkeepingPeriod } from '@utils/bookkeeping/periods/getFilteredBookkeepingPeriods'
 import { getUserVisibleTasks } from '@utils/bookkeeping/tasks/bookkeepingTasksFilters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import {
   BOOKKEEPING_TAG_KEY,
   useBookkeepingStatus,
@@ -60,11 +61,13 @@ const BookkeepingPeriodsResponseSchema = Schema.Struct({
 })
 
 const getBookkeepingPeriods = get<
-  Record<string, unknown>,
+  typeof BookkeepingPeriodsResponseSchema.Encoded,
   { businessId: string }
 >(({ businessId }) => {
   return `/v1/businesses/${businessId}/bookkeeping/periods`
 })
+
+const fetchBookkeepingPeriods = createKeyedFetcher(getBookkeepingPeriods, BookkeepingPeriodsResponseSchema)
 
 export const BOOKKEEPING_PERIODS_TAG_KEY = '#bookkeeping-periods'
 
@@ -82,22 +85,16 @@ export function useBookkeepingPeriods() {
       businessId,
       isEnabled: isActiveOrPaused,
     })),
-    ({ accessToken, apiUrl, businessId }) => getBookkeepingPeriods(
-      apiUrl,
-      accessToken,
-      { params: { businessId } },
-    )()
-      .then(Schema.decodeUnknownPromise(BookkeepingPeriodsResponseSchema))
-      .then(
-        ({ data: { periods } }) =>
-          periods
-            .map(period => ({
-              ...period,
-              status: constrainToKnownBookkeepingPeriodStatus(period.status),
-              tasks: getUserVisibleTasks(period.tasks),
-            }))
-            .filter(period => isActiveBookkeepingPeriod(period)),
-      ),
+    key => fetchBookkeepingPeriods(key).then(
+      ({ data: { periods } }) =>
+        periods
+          .map(period => ({
+            ...period,
+            status: constrainToKnownBookkeepingPeriodStatus(period.status),
+            tasks: getUserVisibleTasks(period.tasks),
+          }))
+          .filter(period => isActiveBookkeepingPeriod(period)),
+    ),
   )
 
   return new Proxy(swrResponse, {

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus.ts
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus.ts
@@ -1,12 +1,13 @@
-import { Schema } from 'effect'
-
-import { BookkeepingStatus, type BookkeepingStatusData, BookkeepingStatusResponseSchema } from '@schemas/bookkeepingStatus'
+import { BookkeepingStatus, type BookkeepingStatusData, BookkeepingStatusDataSchema } from '@schemas/bookkeepingStatus'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 import { useLegacyMode } from '@providers/LegacyModeProvider/LegacyModeProvider'
 
 export { BookkeepingStatus }
+
+const BookkeepingStatusResponseSchema = UnwrappedDataResponseSchema(BookkeepingStatusDataSchema)
 
 const getBookkeepingStatus = get<
   typeof BookkeepingStatusResponseSchema.Encoded,
@@ -21,7 +22,7 @@ export const BOOKKEEPING_STATUS_TAG_KEY = '#bookkeeping-status'
 export const useBookkeepingStatus = createQueryHook({
   tags: [BOOKKEEPING_TAG_KEY, BOOKKEEPING_STATUS_TAG_KEY],
   request: getBookkeepingStatus,
-  schema: BookkeepingStatusResponseSchema.pipe(Schema.pluck('data')),
+  schema: BookkeepingStatusResponseSchema,
   isLocalized: false,
 })
 

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus.ts
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus.ts
@@ -1,3 +1,5 @@
+import { Schema } from 'effect'
+
 import { BookkeepingStatus, type BookkeepingStatusData, BookkeepingStatusResponseSchema } from '@schemas/bookkeepingStatus'
 import { get } from '@utils/api/authenticatedHttp'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
@@ -19,8 +21,7 @@ export const BOOKKEEPING_STATUS_TAG_KEY = '#bookkeeping-status'
 export const useBookkeepingStatus = createQueryHook({
   tags: [BOOKKEEPING_TAG_KEY, BOOKKEEPING_STATUS_TAG_KEY],
   request: getBookkeepingStatus,
-  schema: BookkeepingStatusResponseSchema,
-  select: ({ data }) => data,
+  schema: BookkeepingStatusResponseSchema.pipe(Schema.pluck('data')),
   isLocalized: false,
 })
 

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus.ts
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus.ts
@@ -1,17 +1,13 @@
-import { Schema } from 'effect'
-import useSWR from 'swr'
-
 import { BookkeepingStatus, type BookkeepingStatusData, BookkeepingStatusResponseSchema } from '@schemas/bookkeepingStatus'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 import { useLegacyMode } from '@providers/LegacyModeProvider/LegacyModeProvider'
 
 export { BookkeepingStatus }
 
 const getBookkeepingStatus = get<
-  Record<string, unknown>,
+  typeof BookkeepingStatusResponseSchema.Encoded,
   { businessId: string }
 >(({ businessId }) => {
   return `/v1/businesses/${businessId}/bookkeeping/status`
@@ -20,25 +16,13 @@ const getBookkeepingStatus = get<
 export const BOOKKEEPING_TAG_KEY = '#bookkeeping'
 export const BOOKKEEPING_STATUS_TAG_KEY = '#bookkeeping-status'
 
-const buildKey = createBuildKey<{ businessId: string }>([BOOKKEEPING_TAG_KEY, BOOKKEEPING_STATUS_TAG_KEY])
-
-export function useBookkeepingStatus() {
-  const { businessId, auth } = useBuildKeyInputs()
-
-  return useSWR(
-    () => buildKey({
-      ...auth,
-      businessId,
-    }),
-    ({ accessToken, apiUrl, businessId }) => getBookkeepingStatus(
-      apiUrl,
-      accessToken,
-      { params: { businessId } },
-    )()
-      .then(Schema.decodeUnknownPromise(BookkeepingStatusResponseSchema))
-      .then(({ data }) => data),
-  )
-}
+export const useBookkeepingStatus = createQueryHook({
+  tags: [BOOKKEEPING_TAG_KEY, BOOKKEEPING_STATUS_TAG_KEY],
+  request: getBookkeepingStatus,
+  schema: BookkeepingStatusResponseSchema,
+  select: ({ data }) => data,
+  isLocalized: false,
+})
 
 export const useBookkeepingStatusGlobalCacheActions = createResourceGlobalCacheActions<BookkeepingStatusData>(BOOKKEEPING_STATUS_TAG_KEY)
 

--- a/src/hooks/api/businesses/[business-id]/call-bookings/useCallBookings.tsx
+++ b/src/hooks/api/businesses/[business-id]/call-bookings/useCallBookings.tsx
@@ -1,10 +1,6 @@
-import { Schema } from 'effect'
-import useSWRInfinite from 'swr/infinite'
-
 import type {
   CallBooking,
   CreateCallBookingBody,
-  ListCallBookingsResponse,
 } from '@schemas/callBooking'
 import {
   CallBookingPurpose,
@@ -12,13 +8,9 @@ import {
   CallBookingType,
   ListCallBookingsResponseSchema,
 } from '@schemas/callBooking'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
-import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createInfiniteQueryHook } from '@hooks/utils/swr/createInfiniteQueryHook'
 
 export type { CallBooking, CreateCallBookingBody }
 export { CallBookingPurpose, CallBookingState, CallBookingType }
@@ -29,59 +21,25 @@ type ListCallBookingsParams = {
   limit?: number
 }
 
-const listCallBookings = get<
-  Record<string, unknown>,
+const listCallBookings = getWithQuery<
+  typeof ListCallBookingsResponseSchema.Encoded,
   ListCallBookingsParams
->(({ businessId, cursor, limit }) => {
-  const parameters = toDefinedSearchParameters({
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/call-bookings`,
+  ({ cursor, limit }) => ({
     cursor,
     limit,
     status: 'SCHEDULED',
-  })
-
-  return `/v1/businesses/${businessId}/call-bookings?${parameters}`
-})
+  }),
+)
 
 export const CALL_BOOKINGS_TAG_KEY = '#call-bookings'
 
-const keyLoader = createInfiniteKeyLoader<
-  { businessId: string, limit?: number },
-  ListCallBookingsResponse
->([CALL_BOOKINGS_TAG_KEY])
-
-export function useCallBookings({ limit }: { limit?: number } = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWRInfinite(
-    (_index, previousPageData: ListCallBookingsResponse | null) => withLocale(keyLoader(
-      previousPageData,
-      {
-        ...auth,
-        businessId,
-        limit,
-      },
-    )),
-    ({ accessToken, apiUrl, businessId, cursor, limit }) => listCallBookings(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          cursor,
-          limit,
-        },
-      },
-    )().then(Schema.decodeUnknownPromise(ListCallBookingsResponseSchema)),
-    {
-      keepPreviousData: true,
-      revalidateFirstPage: false,
-      initialSize: 1,
-    },
-  )
-
-  usePreserveInfiniteSize(swrResponse)
-
-  return useSWRInfiniteResult(swrResponse)
-}
+export const useCallBookings = createInfiniteQueryHook({
+  tags: [CALL_BOOKINGS_TAG_KEY],
+  request: listCallBookings,
+  schema: ListCallBookingsResponseSchema,
+})
 
 export const useCallBookingsGlobalCacheActions = createInfiniteQueryGlobalCacheActions<CallBooking>(CALL_BOOKINGS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/call-bookings/useCreateCallBooking.tsx
+++ b/src/hooks/api/businesses/[business-id]/call-bookings/useCreateCallBooking.tsx
@@ -1,56 +1,34 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import {
-  type CallBookingItemResponse,
   CallBookingItemResponseSchema,
   type CreateCallBookingBodyEncoded,
 } from '@schemas/callBooking'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCallBookingsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/call-bookings/useCallBookings'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CREATE_CALL_BOOKING_TAG_KEY = '#create-call-booking'
 
 const createCallBooking = post<
-  CallBookingItemResponse,
+  typeof CallBookingItemResponseSchema.Encoded,
   CreateCallBookingBodyEncoded,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/call-bookings`)
 
-const buildKey = createBuildKey<{ businessId: string }>([CREATE_CALL_BOOKING_TAG_KEY])
+const useCreateCallBookingMutation = createMutationHook({
+  tags: [CREATE_CALL_BOOKING_TAG_KEY],
+  request: createCallBooking,
+  schema: CallBookingItemResponseSchema,
+  swrOptions: { throwOnError: true },
+})
 
 export function useCreateCallBooking() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReload: forceReloadCallBookings } = useCallBookingsGlobalCacheActions()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: body }: { arg: CreateCallBookingBodyEncoded },
-    ) => createCallBooking(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body,
-      },
-    ).then(Schema.decodeUnknownPromise(CallBookingItemResponseSchema)),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const { trigger: originalTrigger } = rawMutationResponse
+  const mutationResponse = useCreateCallBookingMutation()
+  const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
@@ -63,7 +41,5 @@ export function useCreateCallBooking() {
     [originalTrigger, forceReloadCallBookings],
   )
 
-  const proxiedMutationResponse = withStableTrigger(rawMutationResponse, stableProxiedTrigger)
-
-  return new SWRMutationResult(proxiedMutationResponse)
+  return withStableTrigger(mutationResponse, stableProxiedTrigger)
 }

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useArchiveCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useArchiveCatalogService.ts
@@ -1,57 +1,44 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { CatalogServiceSchema } from '@schemas/catalogService'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCatalogServicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const ARCHIVE_CATALOG_SERVICE_TAG_KEY = '#archive-catalog-service'
 
 const ArchiveCatalogServiceResponseSchema = Schema.Struct({
   data: CatalogServiceSchema,
 })
-type ArchiveCatalogServiceResponse = typeof ArchiveCatalogServiceResponseSchema.Type
 
-const archiveCatalogService = post<ArchiveCatalogServiceResponse>(
+const archiveCatalogService = post<
+  typeof ArchiveCatalogServiceResponseSchema.Encoded,
+  Record<string, unknown>,
+  { businessId: string, serviceId: string }
+>(
   ({ businessId, serviceId }) =>
     `/v1/businesses/${businessId}/catalog/services/${serviceId}/archive`,
 )
 
-const buildKey = createBuildKey<{ businessId: string, serviceId: string }>([ARCHIVE_CATALOG_SERVICE_TAG_KEY])
+const useArchiveCatalogServiceMutation = createMutationHook({
+  tags: [ARCHIVE_CATALOG_SERVICE_TAG_KEY],
+  request: archiveCatalogService,
+  keyParams: ['serviceId'],
+  argToBody: (_arg: never) => undefined,
+  schema: ArchiveCatalogServiceResponseSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseArchiveCatalogServiceProps = {
   serviceId: string
 }
 
 export function useArchiveCatalogService({ serviceId }: UseArchiveCatalogServiceProps) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReload: forceReloadCatalogServices } = useCatalogServicesGlobalCacheActions()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      serviceId,
-    })),
-    ({ accessToken, apiUrl, businessId, serviceId: sid }) => archiveCatalogService(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, serviceId: sid },
-      },
-    ).then(Schema.decodeUnknownPromise(ArchiveCatalogServiceResponseSchema)),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useArchiveCatalogServiceMutation({ serviceId })
   const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useArchiveCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useArchiveCatalogService.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { CatalogServiceSchema } from '@schemas/catalogService'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCatalogServicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
@@ -9,9 +9,7 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const ARCHIVE_CATALOG_SERVICE_TAG_KEY = '#archive-catalog-service'
 
-const ArchiveCatalogServiceResponseSchema = Schema.Struct({
-  data: CatalogServiceSchema,
-})
+const ArchiveCatalogServiceResponseSchema = UnwrappedDataResponseSchema(CatalogServiceSchema)
 
 const archiveCatalogService = post<
   typeof ArchiveCatalogServiceResponseSchema.Encoded,

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useReactivateCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useReactivateCatalogService.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { CatalogServiceSchema } from '@schemas/catalogService'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCatalogServicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
@@ -9,9 +9,7 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const REACTIVATE_CATALOG_SERVICE_TAG_KEY = '#reactivate-catalog-service'
 
-const ReactivateCatalogServiceResponseSchema = Schema.Struct({
-  data: CatalogServiceSchema,
-})
+const ReactivateCatalogServiceResponseSchema = UnwrappedDataResponseSchema(CatalogServiceSchema)
 
 const reactivateCatalogService = post<
   typeof ReactivateCatalogServiceResponseSchema.Encoded,

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useReactivateCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useReactivateCatalogService.ts
@@ -1,57 +1,44 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { CatalogServiceSchema } from '@schemas/catalogService'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCatalogServicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const REACTIVATE_CATALOG_SERVICE_TAG_KEY = '#reactivate-catalog-service'
 
 const ReactivateCatalogServiceResponseSchema = Schema.Struct({
   data: CatalogServiceSchema,
 })
-type ReactivateCatalogServiceResponse = typeof ReactivateCatalogServiceResponseSchema.Type
 
-const reactivateCatalogService = post<ReactivateCatalogServiceResponse>(
+const reactivateCatalogService = post<
+  typeof ReactivateCatalogServiceResponseSchema.Encoded,
+  Record<string, unknown>,
+  { businessId: string, serviceId: string }
+>(
   ({ businessId, serviceId }) =>
     `/v1/businesses/${businessId}/catalog/services/${serviceId}/reactivate`,
 )
 
-const buildKey = createBuildKey<{ businessId: string, serviceId: string }>([REACTIVATE_CATALOG_SERVICE_TAG_KEY])
+const useReactivateCatalogServiceMutation = createMutationHook({
+  tags: [REACTIVATE_CATALOG_SERVICE_TAG_KEY],
+  request: reactivateCatalogService,
+  keyParams: ['serviceId'],
+  argToBody: (_arg: never) => undefined,
+  schema: ReactivateCatalogServiceResponseSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseReactivateCatalogServiceProps = {
   serviceId: string
 }
 
 export function useReactivateCatalogService({ serviceId }: UseReactivateCatalogServiceProps) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReload: forceReloadCatalogServices } = useCatalogServicesGlobalCacheActions()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      serviceId,
-    })),
-    ({ accessToken, apiUrl, businessId, serviceId: sid }) => reactivateCatalogService(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, serviceId: sid },
-      },
-    ).then(Schema.decodeUnknownPromise(ReactivateCatalogServiceResponseSchema)),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useReactivateCatalogServiceMutation({ serviceId })
   const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useUpdateCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useUpdateCatalogService.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { CatalogServiceSchema, type UpdateCatalogServiceEncoded } from '@schemas/catalogService'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { patch } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCatalogServicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
@@ -11,9 +11,7 @@ const UPDATE_CATALOG_SERVICE_TAG_KEY = '#update-catalog-service'
 
 type UpdateCatalogServiceBody = UpdateCatalogServiceEncoded
 
-const UpdateCatalogServiceResponseSchema = Schema.Struct({
-  data: CatalogServiceSchema,
-})
+const UpdateCatalogServiceResponseSchema = UnwrappedDataResponseSchema(CatalogServiceSchema)
 
 const updateCatalogService = patch<
   typeof UpdateCatalogServiceResponseSchema.Encoded,
@@ -42,7 +40,7 @@ export function useUpdateCatalogService({ serviceId }: UseUpdateCatalogServicePr
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const triggerResult = await originalTrigger(...triggerParameters)
-      void patchCatalogServiceByKey(triggerResult.data)
+      void patchCatalogServiceByKey(triggerResult)
       return triggerResult
     },
     [originalTrigger, patchCatalogServiceByKey],

--- a/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useUpdateCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/[service-id]/useUpdateCatalogService.ts
@@ -1,14 +1,11 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { CatalogServiceSchema, type UpdateCatalogServiceEncoded } from '@schemas/catalogService'
 import { patch } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCatalogServicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPDATE_CATALOG_SERVICE_TAG_KEY = '#update-catalog-service'
 
@@ -17,48 +14,29 @@ type UpdateCatalogServiceBody = UpdateCatalogServiceEncoded
 const UpdateCatalogServiceResponseSchema = Schema.Struct({
   data: CatalogServiceSchema,
 })
-type UpdateCatalogServiceResponse = typeof UpdateCatalogServiceResponseSchema.Type
 
 const updateCatalogService = patch<
-  UpdateCatalogServiceResponse,
+  typeof UpdateCatalogServiceResponseSchema.Encoded,
   UpdateCatalogServiceBody,
   { businessId: string, serviceId: string }
 >(({ businessId, serviceId }) => `/v1/businesses/${businessId}/catalog/services/${serviceId}`)
 
-const buildKey = createBuildKey<{ businessId: string, serviceId: string }>([UPDATE_CATALOG_SERVICE_TAG_KEY])
+const useUpdateCatalogServiceMutation = createMutationHook({
+  tags: [UPDATE_CATALOG_SERVICE_TAG_KEY],
+  request: updateCatalogService,
+  keyParams: ['serviceId'],
+  schema: UpdateCatalogServiceResponseSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseUpdateCatalogServiceProps = {
   serviceId: string
 }
 
 export function useUpdateCatalogService({ serviceId }: UseUpdateCatalogServiceProps) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { patchByKey: patchCatalogServiceByKey } = useCatalogServicesGlobalCacheActions()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      serviceId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, serviceId },
-      { arg: body }: { arg: UpdateCatalogServiceBody },
-    ) => updateCatalogService(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, serviceId },
-        body,
-      },
-    ).then(Schema.decodeUnknownPromise(UpdateCatalogServiceResponseSchema)),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useUpdateCatalogServiceMutation({ serviceId })
   const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(

--- a/src/hooks/api/businesses/[business-id]/catalog/services/useCreateCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/useCreateCatalogService.ts
@@ -1,14 +1,11 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { CatalogServiceSchema, type CreateCatalogServiceEncoded } from '@schemas/catalogService'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCatalogServicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CREATE_CATALOG_SERVICE_TAG_KEY = '#create-catalog-service'
 
@@ -17,43 +14,24 @@ type CreateCatalogServiceBody = CreateCatalogServiceEncoded
 const CreateCatalogServiceResponseSchema = Schema.Struct({
   data: CatalogServiceSchema,
 })
-type CreateCatalogServiceResponse = typeof CreateCatalogServiceResponseSchema.Type
 
 const createCatalogService = post<
-  CreateCatalogServiceResponse,
+  typeof CreateCatalogServiceResponseSchema.Encoded,
   CreateCatalogServiceBody,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/catalog/services`)
 
-const buildKey = createBuildKey<{ businessId: string }>([CREATE_CATALOG_SERVICE_TAG_KEY])
+const useCreateCatalogServiceMutation = createMutationHook({
+  tags: [CREATE_CATALOG_SERVICE_TAG_KEY],
+  request: createCatalogService,
+  schema: CreateCatalogServiceResponseSchema,
+  swrOptions: { throwOnError: true },
+})
 
 export function useCreateCatalogService() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReload: forceReloadCatalogServices } = useCatalogServicesGlobalCacheActions()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: body }: { arg: CreateCatalogServiceBody },
-    ) => createCatalogService(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body,
-      },
-    ).then(Schema.decodeUnknownPromise(CreateCatalogServiceResponseSchema)),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useCreateCatalogServiceMutation()
   const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(

--- a/src/hooks/api/businesses/[business-id]/catalog/services/useCreateCatalogService.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/useCreateCatalogService.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { CatalogServiceSchema, type CreateCatalogServiceEncoded } from '@schemas/catalogService'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCatalogServicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices'
@@ -11,9 +11,7 @@ const CREATE_CATALOG_SERVICE_TAG_KEY = '#create-catalog-service'
 
 type CreateCatalogServiceBody = CreateCatalogServiceEncoded
 
-const CreateCatalogServiceResponseSchema = Schema.Struct({
-  data: CatalogServiceSchema,
-})
+const CreateCatalogServiceResponseSchema = UnwrappedDataResponseSchema(CatalogServiceSchema)
 
 const createCatalogService = post<
   typeof CreateCatalogServiceResponseSchema.Encoded,

--- a/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
@@ -1,60 +1,39 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
 
 import { type CatalogService, CatalogServiceSchema } from '@schemas/catalogService'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const LIST_CATALOG_SERVICES_TAG_KEY = '#list-catalog-services'
 
 const ListCatalogServicesResponseSchema = Schema.Struct({
   data: Schema.Array(CatalogServiceSchema),
 })
-type ListCatalogServicesResponse = typeof ListCatalogServicesResponseSchema.Type
 
-const buildKey = createBuildKey<{ businessId: string, allowArchived?: boolean }>([LIST_CATALOG_SERVICES_TAG_KEY])
+type ListCatalogServicesParams = {
+  businessId: string
+  allowArchived?: boolean
+}
 
-const listCatalogServices = get<
+const listCatalogServices = getWithQuery<
   typeof ListCatalogServicesResponseSchema.Encoded,
-  { businessId: string, allowArchived?: boolean }
->(({ businessId, allowArchived }) => {
-  const parameters = toDefinedSearchParameters({ allowArchived })
-  return `/v1/businesses/${businessId}/catalog/services?${parameters}`
-})
+  ListCatalogServicesParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/catalog/services`,
+)
 
 export type UseListCatalogServicesOptions = {
   allowArchived?: boolean
   isEnabled?: boolean
 }
 
-export function useListCatalogServices({
-  allowArchived,
-  isEnabled = true,
-}: UseListCatalogServicesOptions = {}): SWRQueryResult<ListCatalogServicesResponse> {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      allowArchived,
-      isEnabled,
-    })),
-    ({ accessToken, apiUrl, businessId, allowArchived: allowArchivedParam }) => listCatalogServices(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, allowArchived: allowArchivedParam },
-      },
-    )().then(Schema.decodeUnknownPromise(ListCatalogServicesResponseSchema)),
-  )
-
-  return new SWRQueryResult(response)
-}
+export const useListCatalogServices = createQueryHook({
+  tags: [LIST_CATALOG_SERVICES_TAG_KEY],
+  request: listCatalogServices,
+  schema: ListCatalogServicesResponseSchema,
+})
 
 export const useCatalogServicesGlobalCacheActions = createInfiniteQueryGlobalCacheActions<
   CatalogService

--- a/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
@@ -1,24 +1,21 @@
-import { Schema } from 'effect'
-
 import { type CatalogService, CatalogServiceSchema } from '@schemas/catalogService'
-import { UnwrappedDataResponseSchema } from '@schemas/utils'
+import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
+import { createInfiniteQueryHook } from '@hooks/utils/swr/createInfiniteQueryHook'
 
 const LIST_CATALOG_SERVICES_TAG_KEY = '#list-catalog-services'
 
-const ListCatalogServicesResponseSchema = UnwrappedDataResponseSchema(
-  Schema.Array(CatalogServiceSchema),
-)
+const ListCatalogServicesResultSchema = PaginatedResponseSchema(CatalogServiceSchema)
 
 type ListCatalogServicesParams = {
   businessId: string
   allowArchived?: boolean
+  cursor?: string
 }
 
 const listCatalogServices = getWithQuery<
-  typeof ListCatalogServicesResponseSchema.Encoded,
+  typeof ListCatalogServicesResultSchema.Encoded,
   ListCatalogServicesParams
 >(
   ['businessId'],
@@ -30,10 +27,10 @@ export type UseListCatalogServicesOptions = {
   isEnabled?: boolean
 }
 
-export const useListCatalogServices = createQueryHook({
+export const useListCatalogServices = createInfiniteQueryHook({
   tags: [LIST_CATALOG_SERVICES_TAG_KEY],
   request: listCatalogServices,
-  schema: ListCatalogServicesResponseSchema,
+  schema: ListCatalogServicesResultSchema,
 })
 
 export const useCatalogServicesGlobalCacheActions = createInfiniteQueryGlobalCacheActions<

--- a/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
+++ b/src/hooks/api/businesses/[business-id]/catalog/services/useListCatalogServices.ts
@@ -1,15 +1,16 @@
 import { Schema } from 'effect'
 
 import { type CatalogService, CatalogServiceSchema } from '@schemas/catalogService'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const LIST_CATALOG_SERVICES_TAG_KEY = '#list-catalog-services'
 
-const ListCatalogServicesResponseSchema = Schema.Struct({
-  data: Schema.Array(CatalogServiceSchema),
-})
+const ListCatalogServicesResponseSchema = UnwrappedDataResponseSchema(
+  Schema.Array(CatalogServiceSchema),
+)
 
 type ListCatalogServicesParams = {
   businessId: string

--- a/src/hooks/api/businesses/[business-id]/categories/useCategories.ts
+++ b/src/hooks/api/businesses/[business-id]/categories/useCategories.ts
@@ -1,14 +1,15 @@
 import { Schema } from 'effect'
 
 import { type CategoriesListMode, CategoryListSchema } from '@schemas/categorization'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const CATEGORIES_TAG_KEY = '#categories'
 
-const CategoriesResponseSchema = Schema.Struct({
-  data: CategoryListSchema.pipe(Schema.pluck('categories')),
-})
+const CategoriesResponseSchema = UnwrappedDataResponseSchema(
+  CategoryListSchema.pipe(Schema.pluck('categories')),
+)
 
 type GetCategoriesParams = {
   businessId: string
@@ -30,7 +31,7 @@ type UseCategoriesOptions = {
 export const useCategories = createQueryHook({
   tags: [CATEGORIES_TAG_KEY],
   request: getCategories,
-  schema: CategoriesResponseSchema.pipe(Schema.pluck('data')),
+  schema: CategoriesResponseSchema,
 })
 
 export function usePreloadCategories(options?: UseCategoriesOptions) {

--- a/src/hooks/api/businesses/[business-id]/categories/useCategories.ts
+++ b/src/hooks/api/businesses/[business-id]/categories/useCategories.ts
@@ -1,59 +1,38 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
 
-import { type CategoriesListMode, CategoryListSchema, type NestedCategorization } from '@schemas/categorization'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { type CategoriesListMode, CategoryListSchema } from '@schemas/categorization'
+import { getWithQuery } from '@utils/api/getWithQuery'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const CATEGORIES_TAG_KEY = '#categories'
 
-const buildKey = createBuildKey<{ businessId: string, mode?: CategoriesListMode }>([CATEGORIES_TAG_KEY])
-
-export const getCategories = get<
-  {
-    data: {
-      type: 'Category_List'
-      categories: NestedCategorization[]
-    }
-  },
-  {
-    businessId: string
-    mode?: CategoriesListMode
-  }
->(({ businessId, mode }) => {
-  const parameters = toDefinedSearchParameters({ mode })
-
-  return `/v1/businesses/${businessId}/categories?${parameters}`
+const CategoriesResponseSchema = Schema.Struct({
+  data: CategoryListSchema,
 })
+
+type GetCategoriesParams = {
+  businessId: string
+  mode?: CategoriesListMode
+}
+
+export const getCategories = getWithQuery<
+  typeof CategoriesResponseSchema.Encoded,
+  GetCategoriesParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/categories`,
+)
 
 type UseCategoriesOptions = {
   mode?: CategoriesListMode
 }
 
-export function useCategories({ mode }: UseCategoriesOptions = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  return useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      mode,
-    })),
-    ({ accessToken, apiUrl, businessId, mode }) => getCategories(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          mode,
-        },
-      })()
-      .then(({ data }) => Schema.decodeUnknownPromise(CategoryListSchema)(data))
-      .then(categoryList => categoryList.categories),
-  )
-}
+export const useCategories = createQueryHook({
+  tags: [CATEGORIES_TAG_KEY],
+  request: getCategories,
+  schema: CategoriesResponseSchema,
+  select: ({ data }) => data.categories,
+})
 
 export function usePreloadCategories(options?: UseCategoriesOptions) {
   /*

--- a/src/hooks/api/businesses/[business-id]/categories/useCategories.ts
+++ b/src/hooks/api/businesses/[business-id]/categories/useCategories.ts
@@ -1,5 +1,3 @@
-import { Schema } from 'effect'
-
 import { type CategoriesListMode, CategoryListSchema } from '@schemas/categorization'
 import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
@@ -7,9 +5,7 @@ import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const CATEGORIES_TAG_KEY = '#categories'
 
-const CategoriesResponseSchema = UnwrappedDataResponseSchema(
-  CategoryListSchema.pipe(Schema.pluck('categories')),
-)
+const CategoriesResponseSchema = UnwrappedDataResponseSchema(CategoryListSchema)
 
 type GetCategoriesParams = {
   businessId: string
@@ -32,6 +28,7 @@ export const useCategories = createQueryHook({
   tags: [CATEGORIES_TAG_KEY],
   request: getCategories,
   schema: CategoriesResponseSchema,
+  select: data => data.categories,
 })
 
 export function usePreloadCategories(options?: UseCategoriesOptions) {

--- a/src/hooks/api/businesses/[business-id]/categories/useCategories.ts
+++ b/src/hooks/api/businesses/[business-id]/categories/useCategories.ts
@@ -7,7 +7,7 @@ import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 export const CATEGORIES_TAG_KEY = '#categories'
 
 const CategoriesResponseSchema = Schema.Struct({
-  data: CategoryListSchema,
+  data: CategoryListSchema.pipe(Schema.pluck('categories')),
 })
 
 type GetCategoriesParams = {
@@ -30,8 +30,7 @@ type UseCategoriesOptions = {
 export const useCategories = createQueryHook({
   tags: [CATEGORIES_TAG_KEY],
   request: getCategories,
-  schema: CategoriesResponseSchema,
-  select: ({ data }) => data.categories,
+  schema: CategoriesResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export function usePreloadCategories(options?: UseCategoriesOptions) {

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/[categorization-rule-id]/archive/useArchiveCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/[categorization-rule-id]/archive/useArchiveCategorizationRule.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect/index'
 
 import { CategorizationRuleSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCategorizationRulesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules'
@@ -9,9 +9,7 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const ARCHIVE_CATEGORIZATION_RULE_TAG = '#archive-categorization-rule'
 
-const ArchiveCategorizationRuleReturnSchema = Schema.Struct({
-  data: CategorizationRuleSchema,
-})
+const ArchiveCategorizationRuleReturnSchema = UnwrappedDataResponseSchema(CategorizationRuleSchema)
 
 export const archiveCategorizationRule = post<
   typeof ArchiveCategorizationRuleReturnSchema.Encoded,

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/[categorization-rule-id]/archive/useArchiveCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/[categorization-rule-id]/archive/useArchiveCategorizationRule.ts
@@ -1,56 +1,39 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect/index'
-import useSWRMutation from 'swr/mutation'
 
 import { CategorizationRuleSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useCategorizationRulesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const ARCHIVE_CATEGORIZATION_RULE_TAG = '#archive-categorization-rule'
-
-const buildKey = createBuildKey<{ businessId: string }>([ARCHIVE_CATEGORIZATION_RULE_TAG])
 
 const ArchiveCategorizationRuleReturnSchema = Schema.Struct({
   data: CategorizationRuleSchema,
 })
 
-type ArchiveCategorizationRuleReturn = typeof ArchiveCategorizationRuleReturnSchema.Type
-
-export const archiveCategorizationRule = post<ArchiveCategorizationRuleReturn>(
+export const archiveCategorizationRule = post<
+  typeof ArchiveCategorizationRuleReturnSchema.Encoded,
+  Record<string, unknown>,
+  { businessId: string, categorizationRuleId: string }
+>(
   ({ businessId, categorizationRuleId }) =>
     `/v1/businesses/${businessId}/categorization-rules/${categorizationRuleId}/archive`,
 )
 
+const useArchiveCategorizationRuleMutation = createMutationHook({
+  tags: [ARCHIVE_CATEGORIZATION_RULE_TAG],
+  request: archiveCategorizationRule,
+  argToParams: (categorizationRuleId: string) => ({ categorizationRuleId }),
+  argToBody: () => undefined,
+  schema: ArchiveCategorizationRuleReturnSchema,
+})
+
 export function useArchiveCategorizationRule() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReload: forceReloadCategorizationRules } = useCategorizationRulesGlobalCacheActions()
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: categorizationRuleId }: { arg: string },
-    ) => archiveCategorizationRule(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          categorizationRuleId,
-        },
-      },
-    ).then(Schema.decodeUnknownPromise(ArchiveCategorizationRuleReturnSchema)),
-    {
-      revalidate: false,
-    },
-  )
+  const mutationResponse = useArchiveCategorizationRuleMutation()
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/suggestions/useRejectCategorizationRulesUpdateSuggestion.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/suggestions/useRejectCategorizationRulesUpdateSuggestion.ts
@@ -1,54 +1,20 @@
-import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
-
 import { del } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const REJECT_CATEGORIZATION_RULE_SUGGESTION_TAG = '#reject-categorization-rule-suggestion'
 
-const buildKey = createBuildKey<{ businessId: string }>([REJECT_CATEGORIZATION_RULE_SUGGESTION_TAG])
-
-export const rejectCategorizationRulesUpdateSuggestion = del<never>(
+export const rejectCategorizationRulesUpdateSuggestion = del<
+  never,
+  Record<string, unknown>,
+  { businessId: string, suggestionId: string }
+>(
   ({ businessId, suggestionId }) =>
     `/v1/businesses/${businessId}/categorization-rules/suggestions/${suggestionId}`,
 )
 
-export function useRejectCategorizationRulesUpdateSuggestion() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: suggestionId }: { arg: string },
-    ) => rejectCategorizationRulesUpdateSuggestion(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          suggestionId,
-        },
-      },
-    ),
-    {
-      revalidate: false,
-    },
-  )
-  const { trigger: originalTrigger } = mutationResponse
-
-  const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const triggerResultPromise = originalTrigger(...triggerParameters)
-      return triggerResultPromise
-    }, [originalTrigger],
-  )
-
-  return withStableTrigger(mutationResponse, stableProxiedTrigger)
-}
+export const useRejectCategorizationRulesUpdateSuggestion = createMutationHook({
+  tags: [REJECT_CATEGORIZATION_RULE_SUGGESTION_TAG],
+  request: rejectCategorizationRulesUpdateSuggestion,
+  argToParams: (suggestionId: string) => ({ suggestionId }),
+  argToBody: () => undefined,
+})

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useCreateCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useCreateCategorizationRule.ts
@@ -1,63 +1,44 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect/index'
-import useSWRMutation from 'swr/mutation'
 
 import { CategorizationRuleSchema, type CreateCategorizationRuleSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useCategorizationRulesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CREATE_CATEGORIZATION_RULE_TAG = '#create-categorization-rule'
-
-const buildKey = createBuildKey<{ businessId: string }>([CREATE_CATEGORIZATION_RULE_TAG])
 
 const CreateCategorizationRuleReturnSchema = Schema.Struct({
   data: CategorizationRuleSchema,
 })
 
-type CreateCategorizationRuleReturn = typeof CreateCategorizationRuleReturnSchema.Type
 type CreateCategorizationRuleBody = typeof CreateCategorizationRuleSchema.Encoded
 
-const createCategorizationRule = post<CreateCategorizationRuleReturn, CreateCategorizationRuleBody>(
+const createCategorizationRule = post<
+  typeof CreateCategorizationRuleReturnSchema.Encoded,
+  CreateCategorizationRuleBody,
+  { businessId: string }
+>(
   ({ businessId }) =>
     `/v1/businesses/${businessId}/categorization-rules`,
 )
 
+const useCreateCategorizationRuleMutation = createMutationHook({
+  tags: [CREATE_CATEGORIZATION_RULE_TAG],
+  request: createCategorizationRule,
+  schema: CreateCategorizationRuleReturnSchema,
+})
+
 export function useCreateCategorizationRule() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
 
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
   const { forceReload: forceReloadCategorizationRules } = useCategorizationRulesGlobalCacheActions()
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { ...body } }: { arg: CreateCategorizationRuleBody },
-    ) => createCategorizationRule(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-        },
-        body,
-      },
-    ).then(Schema.decodeUnknownPromise(CreateCategorizationRuleReturnSchema)),
-    {
-      revalidate: false,
-    },
-  )
-
+  const mutationResponse = useCreateCategorizationRuleMutation()
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useCreateCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useCreateCategorizationRule.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect/index'
 
 import { CategorizationRuleSchema, type CreateCategorizationRuleSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
@@ -11,9 +11,7 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CREATE_CATEGORIZATION_RULE_TAG = '#create-categorization-rule'
 
-const CreateCategorizationRuleReturnSchema = Schema.Struct({
-  data: CategorizationRuleSchema,
-})
+const CreateCategorizationRuleReturnSchema = UnwrappedDataResponseSchema(CategorizationRuleSchema)
 
 type CreateCategorizationRuleBody = typeof CreateCategorizationRuleSchema.Encoded
 

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules.ts
@@ -1,22 +1,11 @@
-import { Schema } from 'effect'
-import useSWRInfinite from 'swr/infinite'
-
 import { type PaginationParams, SortOrder, type SortParams } from '@internal-types/utility/pagination'
 import { type CategorizationRule, CategorizationRuleSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
-import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createInfiniteQueryHook } from '@hooks/utils/swr/createInfiniteQueryHook'
 
 export const LIST_CATEGORIZATION_RULES_TAG_KEY = '#list-categorization-rules'
-
-type ListCategorizationRulesBaseParams = {
-  businessId: string
-}
 
 export type ListCategorizationRulesFilterParams = {
   externalIds?: ReadonlyArray<string>
@@ -27,95 +16,30 @@ enum SortBy {
   CreatedAt = 'created_at',
 }
 
-type ListCategorizationRulesOptions = ListCategorizationRulesFilterParams & PaginationParams & SortParams<SortBy>
-
-type ListCategorizationRulesParams = ListCategorizationRulesBaseParams & ListCategorizationRulesOptions
+type ListCategorizationRulesParams = {
+  businessId: string
+  cursor?: string
+} & ListCategorizationRulesFilterParams & Omit<PaginationParams, 'cursor'> & SortParams<SortBy>
 
 const ListCategorizationRulesReturnSchema = PaginatedResponseSchema(CategorizationRuleSchema)
 
-type ListCategorizationRulesReturn = typeof ListCategorizationRulesReturnSchema.Type
-
-export const listCategorizationRules = get<
-  ListCategorizationRulesReturn,
+export const listCategorizationRules = getWithQuery<
+  typeof ListCategorizationRulesReturnSchema.Encoded,
   ListCategorizationRulesParams
->(({ businessId, externalIds, includeArchived, sortBy, sortOrder, cursor, limit, showTotalCount }) => {
-  const parameters = toDefinedSearchParameters({
-    externalIds,
-    includeArchived,
-    sortBy,
-    sortOrder,
-    cursor,
-    limit,
-    showTotalCount,
-  })
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/categorization-rules`,
+)
 
-  const baseUrl = `/v1/businesses/${businessId}/categorization-rules`
-  return parameters ? `${baseUrl}?${parameters}` : baseUrl
+export const useListCategorizationRules = createInfiniteQueryHook({
+  tags: [LIST_CATEGORIZATION_RULES_TAG_KEY],
+  request: listCategorizationRules,
+  schema: ListCategorizationRulesReturnSchema,
+  keyDefaults: {
+    sortBy: SortBy.CreatedAt,
+    sortOrder: SortOrder.DESC,
+    showTotalCount: true,
+  },
 })
-
-const keyLoader = createInfiniteKeyLoader<Omit<ListCategorizationRulesParams, 'cursor'>, ListCategorizationRulesReturn>([LIST_CATEGORIZATION_RULES_TAG_KEY])
-
-export function useListCategorizationRules({
-  externalIds,
-  includeArchived,
-  sortBy = SortBy.CreatedAt,
-  sortOrder = SortOrder.DESC,
-  limit,
-  showTotalCount = true,
-}: ListCategorizationRulesOptions = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWRInfinite(
-    (_index, previousPageData: ListCategorizationRulesReturn | null) => withLocale(keyLoader(
-      previousPageData,
-      {
-        ...auth,
-        businessId,
-        externalIds,
-        includeArchived,
-        sortBy,
-        sortOrder,
-        limit,
-        showTotalCount,
-      },
-    )),
-    ({
-      accessToken,
-      apiUrl,
-      businessId,
-      cursor,
-      externalIds,
-      includeArchived,
-      sortBy,
-      sortOrder,
-      limit,
-      showTotalCount,
-    }) => listCategorizationRules(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          externalIds,
-          includeArchived,
-          sortBy,
-          sortOrder,
-          cursor,
-          limit,
-          showTotalCount,
-        },
-      },
-    )().then(Schema.decodeUnknownPromise(ListCategorizationRulesReturnSchema)),
-    {
-      keepPreviousData: true,
-      revalidateFirstPage: false,
-      initialSize: 1,
-    },
-  )
-
-  usePreserveInfiniteSize(swrResponse)
-
-  return useSWRInfiniteResult(swrResponse)
-}
 
 export const useCategorizationRulesGlobalCacheActions = createInfiniteQueryGlobalCacheActions<CategorizationRule>(LIST_CATEGORIZATION_RULES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule.ts
@@ -7,7 +7,6 @@ import {
   type PatchCategorizationRuleSchema,
 } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { patch, post } from '@utils/api/authenticatedHttp'
-import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useCategorizationRulesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
@@ -32,40 +31,29 @@ const createCategorizationRule = post<UpsertCategorizationRuleReturnEncoded, Cre
     `/v1/businesses/${businessId}/categorization-rules`,
 )
 
-const updateCategorizationRule = patch<UpsertCategorizationRuleReturnEncoded, PatchCategorizationRuleBody>(
+const updateCategorizationRule = patch<
+  UpsertCategorizationRuleReturnEncoded,
+  PatchCategorizationRuleBody,
+  { businessId: string, categorizationRuleId: string }
+>(
   ({ businessId, categorizationRuleId }) =>
     `/v1/businesses/${businessId}/categorization-rules/${categorizationRuleId}`,
 )
 
-type UpsertCategorizationRuleParams = { businessId: string, categorizationRuleId?: string }
-type UpsertCategorizationRuleBody = CreateCategorizationRuleBody | PatchCategorizationRuleBody
-
-const upsertCategorizationRule = (
-  baseUrl: string,
-  accessToken: string | undefined,
-  options?: { params?: UpsertCategorizationRuleParams, body?: UpsertCategorizationRuleBody },
-): Promise<UpsertCategorizationRuleReturnEncoded> => {
-  const { params, body } = options ?? {}
-
-  if (params?.categorizationRuleId !== undefined) {
-    return updateCategorizationRule(baseUrl, accessToken, {
-      params: { businessId: params.businessId, categorizationRuleId: params.categorizationRuleId },
-      body: body as PatchCategorizationRuleBody,
-    })
-  }
-
-  return createCategorizationRule(baseUrl, accessToken, {
-    params: { businessId: params?.businessId },
-    body: body as CreateCategorizationRuleBody,
-  })
-}
-
-const useUpsertCategorizationRuleMutation = createMutationHook({
+const useCreateCategorizationRuleMutation = createMutationHook({
   tags: [UPSERT_CATEGORIZATION_RULE_TAG],
-  request: upsertCategorizationRule,
-  argToParams: (arg: UpsertCategorizationRuleArg) =>
-    arg.mode === 'update' ? { categorizationRuleId: arg.categorizationRuleId } : {},
-  argToBody: (arg: UpsertCategorizationRuleArg) => arg.body,
+  request: createCategorizationRule,
+  schema: UpsertCategorizationRuleReturnSchema,
+  swrOptions: { throwOnError: true },
+})
+
+type UpdateCategorizationRuleArg = { categorizationRuleId: string, body: PatchCategorizationRuleBody }
+
+const useUpdateCategorizationRuleMutation = createMutationHook({
+  tags: [UPSERT_CATEGORIZATION_RULE_TAG],
+  request: updateCategorizationRule,
+  argToParams: ({ categorizationRuleId }: UpdateCategorizationRuleArg) => ({ categorizationRuleId }),
+  argToBody: ({ body }: UpdateCategorizationRuleArg) => body,
   schema: UpsertCategorizationRuleReturnSchema,
   swrOptions: { throwOnError: true },
 })
@@ -75,29 +63,45 @@ export function useUpsertCategorizationRule() {
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
   const { forceReload: forceReloadCategorizationRules, patchByKey: patchCategorizationRuleByKey } = useCategorizationRulesGlobalCacheActions()
 
-  const mutationResponse = useUpsertCategorizationRuleMutation()
-  const { trigger: originalTrigger } = mutationResponse
+  const createResponse = useCreateCategorizationRuleMutation()
+  const updateResponse = useUpdateCategorizationRuleMutation()
+
+  const { trigger: createTrigger } = createResponse
+  const { trigger: updateTrigger } = updateResponse
 
   const stableProxiedTrigger = useCallback(
-    async (
-      arg: UpsertCategorizationRuleArg,
-      options?: Parameters<typeof originalTrigger>[1],
-    ) => {
-      const triggerResult = await originalTrigger(arg, options)
-
+    async (arg: UpsertCategorizationRuleArg) => {
       if (arg.mode === 'create') {
+        const triggerResult = await createTrigger(arg.body)
+
         void forceReloadCategorizationRules()
         void forceReloadBankTransactions()
         void debouncedInvalidateProfitAndLoss()
+
+        return triggerResult
       }
-      else if (triggerResult) {
+
+      const triggerResult = await updateTrigger({
+        categorizationRuleId: arg.categorizationRuleId,
+        body: arg.body,
+      })
+
+      if (triggerResult) {
         void patchCategorizationRuleByKey(triggerResult.data)
       }
 
       return triggerResult
     },
-    [originalTrigger, forceReloadCategorizationRules, forceReloadBankTransactions, debouncedInvalidateProfitAndLoss, patchCategorizationRuleByKey],
+    [createTrigger, updateTrigger, forceReloadCategorizationRules, forceReloadBankTransactions, debouncedInvalidateProfitAndLoss, patchCategorizationRuleByKey],
   )
 
-  return withStableTrigger(mutationResponse, stableProxiedTrigger)
+  const mutationResponse = updateResponse.isMutating ? updateResponse : createResponse
+
+  return {
+    trigger: stableProxiedTrigger,
+    data: mutationResponse.data,
+    isMutating: mutationResponse.isMutating,
+    error: mutationResponse.error,
+    isError: mutationResponse.isError,
+  }
 }

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule.ts
@@ -7,6 +7,7 @@ import {
 } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { patch, post } from '@utils/api/authenticatedHttp'
+import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useCategorizationRulesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
@@ -14,24 +15,32 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPSERT_CATEGORIZATION_RULE_TAG = '#upsert-categorization-rule'
 
+export enum UpsertCategorizationRuleMode {
+  Create = 'Create',
+  Update = 'Update',
+}
+
 const UpsertCategorizationRuleReturnSchema = UnwrappedDataResponseSchema(CategorizationRuleSchema)
 
 type UpsertCategorizationRuleReturnEncoded = typeof UpsertCategorizationRuleReturnSchema.Encoded
 type CreateCategorizationRuleBody = typeof CreateCategorizationRuleSchema.Encoded
 type PatchCategorizationRuleBody = typeof PatchCategorizationRuleSchema.Encoded
 
-export type UpsertCategorizationRuleArg =
-  | { mode: 'create', body: CreateCategorizationRuleBody }
-  | { mode: 'update', categorizationRuleId: string, body: PatchCategorizationRuleBody }
+/*
+ * Create and patch accept different fields; the shared body type keeps both mutations'
+ * triggers call-compatible so the mode-selected response can back `withStableTrigger`.
+ * Callers pass the body matching the mode the hook was created with.
+ */
+type UpsertCategorizationRuleBody = CreateCategorizationRuleBody | PatchCategorizationRuleBody
 
-const createCategorizationRule = post<UpsertCategorizationRuleReturnEncoded, CreateCategorizationRuleBody>(
+const createCategorizationRule = post<UpsertCategorizationRuleReturnEncoded, UpsertCategorizationRuleBody>(
   ({ businessId }) =>
     `/v1/businesses/${businessId}/categorization-rules`,
 )
 
 const updateCategorizationRule = patch<
   UpsertCategorizationRuleReturnEncoded,
-  PatchCategorizationRuleBody,
+  UpsertCategorizationRuleBody,
   { businessId: string, categorizationRuleId: string }
 >(
   ({ businessId, categorizationRuleId }) =>
@@ -45,32 +54,41 @@ const useCreateCategorizationRuleMutation = createMutationHook({
   swrOptions: { throwOnError: true },
 })
 
-type UpdateCategorizationRuleArg = { categorizationRuleId: string, body: PatchCategorizationRuleBody }
-
 const useUpdateCategorizationRuleMutation = createMutationHook({
   tags: [UPSERT_CATEGORIZATION_RULE_TAG],
   request: updateCategorizationRule,
-  argToParams: ({ categorizationRuleId }: UpdateCategorizationRuleArg) => ({ categorizationRuleId }),
-  argToBody: ({ body }: UpdateCategorizationRuleArg) => body,
+  keyParams: ['categorizationRuleId'],
   schema: UpsertCategorizationRuleReturnSchema,
   swrOptions: { throwOnError: true },
 })
 
-export function useUpsertCategorizationRule() {
+type UseUpsertCategorizationRuleProps =
+  | { mode: UpsertCategorizationRuleMode.Create }
+  | { mode: UpsertCategorizationRuleMode.Update, categorizationRuleId: string }
+
+export function useUpsertCategorizationRule(props: UseUpsertCategorizationRuleProps) {
+  const { mode } = props
+  const categorizationRuleId = mode === UpsertCategorizationRuleMode.Update ? props.categorizationRuleId : undefined
+
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
   const { forceReload: forceReloadCategorizationRules, patchByKey: patchCategorizationRuleByKey } = useCategorizationRulesGlobalCacheActions()
 
   const createResponse = useCreateCategorizationRuleMutation()
-  const updateResponse = useUpdateCategorizationRuleMutation()
+  const updateResponse = useUpdateCategorizationRuleMutation({
+    categorizationRuleId: categorizationRuleId ?? '',
+    isEnabled: categorizationRuleId !== undefined,
+  })
+
+  const mutationResponse = mode === UpsertCategorizationRuleMode.Create ? createResponse : updateResponse
 
   const { trigger: createTrigger } = createResponse
   const { trigger: updateTrigger } = updateResponse
 
   const stableProxiedTrigger = useCallback(
-    async (arg: UpsertCategorizationRuleArg) => {
-      if (arg.mode === 'create') {
-        const triggerResult = await createTrigger(arg.body)
+    async (body: UpsertCategorizationRuleBody) => {
+      if (mode === UpsertCategorizationRuleMode.Create) {
+        const triggerResult = await createTrigger(body)
 
         void forceReloadCategorizationRules()
         void forceReloadBankTransactions()
@@ -79,10 +97,7 @@ export function useUpsertCategorizationRule() {
         return triggerResult
       }
 
-      const triggerResult = await updateTrigger({
-        categorizationRuleId: arg.categorizationRuleId,
-        body: arg.body,
-      })
+      const triggerResult = await updateTrigger(body)
 
       if (triggerResult) {
         void patchCategorizationRuleByKey(triggerResult)
@@ -90,16 +105,16 @@ export function useUpsertCategorizationRule() {
 
       return triggerResult
     },
-    [createTrigger, updateTrigger, forceReloadCategorizationRules, forceReloadBankTransactions, debouncedInvalidateProfitAndLoss, patchCategorizationRuleByKey],
+    [
+      mode,
+      createTrigger,
+      updateTrigger,
+      forceReloadCategorizationRules,
+      forceReloadBankTransactions,
+      debouncedInvalidateProfitAndLoss,
+      patchCategorizationRuleByKey,
+    ],
   )
 
-  const mutationResponse = updateResponse.isMutating ? updateResponse : createResponse
-
-  return {
-    trigger: stableProxiedTrigger,
-    data: mutationResponse.data,
-    isMutating: mutationResponse.isMutating,
-    error: mutationResponse.error,
-    isError: mutationResponse.isError,
-  }
+  return withStableTrigger(mutationResponse, stableProxiedTrigger)
 }

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule.ts
@@ -1,11 +1,11 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect/index'
 
 import {
   CategorizationRuleSchema,
   type CreateCategorizationRuleSchema,
   type PatchCategorizationRuleSchema,
 } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useCategorizationRulesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules'
@@ -14,9 +14,7 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPSERT_CATEGORIZATION_RULE_TAG = '#upsert-categorization-rule'
 
-const UpsertCategorizationRuleReturnSchema = Schema.Struct({
-  data: CategorizationRuleSchema,
-})
+const UpsertCategorizationRuleReturnSchema = UnwrappedDataResponseSchema(CategorizationRuleSchema)
 
 type UpsertCategorizationRuleReturnEncoded = typeof UpsertCategorizationRuleReturnSchema.Encoded
 type CreateCategorizationRuleBody = typeof CreateCategorizationRuleSchema.Encoded
@@ -87,7 +85,7 @@ export function useUpsertCategorizationRule() {
       })
 
       if (triggerResult) {
-        void patchCategorizationRuleByKey(triggerResult.data)
+        void patchCategorizationRuleByKey(triggerResult)
       }
 
       return triggerResult

--- a/src/hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule.ts
+++ b/src/hooks/api/businesses/[business-id]/categorization-rules/useUpsertCategorizationRule.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect/index'
-import useSWRMutation from 'swr/mutation'
 
 import {
   CategorizationRuleSchema,
@@ -8,22 +7,19 @@ import {
   type PatchCategorizationRuleSchema,
 } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 import { patch, post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useCategorizationRulesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/categorization-rules/useListCategorizationRules'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPSERT_CATEGORIZATION_RULE_TAG = '#upsert-categorization-rule'
-
-const buildKey = createBuildKey<{ businessId: string }>([UPSERT_CATEGORIZATION_RULE_TAG])
 
 const UpsertCategorizationRuleReturnSchema = Schema.Struct({
   data: CategorizationRuleSchema,
 })
 
-type UpsertCategorizationRuleReturn = typeof UpsertCategorizationRuleReturnSchema.Type
+type UpsertCategorizationRuleReturnEncoded = typeof UpsertCategorizationRuleReturnSchema.Encoded
 type CreateCategorizationRuleBody = typeof CreateCategorizationRuleSchema.Encoded
 type PatchCategorizationRuleBody = typeof PatchCategorizationRuleSchema.Encoded
 
@@ -31,58 +27,55 @@ export type UpsertCategorizationRuleArg =
   | { mode: 'create', body: CreateCategorizationRuleBody }
   | { mode: 'update', categorizationRuleId: string, body: PatchCategorizationRuleBody }
 
-const createCategorizationRule = post<UpsertCategorizationRuleReturn, CreateCategorizationRuleBody>(
+const createCategorizationRule = post<UpsertCategorizationRuleReturnEncoded, CreateCategorizationRuleBody>(
   ({ businessId }) =>
     `/v1/businesses/${businessId}/categorization-rules`,
 )
 
-const updateCategorizationRule = patch<UpsertCategorizationRuleReturn, PatchCategorizationRuleBody>(
+const updateCategorizationRule = patch<UpsertCategorizationRuleReturnEncoded, PatchCategorizationRuleBody>(
   ({ businessId, categorizationRuleId }) =>
     `/v1/businesses/${businessId}/categorization-rules/${categorizationRuleId}`,
 )
 
+type UpsertCategorizationRuleParams = { businessId: string, categorizationRuleId?: string }
+type UpsertCategorizationRuleBody = CreateCategorizationRuleBody | PatchCategorizationRuleBody
+
+const upsertCategorizationRule = (
+  baseUrl: string,
+  accessToken: string | undefined,
+  options?: { params?: UpsertCategorizationRuleParams, body?: UpsertCategorizationRuleBody },
+): Promise<UpsertCategorizationRuleReturnEncoded> => {
+  const { params, body } = options ?? {}
+
+  if (params?.categorizationRuleId !== undefined) {
+    return updateCategorizationRule(baseUrl, accessToken, {
+      params: { businessId: params.businessId, categorizationRuleId: params.categorizationRuleId },
+      body: body as PatchCategorizationRuleBody,
+    })
+  }
+
+  return createCategorizationRule(baseUrl, accessToken, {
+    params: { businessId: params?.businessId },
+    body: body as CreateCategorizationRuleBody,
+  })
+}
+
+const useUpsertCategorizationRuleMutation = createMutationHook({
+  tags: [UPSERT_CATEGORIZATION_RULE_TAG],
+  request: upsertCategorizationRule,
+  argToParams: (arg: UpsertCategorizationRuleArg) =>
+    arg.mode === 'update' ? { categorizationRuleId: arg.categorizationRuleId } : {},
+  argToBody: (arg: UpsertCategorizationRuleArg) => arg.body,
+  schema: UpsertCategorizationRuleReturnSchema,
+  swrOptions: { throwOnError: true },
+})
+
 export function useUpsertCategorizationRule() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReloadBankTransactions } = useBankTransactionsGlobalCacheActions()
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
   const { forceReload: forceReloadCategorizationRules, patchByKey: patchCategorizationRuleByKey } = useCategorizationRulesGlobalCacheActions()
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg }: { arg: UpsertCategorizationRuleArg },
-    ) => {
-      const decode = Schema.decodeUnknownPromise(UpsertCategorizationRuleReturnSchema)
-      if (arg.mode === 'create') {
-        return createCategorizationRule(
-          apiUrl,
-          accessToken,
-          {
-            params: { businessId },
-            body: arg.body,
-          },
-        ).then(decode)
-      }
-      return updateCategorizationRule(
-        apiUrl,
-        accessToken,
-        {
-          params: { businessId, categorizationRuleId: arg.categorizationRuleId },
-          body: arg.body,
-        },
-      ).then(decode)
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
+  const mutationResponse = useUpsertCategorizationRuleMutation()
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(

--- a/src/hooks/api/businesses/[business-id]/counterparties/useListCounterparties.ts
+++ b/src/hooks/api/businesses/[business-id]/counterparties/useListCounterparties.ts
@@ -1,21 +1,10 @@
-import { Schema } from 'effect'
-import useSWRInfinite from 'swr/infinite'
-
 import { type PaginationParams, SortOrder, type SortParams } from '@internal-types/utility/pagination'
 import { BankTransactionCounterpartySchema } from '@schemas/bankTransactions/base'
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
-import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
-import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { getWithQuery } from '@utils/api/getWithQuery'
+import { createInfiniteQueryHook } from '@hooks/utils/swr/createInfiniteQueryHook'
 
 export const LIST_COUNTERPARTIES_TAG_KEY = '#list-counterparties'
-
-type ListCounterpartiesBaseParams = {
-  businessId: string
-}
 
 export type ListCounterpartiesFilterParams = {
   externalIds?: ReadonlyArray<string>
@@ -26,93 +15,28 @@ enum SortBy {
   Name = 'name',
 }
 
-type ListCounterpartiesOptions = ListCounterpartiesFilterParams & PaginationParams & SortParams<SortBy>
-
-type ListCounterpartiesParams = ListCounterpartiesBaseParams & ListCounterpartiesOptions
+type ListCounterpartiesParams = {
+  businessId: string
+  cursor?: string
+} & ListCounterpartiesFilterParams & Omit<PaginationParams, 'cursor'> & SortParams<SortBy>
 
 const ListCounterpartiesReturnSchema = PaginatedResponseSchema(BankTransactionCounterpartySchema)
 
-type ListCounterpartiesReturn = typeof ListCounterpartiesReturnSchema.Type
-
-export const listCounterparties = get<
-  ListCounterpartiesReturn,
+export const listCounterparties = getWithQuery<
+  typeof ListCounterpartiesReturnSchema.Encoded,
   ListCounterpartiesParams
->(({ businessId, externalIds, q, sortBy, sortOrder, cursor, limit, showTotalCount }) => {
-  const parameters = toDefinedSearchParameters({
-    externalIds,
-    q,
-    sortBy,
-    sortOrder,
-    cursor,
-    limit,
-    showTotalCount,
-  })
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/counterparties`,
+)
 
-  const baseUrl = `/v1/businesses/${businessId}/counterparties`
-  return parameters ? `${baseUrl}?${parameters}` : baseUrl
+export const useListCounterparties = createInfiniteQueryHook({
+  tags: [LIST_COUNTERPARTIES_TAG_KEY],
+  request: listCounterparties,
+  schema: ListCounterpartiesReturnSchema,
+  keyDefaults: {
+    sortBy: SortBy.Name,
+    sortOrder: SortOrder.ASC,
+    showTotalCount: true,
+  },
 })
-
-const keyLoader = createInfiniteKeyLoader<Omit<ListCounterpartiesParams, 'cursor'>, ListCounterpartiesReturn>([LIST_COUNTERPARTIES_TAG_KEY])
-
-export function useListCounterparties({
-  externalIds,
-  q,
-  sortBy = SortBy.Name,
-  sortOrder = SortOrder.ASC,
-  limit,
-  showTotalCount = true,
-}: ListCounterpartiesOptions = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWRInfinite(
-    (_index, previousPageData: ListCounterpartiesReturn | null) => withLocale(keyLoader(
-      previousPageData,
-      {
-        ...auth,
-        businessId,
-        externalIds,
-        q,
-        sortBy,
-        sortOrder,
-        limit,
-        showTotalCount,
-      },
-    )),
-    ({
-      accessToken,
-      apiUrl,
-      businessId,
-      cursor,
-      externalIds,
-      q,
-      sortBy,
-      sortOrder,
-      limit,
-      showTotalCount,
-    }) => listCounterparties(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          externalIds,
-          q,
-          sortBy,
-          sortOrder,
-          cursor,
-          limit,
-          showTotalCount,
-        },
-      },
-    )().then(Schema.decodeUnknownPromise(ListCounterpartiesReturnSchema)),
-    {
-      keepPreviousData: true,
-      revalidateFirstPage: false,
-      initialSize: 1,
-    },
-  )
-
-  usePreserveInfiniteSize(swrResponse)
-
-  return useSWRInfiniteResult(swrResponse)
-}

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/parse-csv/useCustomAccountParseCsv.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/parse-csv/useCustomAccountParseCsv.ts
@@ -2,6 +2,7 @@ import { pipe, Schema } from 'effect'
 
 import { PreviewCellSchema, type PreviewCsv, PreviewRowSchema } from '@schemas/csvUpload'
 import type { CustomAccountTransactionRow, RawCustomTransaction } from '@schemas/customAccounts'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { postWithFormData } from '@utils/api/authenticatedHttp'
 import { CUSTOM_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
@@ -57,9 +58,7 @@ const ParseCsvResponseSchema = Schema.Struct({
   ),
 })
 
-const ParseCsvReturnSchema = Schema.Struct({
-  data: ParseCsvResponseSchema,
-})
+const ParseCsvReturnSchema = UnwrappedDataResponseSchema(ParseCsvResponseSchema)
 
 export type CustomAccountParseCsvResponse = {
   isValid: boolean
@@ -104,7 +103,7 @@ export const useCustomAccountParseCsv = createMutationHook({
   argToParams: ({ customAccountId }: CustomAccountParseCsvArgs) => ({ customAccountId }),
   argToBody: ({ file }: CustomAccountParseCsvArgs) => ({ file }),
   schema: ParseCsvReturnSchema,
-  select: ({ data }): CustomAccountParseCsvResponse => ({
+  select: (data): CustomAccountParseCsvResponse => ({
     isValid: data.isValid,
     newTransactionsPreview: data.newTransactionsPreview,
     newTransactionsRequest: data.newTransactionsRequest as { transactions: RawCustomTransaction[] },

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/parse-csv/useCustomAccountParseCsv.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/parse-csv/useCustomAccountParseCsv.ts
@@ -1,13 +1,10 @@
 import { pipe, Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { PreviewCellSchema, type PreviewCsv, PreviewRowSchema } from '@schemas/csvUpload'
 import type { CustomAccountTransactionRow, RawCustomTransaction } from '@schemas/customAccounts'
-import { type APIError } from '@utils/api/apiError'
 import { postWithFormData } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { CUSTOM_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type CustomAccountParseCsvArgs = {
   file: File
@@ -60,6 +57,10 @@ const ParseCsvResponseSchema = Schema.Struct({
   ),
 })
 
+const ParseCsvReturnSchema = Schema.Struct({
+  data: ParseCsvResponseSchema,
+})
+
 export type CustomAccountParseCsvResponse = {
   isValid: boolean
   newTransactionsRequest: { transactions: RawCustomTransaction[] }
@@ -68,24 +69,28 @@ export type CustomAccountParseCsvResponse = {
   totalTransactionsCount: number
 }
 
-const buildKey = createBuildKey<{ businessId: string }>([`${CUSTOM_ACCOUNTS_TAG_KEY}:parse-csv`])
-
-const parseCsv = (baseUrl: string, accessToken: string, {
-  businessId,
-  customAccountId,
-  file,
-}: {
+type ParseCsvParams = {
   businessId: string
   customAccountId: string
+}
+
+type ParseCsvBody = {
   file: File
-}) => {
+}
+
+const parseCsv = (
+  baseUrl: string,
+  accessToken: string | undefined,
+  options?: { params?: ParseCsvParams, body?: ParseCsvBody },
+) => {
+  const { businessId, customAccountId } = options?.params ?? ({} as ParseCsvParams)
+  const { file } = options?.body ?? ({} as ParseCsvBody)
+
   const formData = new FormData()
   formData.append('file', file)
 
   const endpoint = `/v1/businesses/${businessId}/custom-accounts/${customAccountId}/parse-csv`
-  return postWithFormData<
-    { data: typeof ParseCsvResponseSchema.Encoded }
-  >(
+  return postWithFormData<typeof ParseCsvReturnSchema.Encoded>(
     endpoint,
     formData,
     baseUrl,
@@ -93,42 +98,17 @@ const parseCsv = (baseUrl: string, accessToken: string, {
   )
 }
 
-export function useCustomAccountParseCsv() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  return useSWRMutation<
-    CustomAccountParseCsvResponse,
-    APIError,
-    () => ReturnType<typeof buildKey>,
-    CustomAccountParseCsvArgs
-  >
-      (
-      () => withLocale(buildKey({
-        ...auth,
-        businessId,
-      })),
-      (
-        { accessToken, apiUrl, businessId },
-        { arg: { customAccountId, file } }: { arg: CustomAccountParseCsvArgs },
-      ) => parseCsv(
-        apiUrl,
-        accessToken,
-        {
-          businessId,
-          customAccountId,
-          file,
-        },
-      )
-        .then(({ data }) => Schema.decodeUnknownPromise(ParseCsvResponseSchema)(data))
-        .then(decoded => ({
-          isValid: decoded.isValid,
-          newTransactionsPreview: decoded.newTransactionsPreview,
-          newTransactionsRequest: decoded.newTransactionsRequest as { transactions: RawCustomTransaction[] },
-          invalidTransactionsCount: decoded.invalidTransactionsCount,
-          totalTransactionsCount: decoded.totalTransactionsCount,
-        })),
-      {
-        revalidate: false,
-      },
-      )
-}
+export const useCustomAccountParseCsv = createMutationHook({
+  tags: [`${CUSTOM_ACCOUNTS_TAG_KEY}:parse-csv`],
+  request: parseCsv,
+  argToParams: ({ customAccountId }: CustomAccountParseCsvArgs) => ({ customAccountId }),
+  argToBody: ({ file }: CustomAccountParseCsvArgs) => ({ file }),
+  schema: ParseCsvReturnSchema,
+  select: ({ data }): CustomAccountParseCsvResponse => ({
+    isValid: data.isValid,
+    newTransactionsPreview: data.newTransactionsPreview,
+    newTransactionsRequest: data.newTransactionsRequest as { transactions: RawCustomTransaction[] },
+    invalidTransactionsCount: data.invalidTransactionsCount,
+    totalTransactionsCount: data.totalTransactionsCount,
+  }),
+})

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/transactions/useCreateCustomAccountTransactions.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/transactions/useCreateCustomAccountTransactions.ts
@@ -1,4 +1,3 @@
-import { useCallback } from 'react'
 import { Schema } from 'effect'
 
 import { BankTransactionDataOnlySchema } from '@schemas/bankTransactions/bankTransactionDataOnly'
@@ -28,7 +27,7 @@ const createCustomAccountTransactions = post<
   `/v1/businesses/${businessId}/custom-accounts/${customAccountId}/transactions`,
 )
 
-const useCreateCustomAccountTransactionsMutation = createMutationHook({
+export const useCreateCustomAccountTransactions = createMutationHook({
   tags: [`${CUSTOM_ACCOUNTS_TAG_KEY}:create-transactions`],
   request: createCustomAccountTransactions,
   argToParams: ({ customAccountId }: CreateCustomAccountTransactionsArgs) => ({ customAccountId }),
@@ -36,24 +35,3 @@ const useCreateCustomAccountTransactionsMutation = createMutationHook({
   schema: CreateCustomAccountTransactionsResponseSchema,
   swrOptions: { throwOnError: false },
 })
-
-export function useCreateCustomAccountTransactions() {
-  const mutationResponse = useCreateCustomAccountTransactionsMutation()
-  const { trigger: originalTrigger } = mutationResponse
-
-  const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const triggerResult = await originalTrigger(...triggerParameters)
-      return triggerResult
-    },
-    [originalTrigger],
-  )
-
-  return {
-    trigger: stableProxiedTrigger,
-    data: mutationResponse.data,
-    error: mutationResponse.error,
-    isError: mutationResponse.isError,
-    isMutating: mutationResponse.isMutating,
-  }
-}

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/transactions/useCreateCustomAccountTransactions.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/transactions/useCreateCustomAccountTransactions.ts
@@ -3,6 +3,7 @@ import { Schema } from 'effect'
 
 import { BankTransactionDataOnlySchema } from '@schemas/bankTransactions/bankTransactionDataOnly'
 import type { RawCustomTransaction } from '@schemas/customAccounts'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { CUSTOM_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
@@ -15,9 +16,9 @@ type CreateCustomAccountTransactionsArgs = CreateCustomAccountTransactionsBody &
   customAccountId: string
 }
 
-const CreateCustomAccountTransactionsResponseSchema = Schema.Struct({
-  data: Schema.Array(BankTransactionDataOnlySchema),
-})
+const CreateCustomAccountTransactionsResponseSchema = UnwrappedDataResponseSchema(
+  Schema.Array(BankTransactionDataOnlySchema),
+)
 
 const createCustomAccountTransactions = post<
   typeof CreateCustomAccountTransactionsResponseSchema.Encoded,
@@ -43,14 +44,14 @@ export function useCreateCustomAccountTransactions() {
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const triggerResult = await originalTrigger(...triggerParameters)
-      return triggerResult?.data
+      return triggerResult
     },
     [originalTrigger],
   )
 
   return {
     trigger: stableProxiedTrigger,
-    data: mutationResponse.data?.data,
+    data: mutationResponse.data,
     error: mutationResponse.error,
     isError: mutationResponse.isError,
     isMutating: mutationResponse.isMutating,

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/transactions/useCreateCustomAccountTransactions.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/transactions/useCreateCustomAccountTransactions.ts
@@ -1,13 +1,11 @@
+import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { BankTransactionDataOnlySchema } from '@schemas/bankTransactions/bankTransactionDataOnly'
 import type { RawCustomTransaction } from '@schemas/customAccounts'
-import { type APIError } from '@utils/api/apiError'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { CUSTOM_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type CreateCustomAccountTransactionsBody = {
   transactions: RawCustomTransaction[]
@@ -21,46 +19,40 @@ const CreateCustomAccountTransactionsResponseSchema = Schema.Struct({
   data: Schema.Array(BankTransactionDataOnlySchema),
 })
 
-type CreateCustomAccountTransactionsResponse = typeof CreateCustomAccountTransactionsResponseSchema.Type
-
 const createCustomAccountTransactions = post<
-  Record<string, unknown>,
+  typeof CreateCustomAccountTransactionsResponseSchema.Encoded,
   CreateCustomAccountTransactionsBody,
   { businessId: string, customAccountId: string }
 >(({ businessId, customAccountId }) =>
   `/v1/businesses/${businessId}/custom-accounts/${customAccountId}/transactions`,
 )
 
-const buildKey = createBuildKey<{ businessId: string }>([`${CUSTOM_ACCOUNTS_TAG_KEY}:create-transactions`])
+const useCreateCustomAccountTransactionsMutation = createMutationHook({
+  tags: [`${CUSTOM_ACCOUNTS_TAG_KEY}:create-transactions`],
+  request: createCustomAccountTransactions,
+  argToParams: ({ customAccountId }: CreateCustomAccountTransactionsArgs) => ({ customAccountId }),
+  argToBody: ({ transactions }: CreateCustomAccountTransactionsArgs) => ({ transactions }),
+  schema: CreateCustomAccountTransactionsResponseSchema,
+  swrOptions: { throwOnError: false },
+})
 
 export function useCreateCustomAccountTransactions() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
+  const mutationResponse = useCreateCustomAccountTransactionsMutation()
+  const { trigger: originalTrigger } = mutationResponse
 
-  return useSWRMutation<
-    CreateCustomAccountTransactionsResponse['data'],
-    APIError,
-    () => ReturnType<typeof buildKey>,
-    CreateCustomAccountTransactionsArgs>(
-      () => withLocale(buildKey({
-        ...auth,
-        businessId,
-      })),
-      (
-        { accessToken, apiUrl, businessId },
-        { arg: { customAccountId, ...body } },
-      ) =>
-        createCustomAccountTransactions(apiUrl, accessToken, {
-          params: {
-            businessId,
-            customAccountId,
-          },
-          body,
-        })
-          .then(Schema.decodeUnknownPromise(CreateCustomAccountTransactionsResponseSchema))
-          .then(({ data }) => data),
-      {
-        revalidate: false,
-        throwOnError: false,
-      },
-      )
+  const stableProxiedTrigger = useCallback(
+    async (...triggerParameters: Parameters<typeof originalTrigger>) => {
+      const triggerResult = await originalTrigger(...triggerParameters)
+      return triggerResult?.data
+    },
+    [originalTrigger],
+  )
+
+  return {
+    trigger: stableProxiedTrigger,
+    data: mutationResponse.data?.data,
+    error: mutationResponse.error,
+    isError: mutationResponse.isError,
+    isMutating: mutationResponse.isMutating,
+  }
 }

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/useCreateCustomAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/useCreateCustomAccount.ts
@@ -1,16 +1,13 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
 import { useSWRConfig } from 'swr'
-import useSWRMutation from 'swr/mutation'
 
 import { CustomAccountSchema, type RawCustomAccount } from '@schemas/customAccounts'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { BANK_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
 import { CUSTOM_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type CreateCustomAccountBody = Pick<
   RawCustomAccount,
@@ -33,40 +30,21 @@ const createCustomAccount = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/custom-accounts`)
 
-const buildKey = createBuildKey<{ businessId: string }>([`${CUSTOM_ACCOUNTS_TAG_KEY}:create`])
+const useCreateCustomAccountMutation = createMutationHook({
+  tags: [`${CUSTOM_ACCOUNTS_TAG_KEY}:create`],
+  request: createCustomAccount,
+  schema: CreateCustomAccountResponseSchema,
+})
 
 export function useCreateCustomAccount() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: body }: { arg: CreateCustomAccountBody },
-    ) => createCustomAccount(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body,
-      },
-    )
-      .then(Schema.decodeUnknownPromise(CreateCustomAccountResponseSchema))
-      .then(({ data }) => data),
-    {
-      revalidate: false,
-    },
-  )
-
+  const mutationResponse = useCreateCustomAccountMutation()
   const { trigger: originalTrigger } = mutationResponse
 
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const triggerResult = await originalTrigger(...triggerParameters)
+      const { data } = await originalTrigger(...triggerParameters)
 
       void mutate(key => withSWRKeyTags(
         key,
@@ -74,7 +52,7 @@ export function useCreateCustomAccount() {
           || tags.includes(BANK_ACCOUNTS_TAG_KEY),
       ))
 
-      return triggerResult
+      return data
     },
     [
       originalTrigger,
@@ -82,5 +60,10 @@ export function useCreateCustomAccount() {
     ],
   )
 
-  return withStableTrigger(mutationResponse, stableProxiedTrigger)
+  return {
+    trigger: stableProxiedTrigger,
+    data: mutationResponse.data?.data,
+    isError: mutationResponse.isError,
+    isMutating: mutationResponse.isMutating,
+  }
 }

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/useCreateCustomAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/useCreateCustomAccount.ts
@@ -4,6 +4,7 @@ import { useSWRConfig } from 'swr'
 import { CustomAccountSchema, type RawCustomAccount } from '@schemas/customAccounts'
 import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
+import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { BANK_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
 import { CUSTOM_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
@@ -58,10 +59,5 @@ export function useCreateCustomAccount() {
     ],
   )
 
-  return {
-    trigger: stableProxiedTrigger,
-    data: mutationResponse.data,
-    isError: mutationResponse.isError,
-    isMutating: mutationResponse.isMutating,
-  }
+  return withStableTrigger(mutationResponse, stableProxiedTrigger)
 }

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/useCreateCustomAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/useCreateCustomAccount.ts
@@ -1,13 +1,11 @@
 import { useCallback } from 'react'
-import { useSWRConfig } from 'swr'
 
 import { CustomAccountSchema, type RawCustomAccount } from '@schemas/customAccounts'
 import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
-import { BANK_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
-import { CUSTOM_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
+import { useBankAccountsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
+import { CUSTOM_ACCOUNTS_TAG_KEY, useCustomAccountsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type CreateCustomAccountBody = Pick<
@@ -36,7 +34,8 @@ const useCreateCustomAccountMutation = createMutationHook({
 })
 
 export function useCreateCustomAccount() {
-  const { mutate } = useSWRConfig()
+  const { invalidate: invalidateCustomAccounts } = useCustomAccountsGlobalCacheActions()
+  const { invalidate: invalidateBankAccounts } = useBankAccountsGlobalCacheActions()
 
   const mutationResponse = useCreateCustomAccountMutation()
   const { trigger: originalTrigger } = mutationResponse
@@ -45,17 +44,15 @@ export function useCreateCustomAccount() {
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const data = await originalTrigger(...triggerParameters)
 
-      void mutate(key => withSWRKeyTags(
-        key,
-        ({ tags }) => tags.includes(CUSTOM_ACCOUNTS_TAG_KEY)
-          || tags.includes(BANK_ACCOUNTS_TAG_KEY),
-      ))
+      void invalidateCustomAccounts()
+      void invalidateBankAccounts()
 
       return data
     },
     [
       originalTrigger,
-      mutate,
+      invalidateCustomAccounts,
+      invalidateBankAccounts,
     ],
   )
 

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/useCreateCustomAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/useCreateCustomAccount.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 import { useSWRConfig } from 'swr'
 
 import { CustomAccountSchema, type RawCustomAccount } from '@schemas/customAccounts'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { BANK_ACCOUNTS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
@@ -20,9 +20,7 @@ type CreateCustomAccountBody = Pick<
   | 'user_created'
 >
 
-const CreateCustomAccountResponseSchema = Schema.Struct({
-  data: CustomAccountSchema,
-})
+const CreateCustomAccountResponseSchema = UnwrappedDataResponseSchema(CustomAccountSchema)
 
 const createCustomAccount = post<
   typeof CreateCustomAccountResponseSchema.Encoded,
@@ -44,7 +42,7 @@ export function useCreateCustomAccount() {
 
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
-      const { data } = await originalTrigger(...triggerParameters)
+      const data = await originalTrigger(...triggerParameters)
 
       void mutate(key => withSWRKeyTags(
         key,
@@ -62,7 +60,7 @@ export function useCreateCustomAccount() {
 
   return {
     trigger: stableProxiedTrigger,
-    data: mutationResponse.data?.data,
+    data: mutationResponse.data,
     isError: mutationResponse.isError,
     isMutating: mutationResponse.isMutating,
   }

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts.ts
@@ -1,10 +1,8 @@
 import { pipe, Schema } from 'effect'
-import useSWR from 'swr'
 
 import { CustomAccountSchema } from '@schemas/customAccounts'
-import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { getWithQuery } from '@utils/api/getWithQuery'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const CUSTOM_ACCOUNTS_TAG_KEY = '#custom-accounts'
 
@@ -17,45 +15,22 @@ const GetCustomAccountsResponseSchema = Schema.Struct({
   }),
 })
 
-type GetCustomAccountsResponseEncoded = typeof GetCustomAccountsResponseSchema.Encoded
-
-const buildKey = createBuildKey<{ businessId: string, userCreated?: boolean }>([CUSTOM_ACCOUNTS_TAG_KEY])
-
-const getCustomAccounts = get<
-  GetCustomAccountsResponseEncoded,
-  {
-    businessId: string
-    userCreated?: boolean
-  }
->(({ businessId, userCreated }) => {
-  const baseUrl = `/v1/businesses/${businessId}/custom-accounts`
-
-  if (userCreated !== undefined) {
-    return `${baseUrl}?user_created=${userCreated}`
-  }
-  return baseUrl
-})
-
-type useCustomAccountsParams = {
+type GetCustomAccountsParams = {
+  businessId: string
   userCreated?: boolean
 }
-export function useCustomAccounts({ userCreated }: useCustomAccountsParams = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
-  return useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      userCreated,
-    })),
-    ({ accessToken, apiUrl, businessId, userCreated }) => getCustomAccounts(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, userCreated },
-      },
-    )()
-      .then(Schema.decodeUnknownPromise(GetCustomAccountsResponseSchema))
-      .then(({ data }) => data.customAccounts),
-  )
-}
+const getCustomAccounts = getWithQuery<
+  typeof GetCustomAccountsResponseSchema.Encoded,
+  GetCustomAccountsParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/custom-accounts`,
+)
+
+export const useCustomAccounts = createQueryHook({
+  tags: [CUSTOM_ACCOUNTS_TAG_KEY],
+  request: getCustomAccounts,
+  schema: GetCustomAccountsResponseSchema,
+  select: ({ data }) => data.customAccounts,
+})

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts.ts
@@ -1,19 +1,20 @@
 import { pipe, Schema } from 'effect'
 
 import { CustomAccountSchema } from '@schemas/customAccounts'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const CUSTOM_ACCOUNTS_TAG_KEY = '#custom-accounts'
 
-const GetCustomAccountsResponseSchema = Schema.Struct({
-  data: Schema.Struct({
-    customAccounts: pipe(
-      Schema.propertySignature(Schema.Array(CustomAccountSchema)),
-      Schema.fromKey('custom_accounts'),
-    ),
-  }),
+const CustomAccountsDataSchema = Schema.Struct({
+  customAccounts: pipe(
+    Schema.propertySignature(Schema.Array(CustomAccountSchema)),
+    Schema.fromKey('custom_accounts'),
+  ),
 })
+
+const GetCustomAccountsResponseSchema = UnwrappedDataResponseSchema(CustomAccountsDataSchema)
 
 type GetCustomAccountsParams = {
   businessId: string
@@ -31,6 +32,6 @@ const getCustomAccounts = getWithQuery<
 export const useCustomAccounts = createQueryHook({
   tags: [CUSTOM_ACCOUNTS_TAG_KEY],
   request: getCustomAccounts,
-  schema: GetCustomAccountsResponseSchema.pipe(Schema.pluck('data')),
+  schema: GetCustomAccountsResponseSchema,
   select: ({ customAccounts }) => customAccounts,
 })

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts.ts
@@ -3,6 +3,7 @@ import { pipe, Schema } from 'effect'
 import { CustomAccountSchema } from '@schemas/customAccounts'
 import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
+import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const CUSTOM_ACCOUNTS_TAG_KEY = '#custom-accounts'
@@ -35,3 +36,6 @@ export const useCustomAccounts = createQueryHook({
   schema: GetCustomAccountsResponseSchema,
   select: ({ customAccounts }) => customAccounts,
 })
+
+export const useCustomAccountsGlobalCacheActions =
+  createResourceGlobalCacheActions<ReadonlyArray<typeof CustomAccountSchema.Type>>(CUSTOM_ACCOUNTS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts.ts
+++ b/src/hooks/api/businesses/[business-id]/custom-accounts/useCustomAccounts.ts
@@ -31,6 +31,6 @@ const getCustomAccounts = getWithQuery<
 export const useCustomAccounts = createQueryHook({
   tags: [CUSTOM_ACCOUNTS_TAG_KEY],
   request: getCustomAccounts,
-  schema: GetCustomAccountsResponseSchema,
-  select: ({ data }) => data.customAccounts,
+  schema: GetCustomAccountsResponseSchema.pipe(Schema.pluck('data')),
+  select: ({ customAccounts }) => customAccounts,
 })

--- a/src/hooks/api/businesses/[business-id]/customers/useListCustomers.ts
+++ b/src/hooks/api/businesses/[business-id]/customers/useListCustomers.ts
@@ -1,102 +1,42 @@
-import { Schema } from 'effect'
-import useSWRInfinite from 'swr/infinite'
-
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { type Customer, CustomerSchema } from '@schemas/customer'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
-import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createInfiniteQueryHook } from '@hooks/utils/swr/createInfiniteQueryHook'
 
 const ListCustomersRawResultSchema = PaginatedResponseSchema(CustomerSchema)
-type ListCustomersRawResult = typeof ListCustomersRawResultSchema.Type
 
-type ListCustomersBaseParams = {
+type ListCustomersPaginatedParams = {
   businessId: string
   query?: string
-}
-
-type ListCustomersPaginatedParams = ListCustomersBaseParams & {
   cursor?: string
   limit?: number
 }
 
-const listCustomers = get<
-  Record<string, unknown>,
+const listCustomers = getWithQuery<
+  typeof ListCustomersRawResultSchema.Encoded,
   ListCustomersPaginatedParams
->(({
-  businessId,
-  cursor,
-  limit,
-  query,
-}) => {
-  const parameters = toDefinedSearchParameters({
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/customers`,
+  ({ cursor, limit, query }) => ({
     cursor,
     identityStatus: 'IDENTIFIED',
     limit,
     q: query,
-  })
-
-  return `/v1/businesses/${businessId}/customers?${parameters}`
-})
+  }),
+)
 
 export const CUSTOMERS_TAG_KEY = '#customers'
 
-const keyLoader = createInfiniteKeyLoader<
-  { businessId: string, query?: string },
-  ListCustomersRawResult
->([CUSTOMERS_TAG_KEY])
+export const useListCustomers = createInfiniteQueryHook({
+  tags: [CUSTOMERS_TAG_KEY],
+  request: listCustomers,
+  schema: ListCustomersRawResultSchema,
+  keyDefaults: { limit: 100 },
+})
 
-type UseListCustomersParams = {
-  query?: string
-  isEnabled?: boolean
-}
-
-export function useListCustomers({ query, isEnabled = true }: UseListCustomersParams = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWRInfinite(
-    (_index, previousPageData: ListCustomersRawResult | null) => withLocale(keyLoader(
-      previousPageData,
-      {
-        ...auth,
-        businessId,
-        query,
-        isEnabled,
-      },
-    )),
-    ({
-      accessToken,
-      apiUrl,
-      businessId,
-      cursor,
-      query,
-    }) => listCustomers(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          cursor,
-          limit: 100,
-          query,
-        },
-      },
-    )().then(Schema.decodeUnknownPromise(ListCustomersRawResultSchema)),
-    {
-      keepPreviousData: true,
-      revalidateFirstPage: false,
-      initialSize: 1,
-    },
-  )
-
-  usePreserveInfiniteSize(swrResponse)
-
-  return useSWRInfiniteResult(swrResponse)
-}
+type UseListCustomersParams = Parameters<typeof useListCustomers>[0]
 
 export function usePreloadCustomers(parameters?: UseListCustomersParams) {
   /*

--- a/src/hooks/api/businesses/[business-id]/customers/useUpsertCustomer.tsx
+++ b/src/hooks/api/businesses/[business-id]/customers/useUpsertCustomer.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { CustomerSchema, type UpsertCustomerEncoded } from '@schemas/customer'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { CUSTOMERS_TAG_KEY, useCustomersGlobalCacheActions } from '@hooks/api/businesses/[business-id]/customers/useListCustomers'
@@ -17,9 +17,7 @@ export enum UpsertCustomerMode {
 
 type UpsertCustomerBody = UpsertCustomerEncoded
 
-const UpsertCustomerReturnSchema = Schema.Struct({
-  data: CustomerSchema,
-})
+const UpsertCustomerReturnSchema = UnwrappedDataResponseSchema(CustomerSchema)
 
 type UpsertCustomerReturnEncoded = typeof UpsertCustomerReturnSchema.Encoded
 
@@ -74,7 +72,7 @@ export const useUpsertCustomer = (props: UseUpsertCustomerProps) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
       if (mode === UpsertCustomerMode.Update) {
-        void patchCustomerByKey(triggerResult.data)
+        void patchCustomerByKey(triggerResult)
         void forceReloadInvoices()
       }
       else {

--- a/src/hooks/api/businesses/[business-id]/customers/useUpsertCustomer.tsx
+++ b/src/hooks/api/businesses/[business-id]/customers/useUpsertCustomer.tsx
@@ -1,15 +1,12 @@
 import { useCallback } from 'react'
-import { Effect, Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
+import { Schema } from 'effect'
 
 import { CustomerSchema, type UpsertCustomerEncoded } from '@schemas/customer'
 import { patch, post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { CUSTOMERS_TAG_KEY, useCustomersGlobalCacheActions } from '@hooks/api/businesses/[business-id]/customers/useListCustomers'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPSERT_CUSTOMER_TAG_KEY = '#upsert-customer'
 
@@ -20,120 +17,61 @@ export enum UpsertCustomerMode {
 
 type UpsertCustomerBody = UpsertCustomerEncoded
 
-const createCustomer = post<
-  UpsertCustomerReturn,
-  UpsertCustomerBody,
-  { businessId: string }
->(({ businessId }) => `/v1/businesses/${businessId}/customers`)
+const UpsertCustomerReturnSchema = Schema.Struct({
+  data: CustomerSchema,
+})
+
+type UpsertCustomerReturnEncoded = typeof UpsertCustomerReturnSchema.Encoded
+
+const createCustomer = post<UpsertCustomerReturnEncoded, UpsertCustomerBody>(
+  ({ businessId }) => `/v1/businesses/${businessId}/customers`,
+)
 
 const updateCustomer = patch<
-  UpsertCustomerReturn,
+  UpsertCustomerReturnEncoded,
   UpsertCustomerBody,
   { businessId: string, customerId: string }
 >(({ businessId, customerId }) => `/v1/businesses/${businessId}/customers/${customerId}`)
 
-const buildKey = createBuildKey<{ businessId: string, customerId?: string }>([UPSERT_CUSTOMER_TAG_KEY, CUSTOMERS_TAG_KEY])
+type UpsertCustomerParams = { businessId: string, customerId?: string }
 
-const UpsertCustomerReturnSchema = Schema.Struct({
-  data: CustomerSchema,
-})
-type UpsertCustomerReturn = typeof UpsertCustomerReturnSchema.Type
+const upsertCustomer = (
+  baseUrl: string,
+  accessToken: string | undefined,
+  options?: { params?: UpsertCustomerParams, body?: UpsertCustomerBody },
+): Promise<UpsertCustomerReturnEncoded> => {
+  const { params, body } = options ?? {}
 
-type RequestArgs = {
-  apiUrl: string
-  accessToken: string
-  body: UpsertCustomerBody
+  if (params?.customerId !== undefined) {
+    return updateCustomer(baseUrl, accessToken, {
+      params: { businessId: params.businessId, customerId: params.customerId },
+      body,
+    })
+  }
+
+  return createCustomer(baseUrl, accessToken, {
+    params: { businessId: params?.businessId },
+    body,
+  })
 }
 
-const CreateParamsSchema = Schema.Struct({
-  businessId: Schema.UUID,
-  customerId: Schema.Undefined,
+const useUpsertCustomerMutation = createMutationHook({
+  tags: [UPSERT_CUSTOMER_TAG_KEY, CUSTOMERS_TAG_KEY],
+  request: upsertCustomer,
+  keyParams: ['customerId'],
+  schema: UpsertCustomerReturnSchema,
+  swrOptions: { throwOnError: true },
 })
-
-const UpdateParamsSchema = Schema.Struct({
-  businessId: Schema.UUID,
-  customerId: Schema.UUID,
-})
-
-type CreateParams = typeof CreateParamsSchema.Type
-type UpdateParams = typeof UpdateParamsSchema.Type
-
-type UpsertParams = CreateParams | UpdateParams
-
-type UpsertRequestFn = (args: RequestArgs) => Promise<UpsertCustomerReturn>
-
-const isParamsValidForMode = <M extends UpsertCustomerMode>(
-  mode: M,
-  params: unknown,
-): params is M extends UpsertCustomerMode.Update ? UpdateParams : CreateParams => {
-  if (mode === UpsertCustomerMode.Update) {
-    return Effect.runSync(Effect.either(Schema.decodeUnknown(UpdateParamsSchema)(params)))._tag === 'Right'
-  }
-
-  if (mode === UpsertCustomerMode.Create) {
-    return Effect.runSync(Effect.either(Schema.decodeUnknown(CreateParamsSchema)(params)))._tag === 'Right'
-  }
-
-  return false
-}
-
-function getRequestFn(
-  mode: UpsertCustomerMode,
-  params: UpsertParams,
-): UpsertRequestFn {
-  if (mode === UpsertCustomerMode.Update) {
-    if (!isParamsValidForMode(UpsertCustomerMode.Update, params)) {
-      throw new Error('Invalid params for update mode')
-    }
-
-    return ({ apiUrl, accessToken, body }: RequestArgs) =>
-      updateCustomer(apiUrl, accessToken, { params, body })
-  }
-  else {
-    if (!isParamsValidForMode(UpsertCustomerMode.Create, params)) {
-      throw new Error('Invalid params for create mode')
-    }
-
-    return ({ apiUrl, accessToken, body }: RequestArgs) =>
-      createCustomer(apiUrl, accessToken, { params, body })
-  }
-}
 
 type UseUpsertCustomerProps =
   | { mode: UpsertCustomerMode.Create }
   | { mode: UpsertCustomerMode.Update, customerId: string }
 
 export const useUpsertCustomer = (props: UseUpsertCustomerProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
   const { mode } = props
   const customerId = mode === UpsertCustomerMode.Update ? props.customerId : undefined
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      customerId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, customerId },
-      { arg: body }: { arg: UpsertCustomerBody },
-    ) => {
-      const request = getRequestFn(mode, { businessId, customerId })
-
-      return request({
-        apiUrl,
-        accessToken,
-        body,
-      }).then(Schema.decodeUnknownPromise(UpsertCustomerReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useUpsertCustomerMutation({ customerId })
 
   const { patchByKey: patchCustomerByKey, forceReload: forceReloadCustomers } = useCustomersGlobalCacheActions()
   const { forceReload: forceReloadInvoices } = useInvoicesGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/customers/useUpsertCustomer.tsx
+++ b/src/hooks/api/businesses/[business-id]/customers/useUpsertCustomer.tsx
@@ -33,31 +33,16 @@ const updateCustomer = patch<
   { businessId: string, customerId: string }
 >(({ businessId, customerId }) => `/v1/businesses/${businessId}/customers/${customerId}`)
 
-type UpsertCustomerParams = { businessId: string, customerId?: string }
-
-const upsertCustomer = (
-  baseUrl: string,
-  accessToken: string | undefined,
-  options?: { params?: UpsertCustomerParams, body?: UpsertCustomerBody },
-): Promise<UpsertCustomerReturnEncoded> => {
-  const { params, body } = options ?? {}
-
-  if (params?.customerId !== undefined) {
-    return updateCustomer(baseUrl, accessToken, {
-      params: { businessId: params.businessId, customerId: params.customerId },
-      body,
-    })
-  }
-
-  return createCustomer(baseUrl, accessToken, {
-    params: { businessId: params?.businessId },
-    body,
-  })
-}
-
-const useUpsertCustomerMutation = createMutationHook({
+const useCreateCustomer = createMutationHook({
   tags: [UPSERT_CUSTOMER_TAG_KEY, CUSTOMERS_TAG_KEY],
-  request: upsertCustomer,
+  request: createCustomer,
+  schema: UpsertCustomerReturnSchema,
+  swrOptions: { throwOnError: true },
+})
+
+const useUpdateCustomer = createMutationHook({
+  tags: [UPSERT_CUSTOMER_TAG_KEY, CUSTOMERS_TAG_KEY],
+  request: updateCustomer,
   keyParams: ['customerId'],
   schema: UpsertCustomerReturnSchema,
   swrOptions: { throwOnError: true },
@@ -71,7 +56,13 @@ export const useUpsertCustomer = (props: UseUpsertCustomerProps) => {
   const { mode } = props
   const customerId = mode === UpsertCustomerMode.Update ? props.customerId : undefined
 
-  const mutationResponse = useUpsertCustomerMutation({ customerId })
+  const createResponse = useCreateCustomer()
+  const updateResponse = useUpdateCustomer({
+    customerId: customerId ?? '',
+    isEnabled: customerId !== undefined,
+  })
+
+  const mutationResponse = mode === UpsertCustomerMode.Create ? createResponse : updateResponse
 
   const { patchByKey: patchCustomerByKey, forceReload: forceReloadCustomers } = useCustomersGlobalCacheActions()
   const { forceReload: forceReloadInvoices } = useInvoicesGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm.ts
+++ b/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm.ts
@@ -1,12 +1,6 @@
-import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
-
 import type { OneOf } from '@internal-types/utility/oneOf'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CONFIRM_EXTERNAL_ACCOUNT_TAG_KEY = '#confirm-external-account'
 
@@ -29,38 +23,9 @@ type ConfirmExternalAccountArg = {
   body?: ConfirmAccountBodyStrict
 }
 
-const buildKey = createBuildKey<{ businessId: string }>([CONFIRM_EXTERNAL_ACCOUNT_TAG_KEY])
-
-export function useConfirmExternalAccount() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { accountId, body } }: { arg: ConfirmExternalAccountArg },
-    ) => confirmExternalAccount(apiUrl, accessToken, {
-      params: { businessId, accountId },
-      body,
-    }),
-    {
-      revalidate: false,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
-
-  const { trigger: originalTrigger } = mutationResponse
-
-  const stableProxiedTrigger = useCallback(
-    (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters),
-    [originalTrigger],
-  )
-
-  return withStableTrigger(mutationResponse, stableProxiedTrigger)
-}
+export const useConfirmExternalAccount = createMutationHook({
+  tags: [CONFIRM_EXTERNAL_ACCOUNT_TAG_KEY],
+  request: confirmExternalAccount,
+  argToParams: ({ accountId }: ConfirmExternalAccountArg) => ({ accountId }),
+  argToBody: ({ body }: ConfirmExternalAccountArg) => body,
+})

--- a/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude.ts
+++ b/src/hooks/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude.ts
@@ -1,12 +1,6 @@
-import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
-
 import type { OneOf } from '@internal-types/utility/oneOf'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const EXCLUDE_EXTERNAL_ACCOUNT_TAG_KEY = '#exclude-external-account'
 
@@ -29,38 +23,9 @@ type ExcludeExternalAccountArg = {
   body?: ExcludeAccountBodyStrict
 }
 
-const buildKey = createBuildKey<{ businessId: string }>([EXCLUDE_EXTERNAL_ACCOUNT_TAG_KEY])
-
-export function useExcludeExternalAccount() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { accountId, body } }: { arg: ExcludeExternalAccountArg },
-    ) => excludeExternalAccount(apiUrl, accessToken, {
-      params: { businessId, accountId },
-      body,
-    }),
-    {
-      revalidate: false,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
-
-  const { trigger: originalTrigger } = mutationResponse
-
-  const stableProxiedTrigger = useCallback(
-    (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters),
-    [originalTrigger],
-  )
-
-  return withStableTrigger(mutationResponse, stableProxiedTrigger)
-}
+export const useExcludeExternalAccount = createMutationHook({
+  tags: [EXCLUDE_EXTERNAL_ACCOUNT_TAG_KEY],
+  request: excludeExternalAccount,
+  argToParams: ({ accountId }: ExcludeExternalAccountArg) => ({ accountId }),
+  argToBody: ({ body }: ExcludeExternalAccountArg) => body,
+})

--- a/src/hooks/api/businesses/[business-id]/external-accounts/update-connection-status.ts
+++ b/src/hooks/api/businesses/[business-id]/external-accounts/update-connection-status.ts
@@ -1,11 +1,5 @@
-import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
-
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPDATE_CONNECTION_STATUS_TAG_KEY = '#update-connection-status'
 
@@ -18,35 +12,13 @@ const updateConnectionStatus = post<
     `/v1/businesses/${businessId}/external-accounts/update-connection-status`,
 )
 
-const buildKey = createBuildKey<{ businessId: string }>([UPDATE_CONNECTION_STATUS_TAG_KEY])
-
-export function useUpdateConnectionStatus() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    ({ accessToken, apiUrl, businessId }) =>
-      updateConnectionStatus(apiUrl, accessToken, {
-        params: { businessId },
-      }),
-    {
-      revalidate: false,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
-
-  const { trigger: originalTrigger } = mutationResponse
-
-  const stableProxiedTrigger = useCallback(
-    (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters),
-    [originalTrigger],
-  )
-
-  return withStableTrigger(mutationResponse, stableProxiedTrigger)
-}
+export const useUpdateConnectionStatus = createMutationHook<
+  Record<string, unknown>,
+  Record<string, unknown>,
+  { businessId: string },
+  Record<string, unknown>,
+  never
+>({
+  tags: [UPDATE_CONNECTION_STATUS_TAG_KEY],
+  request: updateConnectionStatus,
+})

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/finalize-invoice/useFinalizeInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/finalize-invoice/useFinalizeInvoice.tsx
@@ -4,6 +4,7 @@ import { useSWRConfig } from 'swr'
 
 import { InvoiceSchema } from '@schemas/invoices/invoice'
 import { InvoicePaymentMethodsSchema } from '@schemas/invoices/invoicePaymentMethod'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { put } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
@@ -26,14 +27,14 @@ export const FinalizeInvoiceBodySchema = Schema.extend(
 export type FinalizeInvoiceBody = typeof FinalizeInvoiceBodySchema.Type
 export type FinalizeInvoiceBodyEncoded = typeof FinalizeInvoiceBodySchema.Encoded
 
-export const FinalizeInvoiceResponseSchema = Schema.Struct({
-  data: Schema.extend(
+export const FinalizeInvoiceResponseSchema = UnwrappedDataResponseSchema(
+  Schema.extend(
     InvoicePaymentMethodsSchema,
     Schema.Struct({
       invoice: InvoiceSchema,
     }),
   ),
-})
+)
 
 export const finalizeInvoice = put<
   typeof FinalizeInvoiceResponseSchema.Encoded,
@@ -67,7 +68,7 @@ export function useFinalizeInvoice({ invoiceId }: UseFinalizeInvoiceProps) {
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
-      void patchInvoiceByKey(triggerResult.data.invoice)
+      void patchInvoiceByKey(triggerResult.invoice)
 
       void forceReloadInvoiceSummaryStats()
 

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/finalize-invoice/useFinalizeInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/finalize-invoice/useFinalizeInvoice.tsx
@@ -1,19 +1,16 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
 import { useSWRConfig } from 'swr'
-import useSWRMutation from 'swr/mutation'
 
 import { InvoiceSchema } from '@schemas/invoices/invoice'
 import { InvoicePaymentMethodsSchema } from '@schemas/invoices/invoicePaymentMethod'
 import { put } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { INVOICE_PAYMENT_METHODS_TAG_KEY } from '@hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment-methods/useInvoicePaymentMethods'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const FINALIZE_INVOICE_TAG_KEY = '#finalize-invoice'
 
@@ -38,48 +35,28 @@ export const FinalizeInvoiceResponseSchema = Schema.Struct({
   ),
 })
 
-type FinalizeInvoiceResponse = typeof FinalizeInvoiceResponseSchema.Type
-
 export const finalizeInvoice = put<
-  FinalizeInvoiceResponse,
+  typeof FinalizeInvoiceResponseSchema.Encoded,
   FinalizeInvoiceBodyEncoded,
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/finalize-invoice`)
 
-const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([FINALIZE_INVOICE_TAG_KEY])
+const useFinalizeInvoiceMutation = createMutationHook({
+  tags: [FINALIZE_INVOICE_TAG_KEY],
+  request: finalizeInvoice,
+  keyParams: ['invoiceId'],
+  schema: FinalizeInvoiceResponseSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseFinalizeInvoiceProps = {
   invoiceId: string
 }
 
 export function useFinalizeInvoice({ invoiceId }: UseFinalizeInvoiceProps) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      invoiceId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, invoiceId },
-      { arg: body }: { arg: FinalizeInvoiceBodyEncoded },
-    ) => finalizeInvoice(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, invoiceId },
-        body,
-      },
-    ).then(Schema.decodeUnknownPromise(FinalizeInvoiceResponseSchema)),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useFinalizeInvoiceMutation({ invoiceId })
 
   const { patchByKey: patchInvoiceByKey } = useInvoicesGlobalCacheActions()
   const { forceReload: forceReloadInvoiceSummaryStats } = useInvoiceSummaryStatsCacheActions()

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/html/useInvoicePreview.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/html/useInvoicePreview.tsx
@@ -2,6 +2,7 @@ import useSWR from 'swr'
 
 import { getText } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
@@ -12,6 +13,8 @@ const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([INVO
 const getInvoicePreview = getText<{ businessId: string, invoiceId: string }>(
   ({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/html`,
 )
+
+const fetchInvoicePreview = createKeyedFetcher(getInvoicePreview)
 
 type UseInvoicePreviewProps = {
   invoiceId: string
@@ -25,13 +28,7 @@ export function useInvoicePreview({ invoiceId }: UseInvoicePreviewProps) {
       businessId,
       invoiceId,
     })),
-    ({ accessToken, apiUrl, businessId, invoiceId }) => getInvoicePreview(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, invoiceId },
-      },
-    )(),
+    fetchInvoicePreview,
   )
 
   return new SWRQueryResult(response)

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/html/useInvoicePreview.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/html/useInvoicePreview.tsx
@@ -1,38 +1,23 @@
-import useSWR from 'swr'
+import { Schema } from 'effect'
 
 import { getText } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const INVOICE_PREVIEW_TAG_KEY = '#invoices-preview'
-
-const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([INVOICE_PREVIEW_TAG_KEY])
 
 const getInvoicePreview = getText<{ businessId: string, invoiceId: string }>(
   ({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/html`,
 )
 
-const fetchInvoicePreview = createKeyedFetcher(getInvoicePreview)
-
 type UseInvoicePreviewProps = {
   invoiceId: string
 }
-export function useInvoicePreview({ invoiceId }: UseInvoicePreviewProps) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
 
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      invoiceId,
-    })),
-    fetchInvoicePreview,
-  )
-
-  return new SWRQueryResult(response)
-}
+export const useInvoicePreview = createQueryHook({
+  tags: [INVOICE_PREVIEW_TAG_KEY],
+  request: getInvoicePreview,
+  schema: Schema.String,
+})
 
 export function usePreloadInvoicePreview(props: UseInvoicePreviewProps) {
   /*

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/html/useInvoicePreview.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/html/useInvoicePreview.tsx
@@ -1,5 +1,3 @@
-import { Schema } from 'effect'
-
 import { getText } from '@utils/api/authenticatedHttp'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
@@ -16,7 +14,6 @@ type UseInvoicePreviewProps = {
 export const useInvoicePreview = createQueryHook({
   tags: [INVOICE_PREVIEW_TAG_KEY],
   request: getInvoicePreview,
-  schema: Schema.String,
 })
 
 export function usePreloadInvoicePreview(props: UseInvoicePreviewProps) {

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment-methods/useInvoicePaymentMethods.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment-methods/useInvoicePaymentMethods.tsx
@@ -9,28 +9,13 @@ const getInvoicePaymentMethods = get<
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/payment-methods`)
 
-const useInvoicePaymentMethodsQuery = createQueryHook({
+export const useInvoicePaymentMethods = createQueryHook({
   tags: [INVOICE_PAYMENT_METHODS_TAG_KEY],
   request: getInvoicePaymentMethods,
   schema: InvoicePaymentMethodsResponseSchema,
 })
 
-interface UseInvoicePaymentMethodsProps {
-  invoiceId: string
-  isEnabled?: boolean
-}
-
-export function useInvoicePaymentMethods({
-  invoiceId,
-  isEnabled = true,
-}: UseInvoicePaymentMethodsProps) {
-  return useInvoicePaymentMethodsQuery({
-    invoiceId,
-    isEnabled: isEnabled && Boolean(invoiceId),
-  })
-}
-
-export function usePreloadInvoicePaymentMethods(props: UseInvoicePaymentMethodsProps) {
+export function usePreloadInvoicePaymentMethods(props: Parameters<typeof useInvoicePaymentMethods>[0]) {
   /*
    * This will initiate a network request to fill the cache, but will not
    * cause a re-render when `data` changes.

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment-methods/useInvoicePaymentMethods.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment-methods/useInvoicePaymentMethods.tsx
@@ -1,23 +1,19 @@
-import { Schema } from 'effect'
-import useSWR from 'swr'
-
-import {
-  type InvoicePaymentMethodsResponse,
-  InvoicePaymentMethodsResponseSchema,
-} from '@schemas/invoices/invoicePaymentMethod'
+import { InvoicePaymentMethodsResponseSchema } from '@schemas/invoices/invoicePaymentMethod'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const INVOICE_PAYMENT_METHODS_TAG_KEY = '#invoice-payment-methods'
 
-const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([INVOICE_PAYMENT_METHODS_TAG_KEY])
-
 const getInvoicePaymentMethods = get<
-  InvoicePaymentMethodsResponse,
+  typeof InvoicePaymentMethodsResponseSchema.Encoded,
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/payment-methods`)
+
+const useInvoicePaymentMethodsQuery = createQueryHook({
+  tags: [INVOICE_PAYMENT_METHODS_TAG_KEY],
+  request: getInvoicePaymentMethods,
+  schema: InvoicePaymentMethodsResponseSchema,
+})
 
 interface UseInvoicePaymentMethodsProps {
   invoiceId: string
@@ -28,24 +24,10 @@ export function useInvoicePaymentMethods({
   invoiceId,
   isEnabled = true,
 }: UseInvoicePaymentMethodsProps) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      invoiceId,
-      isEnabled: isEnabled && Boolean(invoiceId),
-    })),
-    ({ accessToken, apiUrl, businessId, invoiceId }) => getInvoicePaymentMethods(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, invoiceId },
-      },
-    )().then(Schema.decodeUnknownPromise(InvoicePaymentMethodsResponseSchema)),
-  )
-  return new SWRQueryResult(response)
+  return useInvoicePaymentMethodsQuery({
+    invoiceId,
+    isEnabled: isEnabled && Boolean(invoiceId),
+  })
 }
 
 export function usePreloadInvoicePaymentMethods(props: UseInvoicePaymentMethodsProps) {

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment/useUpsertDedicatedInvoicePayment.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment/useUpsertDedicatedInvoicePayment.tsx
@@ -1,16 +1,13 @@
 import { useCallback } from 'react'
-import { Effect, Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
+import { Schema } from 'effect'
 
 import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { type InvoicePayment, InvoicePaymentSchema, type UpsertDedicatedInvoicePaymentSchema } from '@schemas/invoices/invoicePayment'
 import { post, put } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPSERT_INVOICE_PAYMENT_TAG_KEY = '#upsert-dedicated-invoice-payment'
 
@@ -21,64 +18,66 @@ export enum UpsertDedicatedInvoicePaymentMode {
 
 type UpsertDedicatedInvoicePaymentBody = typeof UpsertDedicatedInvoicePaymentSchema.Encoded
 
+const UpsertDedicatedInvoicePaymentReturnSchema = Schema.Struct({
+  data: InvoicePaymentSchema,
+})
+
+type UpsertDedicatedInvoicePaymentReturnEncoded = typeof UpsertDedicatedInvoicePaymentReturnSchema.Encoded
+
 const createDedicatedInvoicePayment = post<
-  UpsertDedicatedInvoicePaymentReturn,
+  UpsertDedicatedInvoicePaymentReturnEncoded,
   UpsertDedicatedInvoicePaymentBody,
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/payment/`)
 
 const updateDedicatedInvoicePayment = put<
-  UpsertDedicatedInvoicePaymentReturn,
+  UpsertDedicatedInvoicePaymentReturnEncoded,
   UpsertDedicatedInvoicePaymentBody,
   { businessId: string, invoiceId: string, invoicePaymentId: string }
 >(({ businessId, invoiceId, invoicePaymentId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/payment/${invoicePaymentId}`)
 
-const buildKey = createBuildKey<{ businessId: string, invoiceId: string, invoicePaymentId?: string }>([UPSERT_INVOICE_PAYMENT_TAG_KEY])
+export type CreateParams = {
+  readonly businessId: string
+  readonly invoiceId: string
+}
 
-const UpsertDedicatedInvoicePaymentReturnSchema = Schema.Struct({
-  data: InvoicePaymentSchema,
-})
-
-type UpsertDedicatedInvoicePaymentReturn = typeof UpsertDedicatedInvoicePaymentReturnSchema.Type
-
-const CreateParamsSchema = Schema.Struct({
-  businessId: Schema.String,
-  invoiceId: Schema.String,
-})
-
-const UpdateParamsSchema = Schema.Struct({
-  businessId: Schema.String,
-  invoiceId: Schema.String,
-  invoicePaymentId: Schema.String,
-})
-
-export type CreateParams = typeof CreateParamsSchema.Type
-export type UpdateParams = typeof UpdateParamsSchema.Type
+export type UpdateParams = {
+  readonly businessId: string
+  readonly invoiceId: string
+  readonly invoicePaymentId: string
+}
 
 export type UpsertParams = CreateParams | UpdateParams
 
-type RequestArgs = {
-  apiUrl: string
-  accessToken: string
-  body: UpsertDedicatedInvoicePaymentBody
-}
+type UpsertDedicatedInvoicePaymentParams = { businessId: string, invoiceId: string, invoicePaymentId?: string }
 
-type UpsertRequestFn = (args: RequestArgs) => Promise<UpsertDedicatedInvoicePaymentReturn>
+const upsertDedicatedInvoicePayment = (
+  baseUrl: string,
+  accessToken: string | undefined,
+  options?: { params?: UpsertDedicatedInvoicePaymentParams, body?: UpsertDedicatedInvoicePaymentBody },
+): Promise<UpsertDedicatedInvoicePaymentReturnEncoded> => {
+  const { params, body } = options ?? {}
 
-const isParamsValidForMode = <M extends UpsertDedicatedInvoicePaymentMode>(
-  mode: M,
-  params: unknown,
-): params is M extends UpsertDedicatedInvoicePaymentMode.Update ? UpdateParams : CreateParams => {
-  if (mode === UpsertDedicatedInvoicePaymentMode.Update) {
-    return Effect.runSync(Effect.either(Schema.decodeUnknown(UpdateParamsSchema)(params)))._tag === 'Right'
+  if (params?.invoicePaymentId !== undefined) {
+    return updateDedicatedInvoicePayment(baseUrl, accessToken, {
+      params: { businessId: params.businessId, invoiceId: params.invoiceId, invoicePaymentId: params.invoicePaymentId },
+      body,
+    })
   }
 
-  if (mode === UpsertDedicatedInvoicePaymentMode.Create) {
-    return Effect.runSync(Effect.either(Schema.decodeUnknown(CreateParamsSchema)(params)))._tag === 'Right'
-  }
-
-  return false
+  return createDedicatedInvoicePayment(baseUrl, accessToken, {
+    params: params && { businessId: params.businessId, invoiceId: params.invoiceId },
+    body,
+  })
 }
+
+const useUpsertDedicatedInvoicePaymentMutation = createMutationHook({
+  tags: [UPSERT_INVOICE_PAYMENT_TAG_KEY],
+  request: upsertDedicatedInvoicePayment,
+  keyParams: ['invoiceId', 'invoicePaymentId'],
+  schema: UpsertDedicatedInvoicePaymentReturnSchema,
+  swrOptions: { throwOnError: true },
+})
 
 export const updateInvoiceWithPayment = (invoice: Invoice, invoicePayment: InvoicePayment) => {
   const outstandingBalance = invoice.outstandingBalance - invoicePayment.amount
@@ -87,35 +86,11 @@ export const updateInvoiceWithPayment = (invoice: Invoice, invoicePayment: Invoi
   return { ...invoice, status, outstandingBalance }
 }
 
-function getRequestFn(
-  mode: UpsertDedicatedInvoicePaymentMode,
-  params: UpsertParams,
-): UpsertRequestFn {
-  if (mode === UpsertDedicatedInvoicePaymentMode.Update) {
-    if (!isParamsValidForMode(UpsertDedicatedInvoicePaymentMode.Update, params)) {
-      throw new Error('Invalid params for update mode')
-    }
-
-    return ({ apiUrl, accessToken, body }: { apiUrl: string, accessToken: string, body: UpsertDedicatedInvoicePaymentBody }) =>
-      updateDedicatedInvoicePayment(apiUrl, accessToken, { params, body })
-  }
-  else {
-    if (!isParamsValidForMode(UpsertDedicatedInvoicePaymentMode.Create, params)) {
-      throw new Error('Invalid params for create mode')
-    }
-
-    return ({ apiUrl, accessToken, body }: { apiUrl: string, accessToken: string, body: UpsertDedicatedInvoicePaymentBody }) =>
-      createDedicatedInvoicePayment(apiUrl, accessToken, { params, body })
-  }
-}
-
 type UseUpsertDedicatedInvoicePaymentProps =
   | { mode: UpsertDedicatedInvoicePaymentMode.Create, invoiceId: string }
   | { mode: UpsertDedicatedInvoicePaymentMode.Update, invoiceId: string, invoicePaymentId: string }
 
 export const useUpsertDedicatedInvoicePayment = (props: UseUpsertDedicatedInvoicePaymentProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
   const { mode, invoiceId } = props
   const invoicePaymentId = mode === UpsertDedicatedInvoicePaymentMode.Update ? props.invoicePaymentId : undefined
 
@@ -125,32 +100,7 @@ export const useUpsertDedicatedInvoicePayment = (props: UseUpsertDedicatedInvoic
       return updateInvoiceWithPayment(invoice, invoicePayment)
     }, [invoiceId])
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      invoiceId,
-      invoicePaymentId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, invoiceId },
-      { arg: body }: { arg: UpsertDedicatedInvoicePaymentBody },
-    ) => {
-      const request = getRequestFn(mode, { businessId, invoiceId, invoicePaymentId })
-
-      return request({
-        apiUrl,
-        accessToken,
-        body,
-      }).then(Schema.decodeUnknownPromise(UpsertDedicatedInvoicePaymentReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useUpsertDedicatedInvoicePaymentMutation({ invoiceId, invoicePaymentId })
 
   const { patchByTransformation: patchInvoiceWithTransformation } = useInvoicesGlobalCacheActions()
   const { forceReload: forceReloadInvoiceSummaryStats } = useInvoiceSummaryStatsCacheActions()

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment/useUpsertDedicatedInvoicePayment.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment/useUpsertDedicatedInvoicePayment.tsx
@@ -49,31 +49,17 @@ export type UpdateParams = {
 
 export type UpsertParams = CreateParams | UpdateParams
 
-type UpsertDedicatedInvoicePaymentParams = { businessId: string, invoiceId: string, invoicePaymentId?: string }
-
-const upsertDedicatedInvoicePayment = (
-  baseUrl: string,
-  accessToken: string | undefined,
-  options?: { params?: UpsertDedicatedInvoicePaymentParams, body?: UpsertDedicatedInvoicePaymentBody },
-): Promise<UpsertDedicatedInvoicePaymentReturnEncoded> => {
-  const { params, body } = options ?? {}
-
-  if (params?.invoicePaymentId !== undefined) {
-    return updateDedicatedInvoicePayment(baseUrl, accessToken, {
-      params: { businessId: params.businessId, invoiceId: params.invoiceId, invoicePaymentId: params.invoicePaymentId },
-      body,
-    })
-  }
-
-  return createDedicatedInvoicePayment(baseUrl, accessToken, {
-    params: params && { businessId: params.businessId, invoiceId: params.invoiceId },
-    body,
-  })
-}
-
-const useUpsertDedicatedInvoicePaymentMutation = createMutationHook({
+const useCreateDedicatedInvoicePayment = createMutationHook({
   tags: [UPSERT_INVOICE_PAYMENT_TAG_KEY],
-  request: upsertDedicatedInvoicePayment,
+  request: createDedicatedInvoicePayment,
+  keyParams: ['invoiceId'],
+  schema: UpsertDedicatedInvoicePaymentReturnSchema,
+  swrOptions: { throwOnError: true },
+})
+
+const useUpdateDedicatedInvoicePayment = createMutationHook({
+  tags: [UPSERT_INVOICE_PAYMENT_TAG_KEY],
+  request: updateDedicatedInvoicePayment,
   keyParams: ['invoiceId', 'invoicePaymentId'],
   schema: UpsertDedicatedInvoicePaymentReturnSchema,
   swrOptions: { throwOnError: true },
@@ -100,7 +86,14 @@ export const useUpsertDedicatedInvoicePayment = (props: UseUpsertDedicatedInvoic
       return updateInvoiceWithPayment(invoice, invoicePayment)
     }, [invoiceId])
 
-  const mutationResponse = useUpsertDedicatedInvoicePaymentMutation({ invoiceId, invoicePaymentId })
+  const createResponse = useCreateDedicatedInvoicePayment({ invoiceId })
+  const updateResponse = useUpdateDedicatedInvoicePayment({
+    invoiceId,
+    invoicePaymentId: invoicePaymentId ?? '',
+    isEnabled: invoicePaymentId !== undefined,
+  })
+
+  const mutationResponse = mode === UpsertDedicatedInvoicePaymentMode.Create ? createResponse : updateResponse
 
   const { patchByTransformation: patchInvoiceWithTransformation } = useInvoicesGlobalCacheActions()
   const { forceReload: forceReloadInvoiceSummaryStats } = useInvoiceSummaryStatsCacheActions()

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment/useUpsertDedicatedInvoicePayment.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/payment/useUpsertDedicatedInvoicePayment.tsx
@@ -1,8 +1,8 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { type InvoicePayment, InvoicePaymentSchema, type UpsertDedicatedInvoicePaymentSchema } from '@schemas/invoices/invoicePayment'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post, put } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
@@ -18,9 +18,7 @@ export enum UpsertDedicatedInvoicePaymentMode {
 
 type UpsertDedicatedInvoicePaymentBody = typeof UpsertDedicatedInvoicePaymentSchema.Encoded
 
-const UpsertDedicatedInvoicePaymentReturnSchema = Schema.Struct({
-  data: InvoicePaymentSchema,
-})
+const UpsertDedicatedInvoicePaymentReturnSchema = UnwrappedDataResponseSchema(InvoicePaymentSchema)
 
 type UpsertDedicatedInvoicePaymentReturnEncoded = typeof UpsertDedicatedInvoicePaymentReturnSchema.Encoded
 
@@ -104,7 +102,7 @@ export const useUpsertDedicatedInvoicePayment = (props: UseUpsertDedicatedInvoic
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
-      void patchInvoiceWithTransformation(applyPaymentToInvoice(triggerResult.data))
+      void patchInvoiceWithTransformation(applyPaymentToInvoice(triggerResult))
 
       void forceReloadInvoiceSummaryStats()
 

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/pdf/useInvoicePdfDownload.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/pdf/useInvoicePdfDownload.tsx
@@ -6,22 +6,25 @@ import type { Awaitable } from '@internal-types/utility/promises'
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
+const InvoicePdfReturnSchema = Schema.Struct({
+  data: S3PresignedUrlSchema,
+})
+
 const getInvoicePdf = get<
-  { data: S3PresignedUrlSchemaType },
+  typeof InvoicePdfReturnSchema.Encoded,
   { businessId: string, invoiceId: string }
 >(
   ({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/pdf`,
 )
 
-const DOWNLOAD_INVOICE_PDF_TAG_KEY = '#download-invoice-pdf'
+const fetchInvoicePdf = createKeyedFetcher(getInvoicePdf, InvoicePdfReturnSchema)
 
-const InvoicePdfReturnSchema = Schema.Struct({
-  data: S3PresignedUrlSchema,
-})
+const DOWNLOAD_INVOICE_PDF_TAG_KEY = '#download-invoice-pdf'
 
 const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([DOWNLOAD_INVOICE_PDF_TAG_KEY])
 
@@ -44,17 +47,7 @@ export function useInvoicePdfDownload({
       businessId,
       invoiceId,
     })),
-    ({ accessToken, apiUrl, businessId, invoiceId }) => getInvoicePdf(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          invoiceId,
-        },
-      },
-    )()
-      .then(Schema.decodeUnknownPromise(InvoicePdfReturnSchema))
+    key => fetchInvoicePdf(key)
       .then(async ({ data }) => {
         if (onSuccess) {
           await onSuccess(data)

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/pdf/useInvoicePdfDownload.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/pdf/useInvoicePdfDownload.tsx
@@ -2,7 +2,7 @@ import type { Awaitable } from '@internal-types/utility/promises'
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
 import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
-import { getAsMutation } from '@utils/api/postAsQuery'
+import { getAsMutation } from '@utils/api/getAsMutation'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const InvoicePdfReturnSchema = UnwrappedDataResponseSchema(S3PresignedUrlSchema)

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/pdf/useInvoicePdfDownload.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/pdf/useInvoicePdfDownload.tsx
@@ -1,30 +1,36 @@
-import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
-
 import type { Awaitable } from '@internal-types/utility/promises'
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
 import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { getAsMutation } from '@utils/api/postAsQuery'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const InvoicePdfReturnSchema = UnwrappedDataResponseSchema(S3PresignedUrlSchema)
 
+type GetInvoicePdfParams = {
+  businessId: string
+  invoiceId: string
+}
+
 const getInvoicePdf = get<
   typeof InvoicePdfReturnSchema.Encoded,
-  { businessId: string, invoiceId: string }
+  GetInvoicePdfParams
 >(
   ({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/pdf`,
 )
 
-const fetchInvoicePdf = createKeyedFetcher(getInvoicePdf, InvoicePdfReturnSchema)
+const requestInvoicePdf = getAsMutation(getInvoicePdf)
 
 const DOWNLOAD_INVOICE_PDF_TAG_KEY = '#download-invoice-pdf'
 
-const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([DOWNLOAD_INVOICE_PDF_TAG_KEY])
+const useInvoicePdfDownloadMutation = createMutationHook({
+  tags: [DOWNLOAD_INVOICE_PDF_TAG_KEY],
+  request: requestInvoicePdf,
+  keyParams: ['invoiceId'],
+  argToBody: (_arg: undefined) => undefined,
+  schema: InvoicePdfReturnSchema,
+  swrOptions: { throwOnError: false },
+})
 
 type UseInvoicePdfDownloadProps = {
   invoiceId: string
@@ -37,35 +43,11 @@ export function useInvoicePdfDownload({
   onSuccess,
   onError,
 }: UseInvoicePdfDownloadProps) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      invoiceId,
-    })),
-    key => fetchInvoicePdf(key)
-      .then(async (data) => {
-        if (onSuccess) {
-          await onSuccess(data)
-        }
-        return data
-      }),
-    {
-      revalidate: false,
-      throwOnError: false,
+  return useInvoicePdfDownloadMutation({
+    invoiceId,
+    swrOptions: {
+      onSuccess: (data) => { void onSuccess?.(data) },
       onError,
     },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
-  const originalTrigger = mutationResponse.trigger
-
-  const stableProxiedTrigger = useCallback(
-    async (...triggerParameters: Parameters<typeof originalTrigger>) => originalTrigger(...triggerParameters),
-    [originalTrigger],
-  )
-
-  return withStableTrigger(mutationResponse, stableProxiedTrigger)
+  })
 }

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/pdf/useInvoicePdfDownload.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/pdf/useInvoicePdfDownload.tsx
@@ -1,9 +1,9 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
 import type { Awaitable } from '@internal-types/utility/promises'
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
@@ -11,9 +11,7 @@ import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
-const InvoicePdfReturnSchema = Schema.Struct({
-  data: S3PresignedUrlSchema,
-})
+const InvoicePdfReturnSchema = UnwrappedDataResponseSchema(S3PresignedUrlSchema)
 
 const getInvoicePdf = get<
   typeof InvoicePdfReturnSchema.Encoded,
@@ -48,7 +46,7 @@ export function useInvoicePdfDownload({
       invoiceId,
     })),
     key => fetchInvoicePdf(key)
-      .then(async ({ data }) => {
+      .then(async (data) => {
         if (onSuccess) {
           await onSuccess(data)
         }

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/refund/useRefundInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/refund/useRefundInvoice.tsx
@@ -1,8 +1,8 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { type CreateCustomerRefundSchema, CustomerRefundSchema } from '@schemas/invoices/customerRefund'
 import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
@@ -11,9 +11,7 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const REFUND_INVOICE_TAG_KEY = '#refund-invoice'
 
-const RefundInvoiceReturnSchema = Schema.Struct({
-  data: CustomerRefundSchema,
-})
+const RefundInvoiceReturnSchema = UnwrappedDataResponseSchema(CustomerRefundSchema)
 
 const refundInvoice = post<
   typeof RefundInvoiceReturnSchema.Encoded,

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/refund/useRefundInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/refund/useRefundInvoice.tsx
@@ -1,16 +1,13 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { type CreateCustomerRefundSchema, CustomerRefundSchema } from '@schemas/invoices/customerRefund'
 import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const REFUND_INVOICE_TAG_KEY = '#refund-invoice'
 
@@ -18,17 +15,19 @@ const RefundInvoiceReturnSchema = Schema.Struct({
   data: CustomerRefundSchema,
 })
 
-type RefundInvoiceBody = typeof CreateCustomerRefundSchema.Encoded
-
-type RefundInvoiceReturn = typeof RefundInvoiceReturnSchema.Type
-
 const refundInvoice = post<
-  RefundInvoiceReturn,
+  typeof RefundInvoiceReturnSchema.Encoded,
   typeof CreateCustomerRefundSchema.Encoded,
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/refund`)
 
-const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([REFUND_INVOICE_TAG_KEY])
+const useRefundInvoiceMutation = createMutationHook({
+  tags: [REFUND_INVOICE_TAG_KEY],
+  request: refundInvoice,
+  keyParams: ['invoiceId'],
+  schema: RefundInvoiceReturnSchema,
+  swrOptions: { throwOnError: true },
+})
 
 export const updateInvoiceWithRefund = (invoice: Invoice): Invoice => {
   return { ...invoice, status: InvoiceStatus.Refunded }
@@ -36,37 +35,13 @@ export const updateInvoiceWithRefund = (invoice: Invoice): Invoice => {
 
 type UseRefundInvoiceProps = { invoiceId: string }
 export const useRefundInvoice = ({ invoiceId }: UseRefundInvoiceProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
   const applyRefundToInvoice = useCallback(() =>
     (invoice: Invoice) => {
       if (invoice.id !== invoiceId) return invoice
       return updateInvoiceWithRefund(invoice)
     }, [invoiceId])
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      invoiceId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, invoiceId },
-      { arg: body }: { arg: RefundInvoiceBody },
-    ) => {
-      return refundInvoice(
-        apiUrl,
-        accessToken,
-        { params: { businessId, invoiceId }, body },
-      ).then(Schema.decodeUnknownPromise(RefundInvoiceReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useRefundInvoiceMutation({ invoiceId })
 
   const { patchByTransformation: patchInvoiceWithTransformation } = useInvoicesGlobalCacheActions()
   const { forceReload: forceReloadInvoiceSummaryStats } = useInvoiceSummaryStatsCacheActions()

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/reset/useResetInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/reset/useResetInvoice.tsx
@@ -1,15 +1,12 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { InvoiceSchema } from '@schemas/invoices/invoice'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const RESET_INVOICE_TAG_KEY = '#reset-invoice'
 
@@ -17,43 +14,25 @@ const ResetInvoiceReturnSchema = Schema.Struct({
   data: InvoiceSchema,
 })
 
-type ResetInvoiceReturn = typeof ResetInvoiceReturnSchema.Type
-
 const resetInvoice = post<
-  ResetInvoiceReturn,
-  never,
+  typeof ResetInvoiceReturnSchema.Encoded,
+  Record<string, never>,
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/reset`)
 
-const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([RESET_INVOICE_TAG_KEY])
+const useResetInvoiceMutation = createMutationHook({
+  tags: [RESET_INVOICE_TAG_KEY],
+  request: resetInvoice,
+  keyParams: ['invoiceId'],
+  argToBody: (_arg: never) => undefined,
+  schema: ResetInvoiceReturnSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseResetInvoiceProps = { invoiceId: string }
 
 export const useResetInvoice = ({ invoiceId }: UseResetInvoiceProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      invoiceId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, invoiceId },
-    ) => {
-      return resetInvoice(
-        apiUrl,
-        accessToken,
-        { params: { businessId, invoiceId } },
-      ).then(Schema.decodeUnknownPromise(ResetInvoiceReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useResetInvoiceMutation({ invoiceId })
 
   const { patchByKey: patchInvoiceByKey } = useInvoicesGlobalCacheActions()
   const { forceReload: forceReloadInvoiceSummaryStats } = useInvoiceSummaryStatsCacheActions()

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/reset/useResetInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/reset/useResetInvoice.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { InvoiceSchema } from '@schemas/invoices/invoice'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
@@ -10,9 +10,7 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const RESET_INVOICE_TAG_KEY = '#reset-invoice'
 
-const ResetInvoiceReturnSchema = Schema.Struct({
-  data: InvoiceSchema,
-})
+const ResetInvoiceReturnSchema = UnwrappedDataResponseSchema(InvoiceSchema)
 
 const resetInvoice = post<
   typeof ResetInvoiceReturnSchema.Encoded,
@@ -43,7 +41,7 @@ export const useResetInvoice = ({ invoiceId }: UseResetInvoiceProps) => {
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
-      void patchInvoiceByKey(triggerResult.data)
+      void patchInvoiceByKey(triggerResult)
 
       void forceReloadInvoiceSummaryStats()
 

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/void/useVoidInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/void/useVoidInvoice.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { InvoiceSchema } from '@schemas/invoices/invoice'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
@@ -10,9 +10,7 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const VOID_INVOICE_TAG_KEY = '#void-invoice'
 
-const VoidInvoiceReturnSchema = Schema.Struct({
-  data: InvoiceSchema,
-})
+const VoidInvoiceReturnSchema = UnwrappedDataResponseSchema(InvoiceSchema)
 
 const voidInvoice = post<
   typeof VoidInvoiceReturnSchema.Encoded,
@@ -43,7 +41,7 @@ export const useVoidInvoice = ({ invoiceId }: UseVoidInvoiceProps) => {
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
-      void patchInvoiceByKey(triggerResult.data)
+      void patchInvoiceByKey(triggerResult)
 
       void forceReloadInvoiceSummaryStats()
 

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/void/useVoidInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/void/useVoidInvoice.tsx
@@ -1,15 +1,12 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { InvoiceSchema } from '@schemas/invoices/invoice'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const VOID_INVOICE_TAG_KEY = '#void-invoice'
 
@@ -17,43 +14,25 @@ const VoidInvoiceReturnSchema = Schema.Struct({
   data: InvoiceSchema,
 })
 
-type VoidInvoiceReturn = typeof VoidInvoiceReturnSchema.Type
-
 const voidInvoice = post<
-  VoidInvoiceReturn,
-  never,
+  typeof VoidInvoiceReturnSchema.Encoded,
+  Record<string, never>,
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/void`)
 
-const buildKey = createBuildKey<{ businessId: string, invoiceId: string }>([VOID_INVOICE_TAG_KEY])
+const useVoidInvoiceMutation = createMutationHook({
+  tags: [VOID_INVOICE_TAG_KEY],
+  request: voidInvoice,
+  keyParams: ['invoiceId'],
+  argToBody: (_arg: never) => undefined,
+  schema: VoidInvoiceReturnSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseVoidInvoiceProps = { invoiceId: string }
 
 export const useVoidInvoice = ({ invoiceId }: UseVoidInvoiceProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      invoiceId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, invoiceId },
-    ) => {
-      return voidInvoice(
-        apiUrl,
-        accessToken,
-        { params: { businessId, invoiceId } },
-      ).then(Schema.decodeUnknownPromise(VoidInvoiceReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useVoidInvoiceMutation({ invoiceId })
 
   const { patchByKey: patchInvoiceByKey } = useInvoicesGlobalCacheActions()
   const { forceReload: forceReloadInvoiceSummaryStats } = useInvoiceSummaryStatsCacheActions()

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/write-off/useWriteoffInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/write-off/useWriteoffInvoice.tsx
@@ -1,32 +1,34 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { type CreateInvoiceWriteoff, CreateInvoiceWriteoffSchema, InvoiceWriteoffSchema } from '@schemas/invoices/invoiceWriteoff'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CREATE_INVOICE_WRITEOFF_TAG_KEY = '#writeoff-invoice'
-
-const writeoffInvoice = post<
-  WriteoffInvoiceReturn,
-  typeof CreateInvoiceWriteoffSchema.Encoded,
-  { businessId: string, invoiceId: string }
->(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/write-off`)
-
-const buildKey = createBuildKey<{ businessId: string, invoiceId: string, invoiceWriteoffId?: string }>([CREATE_INVOICE_WRITEOFF_TAG_KEY])
 
 const WriteoffInvoiceReturnSchema = Schema.Struct({
   data: InvoiceWriteoffSchema,
 })
 
-type WriteoffInvoiceReturn = typeof WriteoffInvoiceReturnSchema.Type
+const writeoffInvoice = post<
+  typeof WriteoffInvoiceReturnSchema.Encoded,
+  typeof CreateInvoiceWriteoffSchema.Encoded,
+  { businessId: string, invoiceId: string }
+>(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}/write-off`)
+
+const useWriteoffInvoiceMutation = createMutationHook({
+  tags: [CREATE_INVOICE_WRITEOFF_TAG_KEY],
+  request: writeoffInvoice,
+  keyParams: ['invoiceId'],
+  argToBody: (arg: CreateInvoiceWriteoff) => Schema.encodeSync(CreateInvoiceWriteoffSchema)(arg),
+  schema: WriteoffInvoiceReturnSchema,
+  swrOptions: { throwOnError: true },
+})
 
 export const updateInvoiceWithWriteoff = (invoice: Invoice): Invoice => {
   const status = invoice.status === InvoiceStatus.PartiallyPaid ? InvoiceStatus.PartiallyWrittenOff : InvoiceStatus.WrittenOff
@@ -36,38 +38,13 @@ export const updateInvoiceWithWriteoff = (invoice: Invoice): Invoice => {
 
 type UseWriteoffInvoiceProps = { invoiceId: string }
 export const useWriteoffInvoice = ({ invoiceId }: UseWriteoffInvoiceProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
   const applyWriteoffToInvoice = useCallback(() =>
     (invoice: Invoice) => {
       if (invoice.id !== invoiceId) return invoice
       return updateInvoiceWithWriteoff(invoice)
     }, [invoiceId])
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      invoiceId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, invoiceId },
-      { arg: decodedBody }: { arg: CreateInvoiceWriteoff },
-    ) => {
-      const body = Schema.encodeSync(CreateInvoiceWriteoffSchema)(decodedBody)
-      return writeoffInvoice(
-        apiUrl,
-        accessToken,
-        { params: { businessId, invoiceId }, body },
-      ).then(Schema.decodeUnknownPromise(WriteoffInvoiceReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useWriteoffInvoiceMutation({ invoiceId })
 
   const { patchByTransformation: patchInvoiceWithTransformation } = useInvoicesGlobalCacheActions()
   const { forceReload: forceReloadInvoiceSummaryStats } = useInvoiceSummaryStatsCacheActions()

--- a/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/write-off/useWriteoffInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/[invoice-id]/write-off/useWriteoffInvoice.tsx
@@ -3,6 +3,7 @@ import { Schema } from 'effect'
 
 import { type Invoice, InvoiceStatus } from '@schemas/invoices/invoice'
 import { type CreateInvoiceWriteoff, CreateInvoiceWriteoffSchema, InvoiceWriteoffSchema } from '@schemas/invoices/invoiceWriteoff'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
@@ -11,9 +12,7 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CREATE_INVOICE_WRITEOFF_TAG_KEY = '#writeoff-invoice'
 
-const WriteoffInvoiceReturnSchema = Schema.Struct({
-  data: InvoiceWriteoffSchema,
-})
+const WriteoffInvoiceReturnSchema = UnwrappedDataResponseSchema(InvoiceWriteoffSchema)
 
 const writeoffInvoice = post<
   typeof WriteoffInvoiceReturnSchema.Encoded,

--- a/src/hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats.tsx
@@ -1,40 +1,26 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
 
 import { type InvoiceSummaryStatsResponse, InvoiceSummaryStatsResponseSchema } from '@schemas/invoices/invoice'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const INVOICE_SUMMARY_STATS_TAG_KEY = '#invoices-summary-stats'
 
-const buildKey = createBuildKey<{ businessId: string }>([INVOICE_SUMMARY_STATS_TAG_KEY])
+const InvoiceSummaryStatsReturnSchema = Schema.Struct({
+  data: InvoiceSummaryStatsResponseSchema,
+})
 
 const getInvoiceSummaryStats = get<
-  { data: InvoiceSummaryStatsResponse },
+  typeof InvoiceSummaryStatsReturnSchema.Encoded,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/invoices/summary-stats`)
 
-export function useInvoiceSummaryStats() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    ({ accessToken, apiUrl, businessId }) => getInvoiceSummaryStats(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-      },
-    )().then(({ data }) => Schema.decodeUnknownPromise(InvoiceSummaryStatsResponseSchema)(data)),
-  )
-
-  return new SWRQueryResult(response)
-}
+export const useInvoiceSummaryStats = createQueryHook({
+  tags: [INVOICE_SUMMARY_STATS_TAG_KEY],
+  request: getInvoiceSummaryStats,
+  schema: InvoiceSummaryStatsReturnSchema,
+  select: ({ data }) => data,
+})
 
 export const useInvoiceSummaryStatsCacheActions = createResourceGlobalCacheActions<InvoiceSummaryStatsResponse>(INVOICE_SUMMARY_STATS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats.tsx
@@ -1,15 +1,12 @@
-import { Schema } from 'effect'
-
 import { type InvoiceSummaryStatsResponse, InvoiceSummaryStatsResponseSchema } from '@schemas/invoices/invoice'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const INVOICE_SUMMARY_STATS_TAG_KEY = '#invoices-summary-stats'
 
-const InvoiceSummaryStatsReturnSchema = Schema.Struct({
-  data: InvoiceSummaryStatsResponseSchema,
-})
+const InvoiceSummaryStatsReturnSchema = UnwrappedDataResponseSchema(InvoiceSummaryStatsResponseSchema)
 
 const getInvoiceSummaryStats = get<
   typeof InvoiceSummaryStatsReturnSchema.Encoded,
@@ -19,7 +16,7 @@ const getInvoiceSummaryStats = get<
 export const useInvoiceSummaryStats = createQueryHook({
   tags: [INVOICE_SUMMARY_STATS_TAG_KEY],
   request: getInvoiceSummaryStats,
-  schema: InvoiceSummaryStatsReturnSchema.pipe(Schema.pluck('data')),
+  schema: InvoiceSummaryStatsReturnSchema,
 })
 
 export const useInvoiceSummaryStatsCacheActions = createResourceGlobalCacheActions<InvoiceSummaryStatsResponse>(INVOICE_SUMMARY_STATS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats.tsx
@@ -19,8 +19,7 @@ const getInvoiceSummaryStats = get<
 export const useInvoiceSummaryStats = createQueryHook({
   tags: [INVOICE_SUMMARY_STATS_TAG_KEY],
   request: getInvoiceSummaryStats,
-  schema: InvoiceSummaryStatsReturnSchema,
-  select: ({ data }) => data,
+  schema: InvoiceSummaryStatsReturnSchema.pipe(Schema.pluck('data')),
 })
 
 export const useInvoiceSummaryStatsCacheActions = createResourceGlobalCacheActions<InvoiceSummaryStatsResponse>(INVOICE_SUMMARY_STATS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/invoices/useListInvoices.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/useListInvoices.tsx
@@ -1,22 +1,11 @@
-import { Schema } from 'effect'
-import useSWRInfinite from 'swr/infinite'
-
 import { type PaginationParams, SortOrder, type SortParams } from '@internal-types/utility/pagination'
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { type Invoice, InvoiceSchema, type InvoiceStatus } from '@schemas/invoices/invoice'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
-import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createInfiniteQueryHook } from '@hooks/utils/swr/createInfiniteQueryHook'
 
 export const LIST_INVOICES_TAG_KEY = '#list-invoices'
-
-type ListInvoicesBaseParams = {
-  businessId: string
-}
 
 export type ListInvoicesFilterParams = {
   showSalesReceipts?: boolean
@@ -30,19 +19,20 @@ enum SortBy {
   SentAt = 'sent_at',
 }
 
-type ListInvoicesOptions = ListInvoicesFilterParams & PaginationParams & SortParams<SortBy>
-
-type ListInvoicesParams = ListInvoicesBaseParams & ListInvoicesOptions
+type ListInvoicesParams = {
+  businessId: string
+  cursor?: string
+} & ListInvoicesFilterParams & Omit<PaginationParams, 'cursor'> & SortParams<SortBy>
 
 const ListInvoicesReturnSchema = PaginatedResponseSchema(InvoiceSchema)
 
-type ListInvoicesReturn = typeof ListInvoicesReturnSchema.Type
-
-export const listInvoices = get<
-  ListInvoicesReturn,
+export const listInvoices = getWithQuery<
+  typeof ListInvoicesReturnSchema.Encoded,
   ListInvoicesParams
->(({ businessId, showSalesReceipts, status, query, dueAtStart, dueAtEnd, sortBy, sortOrder, cursor, limit, showTotalCount }) => {
-  const parameters = toDefinedSearchParameters({
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/invoices`,
+  ({ showSalesReceipts, status, query, dueAtStart, dueAtEnd, sortBy, sortOrder, cursor, limit, showTotalCount }) => ({
     showSalesReceipts,
     status,
     q: query,
@@ -53,90 +43,18 @@ export const listInvoices = get<
     cursor,
     limit,
     showTotalCount,
-  })
+  }),
+)
 
-  const baseUrl = `/v1/businesses/${businessId}/invoices`
-  return parameters ? `${baseUrl}?${parameters}` : baseUrl
+export const useListInvoices = createInfiniteQueryHook({
+  tags: [LIST_INVOICES_TAG_KEY],
+  request: listInvoices,
+  schema: ListInvoicesReturnSchema,
+  keyDefaults: {
+    sortBy: SortBy.SentAt,
+    sortOrder: SortOrder.DESC,
+    showTotalCount: true,
+  },
 })
-
-const keyLoader = createInfiniteKeyLoader<
-  Omit<ListInvoicesParams, 'cursor'>,
-  ListInvoicesReturn
->([LIST_INVOICES_TAG_KEY])
-
-export function useListInvoices({
-  status,
-  showSalesReceipts,
-  query,
-  dueAtStart,
-  dueAtEnd,
-  sortBy = SortBy.SentAt,
-  sortOrder = SortOrder.DESC,
-  limit,
-  showTotalCount = true,
-}: ListInvoicesOptions = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWRInfinite(
-    (_index, previousPageData: ListInvoicesReturn | null) => withLocale(keyLoader(
-      previousPageData,
-      {
-        ...auth,
-        businessId,
-        showSalesReceipts,
-        status,
-        query,
-        dueAtStart,
-        dueAtEnd,
-        sortBy,
-        sortOrder,
-        limit,
-        showTotalCount,
-      },
-    )),
-    ({
-      accessToken,
-      apiUrl,
-      businessId,
-      cursor,
-      showSalesReceipts,
-      status,
-      query,
-      dueAtStart,
-      dueAtEnd,
-      sortBy,
-      sortOrder,
-      limit,
-      showTotalCount,
-    }) => listInvoices(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          showSalesReceipts,
-          status,
-          query,
-          dueAtStart,
-          dueAtEnd,
-          sortBy,
-          sortOrder,
-          cursor,
-          limit,
-          showTotalCount,
-        },
-      },
-    )().then(Schema.decodeUnknownPromise(ListInvoicesReturnSchema)),
-    {
-      keepPreviousData: true,
-      revalidateFirstPage: false,
-      initialSize: 1,
-    },
-  )
-
-  usePreserveInfiniteSize(swrResponse)
-
-  return useSWRInfiniteResult(swrResponse)
-}
 
 export const useInvoicesGlobalCacheActions = createInfiniteQueryGlobalCacheActions<Invoice>(LIST_INVOICES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/invoices/useUpsertInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/useUpsertInvoice.tsx
@@ -1,15 +1,12 @@
 import { useCallback } from 'react'
-import { Effect, Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
+import { Schema } from 'effect'
 
 import { InvoiceSchema, type UpsertInvoiceSchema } from '@schemas/invoices/invoice'
 import { patch, post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
 import { useInvoicesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/invoices/useListInvoices'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPSERT_INVOICE_TAG_KEY = '#upsert-invoice'
 
@@ -20,120 +17,74 @@ export enum UpsertInvoiceMode {
 
 type UpsertInvoiceBody = typeof UpsertInvoiceSchema.Encoded
 
+const UpsertInvoiceReturnSchema = Schema.Struct({
+  data: InvoiceSchema,
+})
+
+type UpsertInvoiceReturnEncoded = typeof UpsertInvoiceReturnSchema.Encoded
+
 const createInvoice = post<
-  UpsertInvoiceReturn,
+  UpsertInvoiceReturnEncoded,
   UpsertInvoiceBody,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/invoices`)
 
 const updateInvoice = patch<
-  UpsertInvoiceReturn,
+  UpsertInvoiceReturnEncoded,
   UpsertInvoiceBody,
   { businessId: string, invoiceId: string }
 >(({ businessId, invoiceId }) => `/v1/businesses/${businessId}/invoices/${invoiceId}`)
 
-const buildKey = createBuildKey<{ businessId: string, invoiceId?: string }>([UPSERT_INVOICE_TAG_KEY])
+export type CreateParams = {
+  readonly businessId: string
+}
 
-const UpsertInvoiceReturnSchema = Schema.Struct({
-  data: InvoiceSchema,
-})
-
-type UpsertInvoiceReturn = typeof UpsertInvoiceReturnSchema.Type
-
-const CreateParamsSchema = Schema.Struct({
-  businessId: Schema.String,
-})
-
-const UpdateParamsSchema = Schema.Struct({
-  businessId: Schema.String,
-  invoiceId: Schema.String,
-})
-
-export type CreateParams = typeof CreateParamsSchema.Type
-export type UpdateParams = typeof UpdateParamsSchema.Type
+export type UpdateParams = {
+  readonly businessId: string
+  readonly invoiceId: string
+}
 
 export type UpsertParams = CreateParams | UpdateParams
 
-type RequestArgs = {
-  apiUrl: string
-  accessToken: string
-  body: UpsertInvoiceBody
+type UpsertInvoiceParams = { businessId: string, invoiceId?: string }
+
+const upsertInvoice = (
+  baseUrl: string,
+  accessToken: string | undefined,
+  options?: { params?: UpsertInvoiceParams, body?: UpsertInvoiceBody },
+): Promise<UpsertInvoiceReturnEncoded> => {
+  const { params, body } = options ?? {}
+
+  if (params?.invoiceId !== undefined) {
+    return updateInvoice(baseUrl, accessToken, {
+      params: { businessId: params.businessId, invoiceId: params.invoiceId },
+      body,
+    })
+  }
+
+  return createInvoice(baseUrl, accessToken, {
+    params: params && { businessId: params.businessId },
+    body,
+  })
 }
 
-type UpsertRequestFn = (args: RequestArgs) => Promise<UpsertInvoiceReturn>
-
-const isParamsValidForMode = <M extends UpsertInvoiceMode>(
-  mode: M,
-  params: unknown,
-): params is M extends UpsertInvoiceMode.Update ? UpdateParams : CreateParams => {
-  if (mode === UpsertInvoiceMode.Update) {
-    return Effect.runSync(Effect.either(Schema.decodeUnknown(UpdateParamsSchema)(params)))._tag === 'Right'
-  }
-
-  if (mode === UpsertInvoiceMode.Create) {
-    return Effect.runSync(Effect.either(Schema.decodeUnknown(CreateParamsSchema)(params)))._tag === 'Right'
-  }
-
-  return false
-}
-
-function getRequestFn(
-  mode: UpsertInvoiceMode,
-  params: UpsertParams,
-): UpsertRequestFn {
-  if (mode === UpsertInvoiceMode.Update) {
-    if (!isParamsValidForMode(UpsertInvoiceMode.Update, params)) {
-      throw new Error('Invalid params for update mode')
-    }
-
-    return ({ apiUrl, accessToken, body }: { apiUrl: string, accessToken: string, body: UpsertInvoiceBody }) =>
-      updateInvoice(apiUrl, accessToken, { params, body })
-  }
-  else {
-    if (!isParamsValidForMode(UpsertInvoiceMode.Create, params)) {
-      throw new Error('Invalid params for create mode')
-    }
-
-    return ({ apiUrl, accessToken, body }: { apiUrl: string, accessToken: string, body: UpsertInvoiceBody }) =>
-      createInvoice(apiUrl, accessToken, { params, body })
-  }
-}
+const useUpsertInvoiceMutation = createMutationHook({
+  tags: [UPSERT_INVOICE_TAG_KEY],
+  request: upsertInvoice,
+  keyParams: ['invoiceId'],
+  schema: UpsertInvoiceReturnSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseUpsertInvoiceProps =
   | { mode: UpsertInvoiceMode.Create }
   | { mode: UpsertInvoiceMode.Update, invoiceId: string }
 
 export const useUpsertInvoice = (props: UseUpsertInvoiceProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
   const { mode } = props
   const invoiceId = mode === UpsertInvoiceMode.Update ? props.invoiceId : undefined
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      invoiceId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, invoiceId },
-      { arg: body }: { arg: UpsertInvoiceBody },
-    ) => {
-      const request = getRequestFn(mode, { businessId, invoiceId })
-
-      return request({
-        apiUrl,
-        accessToken,
-        body,
-      }).then(Schema.decodeUnknownPromise(UpsertInvoiceReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useUpsertInvoiceMutation({ invoiceId })
 
   const { patchByKey: patchInvoiceByKey, forceReload: forceReloadInvoices } = useInvoicesGlobalCacheActions()
   const { forceReload: forceReloadInvoiceSummaryStats } = useInvoiceSummaryStatsCacheActions()

--- a/src/hooks/api/businesses/[business-id]/invoices/useUpsertInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/useUpsertInvoice.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { InvoiceSchema, type UpsertInvoiceSchema } from '@schemas/invoices/invoice'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useInvoiceSummaryStatsCacheActions } from '@hooks/api/businesses/[business-id]/invoices/summary-stats/useInvoiceSummaryStats'
@@ -17,9 +17,7 @@ export enum UpsertInvoiceMode {
 
 type UpsertInvoiceBody = typeof UpsertInvoiceSchema.Encoded
 
-const UpsertInvoiceReturnSchema = Schema.Struct({
-  data: InvoiceSchema,
-})
+const UpsertInvoiceReturnSchema = UnwrappedDataResponseSchema(InvoiceSchema)
 
 type UpsertInvoiceReturnEncoded = typeof UpsertInvoiceReturnSchema.Encoded
 
@@ -87,7 +85,7 @@ export const useUpsertInvoice = (props: UseUpsertInvoiceProps) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
       if (mode === UpsertInvoiceMode.Update) {
-        void patchInvoiceByKey(triggerResult.data)
+        void patchInvoiceByKey(triggerResult)
       }
       else {
         void forceReloadInvoices()

--- a/src/hooks/api/businesses/[business-id]/invoices/useUpsertInvoice.tsx
+++ b/src/hooks/api/businesses/[business-id]/invoices/useUpsertInvoice.tsx
@@ -46,31 +46,16 @@ export type UpdateParams = {
 
 export type UpsertParams = CreateParams | UpdateParams
 
-type UpsertInvoiceParams = { businessId: string, invoiceId?: string }
-
-const upsertInvoice = (
-  baseUrl: string,
-  accessToken: string | undefined,
-  options?: { params?: UpsertInvoiceParams, body?: UpsertInvoiceBody },
-): Promise<UpsertInvoiceReturnEncoded> => {
-  const { params, body } = options ?? {}
-
-  if (params?.invoiceId !== undefined) {
-    return updateInvoice(baseUrl, accessToken, {
-      params: { businessId: params.businessId, invoiceId: params.invoiceId },
-      body,
-    })
-  }
-
-  return createInvoice(baseUrl, accessToken, {
-    params: params && { businessId: params.businessId },
-    body,
-  })
-}
-
-const useUpsertInvoiceMutation = createMutationHook({
+const useCreateInvoice = createMutationHook({
   tags: [UPSERT_INVOICE_TAG_KEY],
-  request: upsertInvoice,
+  request: createInvoice,
+  schema: UpsertInvoiceReturnSchema,
+  swrOptions: { throwOnError: true },
+})
+
+const useUpdateInvoice = createMutationHook({
+  tags: [UPSERT_INVOICE_TAG_KEY],
+  request: updateInvoice,
   keyParams: ['invoiceId'],
   schema: UpsertInvoiceReturnSchema,
   swrOptions: { throwOnError: true },
@@ -84,7 +69,13 @@ export const useUpsertInvoice = (props: UseUpsertInvoiceProps) => {
   const { mode } = props
   const invoiceId = mode === UpsertInvoiceMode.Update ? props.invoiceId : undefined
 
-  const mutationResponse = useUpsertInvoiceMutation({ invoiceId })
+  const createResponse = useCreateInvoice()
+  const updateResponse = useUpdateInvoice({
+    invoiceId: invoiceId ?? '',
+    isEnabled: invoiceId !== undefined,
+  })
+
+  const mutationResponse = mode === UpsertInvoiceMode.Create ? createResponse : updateResponse
 
   const { patchByKey: patchInvoiceByKey, forceReload: forceReloadInvoices } = useInvoicesGlobalCacheActions()
   const { forceReload: forceReloadInvoiceSummaryStats } = useInvoiceSummaryStatsCacheActions()

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/lines/useListLedgerAccountLines.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/lines/useListLedgerAccountLines.ts
@@ -31,27 +31,8 @@ export const listLedgerAccountLines = getWithQuery<
   ({ businessId, accountId }) => `/v1/businesses/${businessId}/ledger/accounts/${accountId}/lines`,
 )
 
-export type UseListLedgerAccountLinesOptions = {
-  accountId: string
-  include_entries_before_activation?: boolean
-  include_child_account_lines?: boolean
-  start_date?: string
-  end_date?: string
-  sort_by?: 'entry_at' | 'entry_number' | 'created_at'
-  sort_order?: 'ASC' | 'ASCENDING' | 'DESC' | 'DESCENDING' | 'DES'
-  limit?: number
-  show_total_count?: boolean
-}
-
-const useListLedgerAccountLinesQuery = createInfiniteQueryHook({
+export const useListLedgerAccountLines = createInfiniteQueryHook({
   tags: [LIST_LEDGER_ACCOUNT_LINES_TAG_KEY],
   request: listLedgerAccountLines,
   schema: ListLedgerAccountLinesResponseSchema,
 })
-
-export function useListLedgerAccountLines(options: UseListLedgerAccountLinesOptions) {
-  return useListLedgerAccountLinesQuery({
-    ...options,
-    isEnabled: Boolean(options.accountId),
-  })
-}

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/lines/useListLedgerAccountLines.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/lines/useListLedgerAccountLines.ts
@@ -1,14 +1,7 @@
-import { Schema } from 'effect'
-import useSWRInfinite from 'swr/infinite'
-
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { LedgerAccountLineItemSchema } from '@schemas/generalLedger/ledgerEntry'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
-import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
-import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { getWithQuery } from '@utils/api/getWithQuery'
+import { createInfiniteQueryHook } from '@hooks/utils/swr/createInfiniteQueryHook'
 
 export const LIST_LEDGER_ACCOUNT_LINES_TAG_KEY = '#list-ledger-account-lines'
 
@@ -30,41 +23,13 @@ const ListLedgerAccountLinesResponseSchema = PaginatedResponseSchema(LedgerAccou
 
 export type ListLedgerAccountLinesReturn = typeof ListLedgerAccountLinesResponseSchema.Type
 
-export const listLedgerAccountLines = get<
+export const listLedgerAccountLines = getWithQuery<
   typeof ListLedgerAccountLinesResponseSchema.Encoded,
   GetLedgerAccountLinesParams
->(({
-  businessId,
-  accountId,
-  include_entries_before_activation,
-  include_child_account_lines,
-  start_date,
-  end_date,
-  sort_by,
-  sort_order,
-  cursor,
-  limit,
-  show_total_count,
-}) => {
-  const parameters = toDefinedSearchParameters({
-    include_entries_before_activation,
-    include_child_account_lines,
-    start_date,
-    end_date,
-    sort_by,
-    sort_order,
-    cursor,
-    limit,
-    show_total_count,
-  })
-
-  return `/v1/businesses/${businessId}/ledger/accounts/${accountId}/lines?${parameters}`
-})
-
-const keyLoader = createInfiniteKeyLoader<
-  UseListLedgerAccountLinesOptions & { businessId: string },
-  ListLedgerAccountLinesReturn
->([LIST_LEDGER_ACCOUNT_LINES_TAG_KEY])
+>(
+  ['businessId', 'accountId'],
+  ({ businessId, accountId }) => `/v1/businesses/${businessId}/ledger/accounts/${accountId}/lines`,
+)
 
 export type UseListLedgerAccountLinesOptions = {
   accountId: string
@@ -78,78 +43,15 @@ export type UseListLedgerAccountLinesOptions = {
   show_total_count?: boolean
 }
 
-export function useListLedgerAccountLines({
-  accountId,
-  include_entries_before_activation,
-  include_child_account_lines,
-  start_date,
-  end_date,
-  sort_by,
-  sort_order,
-  limit,
-  show_total_count,
-}: UseListLedgerAccountLinesOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
+const useListLedgerAccountLinesQuery = createInfiniteQueryHook({
+  tags: [LIST_LEDGER_ACCOUNT_LINES_TAG_KEY],
+  request: listLedgerAccountLines,
+  schema: ListLedgerAccountLinesResponseSchema,
+})
 
-  const swrResponse = useSWRInfinite(
-    (_index, previousPageData: ListLedgerAccountLinesReturn | null) => withLocale(keyLoader(
-      previousPageData,
-      {
-        ...auth,
-        businessId,
-        accountId,
-        include_entries_before_activation,
-        include_child_account_lines,
-        start_date,
-        end_date,
-        sort_by,
-        sort_order,
-        limit,
-        show_total_count,
-        isEnabled: Boolean(accountId),
-      },
-    )),
-    ({
-      accessToken,
-      apiUrl,
-      businessId,
-      accountId,
-      cursor,
-      include_entries_before_activation,
-      include_child_account_lines,
-      start_date,
-      end_date,
-      sort_by,
-      sort_order,
-      limit,
-      show_total_count,
-    }) => listLedgerAccountLines(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          accountId,
-          cursor,
-          include_entries_before_activation,
-          include_child_account_lines,
-          start_date,
-          end_date,
-          sort_by,
-          sort_order,
-          limit,
-          show_total_count,
-        },
-      },
-    )().then(Schema.decodeUnknownPromise(ListLedgerAccountLinesResponseSchema)),
-    {
-      keepPreviousData: true,
-      revalidateFirstPage: false,
-      initialSize: 1,
-    },
-  )
-
-  usePreserveInfiniteSize(swrResponse)
-
-  return useSWRInfiniteResult(swrResponse)
+export function useListLedgerAccountLines(options: UseListLedgerAccountLinesOptions) {
+  return useListLedgerAccountLinesQuery({
+    ...options,
+    isEnabled: Boolean(options.accountId),
+  })
 }

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/useDeleteLedgerAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/[account-id]/useDeleteLedgerAccount.ts
@@ -1,48 +1,32 @@
 import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useLedgerBalancesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances'
 import { useLedgerEntriesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const deleteAccountFromLedger = del<
   Record<string, never>,
-  { accountId: string, businessId: string }
+  Record<string, never>,
+  { businessId: string, accountId: string }
 >(({ businessId, accountId }) => `/v1/businesses/${businessId}/ledger/accounts/${accountId}`)
 
-const buildKey = createBuildKey<{ businessId: string }>(['#delete-account-from-ledger'])
+const useDeleteAccountFromLedgerMutation = createMutationHook({
+  tags: ['#delete-account-from-ledger'],
+  request: deleteAccountFromLedger,
+  argToParams: (arg: { accountId: string }) => arg,
+  argToBody: () => undefined,
+  swrOptions: { throwOnError: true },
+})
 
 export function useDeleteAccountFromLedger() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { accountId } }: { arg: { accountId: string } },
-    ) => deleteAccountFromLedger(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, accountId },
-      },
-    ),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const { trigger: originalTrigger } = mutationResponse
+  const mutationResponse = useDeleteAccountFromLedgerMutation()
 
   const { invalidate: invalidateLedgerBalances } = useLedgerBalancesCacheActions()
   const { forceReload: forceReloadLedgerEntries } = useLedgerEntriesCacheActions()
+
+  const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/useUpsertLedgerAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/useUpsertLedgerAccount.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { SingleChartAccountSchema } from '@schemas/generalLedger/ledgerAccount'
 import { type UpsertLedgerAccountSchema } from '@schemas/generalLedger/upsertLedgerAccount'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post, put } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useLedgerBalancesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances'
@@ -18,9 +18,7 @@ export enum UpsertLedgerAccountMode {
 
 type UpsertLedgerAccountBody = typeof UpsertLedgerAccountSchema.Encoded
 
-const UpsertLedgerAccountReturnSchema = Schema.Struct({
-  data: SingleChartAccountSchema,
-})
+const UpsertLedgerAccountReturnSchema = UnwrappedDataResponseSchema(SingleChartAccountSchema)
 
 type UpsertLedgerAccountReturnEncoded = typeof UpsertLedgerAccountReturnSchema.Encoded
 

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/useUpsertLedgerAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/useUpsertLedgerAccount.ts
@@ -34,31 +34,16 @@ const updateLedgerAccount = put<
   { businessId: string, accountId: string }
 >(({ businessId, accountId }) => `/v1/businesses/${businessId}/ledger/accounts/${accountId}`)
 
-type UpsertLedgerAccountParams = { businessId: string, accountId?: string }
-
-const upsertLedgerAccount = (
-  baseUrl: string,
-  accessToken: string | undefined,
-  options?: { params?: UpsertLedgerAccountParams, body?: UpsertLedgerAccountBody },
-): Promise<UpsertLedgerAccountReturnEncoded> => {
-  const { params, body } = options ?? {}
-
-  if (params?.accountId !== undefined) {
-    return updateLedgerAccount(baseUrl, accessToken, {
-      params: { businessId: params.businessId, accountId: params.accountId },
-      body,
-    })
-  }
-
-  return createLedgerAccount(baseUrl, accessToken, {
-    params: { businessId: params?.businessId },
-    body,
-  })
-}
-
-const useUpsertLedgerAccountMutation = createMutationHook({
+const useCreateLedgerAccount = createMutationHook({
   tags: [UPSERT_LEDGER_ACCOUNT_TAG_KEY],
-  request: upsertLedgerAccount,
+  request: createLedgerAccount,
+  schema: UpsertLedgerAccountReturnSchema,
+  swrOptions: { throwOnError: true },
+})
+
+const useUpdateLedgerAccount = createMutationHook({
+  tags: [UPSERT_LEDGER_ACCOUNT_TAG_KEY],
+  request: updateLedgerAccount,
   keyParams: ['accountId'],
   schema: UpsertLedgerAccountReturnSchema,
   swrOptions: { throwOnError: true },
@@ -72,7 +57,13 @@ export const useUpsertLedgerAccount = (props: UseUpsertLedgerAccountProps) => {
   const { mode } = props
   const accountId = mode === UpsertLedgerAccountMode.Update ? props.accountId : undefined
 
-  const mutationResponse = useUpsertLedgerAccountMutation({ accountId })
+  const createResponse = useCreateLedgerAccount()
+  const updateResponse = useUpdateLedgerAccount({
+    accountId: accountId ?? '',
+    isEnabled: accountId !== undefined,
+  })
+
+  const mutationResponse = mode === UpsertLedgerAccountMode.Create ? createResponse : updateResponse
 
   const { invalidate: invalidateLedgerBalances } = useLedgerBalancesCacheActions()
   const { forceReload: forceReloadLedgerEntries } = useLedgerEntriesCacheActions()

--- a/src/hooks/api/businesses/[business-id]/ledger/accounts/useUpsertLedgerAccount.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/accounts/useUpsertLedgerAccount.ts
@@ -1,16 +1,13 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { SingleChartAccountSchema } from '@schemas/generalLedger/ledgerAccount'
 import { type UpsertLedgerAccountSchema } from '@schemas/generalLedger/upsertLedgerAccount'
 import { post, put } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useLedgerBalancesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances'
 import { useLedgerEntriesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPSERT_LEDGER_ACCOUNT_TAG_KEY = '#upsert-ledger-account'
 
@@ -21,65 +18,61 @@ export enum UpsertLedgerAccountMode {
 
 type UpsertLedgerAccountBody = typeof UpsertLedgerAccountSchema.Encoded
 
-const createLedgerAccount = post<
-  UpsertLedgerAccountReturn,
-  UpsertLedgerAccountBody,
-  { businessId: string }
->(({ businessId }) => `/v1/businesses/${businessId}/ledger/accounts`)
-
-const updateLedgerAccount = put<
-  UpsertLedgerAccountReturn,
-  UpsertLedgerAccountBody,
-  { businessId: string, accountId: string }
->(({ businessId, accountId }) => `/v1/businesses/${businessId}/ledger/accounts/${accountId}`)
-
-const buildKey = createBuildKey<{ businessId: string, accountId?: string }>([UPSERT_LEDGER_ACCOUNT_TAG_KEY])
-
 const UpsertLedgerAccountReturnSchema = Schema.Struct({
   data: SingleChartAccountSchema,
 })
 
-type UpsertLedgerAccountReturn = typeof UpsertLedgerAccountReturnSchema.Type
+type UpsertLedgerAccountReturnEncoded = typeof UpsertLedgerAccountReturnSchema.Encoded
+
+const createLedgerAccount = post<UpsertLedgerAccountReturnEncoded, UpsertLedgerAccountBody>(
+  ({ businessId }) => `/v1/businesses/${businessId}/ledger/accounts`,
+)
+
+const updateLedgerAccount = put<
+  UpsertLedgerAccountReturnEncoded,
+  UpsertLedgerAccountBody,
+  { businessId: string, accountId: string }
+>(({ businessId, accountId }) => `/v1/businesses/${businessId}/ledger/accounts/${accountId}`)
+
+type UpsertLedgerAccountParams = { businessId: string, accountId?: string }
+
+const upsertLedgerAccount = (
+  baseUrl: string,
+  accessToken: string | undefined,
+  options?: { params?: UpsertLedgerAccountParams, body?: UpsertLedgerAccountBody },
+): Promise<UpsertLedgerAccountReturnEncoded> => {
+  const { params, body } = options ?? {}
+
+  if (params?.accountId !== undefined) {
+    return updateLedgerAccount(baseUrl, accessToken, {
+      params: { businessId: params.businessId, accountId: params.accountId },
+      body,
+    })
+  }
+
+  return createLedgerAccount(baseUrl, accessToken, {
+    params: { businessId: params?.businessId },
+    body,
+  })
+}
+
+const useUpsertLedgerAccountMutation = createMutationHook({
+  tags: [UPSERT_LEDGER_ACCOUNT_TAG_KEY],
+  request: upsertLedgerAccount,
+  keyParams: ['accountId'],
+  schema: UpsertLedgerAccountReturnSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseUpsertLedgerAccountProps =
   | { mode: UpsertLedgerAccountMode.Create }
   | { mode: UpsertLedgerAccountMode.Update, accountId: string }
 
 export const useUpsertLedgerAccount = (props: UseUpsertLedgerAccountProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
   const { mode } = props
   const accountId = mode === UpsertLedgerAccountMode.Update ? props.accountId : undefined
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      accountId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, accountId },
-      { arg: body }: { arg: UpsertLedgerAccountBody },
-    ) => {
-      if (mode === UpsertLedgerAccountMode.Update) {
-        if (!accountId) {
-          throw new Error('Cannot update a ledger account without an account id')
-        }
-
-        return updateLedgerAccount(apiUrl, accessToken, { params: { businessId, accountId }, body })
-          .then(Schema.decodeUnknownPromise(UpsertLedgerAccountReturnSchema))
-      }
-
-      return createLedgerAccount(apiUrl, accessToken, { params: { businessId }, body })
-        .then(Schema.decodeUnknownPromise(UpsertLedgerAccountReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useUpsertLedgerAccountMutation({ accountId })
 
   const { invalidate: invalidateLedgerBalances } = useLedgerBalancesCacheActions()
   const { forceReload: forceReloadLedgerEntries } = useLedgerEntriesCacheActions()

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
@@ -1,5 +1,4 @@
 import type { S3PresignedUrl } from '@internal-types/general'
-import type { Awaitable } from '@internal-types/utility/promises'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import type { MutationRequest } from '@utils/api/postAsQuery'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
@@ -25,7 +24,7 @@ const requestLedgerAccountBalancesCSV: MutationRequest<
 > = (baseUrl, accessToken, options) =>
   getLedgerAccountBalancesCSV(baseUrl, accessToken, { params: options?.params })()
 
-const useAccountBalancesDownloadMutation = createMutationHook({
+export const useAccountBalancesDownload = createMutationHook({
   tags: ['#account-balances', '#exports', '#csv'],
   request: requestLedgerAccountBalancesCSV,
   keyParams: ['startDate', 'endDate'],
@@ -33,21 +32,3 @@ const useAccountBalancesDownloadMutation = createMutationHook({
   select: ({ data }) => data,
   swrOptions: { throwOnError: false },
 })
-
-type UseAccountBalancesDownloadOptions = {
-  startDate?: Date
-  endDate?: Date
-  onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>
-}
-
-export function useAccountBalancesDownload({
-  startDate,
-  endDate,
-  onSuccess,
-}: UseAccountBalancesDownloadOptions) {
-  return useAccountBalancesDownloadMutation({
-    startDate,
-    endDate,
-    swrOptions: { onSuccess },
-  })
-}

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
@@ -1,19 +1,22 @@
 import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
-import { get } from '@utils/api/authenticatedHttp'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import type { MutationRequest } from '@utils/api/postAsQuery'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type GetAccountBalancesCSVParams = {
   businessId: string
-  startCutoff?: Date
-  endCutoff?: Date
+  startDate?: Date
+  endDate?: Date
 }
 
-const getLedgerAccountBalancesCSV = get<
+const getLedgerAccountBalancesCSV = getWithQuery<
   { data: S3PresignedUrl },
   GetAccountBalancesCSVParams
->(({ businessId }) => `/v1/businesses/${businessId}/ledger/balances/exports/csv`)
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/ledger/balances/exports/csv`,
+)
 
 const requestLedgerAccountBalancesCSV: MutationRequest<
   { data: S3PresignedUrl },
@@ -25,26 +28,26 @@ const requestLedgerAccountBalancesCSV: MutationRequest<
 const useAccountBalancesDownloadMutation = createMutationHook({
   tags: ['#account-balances', '#exports', '#csv'],
   request: requestLedgerAccountBalancesCSV,
-  keyParams: ['startCutoff', 'endCutoff'],
+  keyParams: ['startDate', 'endDate'],
   argToBody: (_arg: undefined) => undefined,
   select: ({ data }) => data,
   swrOptions: { throwOnError: false },
 })
 
 type UseAccountBalancesDownloadOptions = {
-  startCutoff?: Date
-  endCutoff?: Date
+  startDate?: Date
+  endDate?: Date
   onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>
 }
 
 export function useAccountBalancesDownload({
-  startCutoff,
-  endCutoff,
+  startDate,
+  endDate,
   onSuccess,
 }: UseAccountBalancesDownloadOptions) {
   return useAccountBalancesDownloadMutation({
-    startCutoff,
-    endCutoff,
+    startDate,
+    endDate,
     swrOptions: { onSuccess },
   })
 }

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
@@ -1,6 +1,6 @@
 import type { S3PresignedUrl } from '@internal-types/general'
+import { getAsMutation } from '@utils/api/getAsMutation'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { getAsMutation } from '@utils/api/postAsQuery'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type GetAccountBalancesCSVParams = {

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
@@ -1,6 +1,6 @@
 import type { S3PresignedUrl } from '@internal-types/general'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import type { MutationRequest } from '@utils/api/postAsQuery'
+import { getAsMutation } from '@utils/api/postAsQuery'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type GetAccountBalancesCSVParams = {
@@ -17,12 +17,7 @@ const getLedgerAccountBalancesCSV = getWithQuery<
   ({ businessId }) => `/v1/businesses/${businessId}/ledger/balances/exports/csv`,
 )
 
-const requestLedgerAccountBalancesCSV: MutationRequest<
-  { data: S3PresignedUrl },
-  Record<string, unknown>,
-  GetAccountBalancesCSVParams
-> = (baseUrl, accessToken, options) =>
-  getLedgerAccountBalancesCSV(baseUrl, accessToken, { params: options?.params })()
+const requestLedgerAccountBalancesCSV = getAsMutation(getLedgerAccountBalancesCSV)
 
 export const useAccountBalancesDownload = createMutationHook({
   tags: ['#account-balances', '#exports', '#csv'],

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/exports/csv/useAccountBalancesDownload.ts
@@ -1,16 +1,35 @@
-import useSWRMutation from 'swr/mutation'
-
 import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import type { MutationRequest } from '@utils/api/postAsQuery'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
-const getLedgerAccountBalancesCSV = get<{ data: S3PresignedUrl }>(
-  ({ businessId }) => `/v1/businesses/${businessId}/ledger/balances/exports/csv`,
-)
+type GetAccountBalancesCSVParams = {
+  businessId: string
+  startCutoff?: Date
+  endCutoff?: Date
+}
 
-const buildKey = createBuildKey<{ businessId: string, startCutoff?: Date, endCutoff?: Date }>(['#account-balances', '#exports', '#csv'])
+const getLedgerAccountBalancesCSV = get<
+  { data: S3PresignedUrl },
+  GetAccountBalancesCSVParams
+>(({ businessId }) => `/v1/businesses/${businessId}/ledger/balances/exports/csv`)
+
+const requestLedgerAccountBalancesCSV: MutationRequest<
+  { data: S3PresignedUrl },
+  Record<string, unknown>,
+  GetAccountBalancesCSVParams
+> = (baseUrl, accessToken, options) =>
+  getLedgerAccountBalancesCSV(baseUrl, accessToken, { params: options?.params })()
+
+const useAccountBalancesDownloadMutation = createMutationHook({
+  tags: ['#account-balances', '#exports', '#csv'],
+  request: requestLedgerAccountBalancesCSV,
+  keyParams: ['startCutoff', 'endCutoff'],
+  argToBody: (_arg: undefined) => undefined,
+  select: ({ data }) => data,
+  swrOptions: { throwOnError: false },
+})
 
 type UseAccountBalancesDownloadOptions = {
   startCutoff?: Date
@@ -23,32 +42,9 @@ export function useAccountBalancesDownload({
   endCutoff,
   onSuccess,
 }: UseAccountBalancesDownloadOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  return useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      startCutoff,
-      endCutoff,
-    })),
-    ({ accessToken, apiUrl, businessId, startCutoff, endCutoff }) => getLedgerAccountBalancesCSV(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          startCutoff: startCutoff?.toISOString(),
-          endCutoff: endCutoff?.toISOString(),
-        },
-      })().then(({ data }) => {
-      if (onSuccess) {
-        return onSuccess(data)
-      }
-    }),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
+  return useAccountBalancesDownloadMutation({
+    startCutoff,
+    endCutoff,
+    swrOptions: { onSuccess },
+  })
 }

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances.tsx
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances.tsx
@@ -26,8 +26,7 @@ const getLedgerAccountBalances = getWithQuery<
 export const useLedgerBalances = createQueryHook({
   tags: [LEDGER_BALANCES_TAG_KEY],
   request: getLedgerAccountBalances,
-  schema: LedgerBalancesResponseSchema,
-  select: ({ data }) => data,
+  schema: LedgerBalancesResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export const useLedgerBalancesCacheActions = createResourceGlobalCacheActions<LedgerBalancesSchemaType>(LEDGER_BALANCES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances.tsx
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances.tsx
@@ -1,6 +1,5 @@
-import { Schema } from 'effect/index'
-
 import { LedgerBalancesSchema, type LedgerBalancesSchemaType } from '@schemas/generalLedger/ledgerAccount'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
@@ -13,7 +12,7 @@ type GetLedgerAccountBalancesParams = {
   endDate?: Date
 }
 
-const LedgerBalancesResponseSchema = Schema.Struct({ data: LedgerBalancesSchema })
+const LedgerBalancesResponseSchema = UnwrappedDataResponseSchema(LedgerBalancesSchema)
 
 const getLedgerAccountBalances = getWithQuery<
   typeof LedgerBalancesResponseSchema.Encoded,
@@ -26,7 +25,7 @@ const getLedgerAccountBalances = getWithQuery<
 export const useLedgerBalances = createQueryHook({
   tags: [LEDGER_BALANCES_TAG_KEY],
   request: getLedgerAccountBalances,
-  schema: LedgerBalancesResponseSchema.pipe(Schema.pluck('data')),
+  schema: LedgerBalancesResponseSchema,
 })
 
 export const useLedgerBalancesCacheActions = createResourceGlobalCacheActions<LedgerBalancesSchemaType>(LEDGER_BALANCES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances.tsx
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances.tsx
@@ -23,18 +23,11 @@ const getLedgerAccountBalances = getWithQuery<
   ({ businessId }) => `/v1/businesses/${businessId}/ledger/balances`,
 )
 
-const useLedgerBalancesQuery = createQueryHook({
+export const useLedgerBalances = createQueryHook({
   tags: [LEDGER_BALANCES_TAG_KEY],
   request: getLedgerAccountBalances,
   schema: LedgerBalancesResponseSchema,
   select: ({ data }) => data,
 })
-
-export function useLedgerBalances(withDates?: boolean, startDate?: Date, endDate?: Date) {
-  return useLedgerBalancesQuery({
-    startDate: withDates ? startDate : undefined,
-    endDate: withDates ? endDate : undefined,
-  })
-}
 
 export const useLedgerBalancesCacheActions = createResourceGlobalCacheActions<LedgerBalancesSchemaType>(LEDGER_BALANCES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances.tsx
+++ b/src/hooks/api/businesses/[business-id]/ledger/balances/useLedgerBalances.tsx
@@ -1,13 +1,9 @@
 import { Schema } from 'effect/index'
-import useSWR from 'swr'
 
 import { LedgerBalancesSchema, type LedgerBalancesSchemaType } from '@schemas/generalLedger/ledgerAccount'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const LEDGER_BALANCES_TAG_KEY = '#ledger-balances'
 
@@ -17,39 +13,28 @@ type GetLedgerAccountBalancesParams = {
   endDate?: Date
 }
 
-const getLedgerAccountBalances = get<{ data: LedgerBalancesSchemaType }, GetLedgerAccountBalancesParams>(
-  ({ businessId, startDate, endDate }) => {
-    const parameters = toDefinedSearchParameters({ startDate, endDate })
+const LedgerBalancesResponseSchema = Schema.Struct({ data: LedgerBalancesSchema })
 
-    return `/v1/businesses/${businessId}/ledger/balances?${parameters}`
-  },
+const getLedgerAccountBalances = getWithQuery<
+  typeof LedgerBalancesResponseSchema.Encoded,
+  GetLedgerAccountBalancesParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/ledger/balances`,
 )
 
-const buildKey = createBuildKey<{ businessId: string, startDate?: Date, endDate?: Date }>([LEDGER_BALANCES_TAG_KEY])
+const useLedgerBalancesQuery = createQueryHook({
+  tags: [LEDGER_BALANCES_TAG_KEY],
+  request: getLedgerAccountBalances,
+  schema: LedgerBalancesResponseSchema,
+  select: ({ data }) => data,
+})
 
 export function useLedgerBalances(withDates?: boolean, startDate?: Date, endDate?: Date) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      startDate: withDates ? startDate : undefined,
-      endDate: withDates ? endDate : undefined,
-    })),
-    ({ accessToken, apiUrl, businessId, startDate, endDate }) => getLedgerAccountBalances(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          startDate,
-          endDate,
-        },
-      },
-    )().then(({ data }) => Schema.decodeUnknownPromise(LedgerBalancesSchema)(data)),
-  )
-
-  return new SWRQueryResult(response)
+  return useLedgerBalancesQuery({
+    startDate: withDates ? startDate : undefined,
+    endDate: withDates ? endDate : undefined,
+  })
 }
 
 export const useLedgerBalancesCacheActions = createResourceGlobalCacheActions<LedgerBalancesSchemaType>(LEDGER_BALANCES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/reverse/useReverseJournalEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/reverse/useReverseJournalEntry.ts
@@ -1,50 +1,38 @@
 import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useLedgerEntriesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries'
 import { useBalanceSheetGlobalCacheActions } from '@hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet'
 import { useStatementOfCashFlowGlobalCacheActions } from '@hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const REVERSE_JOURNAL_ENTRY_TAG_KEY = '#reverse-journal-entry'
 
-const reverseJournalEntry = post<Record<never, never>>(
-  ({ businessId, entryId }) =>
-    `/v1/businesses/${businessId}/ledger/entries/${entryId}/reverse`,
-)
+const reverseJournalEntry = post<
+  Record<never, never>,
+  Record<string, never>,
+  { businessId: string, entryId: string }
+>(({ businessId, entryId }) => `/v1/businesses/${businessId}/ledger/entries/${entryId}/reverse`)
 
-const buildKey = createBuildKey<{ businessId: string }>([REVERSE_JOURNAL_ENTRY_TAG_KEY])
+const useReverseJournalEntryMutation = createMutationHook({
+  tags: [REVERSE_JOURNAL_ENTRY_TAG_KEY],
+  request: reverseJournalEntry,
+  argToParams: (entryId: string) => ({ entryId }),
+  argToBody: () => undefined,
+  swrOptions: { throwOnError: true },
+})
 
 export const useReverseJournalEntry = () => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
   const { forceReload: forceReloadLedgerEntries } = useLedgerEntriesCacheActions()
   const { debouncedInvalidateProfitAndLoss } = useProfitAndLossGlobalInvalidator()
   const { invalidate: invalidateBalanceSheet } = useBalanceSheetGlobalCacheActions()
   const { invalidate: invalidateStatementOfCashFlow } = useStatementOfCashFlowGlobalCacheActions()
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: entryId }: { arg: string },
-    ) => reverseJournalEntry(apiUrl, accessToken, {
-      params: { businessId, entryId },
-    }),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
+  const mutationResponse = useReverseJournalEntryMutation()
 
-  const { trigger: originalTrigger } = mutationResponse
+  const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/useLedgerAccountsEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/useLedgerAccountsEntry.ts
@@ -1,38 +1,35 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
 
 import { LedgerEntrySchema } from '@schemas/generalLedger/ledgerEntry'
-import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { getWithQuery } from '@utils/api/getWithQuery'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const LEDGER_ACCOUNTS_ENTRY_TAG_KEY = '#ledger-accounts-entry'
 
 const LedgerAccountsEntryResponseSchema = Schema.Struct({ data: LedgerEntrySchema })
 
-const getLedgerAccountsEntry = get<typeof LedgerAccountsEntryResponseSchema.Encoded>(
-  ({ businessId, entryId }) =>
-    `/v1/businesses/${businessId}/ledger/entries/${entryId}`,
+type GetLedgerAccountsEntryParams = {
+  businessId: string
+  entryId?: string
+}
+
+const getLedgerAccountsEntry = getWithQuery<
+  typeof LedgerAccountsEntryResponseSchema.Encoded,
+  GetLedgerAccountsEntryParams
+>(
+  ['businessId', 'entryId'],
+  ({ businessId, entryId }) => `/v1/businesses/${businessId}/ledger/entries/${entryId}`,
 )
 
-const buildKey = createBuildKey<{ businessId: string, entryId?: string }>([LEDGER_ACCOUNTS_ENTRY_TAG_KEY])
+const useLedgerAccountsEntryQuery = createQueryHook({
+  tags: [LEDGER_ACCOUNTS_ENTRY_TAG_KEY],
+  request: getLedgerAccountsEntry,
+  schema: LedgerAccountsEntryResponseSchema,
+})
 
 export function useLedgerAccountsEntry({ entryId }: { entryId?: string }) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(() =>
-    withLocale(buildKey({
-      ...auth,
-      businessId,
-      entryId,
-      isEnabled: Boolean(entryId),
-    })),
-  ({ accessToken, apiUrl, businessId, entryId }) =>
-    getLedgerAccountsEntry(apiUrl, accessToken, {
-      params: { businessId, entryId },
-    })().then(Schema.decodeUnknownPromise(LedgerAccountsEntryResponseSchema)),
-  )
-
-  return new SWRQueryResult(swrResponse)
+  return useLedgerAccountsEntryQuery({
+    entryId,
+    isEnabled: Boolean(entryId),
+  })
 }

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/useLedgerAccountsEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/useLedgerAccountsEntry.ts
@@ -21,15 +21,8 @@ const getLedgerAccountsEntry = getWithQuery<
   ({ businessId, entryId }) => `/v1/businesses/${businessId}/ledger/entries/${entryId}`,
 )
 
-const useLedgerAccountsEntryQuery = createQueryHook({
+export const useLedgerAccountsEntry = createQueryHook({
   tags: [LEDGER_ACCOUNTS_ENTRY_TAG_KEY],
   request: getLedgerAccountsEntry,
   schema: LedgerAccountsEntryResponseSchema,
 })
-
-export function useLedgerAccountsEntry({ entryId }: { entryId?: string }) {
-  return useLedgerAccountsEntryQuery({
-    entryId,
-    isEnabled: Boolean(entryId),
-  })
-}

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/useLedgerAccountsEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/[entry-id]/useLedgerAccountsEntry.ts
@@ -1,12 +1,11 @@
-import { Schema } from 'effect'
-
 import { LedgerEntrySchema } from '@schemas/generalLedger/ledgerEntry'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const LEDGER_ACCOUNTS_ENTRY_TAG_KEY = '#ledger-accounts-entry'
 
-const LedgerAccountsEntryResponseSchema = Schema.Struct({ data: LedgerEntrySchema })
+const LedgerAccountsEntryResponseSchema = UnwrappedDataResponseSchema(LedgerEntrySchema)
 
 type GetLedgerAccountsEntryParams = {
   businessId: string

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
@@ -1,6 +1,6 @@
 import type { S3PresignedUrl } from '@internal-types/general'
+import { getAsMutation } from '@utils/api/getAsMutation'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { getAsMutation } from '@utils/api/postAsQuery'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type GetJournalEntriesCSVParams = {

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
@@ -1,17 +1,35 @@
-import useSWRMutation from 'swr/mutation'
-
 import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
-import { type APIError } from '@utils/api/apiError'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import type { MutationRequest } from '@utils/api/postAsQuery'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
-const getJournalEntriesCSV = get<{ data: S3PresignedUrl }>(
-  ({ businessId }) => `/v1/businesses/${businessId}/ledger/entries/exports/csv`,
-)
+type GetJournalEntriesCSVParams = {
+  businessId: string
+  startCutoff?: Date
+  endCutoff?: Date
+}
 
-const buildKey = createBuildKey<{ businessId: string, startCutoff?: Date, endCutoff?: Date }>(['#journal-entries', '#exports', '#csv'])
+const getJournalEntriesCSV = get<
+  { data: S3PresignedUrl },
+  GetJournalEntriesCSVParams
+>(({ businessId }) => `/v1/businesses/${businessId}/ledger/entries/exports/csv`)
+
+const requestJournalEntriesCSV: MutationRequest<
+  { data: S3PresignedUrl },
+  Record<string, unknown>,
+  GetJournalEntriesCSVParams
+> = (baseUrl, accessToken, options) =>
+  getJournalEntriesCSV(baseUrl, accessToken, { params: options?.params })()
+
+const useJournalEntriesDownloadMutation = createMutationHook({
+  tags: ['#journal-entries', '#exports', '#csv'],
+  request: requestJournalEntriesCSV,
+  keyParams: ['startCutoff', 'endCutoff'],
+  argToBody: (_arg: undefined) => undefined,
+  select: ({ data }) => data,
+  swrOptions: { throwOnError: false },
+})
 
 type UseJournalEntriesDownloadOptions = {
   startCutoff?: Date
@@ -19,49 +37,14 @@ type UseJournalEntriesDownloadOptions = {
   onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>
 }
 
-type MutationParams = () => {
-  accessToken: string
-  apiUrl: string
-  businessId: string
-  startCutoff?: Date
-  endCutoff?: Date
-} | undefined
-
 export function useJournalEntriesDownload({
   startCutoff,
   endCutoff,
   onSuccess,
 }: UseJournalEntriesDownloadOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  return useSWRMutation<
-    unknown,
-    Error | APIError,
-    MutationParams
-  >(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      startCutoff,
-      endCutoff,
-    })),
-    ({ accessToken, apiUrl, businessId, startCutoff, endCutoff }) => getJournalEntriesCSV(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          startCutoff: startCutoff?.toISOString(),
-          endCutoff: endCutoff?.toISOString(),
-        },
-      })().then(({ data }) => {
-      if (onSuccess) {
-        return onSuccess(data)
-      }
-    }),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
+  return useJournalEntriesDownloadMutation({
+    startCutoff,
+    endCutoff,
+    swrOptions: { onSuccess },
+  })
 }

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
@@ -1,6 +1,6 @@
 import type { S3PresignedUrl } from '@internal-types/general'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import type { MutationRequest } from '@utils/api/postAsQuery'
+import { getAsMutation } from '@utils/api/postAsQuery'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type GetJournalEntriesCSVParams = {
@@ -17,12 +17,7 @@ const getJournalEntriesCSV = getWithQuery<
   ({ businessId }) => `/v1/businesses/${businessId}/ledger/entries/exports/csv`,
 )
 
-const requestJournalEntriesCSV: MutationRequest<
-  { data: S3PresignedUrl },
-  Record<string, unknown>,
-  GetJournalEntriesCSVParams
-> = (baseUrl, accessToken, options) =>
-  getJournalEntriesCSV(baseUrl, accessToken, { params: options?.params })()
+const requestJournalEntriesCSV = getAsMutation(getJournalEntriesCSV)
 
 export const useJournalEntriesDownload = createMutationHook({
   tags: ['#journal-entries', '#exports', '#csv'],

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
@@ -1,19 +1,22 @@
 import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
-import { get } from '@utils/api/authenticatedHttp'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import type { MutationRequest } from '@utils/api/postAsQuery'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type GetJournalEntriesCSVParams = {
   businessId: string
-  startCutoff?: Date
-  endCutoff?: Date
+  startDate?: Date
+  endDate?: Date
 }
 
-const getJournalEntriesCSV = get<
+const getJournalEntriesCSV = getWithQuery<
   { data: S3PresignedUrl },
   GetJournalEntriesCSVParams
->(({ businessId }) => `/v1/businesses/${businessId}/ledger/entries/exports/csv`)
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/ledger/entries/exports/csv`,
+)
 
 const requestJournalEntriesCSV: MutationRequest<
   { data: S3PresignedUrl },
@@ -25,26 +28,26 @@ const requestJournalEntriesCSV: MutationRequest<
 const useJournalEntriesDownloadMutation = createMutationHook({
   tags: ['#journal-entries', '#exports', '#csv'],
   request: requestJournalEntriesCSV,
-  keyParams: ['startCutoff', 'endCutoff'],
+  keyParams: ['startDate', 'endDate'],
   argToBody: (_arg: undefined) => undefined,
   select: ({ data }) => data,
   swrOptions: { throwOnError: false },
 })
 
 type UseJournalEntriesDownloadOptions = {
-  startCutoff?: Date
-  endCutoff?: Date
+  startDate?: Date
+  endDate?: Date
   onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>
 }
 
 export function useJournalEntriesDownload({
-  startCutoff,
-  endCutoff,
+  startDate,
+  endDate,
   onSuccess,
 }: UseJournalEntriesDownloadOptions) {
   return useJournalEntriesDownloadMutation({
-    startCutoff,
-    endCutoff,
+    startDate,
+    endDate,
     swrOptions: { onSuccess },
   })
 }

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/exports/csv/useJournalEntriesDownload.ts
@@ -1,5 +1,4 @@
 import type { S3PresignedUrl } from '@internal-types/general'
-import type { Awaitable } from '@internal-types/utility/promises'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import type { MutationRequest } from '@utils/api/postAsQuery'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
@@ -25,7 +24,7 @@ const requestJournalEntriesCSV: MutationRequest<
 > = (baseUrl, accessToken, options) =>
   getJournalEntriesCSV(baseUrl, accessToken, { params: options?.params })()
 
-const useJournalEntriesDownloadMutation = createMutationHook({
+export const useJournalEntriesDownload = createMutationHook({
   tags: ['#journal-entries', '#exports', '#csv'],
   request: requestJournalEntriesCSV,
   keyParams: ['startDate', 'endDate'],
@@ -33,21 +32,3 @@ const useJournalEntriesDownloadMutation = createMutationHook({
   select: ({ data }) => data,
   swrOptions: { throwOnError: false },
 })
-
-type UseJournalEntriesDownloadOptions = {
-  startDate?: Date
-  endDate?: Date
-  onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>
-}
-
-export function useJournalEntriesDownload({
-  startDate,
-  endDate,
-  onSuccess,
-}: UseJournalEntriesDownloadOptions) {
-  return useJournalEntriesDownloadMutation({
-    startDate,
-    endDate,
-    swrOptions: { onSuccess },
-  })
-}

--- a/src/hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries.ts
@@ -1,16 +1,9 @@
-import { Schema } from 'effect'
-import useSWRInfinite from 'swr/infinite'
-
 import { type SortOrder } from '@internal-types/utility/pagination'
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { type LedgerEntry, LedgerEntrySchema } from '@schemas/generalLedger/ledgerEntry'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
-import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createInfiniteQueryHook } from '@hooks/utils/swr/createInfiniteQueryHook'
 
 export const LIST_LEDGER_ENTRIES_TAG_KEY = '#list-ledger-entries'
 
@@ -33,86 +26,18 @@ const ListLedgerEntriesResponseSchema = PaginatedResponseSchema(LedgerEntrySchem
 
 export type ListLedgerEntriesReturn = typeof ListLedgerEntriesResponseSchema.Type
 
-export const listLedgerEntries = get<
+export const listLedgerEntries = getWithQuery<
   typeof ListLedgerEntriesResponseSchema.Encoded,
   GetLedgerEntriesParams
->(({ businessId, sortBy, sortOrder, cursor, limit, showTotalCount }) => {
-  const parameters = toDefinedSearchParameters({
-    sortBy,
-    sortOrder,
-    cursor,
-    limit,
-    showTotalCount,
-  })
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/ledger/entries`,
+)
 
-  return `/v1/businesses/${businessId}/ledger/entries?${parameters}`
+export const useListLedgerEntries = createInfiniteQueryHook({
+  tags: [LIST_LEDGER_ENTRIES_TAG_KEY],
+  request: listLedgerEntries,
+  schema: ListLedgerEntriesResponseSchema,
 })
-
-const keyLoader = createInfiniteKeyLoader<
-  UseListLedgerEntriesOptions & { businessId: string },
-  ListLedgerEntriesReturn
->([LIST_LEDGER_ENTRIES_TAG_KEY])
-
-export type UseListLedgerEntriesOptions = {
-  sortBy?: LedgerEntriesSortBy
-  sortOrder?: SortOrder
-  limit?: number
-  showTotalCount?: boolean
-}
-
-export function useListLedgerEntries({
-  sortBy,
-  sortOrder,
-  limit,
-  showTotalCount,
-}: UseListLedgerEntriesOptions = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWRInfinite(
-    (_index, previousPageData: ListLedgerEntriesReturn | null) => withLocale(keyLoader(
-      previousPageData,
-      {
-        ...auth,
-        businessId,
-        sortBy,
-        sortOrder,
-        limit,
-        showTotalCount,
-      },
-    )),
-    ({
-      accessToken,
-      apiUrl,
-      businessId,
-      cursor,
-      sortBy,
-      sortOrder,
-      limit,
-      showTotalCount,
-    }) => listLedgerEntries(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          sortBy,
-          sortOrder,
-          cursor,
-          limit,
-          showTotalCount,
-        },
-      },
-    )().then(Schema.decodeUnknownPromise(ListLedgerEntriesResponseSchema)),
-    {
-      keepPreviousData: true,
-      revalidateFirstPage: false,
-      initialSize: 1,
-    },
-  )
-
-  usePreserveInfiniteSize(swrResponse)
-
-  return useSWRInfiniteResult(swrResponse)
-}
 
 export const useLedgerEntriesCacheActions = createInfiniteQueryGlobalCacheActions<LedgerEntry>(LIST_LEDGER_ENTRIES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/ledger/journal-entries/useUpsertJournalEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/journal-entries/useUpsertJournalEntry.ts
@@ -1,15 +1,12 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { useLedgerEntriesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries'
 import { useBalanceSheetGlobalCacheActions } from '@hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet'
 import { useStatementOfCashFlowGlobalCacheActions } from '@hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow'
 import { useProfitAndLossGlobalInvalidator } from '@hooks/features/profitAndLoss/useProfitAndLossGlobalInvalidator'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
-import { type JournalEntryReturn, JournalEntryReturnSchema, type UpsertJournalEntrySchema } from '@components/Journal/JournalEntryForm/journalEntryFormSchemas'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
+import { JournalEntryReturnSchema, type UpsertJournalEntrySchema } from '@components/Journal/JournalEntryForm/journalEntryFormSchemas'
 
 const UPSERT_JOURNAL_ENTRY_TAG_KEY = '#upsert-journal-entry'
 
@@ -20,23 +17,24 @@ export enum UpsertJournalEntryMode {
 
 type UpsertJournalEntryBody = typeof UpsertJournalEntrySchema.Encoded
 
-type UpsertJournalEntryReturn = JournalEntryReturn
-
 const createJournalEntry = post<
-  UpsertJournalEntryReturn,
+  typeof JournalEntryReturnSchema.Encoded,
   UpsertJournalEntryBody,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/ledger/journal-entries`)
 
-const buildKey = createBuildKey<{ businessId: string }>([UPSERT_JOURNAL_ENTRY_TAG_KEY])
+const useCreateJournalEntry = createMutationHook({
+  tags: [UPSERT_JOURNAL_ENTRY_TAG_KEY],
+  request: createJournalEntry,
+  schema: JournalEntryReturnSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseUpsertJournalEntryProps =
   | { mode: UpsertJournalEntryMode.Create }
   | { mode: UpsertJournalEntryMode.Update, journalEntryId: string }
 
 export const useUpsertJournalEntry = (props: UseUpsertJournalEntryProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
   const { mode } = props
   // For now, we only support create mode since the API doesn't have an update endpoint
   if (mode === UpsertJournalEntryMode.Update) {
@@ -49,25 +47,7 @@ export const useUpsertJournalEntry = (props: UseUpsertJournalEntryProps) => {
   const { invalidate: invalidateBalanceSheet } = useBalanceSheetGlobalCacheActions()
   const { invalidate: invalidateStatementOfCashFlow } = useStatementOfCashFlowGlobalCacheActions()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: body }: { arg: UpsertJournalEntryBody },
-    ) => {
-      return createJournalEntry(apiUrl, accessToken, {
-        params: { businessId },
-        body,
-      }).then(Schema.decodeUnknownPromise(JournalEntryReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
+  const rawMutationResponse = useCreateJournalEntry()
 
   const trigger = useCallback(
     async (body: UpsertJournalEntryBody) => {
@@ -89,7 +69,7 @@ export const useUpsertJournalEntry = (props: UseUpsertJournalEntryProps) => {
   return {
     trigger,
     data: rawMutationResponse.data,
-    isError: !!rawMutationResponse.error,
+    isError: rawMutationResponse.isError,
     isMutating: rawMutationResponse.isMutating,
   }
 }

--- a/src/hooks/api/businesses/[business-id]/ledger/journal-entries/useUpsertJournalEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/ledger/journal-entries/useUpsertJournalEntry.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 
 import { post } from '@utils/api/authenticatedHttp'
+import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useLedgerEntriesCacheActions } from '@hooks/api/businesses/[business-id]/ledger/entries/useListLedgerEntries'
 import { useBalanceSheetGlobalCacheActions } from '@hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet'
 import { useStatementOfCashFlowGlobalCacheActions } from '@hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow'
@@ -48,10 +49,11 @@ export const useUpsertJournalEntry = (props: UseUpsertJournalEntryProps) => {
   const { invalidate: invalidateStatementOfCashFlow } = useStatementOfCashFlowGlobalCacheActions()
 
   const rawMutationResponse = useCreateJournalEntry()
+  const { trigger: originalTrigger } = rawMutationResponse
 
-  const trigger = useCallback(
+  const stableProxiedTrigger = useCallback(
     async (body: UpsertJournalEntryBody) => {
-      const result = await rawMutationResponse.trigger(body)
+      const result = await originalTrigger(body)
 
       // Invalidate all relevant caches after successful journal entry creation
       void forceReloadLedgerEntries()
@@ -63,13 +65,8 @@ export const useUpsertJournalEntry = (props: UseUpsertJournalEntryProps) => {
 
       return result
     },
-    [rawMutationResponse, forceReloadLedgerEntries, debouncedInvalidateProfitAndLoss, invalidateBalanceSheet, invalidateStatementOfCashFlow],
+    [originalTrigger, forceReloadLedgerEntries, debouncedInvalidateProfitAndLoss, invalidateBalanceSheet, invalidateStatementOfCashFlow],
   )
 
-  return {
-    trigger,
-    data: rawMutationResponse.data,
-    isError: rawMutationResponse.isError,
-    isMutating: rawMutationResponse.isMutating,
-  }
+  return withStableTrigger(rawMutationResponse, stableProxiedTrigger)
 }

--- a/src/hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary.tsx
@@ -1,15 +1,12 @@
-import { Schema } from 'effect'
-
 import { type MileageSummary, MileageSummarySchema } from '@schemas/mileage'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const MILEAGE_SUMMARY_TAG_KEY = '#mileage-summary'
 
-const MileageSummaryResponseSchema = Schema.Struct({
-  data: MileageSummarySchema,
-})
+const MileageSummaryResponseSchema = UnwrappedDataResponseSchema(MileageSummarySchema)
 
 const getMileageSummary = get<
   typeof MileageSummaryResponseSchema.Encoded,
@@ -19,7 +16,7 @@ const getMileageSummary = get<
 export const useMileageSummary = createQueryHook({
   tags: [MILEAGE_SUMMARY_TAG_KEY],
   request: getMileageSummary,
-  schema: MileageSummaryResponseSchema.pipe(Schema.pluck('data')),
+  schema: MileageSummaryResponseSchema,
 })
 
 export const useMileageSummaryGlobalCacheActions = createResourceGlobalCacheActions<MileageSummary>(MILEAGE_SUMMARY_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary.tsx
@@ -1,40 +1,26 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
 
 import { type MileageSummary, MileageSummarySchema } from '@schemas/mileage'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const MILEAGE_SUMMARY_TAG_KEY = '#mileage-summary'
 
-const buildKey = createBuildKey<{ businessId: string }>([MILEAGE_SUMMARY_TAG_KEY])
+const MileageSummaryResponseSchema = Schema.Struct({
+  data: MileageSummarySchema,
+})
 
 const getMileageSummary = get<
-  { data: MileageSummary },
+  typeof MileageSummaryResponseSchema.Encoded,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/mileage/summary`)
 
-export function useMileageSummary() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    ({ accessToken, apiUrl, businessId }) => getMileageSummary(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-      },
-    )().then(({ data }) => Schema.decodeUnknownPromise(MileageSummarySchema)(data)),
-  )
-
-  return new SWRQueryResult(response)
-}
+export const useMileageSummary = createQueryHook({
+  tags: [MILEAGE_SUMMARY_TAG_KEY],
+  request: getMileageSummary,
+  schema: MileageSummaryResponseSchema,
+  select: ({ data }) => data,
+})
 
 export const useMileageSummaryGlobalCacheActions = createResourceGlobalCacheActions<MileageSummary>(MILEAGE_SUMMARY_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary.tsx
@@ -19,8 +19,7 @@ const getMileageSummary = get<
 export const useMileageSummary = createQueryHook({
   tags: [MILEAGE_SUMMARY_TAG_KEY],
   request: getMileageSummary,
-  schema: MileageSummaryResponseSchema,
-  select: ({ data }) => data,
+  schema: MileageSummaryResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export const useMileageSummaryGlobalCacheActions = createResourceGlobalCacheActions<MileageSummary>(MILEAGE_SUMMARY_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/mileage/trips/[trip-id]/useDeleteTrip.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/trips/[trip-id]/useDeleteTrip.tsx
@@ -1,53 +1,34 @@
 import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useMileageSummaryGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary'
 import { useTripsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/trips/useListTrips'
 import { useVehiclesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const DELETE_TRIP_TAG_KEY = '#delete-trip'
 
 const deleteTrip = del<
   Record<string, never>,
+  Record<string, never>,
   { businessId: string, tripId: string }
 >(({ businessId, tripId }) => `/v1/businesses/${businessId}/mileage/trips/${tripId}`)
 
-const buildKey = createBuildKey<{ businessId: string, tripId: string }>([DELETE_TRIP_TAG_KEY])
+const useDeleteTripMutation = createMutationHook({
+  tags: [DELETE_TRIP_TAG_KEY],
+  request: deleteTrip,
+  keyParams: ['tripId'],
+  argToBody: (_arg: never) => undefined,
+  swrOptions: { throwOnError: true },
+})
 
 type UseDeleteTripProps = {
   tripId: string
 }
 
 export const useDeleteTrip = ({ tripId }: UseDeleteTripProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      tripId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, tripId },
-    ) => {
-      return deleteTrip(
-        apiUrl,
-        accessToken,
-        { params: { businessId, tripId } },
-      )
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useDeleteTripMutation({ tripId })
 
   const { forceReload: forceReloadTrips } = useTripsGlobalCacheActions()
   const { forceReload: forceReloadVehicles } = useVehiclesGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/mileage/trips/useListTrips.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/trips/useListTrips.tsx
@@ -1,15 +1,8 @@
-import { Schema } from 'effect'
-import useSWRInfinite from 'swr/infinite'
-
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { type Trip, TripSchema } from '@schemas/trip'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
-import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createInfiniteQueryHook } from '@hooks/utils/swr/createInfiniteQueryHook'
 
 export const LIST_TRIPS_TAG_KEY = '#list-trips'
 
@@ -20,67 +13,35 @@ export type ListTripsFilterParams = {
   year?: number
 }
 
+type ListTripsParams = ListTripsFilterParams & {
+  businessId: string
+  cursor?: string
+  limit?: number
+}
+
 const ListTripsResponseSchema = PaginatedResponseSchema(TripSchema)
-type ListTripsResponse = typeof ListTripsResponseSchema.Type
 
-const keyLoader = createInfiniteKeyLoader<
-  ListTripsFilterParams & { businessId: string },
-  ListTripsResponse
->([LIST_TRIPS_TAG_KEY])
-
-const listTrips = get<
+const listTrips = getWithQuery<
   typeof ListTripsResponseSchema.Encoded,
-  { businessId: string, cursor?: string, limit?: number, query?: string, vehicleId?: string, purpose?: string, year?: number }
->(({ businessId, cursor, limit, query, vehicleId, purpose, year }) => {
-  const parameters = toDefinedSearchParameters({
+  ListTripsParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/mileage/trips`,
+  ({ cursor, limit, query, vehicleId, purpose, year }) => ({
     cursor,
     limit,
     q: query,
     vehicle_ids: vehicleId,
     purpose,
     year,
-  })
-  const baseUrl = `/v1/businesses/${businessId}/mileage/trips`
-  return parameters ? `${baseUrl}?${parameters}` : baseUrl
+  }),
+)
+
+export const useListTrips = createInfiniteQueryHook({
+  tags: [LIST_TRIPS_TAG_KEY],
+  request: listTrips,
+  schema: ListTripsResponseSchema,
+  keyDefaults: { limit: 200 },
 })
-
-export function useListTrips(filterParams: ListTripsFilterParams = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWRInfinite(
-    (_index, previousPageData: ListTripsResponse | null) => withLocale(keyLoader(
-      previousPageData,
-      {
-        ...auth,
-        businessId,
-        ...filterParams,
-      },
-    )),
-    ({ accessToken, apiUrl, businessId, cursor, query, vehicleId, purpose, year }) => listTrips(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          cursor,
-          limit: 200,
-          query,
-          vehicleId,
-          purpose,
-          year,
-        },
-      },
-    )().then(Schema.decodeUnknownPromise(ListTripsResponseSchema)),
-    {
-      keepPreviousData: true,
-      revalidateFirstPage: false,
-      initialSize: 1,
-    },
-  )
-
-  usePreserveInfiniteSize(swrResponse)
-
-  return useSWRInfiniteResult(swrResponse)
-}
 
 export const useTripsGlobalCacheActions = createInfiniteQueryGlobalCacheActions<Trip>(LIST_TRIPS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/mileage/trips/useUpsertTrip.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/trips/useUpsertTrip.tsx
@@ -28,7 +28,11 @@ const createTrip = post<UpsertTripReturnEncoded, UpsertTripBody>(
   ({ businessId }) => `/v1/businesses/${businessId}/mileage/trips`,
 )
 
-const updateTrip = patch<UpsertTripReturnEncoded, UpsertTripBody>(
+const updateTrip = patch<
+  UpsertTripReturnEncoded,
+  UpsertTripBody,
+  { businessId: string, tripId: string }
+>(
   ({ businessId, tripId }) => `/v1/businesses/${businessId}/mileage/trips/${tripId}`,
 )
 
@@ -37,31 +41,16 @@ export type UpdateParams = { readonly businessId: string, readonly tripId: strin
 
 export type UpsertParams = CreateParams | UpdateParams
 
-type UpsertTripParams = { businessId: string, tripId?: string }
-
-const upsertTrip = (
-  baseUrl: string,
-  accessToken: string | undefined,
-  options?: { params?: UpsertTripParams, body?: UpsertTripBody },
-): Promise<UpsertTripReturnEncoded> => {
-  const { params, body } = options ?? {}
-
-  if (params?.tripId !== undefined) {
-    return updateTrip(baseUrl, accessToken, {
-      params: { businessId: params.businessId, tripId: params.tripId },
-      body,
-    })
-  }
-
-  return createTrip(baseUrl, accessToken, {
-    params: { businessId: params?.businessId },
-    body,
-  })
-}
-
-const useUpsertTripMutation = createMutationHook({
+const useCreateTrip = createMutationHook({
   tags: [UPSERT_TRIP_TAG_KEY],
-  request: upsertTrip,
+  request: createTrip,
+  schema: UpsertTripReturnSchema,
+  swrOptions: { throwOnError: true },
+})
+
+const useUpdateTrip = createMutationHook({
+  tags: [UPSERT_TRIP_TAG_KEY],
+  request: updateTrip,
   keyParams: ['tripId'],
   schema: UpsertTripReturnSchema,
   swrOptions: { throwOnError: true },
@@ -75,7 +64,13 @@ export const useUpsertTrip = (props: UseUpsertTripProps) => {
   const { mode } = props
   const tripId = mode === UpsertTripMode.Update ? props.tripId : undefined
 
-  const mutationResponse = useUpsertTripMutation({ tripId })
+  const createResponse = useCreateTrip()
+  const updateResponse = useUpdateTrip({
+    tripId: tripId ?? '',
+    isEnabled: tripId !== undefined,
+  })
+
+  const mutationResponse = mode === UpsertTripMode.Create ? createResponse : updateResponse
 
   const { patchByKey: patchTripByKey, forceReload: forceReloadTrips } = useTripsGlobalCacheActions()
   const { forceReload: forceReloadVehicles } = useVehiclesGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/mileage/trips/useUpsertTrip.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/trips/useUpsertTrip.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { TripSchema, type UpsertTripEncoded } from '@schemas/trip'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useMileageSummaryGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary'
@@ -18,9 +18,7 @@ export enum UpsertTripMode {
 
 type UpsertTripBody = UpsertTripEncoded
 
-const UpsertTripReturnSchema = Schema.Struct({
-  data: TripSchema,
-})
+const UpsertTripReturnSchema = UnwrappedDataResponseSchema(TripSchema)
 
 type UpsertTripReturnEncoded = typeof UpsertTripReturnSchema.Encoded
 
@@ -83,7 +81,7 @@ export const useUpsertTrip = (props: UseUpsertTripProps) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
       if (mode === UpsertTripMode.Update) {
-        void patchTripByKey(triggerResult.data)
+        void patchTripByKey(triggerResult)
       }
       else {
         void forceReloadTrips()

--- a/src/hooks/api/businesses/[business-id]/mileage/trips/useUpsertTrip.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/trips/useUpsertTrip.tsx
@@ -1,16 +1,13 @@
 import { useCallback } from 'react'
-import { Effect, Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
+import { Schema } from 'effect'
 
 import { TripSchema, type UpsertTripEncoded } from '@schemas/trip'
 import { patch, post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useMileageSummaryGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/summary/useMileageSummary'
 import { useTripsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/trips/useListTrips'
 import { useVehiclesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPSERT_TRIP_TAG_KEY = '#upsert-trip'
 
@@ -21,120 +18,64 @@ export enum UpsertTripMode {
 
 type UpsertTripBody = UpsertTripEncoded
 
-const createTrip = post<
-  UpsertTripReturn,
-  UpsertTripBody,
-  { businessId: string }
->(({ businessId }) => `/v1/businesses/${businessId}/mileage/trips`)
-
-const updateTrip = patch<
-  UpsertTripReturn,
-  UpsertTripBody,
-  { businessId: string, tripId: string }
->(({ businessId, tripId }) => `/v1/businesses/${businessId}/mileage/trips/${tripId}`)
-
-const buildKey = createBuildKey<{ businessId: string, tripId?: string }>([UPSERT_TRIP_TAG_KEY])
-
 const UpsertTripReturnSchema = Schema.Struct({
   data: TripSchema,
 })
 
-type UpsertTripReturn = typeof UpsertTripReturnSchema.Type
+type UpsertTripReturnEncoded = typeof UpsertTripReturnSchema.Encoded
 
-const CreateParamsSchema = Schema.Struct({
-  businessId: Schema.String,
-})
+const createTrip = post<UpsertTripReturnEncoded, UpsertTripBody>(
+  ({ businessId }) => `/v1/businesses/${businessId}/mileage/trips`,
+)
 
-const UpdateParamsSchema = Schema.Struct({
-  businessId: Schema.String,
-  tripId: Schema.String,
-})
+const updateTrip = patch<UpsertTripReturnEncoded, UpsertTripBody>(
+  ({ businessId, tripId }) => `/v1/businesses/${businessId}/mileage/trips/${tripId}`,
+)
 
-export type CreateParams = typeof CreateParamsSchema.Type
-export type UpdateParams = typeof UpdateParamsSchema.Type
+export type CreateParams = { readonly businessId: string }
+export type UpdateParams = { readonly businessId: string, readonly tripId: string }
 
 export type UpsertParams = CreateParams | UpdateParams
 
-type RequestArgs = {
-  apiUrl: string
-  accessToken: string
-  body: UpsertTripBody
+type UpsertTripParams = { businessId: string, tripId?: string }
+
+const upsertTrip = (
+  baseUrl: string,
+  accessToken: string | undefined,
+  options?: { params?: UpsertTripParams, body?: UpsertTripBody },
+): Promise<UpsertTripReturnEncoded> => {
+  const { params, body } = options ?? {}
+
+  if (params?.tripId !== undefined) {
+    return updateTrip(baseUrl, accessToken, {
+      params: { businessId: params.businessId, tripId: params.tripId },
+      body,
+    })
+  }
+
+  return createTrip(baseUrl, accessToken, {
+    params: { businessId: params?.businessId },
+    body,
+  })
 }
 
-type UpsertRequestFn = (args: RequestArgs) => Promise<UpsertTripReturn>
-
-const isParamsValidForMode = <M extends UpsertTripMode>(
-  mode: M,
-  params: unknown,
-): params is M extends UpsertTripMode.Update ? UpdateParams : CreateParams => {
-  if (mode === UpsertTripMode.Update) {
-    return Effect.runSync(Effect.either(Schema.decodeUnknown(UpdateParamsSchema)(params)))._tag === 'Right'
-  }
-
-  if (mode === UpsertTripMode.Create) {
-    return Effect.runSync(Effect.either(Schema.decodeUnknown(CreateParamsSchema)(params)))._tag === 'Right'
-  }
-
-  return false
-}
-
-function getRequestFn(
-  mode: UpsertTripMode,
-  params: UpsertParams,
-): UpsertRequestFn {
-  if (mode === UpsertTripMode.Update) {
-    if (!isParamsValidForMode(UpsertTripMode.Update, params)) {
-      throw new Error('Invalid params for update mode')
-    }
-
-    return ({ apiUrl, accessToken, body }: { apiUrl: string, accessToken: string, body: UpsertTripBody }) =>
-      updateTrip(apiUrl, accessToken, { params, body })
-  }
-  else {
-    if (!isParamsValidForMode(UpsertTripMode.Create, params)) {
-      throw new Error('Invalid params for create mode')
-    }
-
-    return ({ apiUrl, accessToken, body }: { apiUrl: string, accessToken: string, body: UpsertTripBody }) =>
-      createTrip(apiUrl, accessToken, { params, body })
-  }
-}
+const useUpsertTripMutation = createMutationHook({
+  tags: [UPSERT_TRIP_TAG_KEY],
+  request: upsertTrip,
+  keyParams: ['tripId'],
+  schema: UpsertTripReturnSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseUpsertTripProps =
   | { mode: UpsertTripMode.Create }
   | { mode: UpsertTripMode.Update, tripId: string }
 
 export const useUpsertTrip = (props: UseUpsertTripProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
   const { mode } = props
   const tripId = mode === UpsertTripMode.Update ? props.tripId : undefined
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      tripId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, tripId },
-      { arg: body }: { arg: UpsertTripBody },
-    ) => {
-      const request = getRequestFn(mode, { businessId, tripId })
-
-      return request({
-        apiUrl,
-        accessToken,
-        body,
-      }).then(Schema.decodeUnknownPromise(UpsertTripReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useUpsertTripMutation({ tripId })
 
   const { patchByKey: patchTripByKey, forceReload: forceReloadTrips } = useTripsGlobalCacheActions()
   const { forceReload: forceReloadVehicles } = useVehiclesGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/reactivate/useReactivateVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/reactivate/useReactivateVehicle.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { VehicleSchema } from '@schemas/vehicle'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -9,9 +9,7 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const REACTIVATE_VEHICLE_TAG_KEY = '#reactivate-vehicle'
 
-const ReactivateVehicleReturnSchema = Schema.Struct({
-  data: VehicleSchema,
-})
+const ReactivateVehicleReturnSchema = UnwrappedDataResponseSchema(VehicleSchema)
 
 const reactivateVehicle = post<
   typeof ReactivateVehicleReturnSchema.Encoded,
@@ -43,7 +41,7 @@ export const useReactivateVehicle = ({ vehicleId }: UseReactivateVehicleProps) =
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
-      void patchVehicleByKey(triggerResult.data)
+      void patchVehicleByKey(triggerResult)
 
       return triggerResult
     },

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/reactivate/useReactivateVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/reactivate/useReactivateVehicle.tsx
@@ -1,14 +1,11 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { VehicleSchema } from '@schemas/vehicle'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useVehiclesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const REACTIVATE_VEHICLE_TAG_KEY = '#reactivate-vehicle'
 
@@ -16,45 +13,27 @@ const ReactivateVehicleReturnSchema = Schema.Struct({
   data: VehicleSchema,
 })
 
-type ReactivateVehicleReturn = typeof ReactivateVehicleReturnSchema.Type
-
 const reactivateVehicle = post<
-  ReactivateVehicleReturn,
-  never,
+  typeof ReactivateVehicleReturnSchema.Encoded,
+  Record<string, never>,
   { businessId: string, vehicleId: string }
 >(({ businessId, vehicleId }) => `/v1/businesses/${businessId}/mileage/vehicles/${vehicleId}/reactivate`)
 
-const buildKey = createBuildKey<{ businessId: string, vehicleId: string }>([REACTIVATE_VEHICLE_TAG_KEY])
+const useReactivateVehicleMutation = createMutationHook({
+  tags: [REACTIVATE_VEHICLE_TAG_KEY],
+  request: reactivateVehicle,
+  keyParams: ['vehicleId'],
+  argToBody: (_arg: never) => undefined,
+  schema: ReactivateVehicleReturnSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseReactivateVehicleProps = {
   vehicleId: string
 }
 
 export const useReactivateVehicle = ({ vehicleId }: UseReactivateVehicleProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      vehicleId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, vehicleId },
-    ) => {
-      return reactivateVehicle(
-        apiUrl,
-        accessToken,
-        { params: { businessId, vehicleId } },
-      ).then(Schema.decodeUnknownPromise(ReactivateVehicleReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useReactivateVehicleMutation({ vehicleId })
 
   const { patchByKey: patchVehicleByKey } = useVehiclesGlobalCacheActions()
 

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useArchiveVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useArchiveVehicle.tsx
@@ -1,14 +1,11 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { VehicleSchema } from '@schemas/vehicle'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useVehiclesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const ARCHIVE_VEHICLE_TAG_KEY = '#archive-vehicle'
 
@@ -16,45 +13,27 @@ const ArchiveVehicleReturnSchema = Schema.Struct({
   data: VehicleSchema,
 })
 
-type ArchiveVehicleReturn = typeof ArchiveVehicleReturnSchema.Type
-
 const archiveVehicle = post<
-  ArchiveVehicleReturn,
-  never,
+  typeof ArchiveVehicleReturnSchema.Encoded,
+  Record<string, never>,
   { businessId: string, vehicleId: string }
 >(({ businessId, vehicleId }) => `/v1/businesses/${businessId}/mileage/vehicles/${vehicleId}/archive`)
 
-const buildKey = createBuildKey<{ businessId: string, vehicleId: string }>([ARCHIVE_VEHICLE_TAG_KEY])
+const useArchiveVehicleMutation = createMutationHook({
+  tags: [ARCHIVE_VEHICLE_TAG_KEY],
+  request: archiveVehicle,
+  keyParams: ['vehicleId'],
+  argToBody: (_arg: never) => undefined,
+  schema: ArchiveVehicleReturnSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseArchiveVehicleProps = {
   vehicleId: string
 }
 
 export const useArchiveVehicle = ({ vehicleId }: UseArchiveVehicleProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      vehicleId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, vehicleId },
-    ) => {
-      return archiveVehicle(
-        apiUrl,
-        accessToken,
-        { params: { businessId, vehicleId } },
-      ).then(Schema.decodeUnknownPromise(ArchiveVehicleReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useArchiveVehicleMutation({ vehicleId })
 
   const { patchByKey: patchVehicleByKey } = useVehiclesGlobalCacheActions()
 

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useArchiveVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useArchiveVehicle.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { VehicleSchema } from '@schemas/vehicle'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -9,9 +9,7 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const ARCHIVE_VEHICLE_TAG_KEY = '#archive-vehicle'
 
-const ArchiveVehicleReturnSchema = Schema.Struct({
-  data: VehicleSchema,
-})
+const ArchiveVehicleReturnSchema = UnwrappedDataResponseSchema(VehicleSchema)
 
 const archiveVehicle = post<
   typeof ArchiveVehicleReturnSchema.Encoded,
@@ -43,7 +41,7 @@ export const useArchiveVehicle = ({ vehicleId }: UseArchiveVehicleProps) => {
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
-      void patchVehicleByKey(triggerResult.data)
+      void patchVehicleByKey(triggerResult)
 
       return triggerResult
     },

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useDeleteVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/[vehicle-id]/useDeleteVehicle.tsx
@@ -1,51 +1,32 @@
 import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useVehiclesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const DELETE_VEHICLE_TAG_KEY = '#delete-vehicle'
 
 const deleteVehicle = del<
   Record<string, never>,
+  Record<string, never>,
   { businessId: string, vehicleId: string }
 >(({ businessId, vehicleId }) => `/v1/businesses/${businessId}/mileage/vehicles/${vehicleId}`)
 
-const buildKey = createBuildKey<{ businessId: string, vehicleId: string }>([DELETE_VEHICLE_TAG_KEY])
+const useDeleteVehicleMutation = createMutationHook({
+  tags: [DELETE_VEHICLE_TAG_KEY],
+  request: deleteVehicle,
+  keyParams: ['vehicleId'],
+  argToBody: (_arg: never) => undefined,
+  swrOptions: { throwOnError: true },
+})
 
 type UseDeleteVehicleProps = {
   vehicleId: string
 }
 
 export const useDeleteVehicle = ({ vehicleId }: UseDeleteVehicleProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      vehicleId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, vehicleId },
-    ) => {
-      return deleteVehicle(
-        apiUrl,
-        accessToken,
-        { params: { businessId, vehicleId } },
-      )
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useDeleteVehicleMutation({ vehicleId })
 
   const { forceReload: forceReloadVehicles } = useVehiclesGlobalCacheActions()
 

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
@@ -27,8 +27,7 @@ export const VEHICLES_TAG_KEY = '#list-vehicles'
 export const useListVehicles = createQueryHook({
   tags: [VEHICLES_TAG_KEY],
   request: listVehicles,
-  schema: ListVehiclesResponseSchema,
-  select: ({ data }) => data,
+  schema: ListVehiclesResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export const useVehiclesGlobalCacheActions = createInfiniteQueryGlobalCacheActions<Vehicle>(VEHICLES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
@@ -32,12 +32,15 @@ export const useListVehicles = createQueryHook({
 
 const useVehiclesResourceCacheActions = createResourceGlobalCacheActions<ReadonlyArray<Vehicle>>(VEHICLES_TAG_KEY)
 
+const patchVehicleById = (updatedVehicle: Vehicle) =>
+  (vehicles?: ReadonlyArray<Vehicle>) =>
+    vehicles?.map(vehicle => vehicle.id === updatedVehicle.id ? updatedVehicle : vehicle)
+
 export function useVehiclesGlobalCacheActions() {
   const actions = useVehiclesResourceCacheActions()
 
   const patchByKey = useCallback(
-    (updatedVehicle: Vehicle) =>
-      actions.patchCache(vehicles => vehicles?.map(vehicle => vehicle.id === updatedVehicle.id ? updatedVehicle : vehicle)),
+    (updatedVehicle: Vehicle) => actions.patchCache(patchVehicleById(updatedVehicle)),
     [actions],
   )
 

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
@@ -1,5 +1,6 @@
 import { Schema } from 'effect'
 
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { type Vehicle, VehicleSchema } from '@schemas/vehicle'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
@@ -10,9 +11,7 @@ type ListVehiclesParams = {
   allowArchived?: boolean
 }
 
-const ListVehiclesResponseSchema = Schema.Struct({
-  data: Schema.Array(VehicleSchema),
-})
+const ListVehiclesResponseSchema = UnwrappedDataResponseSchema(Schema.Array(VehicleSchema))
 
 const listVehicles = getWithQuery<
   typeof ListVehiclesResponseSchema.Encoded,
@@ -27,7 +26,7 @@ export const VEHICLES_TAG_KEY = '#list-vehicles'
 export const useListVehicles = createQueryHook({
   tags: [VEHICLES_TAG_KEY],
   request: listVehicles,
-  schema: ListVehiclesResponseSchema.pipe(Schema.pluck('data')),
+  schema: ListVehiclesResponseSchema,
 })
 
 export const useVehiclesGlobalCacheActions = createInfiniteQueryGlobalCacheActions<Vehicle>(VEHICLES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
@@ -1,13 +1,9 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
 
 import { type Vehicle, VehicleSchema } from '@schemas/vehicle'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 type ListVehiclesParams = {
   businessId: string
@@ -18,50 +14,21 @@ const ListVehiclesResponseSchema = Schema.Struct({
   data: Schema.Array(VehicleSchema),
 })
 
-type ListVehiclesResponse = typeof ListVehiclesResponseSchema.Type
-type ListVehiclesResponseEncoded = typeof ListVehiclesResponseSchema.Encoded
-
-const listVehicles = get<
-  ListVehiclesResponseEncoded,
+const listVehicles = getWithQuery<
+  typeof ListVehiclesResponseSchema.Encoded,
   ListVehiclesParams
->(({ businessId, allowArchived }) => {
-  const parameters = toDefinedSearchParameters({ allowArchived })
-  return `/v1/businesses/${businessId}/mileage/vehicles?${parameters}`
-})
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/mileage/vehicles`,
+)
 
 export const VEHICLES_TAG_KEY = '#list-vehicles'
 
-const buildKey = createBuildKey<{ businessId: string, allowArchived?: boolean }>([VEHICLES_TAG_KEY])
-
-class ListVehiclesSWRResponse extends SWRQueryResult<ListVehiclesResponse> {
-  // @ts-expect-error override narrows return type to unwrap nested data
-  override get data() {
-    return this.swrResponse.data?.data
-  }
-}
-
-export function useListVehicles({ allowArchived }: { allowArchived?: boolean } = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      allowArchived,
-    })),
-    ({ accessToken, apiUrl, businessId, allowArchived }) => listVehicles(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          allowArchived,
-        },
-      },
-    )().then(Schema.decodeUnknownPromise(ListVehiclesResponseSchema)),
-  )
-
-  return new ListVehiclesSWRResponse(response)
-}
+export const useListVehicles = createQueryHook({
+  tags: [VEHICLES_TAG_KEY],
+  request: listVehicles,
+  schema: ListVehiclesResponseSchema,
+  select: ({ data }) => data,
+})
 
 export const useVehiclesGlobalCacheActions = createInfiniteQueryGlobalCacheActions<Vehicle>(VEHICLES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles.ts
@@ -1,9 +1,10 @@
+import { useCallback, useMemo } from 'react'
 import { Schema } from 'effect'
 
 import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { type Vehicle, VehicleSchema } from '@schemas/vehicle'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
+import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 type ListVehiclesParams = {
@@ -29,4 +30,19 @@ export const useListVehicles = createQueryHook({
   schema: ListVehiclesResponseSchema,
 })
 
-export const useVehiclesGlobalCacheActions = createInfiniteQueryGlobalCacheActions<Vehicle>(VEHICLES_TAG_KEY)
+const useVehiclesResourceCacheActions = createResourceGlobalCacheActions<ReadonlyArray<Vehicle>>(VEHICLES_TAG_KEY)
+
+export function useVehiclesGlobalCacheActions() {
+  const actions = useVehiclesResourceCacheActions()
+
+  const patchByKey = useCallback(
+    (updatedVehicle: Vehicle) =>
+      actions.patchCache(vehicles => vehicles?.map(vehicle => vehicle.id === updatedVehicle.id ? updatedVehicle : vehicle)),
+    [actions],
+  )
+
+  return useMemo(() => ({
+    ...actions,
+    patchByKey,
+  }), [actions, patchByKey])
+}

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/useUpsertVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/useUpsertVehicle.tsx
@@ -1,15 +1,12 @@
 import { useCallback } from 'react'
-import { Effect, Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
+import { Schema } from 'effect'
 
 import { type UpsertVehicleEncoded, VehicleSchema } from '@schemas/vehicle'
 import { patch, post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTripsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/trips/useListTrips'
 import { useVehiclesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/mileage/vehicles/useListVehicles'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPSERT_VEHICLE_TAG_KEY = '#upsert-vehicle'
 
@@ -20,120 +17,59 @@ export enum UpsertVehicleMode {
 
 type UpsertVehicleBody = UpsertVehicleEncoded
 
-const createVehicle = post<
-  UpsertVehicleReturn,
-  UpsertVehicleBody,
-  { businessId: string }
->(({ businessId }) => `/v1/businesses/${businessId}/mileage/vehicles`)
-
-const updateVehicle = patch<
-  UpsertVehicleReturn,
-  UpsertVehicleBody,
-  { businessId: string, vehicleId: string }
->(({ businessId, vehicleId }) => `/v1/businesses/${businessId}/mileage/vehicles/${vehicleId}`)
-
-const buildKey = createBuildKey<{ businessId: string, vehicleId?: string }>([UPSERT_VEHICLE_TAG_KEY])
-
 const UpsertVehicleReturnSchema = Schema.Struct({
   data: VehicleSchema,
 })
-type UpsertVehicleReturn = typeof UpsertVehicleReturnSchema.Type
 
-type RequestArgs = {
-  apiUrl: string
-  accessToken: string
-  body: UpsertVehicleBody
+type UpsertVehicleReturnEncoded = typeof UpsertVehicleReturnSchema.Encoded
+
+const createVehicle = post<UpsertVehicleReturnEncoded, UpsertVehicleBody>(
+  ({ businessId }) => `/v1/businesses/${businessId}/mileage/vehicles`,
+)
+
+const updateVehicle = patch<UpsertVehicleReturnEncoded, UpsertVehicleBody>(
+  ({ businessId, vehicleId }) => `/v1/businesses/${businessId}/mileage/vehicles/${vehicleId}`,
+)
+
+type UpsertVehicleParams = { businessId: string, vehicleId?: string }
+
+const upsertVehicle = (
+  baseUrl: string,
+  accessToken: string | undefined,
+  options?: { params?: UpsertVehicleParams, body?: UpsertVehicleBody },
+): Promise<UpsertVehicleReturnEncoded> => {
+  const { params, body } = options ?? {}
+
+  if (params?.vehicleId !== undefined) {
+    return updateVehicle(baseUrl, accessToken, {
+      params: { businessId: params.businessId, vehicleId: params.vehicleId },
+      body,
+    })
+  }
+
+  return createVehicle(baseUrl, accessToken, {
+    params: { businessId: params?.businessId },
+    body,
+  })
 }
 
-const CreateParamsSchema = Schema.Struct({
-  businessId: Schema.UUID,
-  vehicleId: Schema.Undefined,
+const useUpsertVehicleMutation = createMutationHook({
+  tags: [UPSERT_VEHICLE_TAG_KEY],
+  request: upsertVehicle,
+  keyParams: ['vehicleId'],
+  schema: UpsertVehicleReturnSchema,
+  swrOptions: { throwOnError: true },
 })
-
-const UpdateParamsSchema = Schema.Struct({
-  businessId: Schema.UUID,
-  vehicleId: Schema.UUID,
-})
-
-type CreateParams = typeof CreateParamsSchema.Type
-type UpdateParams = typeof UpdateParamsSchema.Type
-
-type UpsertParams = CreateParams | UpdateParams
-
-type UpsertRequestFn = (args: RequestArgs) => Promise<UpsertVehicleReturn>
-
-const isParamsValidForMode = <M extends UpsertVehicleMode>(
-  mode: M,
-  params: unknown,
-): params is M extends UpsertVehicleMode.Update ? UpdateParams : CreateParams => {
-  if (mode === UpsertVehicleMode.Update) {
-    return Effect.runSync(Effect.either(Schema.decodeUnknown(UpdateParamsSchema)(params)))._tag === 'Right'
-  }
-
-  if (mode === UpsertVehicleMode.Create) {
-    return Effect.runSync(Effect.either(Schema.decodeUnknown(CreateParamsSchema)(params)))._tag === 'Right'
-  }
-
-  return false
-}
-
-function getRequestFn(
-  mode: UpsertVehicleMode,
-  params: UpsertParams,
-): UpsertRequestFn {
-  if (mode === UpsertVehicleMode.Update) {
-    if (!isParamsValidForMode(UpsertVehicleMode.Update, params)) {
-      throw new Error('Invalid params for update mode')
-    }
-
-    return ({ apiUrl, accessToken, body }: { apiUrl: string, accessToken: string, body: UpsertVehicleBody }) =>
-      updateVehicle(apiUrl, accessToken, { params, body })
-  }
-  else {
-    if (!isParamsValidForMode(UpsertVehicleMode.Create, params)) {
-      throw new Error('Invalid params for create mode')
-    }
-
-    return ({ apiUrl, accessToken, body }: { apiUrl: string, accessToken: string, body: UpsertVehicleBody }) =>
-      createVehicle(apiUrl, accessToken, { params, body })
-  }
-}
 
 type UseUpsertVehicleProps =
   | { mode: UpsertVehicleMode.Create }
   | { mode: UpsertVehicleMode.Update, vehicleId: string }
 
 export const useUpsertVehicle = (props: UseUpsertVehicleProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
   const { mode } = props
   const vehicleId = mode === UpsertVehicleMode.Update ? props.vehicleId : undefined
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      vehicleId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, vehicleId },
-      { arg: body }: { arg: UpsertVehicleBody },
-    ) => {
-      const request = getRequestFn(mode, { businessId, vehicleId })
-
-      return request({
-        apiUrl,
-        accessToken,
-        body,
-      }).then(Schema.decodeUnknownPromise(UpsertVehicleReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useUpsertVehicleMutation({ vehicleId })
 
   const { patchByKey: patchVehicleByKey, forceReload: forceReloadVehicles } = useVehiclesGlobalCacheActions()
   const { forceReload: forceReloadTrips } = useTripsGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/useUpsertVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/useUpsertVehicle.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { type UpsertVehicleEncoded, VehicleSchema } from '@schemas/vehicle'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -17,9 +17,7 @@ export enum UpsertVehicleMode {
 
 type UpsertVehicleBody = UpsertVehicleEncoded
 
-const UpsertVehicleReturnSchema = Schema.Struct({
-  data: VehicleSchema,
-})
+const UpsertVehicleReturnSchema = UnwrappedDataResponseSchema(VehicleSchema)
 
 type UpsertVehicleReturnEncoded = typeof UpsertVehicleReturnSchema.Encoded
 
@@ -76,7 +74,7 @@ export const useUpsertVehicle = (props: UseUpsertVehicleProps) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
       if (mode === UpsertVehicleMode.Update) {
-        void patchVehicleByKey(triggerResult.data)
+        void patchVehicleByKey(triggerResult)
         void forceReloadTrips()
       }
       else {

--- a/src/hooks/api/businesses/[business-id]/mileage/vehicles/useUpsertVehicle.tsx
+++ b/src/hooks/api/businesses/[business-id]/mileage/vehicles/useUpsertVehicle.tsx
@@ -27,35 +27,24 @@ const createVehicle = post<UpsertVehicleReturnEncoded, UpsertVehicleBody>(
   ({ businessId }) => `/v1/businesses/${businessId}/mileage/vehicles`,
 )
 
-const updateVehicle = patch<UpsertVehicleReturnEncoded, UpsertVehicleBody>(
+const updateVehicle = patch<
+  UpsertVehicleReturnEncoded,
+  UpsertVehicleBody,
+  { businessId: string, vehicleId: string }
+>(
   ({ businessId, vehicleId }) => `/v1/businesses/${businessId}/mileage/vehicles/${vehicleId}`,
 )
 
-type UpsertVehicleParams = { businessId: string, vehicleId?: string }
-
-const upsertVehicle = (
-  baseUrl: string,
-  accessToken: string | undefined,
-  options?: { params?: UpsertVehicleParams, body?: UpsertVehicleBody },
-): Promise<UpsertVehicleReturnEncoded> => {
-  const { params, body } = options ?? {}
-
-  if (params?.vehicleId !== undefined) {
-    return updateVehicle(baseUrl, accessToken, {
-      params: { businessId: params.businessId, vehicleId: params.vehicleId },
-      body,
-    })
-  }
-
-  return createVehicle(baseUrl, accessToken, {
-    params: { businessId: params?.businessId },
-    body,
-  })
-}
-
-const useUpsertVehicleMutation = createMutationHook({
+const useCreateVehicle = createMutationHook({
   tags: [UPSERT_VEHICLE_TAG_KEY],
-  request: upsertVehicle,
+  request: createVehicle,
+  schema: UpsertVehicleReturnSchema,
+  swrOptions: { throwOnError: true },
+})
+
+const useUpdateVehicle = createMutationHook({
+  tags: [UPSERT_VEHICLE_TAG_KEY],
+  request: updateVehicle,
   keyParams: ['vehicleId'],
   schema: UpsertVehicleReturnSchema,
   swrOptions: { throwOnError: true },
@@ -69,7 +58,13 @@ export const useUpsertVehicle = (props: UseUpsertVehicleProps) => {
   const { mode } = props
   const vehicleId = mode === UpsertVehicleMode.Update ? props.vehicleId : undefined
 
-  const mutationResponse = useUpsertVehicleMutation({ vehicleId })
+  const createResponse = useCreateVehicle()
+  const updateResponse = useUpdateVehicle({
+    vehicleId: vehicleId ?? '',
+    isEnabled: vehicleId !== undefined,
+  })
+
+  const mutationResponse = mode === UpsertVehicleMode.Create ? createResponse : updateResponse
 
   const { patchByKey: patchVehicleByKey, forceReload: forceReloadVehicles } = useVehiclesGlobalCacheActions()
   const { forceReload: forceReloadTrips } = useTripsGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/plaid/hosted-link.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/hosted-link.ts
@@ -7,6 +7,7 @@ import {
 } from '@schemas/linkedAccounts/plaid'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
@@ -17,11 +18,16 @@ const PlaidHostedLinkStatusResponseSchema = Schema.Struct({
 })
 
 const getPlaidHostedLinkStatus = get<
-  { data: ApiPlaidHostedLinkStatus },
+  typeof PlaidHostedLinkStatusResponseSchema.Encoded,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/plaid/hosted-link`)
 
 const buildKey = createBuildKey<{ businessId: string }>([PLAID_HOSTED_LINK_TAG_KEY])
+
+const fetchPlaidHostedLinkStatus = createKeyedFetcher(
+  getPlaidHostedLinkStatus,
+  PlaidHostedLinkStatusResponseSchema,
+)
 
 export function usePlaidHostedLinkStatus(
   config?: SWRConfiguration<ApiPlaidHostedLinkStatus>,
@@ -31,10 +37,7 @@ export function usePlaidHostedLinkStatus(
 
   const swrResponse = useSWR(
     () => buildKey({ ...auth, businessId, isEnabled: enabled }),
-    ({ accessToken, apiUrl, businessId }) =>
-      getPlaidHostedLinkStatus(apiUrl, accessToken, { params: { businessId } })()
-        .then(Schema.decodeUnknownPromise(PlaidHostedLinkStatusResponseSchema))
-        .then(({ data }) => data),
+    key => fetchPlaidHostedLinkStatus(key).then(({ data }) => data),
     config,
   )
 

--- a/src/hooks/api/businesses/[business-id]/plaid/hosted-link.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/hosted-link.ts
@@ -1,15 +1,7 @@
-import useSWR, { type SWRConfiguration } from 'swr'
-
-import {
-  type ApiPlaidHostedLinkStatus,
-  ApiPlaidHostedLinkStatusSchema,
-} from '@schemas/linkedAccounts/plaid'
+import { ApiPlaidHostedLinkStatusSchema } from '@schemas/linkedAccounts/plaid'
 import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const PLAID_HOSTED_LINK_TAG_KEY = '#plaid-hosted-link'
 
@@ -22,24 +14,9 @@ const getPlaidHostedLinkStatus = get<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/plaid/hosted-link`)
 
-const buildKey = createBuildKey<{ businessId: string }>([PLAID_HOSTED_LINK_TAG_KEY])
-
-const fetchPlaidHostedLinkStatus = createKeyedFetcher(
-  getPlaidHostedLinkStatus,
-  PlaidHostedLinkStatusResponseSchema,
-)
-
-export function usePlaidHostedLinkStatus(
-  config?: SWRConfiguration<ApiPlaidHostedLinkStatus>,
-  enabled = false,
-) {
-  const { businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(
-    () => buildKey({ ...auth, businessId, isEnabled: enabled }),
-    key => fetchPlaidHostedLinkStatus(key),
-    config,
-  )
-
-  return new SWRQueryResult(swrResponse)
-}
+export const usePlaidHostedLinkStatus = createQueryHook({
+  tags: [PLAID_HOSTED_LINK_TAG_KEY],
+  request: getPlaidHostedLinkStatus,
+  schema: PlaidHostedLinkStatusResponseSchema,
+  isLocalized: false,
+})

--- a/src/hooks/api/businesses/[business-id]/plaid/hosted-link.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/hosted-link.ts
@@ -1,10 +1,10 @@
-import { Schema } from 'effect'
 import useSWR, { type SWRConfiguration } from 'swr'
 
 import {
   type ApiPlaidHostedLinkStatus,
   ApiPlaidHostedLinkStatusSchema,
 } from '@schemas/linkedAccounts/plaid'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
@@ -13,9 +13,9 @@ import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 export const PLAID_HOSTED_LINK_TAG_KEY = '#plaid-hosted-link'
 
-const PlaidHostedLinkStatusResponseSchema = Schema.Struct({
-  data: ApiPlaidHostedLinkStatusSchema,
-})
+const PlaidHostedLinkStatusResponseSchema = UnwrappedDataResponseSchema(
+  ApiPlaidHostedLinkStatusSchema,
+)
 
 const getPlaidHostedLinkStatus = get<
   typeof PlaidHostedLinkStatusResponseSchema.Encoded,
@@ -37,7 +37,7 @@ export function usePlaidHostedLinkStatus(
 
   const swrResponse = useSWR(
     () => buildKey({ ...auth, businessId, isEnabled: enabled }),
-    key => fetchPlaidHostedLinkStatus(key).then(({ data }) => data),
+    key => fetchPlaidHostedLinkStatus(key),
     config,
   )
 

--- a/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/sandbox-reset-item-login.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/sandbox-reset-item-login.ts
@@ -1,11 +1,5 @@
-import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
-
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const BREAK_PLAID_ITEM_CONNECTION_TAG_KEY = '#break-plaid-item-connection'
 
@@ -22,37 +16,9 @@ const breakPlaidItemConnection = post<
     `/v1/businesses/${businessId}/plaid/items/${plaidItemId}/sandbox-reset-item-login`,
 )
 
-const buildKey = createBuildKey<{ businessId: string }>([BREAK_PLAID_ITEM_CONNECTION_TAG_KEY])
-
-export function useBreakPlaidItemConnection() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { plaidItemId } }: { arg: { plaidItemId: string } },
-    ) => breakPlaidItemConnection(apiUrl, accessToken, {
-      params: { businessId, plaidItemId },
-    }),
-    {
-      revalidate: false,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
-
-  const { trigger: originalTrigger } = mutationResponse
-
-  const stableProxiedTrigger = useCallback(
-    (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters),
-    [originalTrigger],
-  )
-
-  return withStableTrigger(mutationResponse, stableProxiedTrigger)
-}
+export const useBreakPlaidItemConnection = createMutationHook({
+  tags: [BREAK_PLAID_ITEM_CONNECTION_TAG_KEY],
+  request: breakPlaidItemConnection,
+  argToParams: ({ plaidItemId }: { plaidItemId: string }) => ({ plaidItemId }),
+  argToBody: () => undefined,
+})

--- a/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/unlink.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/items/[plaid-item-id]/unlink.ts
@@ -1,9 +1,5 @@
-import useSWRMutation from 'swr/mutation'
-
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UNLINK_PLAID_ITEM_TAG_KEY = '#unlink-plaid-item'
 
@@ -16,27 +12,9 @@ const unlinkPlaidItem = post<
     `/v1/businesses/${businessId}/plaid/items/${plaidItemId}/unlink`,
 )
 
-const buildKey = createBuildKey<{ businessId: string }>([UNLINK_PLAID_ITEM_TAG_KEY])
-
-export function useUnlinkPlaidItem() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { plaidItemId } }: { arg: { plaidItemId: string } },
-    ) => unlinkPlaidItem(apiUrl, accessToken, {
-      params: { businessId, plaidItemId },
-    }),
-    {
-      revalidate: false,
-    },
-  )
-
-  return new SWRMutationResult(rawMutationResponse)
-}
+export const useUnlinkPlaidItem = createMutationHook({
+  tags: [UNLINK_PLAID_ITEM_TAG_KEY],
+  request: unlinkPlaidItem,
+  argToParams: ({ plaidItemId }: { plaidItemId: string }) => ({ plaidItemId }),
+  argToBody: () => undefined,
+})

--- a/src/hooks/api/businesses/[business-id]/plaid/link/exchange.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/link/exchange.ts
@@ -1,10 +1,6 @@
-import useSWRMutation from 'swr/mutation'
-
 import type { PublicToken } from '@internal-types/linkedAccounts'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const EXCHANGE_PLAID_PUBLIC_TOKEN_TAG_KEY = '#exchange-plaid-public-token'
 
@@ -14,32 +10,7 @@ const exchangePlaidPublicToken = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/plaid/link/exchange`)
 
-const buildKey = createBuildKey<{ businessId: string }>([EXCHANGE_PLAID_PUBLIC_TOKEN_TAG_KEY])
-
-export function useExchangePlaidPublicToken() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: body }: { arg: PublicToken },
-    ) => exchangePlaidPublicToken(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body,
-      },
-    ),
-    {
-      revalidate: false,
-    },
-  )
-
-  return new SWRMutationResult(rawMutationResponse)
-}
+export const useExchangePlaidPublicToken = createMutationHook({
+  tags: [EXCHANGE_PLAID_PUBLIC_TOKEN_TAG_KEY],
+  request: exchangePlaidPublicToken,
+})

--- a/src/hooks/api/businesses/[business-id]/plaid/link/index.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/link/index.ts
@@ -1,6 +1,4 @@
-import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import {
   ApiLinkTokenSchema,
@@ -9,62 +7,29 @@ import {
   encodeCreatePlaidLinkParams,
 } from '@schemas/linkedAccounts/plaid'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CREATE_PLAID_LINK_TAG_KEY = '#create-plaid-link'
 
-const CreatePlaidLinkReturnSchema = Schema.Struct({
-  data: ApiLinkTokenSchema,
-})
-type CreatePlaidLinkReturn = typeof CreatePlaidLinkReturnSchema.Type
+const CreatePlaidLinkResponseSchema = Schema.transform(
+  Schema.Struct({ data: ApiLinkTokenSchema }),
+  Schema.typeSchema(ApiLinkTokenSchema),
+  {
+    strict: true,
+    decode: ({ data }) => data,
+    encode: data => ({ data }),
+  },
+)
 
 const createPlaidLink = post<
-  CreatePlaidLinkReturn,
+  typeof CreatePlaidLinkResponseSchema.Encoded,
   CreatePlaidLinkParamsEncoded,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/plaid/link`)
 
-const buildKey = createBuildKey<{ businessId: string }>([CREATE_PLAID_LINK_TAG_KEY])
-
-export function useCreatePlaidLink() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: params }: { arg: CreatePlaidLinkParams },
-    ) => createPlaidLink(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body: encodeCreatePlaidLinkParams(params),
-      },
-    )
-      .then(Schema.decodeUnknownPromise(CreatePlaidLinkReturnSchema))
-      .then(({ data }) => data),
-    {
-      revalidate: false,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
-
-  const { trigger: originalTrigger } = mutationResponse
-
-  const stableProxiedTrigger = useCallback(
-    (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters),
-    [originalTrigger],
-  )
-
-  return withStableTrigger(mutationResponse, stableProxiedTrigger)
-}
+export const useCreatePlaidLink = createMutationHook({
+  tags: [CREATE_PLAID_LINK_TAG_KEY],
+  request: createPlaidLink,
+  argToBody: (params: CreatePlaidLinkParams) => encodeCreatePlaidLinkParams(params),
+  schema: CreatePlaidLinkResponseSchema,
+})

--- a/src/hooks/api/businesses/[business-id]/plaid/link/index.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/link/index.ts
@@ -1,25 +1,16 @@
-import { Schema } from 'effect'
-
 import {
   ApiLinkTokenSchema,
   type CreatePlaidLinkParams,
   type CreatePlaidLinkParamsEncoded,
   encodeCreatePlaidLinkParams,
 } from '@schemas/linkedAccounts/plaid'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CREATE_PLAID_LINK_TAG_KEY = '#create-plaid-link'
 
-const CreatePlaidLinkResponseSchema = Schema.transform(
-  Schema.Struct({ data: ApiLinkTokenSchema }),
-  Schema.typeSchema(ApiLinkTokenSchema),
-  {
-    strict: true,
-    decode: ({ data }) => data,
-    encode: data => ({ data }),
-  },
-)
+const CreatePlaidLinkResponseSchema = UnwrappedDataResponseSchema(ApiLinkTokenSchema)
 
 const createPlaidLink = post<
   typeof CreatePlaidLinkResponseSchema.Encoded,

--- a/src/hooks/api/businesses/[business-id]/plaid/update-mode-link.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/update-mode-link.ts
@@ -1,69 +1,34 @@
-import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { ApiLinkTokenSchema } from '@schemas/linkedAccounts/plaid'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { withStableTrigger } from '@utils/swr/withStableTrigger'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CREATE_PLAID_UPDATE_MODE_LINK_TAG_KEY = '#create-plaid-update-mode-link'
 
-const CreatePlaidUpdateModeLinkReturnSchema = Schema.Struct({
-  data: ApiLinkTokenSchema,
-})
-type CreatePlaidUpdateModeLinkReturn = typeof CreatePlaidUpdateModeLinkReturnSchema.Type
+const CreatePlaidUpdateModeLinkResponseSchema = Schema.transform(
+  Schema.Struct({ data: ApiLinkTokenSchema }),
+  Schema.typeSchema(ApiLinkTokenSchema),
+  {
+    strict: true,
+    decode: ({ data }) => data,
+    encode: data => ({ data }),
+  },
+)
 
 type CreatePlaidUpdateModeLinkBody = {
   plaid_item_id: string
 }
 
 const createPlaidUpdateModeLink = post<
-  CreatePlaidUpdateModeLinkReturn,
+  typeof CreatePlaidUpdateModeLinkResponseSchema.Encoded,
   CreatePlaidUpdateModeLinkBody,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/plaid/update-mode-link`)
 
-const buildKey = createBuildKey<{ businessId: string }>([CREATE_PLAID_UPDATE_MODE_LINK_TAG_KEY])
-
-export function useCreatePlaidUpdateModeLink() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      access_token: auth?.access_token,
-      apiUrl: auth?.apiUrl,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { plaidItemId } }: { arg: { plaidItemId: string } },
-    ) => createPlaidUpdateModeLink(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body: { plaid_item_id: plaidItemId },
-      },
-    )
-      .then(Schema.decodeUnknownPromise(CreatePlaidUpdateModeLinkReturnSchema))
-      .then(({ data }) => data),
-    {
-      revalidate: false,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
-
-  const { trigger: originalTrigger } = mutationResponse
-
-  const stableProxiedTrigger = useCallback(
-    (...triggerParameters: Parameters<typeof originalTrigger>) =>
-      originalTrigger(...triggerParameters),
-    [originalTrigger],
-  )
-
-  return withStableTrigger(mutationResponse, stableProxiedTrigger)
-}
+export const useCreatePlaidUpdateModeLink = createMutationHook({
+  tags: [CREATE_PLAID_UPDATE_MODE_LINK_TAG_KEY],
+  request: createPlaidUpdateModeLink,
+  argToBody: ({ plaidItemId }: { plaidItemId: string }) => ({ plaid_item_id: plaidItemId }),
+  schema: CreatePlaidUpdateModeLinkResponseSchema,
+})

--- a/src/hooks/api/businesses/[business-id]/plaid/update-mode-link.ts
+++ b/src/hooks/api/businesses/[business-id]/plaid/update-mode-link.ts
@@ -1,20 +1,11 @@
-import { Schema } from 'effect'
-
 import { ApiLinkTokenSchema } from '@schemas/linkedAccounts/plaid'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CREATE_PLAID_UPDATE_MODE_LINK_TAG_KEY = '#create-plaid-update-mode-link'
 
-const CreatePlaidUpdateModeLinkResponseSchema = Schema.transform(
-  Schema.Struct({ data: ApiLinkTokenSchema }),
-  Schema.typeSchema(ApiLinkTokenSchema),
-  {
-    strict: true,
-    decode: ({ data }) => data,
-    encode: data => ({ data }),
-  },
-)
+const CreatePlaidUpdateModeLinkResponseSchema = UnwrappedDataResponseSchema(ApiLinkTokenSchema)
 
 type CreatePlaidUpdateModeLinkBody = {
   plaid_item_id: string

--- a/src/hooks/api/businesses/[business-id]/reports/balance-sheet/exports/excel/useBalanceSheetDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/balance-sheet/exports/excel/useBalanceSheetDownload.ts
@@ -2,26 +2,25 @@ import useSWRMutation from 'swr/mutation'
 
 import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import type { GetBalanceSheetParams } from '@hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
-const getBalanceSheetExcel = get<
+const getBalanceSheetExcel = getWithQuery<
   { data: S3PresignedUrl },
   GetBalanceSheetParams
 >(
-  ({ businessId, effectiveDate }) => {
-    const parameters = toDefinedSearchParameters({ effectiveDate })
-
-    return `/v1/businesses/${businessId}/reports/balance-sheet/exports/excel?${parameters}`
-  },
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/reports/balance-sheet/exports/excel`,
 )
+
+const fetchBalanceSheetExcel = createKeyedFetcher(getBalanceSheetExcel)
 
 const DOWNLOAD_BALANCE_SHEET_TAG_KEY = '#download-balance-sheet'
 
-const buildKey = createBuildKey<{ businessId: string, effectiveDate: Date }>([DOWNLOAD_BALANCE_SHEET_TAG_KEY])
+const buildKey = createBuildKey<GetBalanceSheetParams>([DOWNLOAD_BALANCE_SHEET_TAG_KEY])
 
 type UseBalanceSheetOptions = {
   effectiveDate: Date
@@ -40,15 +39,7 @@ export function useBalanceSheetDownload({
       businessId,
       effectiveDate,
     })),
-    ({ accessToken, apiUrl, businessId, effectiveDate }) => getBalanceSheetExcel(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          effectiveDate,
-        },
-      })().then(({ data }) => {
+    key => fetchBalanceSheetExcel(key).then(({ data }) => {
       if (onSuccess) {
         return onSuccess(data)
       }

--- a/src/hooks/api/businesses/[business-id]/reports/balance-sheet/exports/excel/useBalanceSheetDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/balance-sheet/exports/excel/useBalanceSheetDownload.ts
@@ -1,6 +1,6 @@
 import type { S3PresignedUrl } from '@internal-types/general'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import type { MutationRequest } from '@utils/api/postAsQuery'
+import { getAsMutation } from '@utils/api/postAsQuery'
 import type { GetBalanceSheetParams } from '@hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
@@ -12,12 +12,7 @@ const getBalanceSheetExcel = getWithQuery<
   ({ businessId }) => `/v1/businesses/${businessId}/reports/balance-sheet/exports/excel`,
 )
 
-const requestBalanceSheetExcel: MutationRequest<
-  { data: S3PresignedUrl },
-  Record<string, unknown>,
-  GetBalanceSheetParams
-> = (baseUrl, accessToken, options) =>
-  getBalanceSheetExcel(baseUrl, accessToken, { params: options?.params })()
+const requestBalanceSheetExcel = getAsMutation(getBalanceSheetExcel)
 
 export const useBalanceSheetDownload = createMutationHook({
   tags: ['#download-balance-sheet'],

--- a/src/hooks/api/businesses/[business-id]/reports/balance-sheet/exports/excel/useBalanceSheetDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/balance-sheet/exports/excel/useBalanceSheetDownload.ts
@@ -1,12 +1,8 @@
-import useSWRMutation from 'swr/mutation'
-
 import type { S3PresignedUrl } from '@internal-types/general'
-import type { Awaitable } from '@internal-types/utility/promises'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
+import type { MutationRequest } from '@utils/api/postAsQuery'
 import type { GetBalanceSheetParams } from '@hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const getBalanceSheetExcel = getWithQuery<
   { data: S3PresignedUrl },
@@ -16,37 +12,18 @@ const getBalanceSheetExcel = getWithQuery<
   ({ businessId }) => `/v1/businesses/${businessId}/reports/balance-sheet/exports/excel`,
 )
 
-const fetchBalanceSheetExcel = createKeyedFetcher(getBalanceSheetExcel)
+const requestBalanceSheetExcel: MutationRequest<
+  { data: S3PresignedUrl },
+  Record<string, unknown>,
+  GetBalanceSheetParams
+> = (baseUrl, accessToken, options) =>
+  getBalanceSheetExcel(baseUrl, accessToken, { params: options?.params })()
 
-const DOWNLOAD_BALANCE_SHEET_TAG_KEY = '#download-balance-sheet'
-
-const buildKey = createBuildKey<GetBalanceSheetParams>([DOWNLOAD_BALANCE_SHEET_TAG_KEY])
-
-type UseBalanceSheetOptions = {
-  effectiveDate: Date
-  onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>
-}
-
-export function useBalanceSheetDownload({
-  effectiveDate,
-  onSuccess,
-}: UseBalanceSheetOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  return useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      effectiveDate,
-    })),
-    key => fetchBalanceSheetExcel(key).then(({ data }) => {
-      if (onSuccess) {
-        return onSuccess(data)
-      }
-    }),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
-}
+export const useBalanceSheetDownload = createMutationHook({
+  tags: ['#download-balance-sheet'],
+  request: requestBalanceSheetExcel,
+  keyParams: ['effectiveDate'],
+  argToBody: (_arg: undefined) => undefined,
+  select: ({ data }) => data,
+  swrOptions: { throwOnError: false },
+})

--- a/src/hooks/api/businesses/[business-id]/reports/balance-sheet/exports/excel/useBalanceSheetDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/balance-sheet/exports/excel/useBalanceSheetDownload.ts
@@ -1,6 +1,6 @@
 import type { S3PresignedUrl } from '@internal-types/general'
+import { getAsMutation } from '@utils/api/getAsMutation'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { getAsMutation } from '@utils/api/postAsQuery'
 import type { GetBalanceSheetParams } from '@hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 

--- a/src/hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet.ts
@@ -1,13 +1,9 @@
 import { endOfDay } from 'date-fns'
-import useSWR from 'swr'
 
 import type { BalanceSheet } from '@internal-types/balanceSheet'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export type GetBalanceSheetParams = {
   businessId: string
@@ -22,29 +18,20 @@ const getBalanceSheet = getWithQuery<
   ({ businessId }) => `/v1/businesses/${businessId}/reports/balance-sheet`,
 )
 
-const fetchBalanceSheet = createKeyedFetcher(getBalanceSheet)
-
 export const BALANCE_SHEET_TAG_KEY = '#balance-sheet'
 
-const buildKey = createBuildKey<GetBalanceSheetParams>([BALANCE_SHEET_TAG_KEY])
+const useBalanceSheetQuery = createQueryHook({
+  tags: [BALANCE_SHEET_TAG_KEY],
+  request: getBalanceSheet,
+  select: ({ data }) => data,
+})
 
 export function useBalanceSheet({
   effectiveDate = endOfDay(new Date()),
 }: {
   effectiveDate?: Date
 }) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      effectiveDate,
-    })),
-    key => fetchBalanceSheet(key).then(({ data }) => data),
-  )
-
-  return new SWRQueryResult(response)
+  return useBalanceSheetQuery({ effectiveDate })
 }
 
 export const useBalanceSheetGlobalCacheActions = createResourceGlobalCacheActions<BalanceSheet>(BALANCE_SHEET_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet.ts
@@ -1,5 +1,3 @@
-import { endOfDay } from 'date-fns'
-
 import type { BalanceSheet } from '@internal-types/balanceSheet'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
@@ -20,18 +18,10 @@ const getBalanceSheet = getWithQuery<
 
 export const BALANCE_SHEET_TAG_KEY = '#balance-sheet'
 
-const useBalanceSheetQuery = createQueryHook({
+export const useBalanceSheet = createQueryHook({
   tags: [BALANCE_SHEET_TAG_KEY],
   request: getBalanceSheet,
   select: ({ data }) => data,
 })
-
-export function useBalanceSheet({
-  effectiveDate = endOfDay(new Date()),
-}: {
-  effectiveDate?: Date
-}) {
-  return useBalanceSheetQuery({ effectiveDate })
-}
 
 export const useBalanceSheetGlobalCacheActions = createResourceGlobalCacheActions<BalanceSheet>(BALANCE_SHEET_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/balance-sheet/useBalanceSheet.ts
@@ -2,10 +2,10 @@ import { endOfDay } from 'date-fns'
 import useSWR from 'swr'
 
 import type { BalanceSheet } from '@internal-types/balanceSheet'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
@@ -14,20 +14,19 @@ export type GetBalanceSheetParams = {
   effectiveDate: Date
 }
 
-const getBalanceSheet = get<
+const getBalanceSheet = getWithQuery<
   { data: BalanceSheet },
   GetBalanceSheetParams
 >(
-  ({ businessId, effectiveDate }) => {
-    const parameters = toDefinedSearchParameters({ effectiveDate })
-
-    return `/v1/businesses/${businessId}/reports/balance-sheet?${parameters}`
-  },
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/reports/balance-sheet`,
 )
+
+const fetchBalanceSheet = createKeyedFetcher(getBalanceSheet)
 
 export const BALANCE_SHEET_TAG_KEY = '#balance-sheet'
 
-const buildKey = createBuildKey<{ businessId: string, effectiveDate: Date }>([BALANCE_SHEET_TAG_KEY])
+const buildKey = createBuildKey<GetBalanceSheetParams>([BALANCE_SHEET_TAG_KEY])
 
 export function useBalanceSheet({
   effectiveDate = endOfDay(new Date()),
@@ -42,16 +41,7 @@ export function useBalanceSheet({
       businessId,
       effectiveDate,
     })),
-    ({ accessToken, apiUrl, businessId, effectiveDate }) => getBalanceSheet(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          effectiveDate,
-        },
-      },
-    )().then(({ data }) => data),
+    key => fetchBalanceSheet(key).then(({ data }) => data),
   )
 
   return new SWRQueryResult(response)

--- a/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/exports/csv/useCashflowStatementDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/exports/csv/useCashflowStatementDownload.ts
@@ -1,6 +1,6 @@
 import type { S3PresignedUrl } from '@internal-types/general'
+import { getAsMutation } from '@utils/api/getAsMutation'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { getAsMutation } from '@utils/api/postAsQuery'
 import type { GetStatementOfCashFlowParams } from '@hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 

--- a/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/exports/csv/useCashflowStatementDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/exports/csv/useCashflowStatementDownload.ts
@@ -1,6 +1,6 @@
 import type { S3PresignedUrl } from '@internal-types/general'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import type { MutationRequest } from '@utils/api/postAsQuery'
+import { getAsMutation } from '@utils/api/postAsQuery'
 import type { GetStatementOfCashFlowParams } from '@hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
@@ -12,12 +12,7 @@ const getCashflowStatementCSV = getWithQuery<
   ({ businessId }) => `/v1/businesses/${businessId}/reports/cashflow-statement/exports/csv`,
 )
 
-const requestCashflowStatementCSV: MutationRequest<
-  { data: S3PresignedUrl },
-  Record<string, unknown>,
-  GetStatementOfCashFlowParams
-> = (baseUrl, accessToken, options) =>
-  getCashflowStatementCSV(baseUrl, accessToken, { params: options?.params })()
+const requestCashflowStatementCSV = getAsMutation(getCashflowStatementCSV)
 
 export const useCashflowStatementDownload = createMutationHook({
   tags: ['#download-cashflow-statement'],

--- a/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/exports/csv/useCashflowStatementDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/exports/csv/useCashflowStatementDownload.ts
@@ -2,26 +2,25 @@ import useSWRMutation from 'swr/mutation'
 
 import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import type { GetStatementOfCashFlowParams } from '@hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
-const getCashflowStatementCSV = get<
+const getCashflowStatementCSV = getWithQuery<
   { data: S3PresignedUrl },
   GetStatementOfCashFlowParams
 >(
-  ({ businessId, startDate, endDate }) => {
-    const parameters = toDefinedSearchParameters({ startDate, endDate })
-
-    return `/v1/businesses/${businessId}/reports/cashflow-statement/exports/csv?${parameters}`
-  },
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/reports/cashflow-statement/exports/csv`,
 )
+
+const fetchCashflowStatementCSV = createKeyedFetcher(getCashflowStatementCSV)
 
 const DOWNLOAD_CASHFLOW_STATEMENT_TAG_KEY = '#download-cashflow-statement'
 
-const buildKey = createBuildKey<{ businessId: string, startDate: Date, endDate: Date }>([DOWNLOAD_CASHFLOW_STATEMENT_TAG_KEY])
+const buildKey = createBuildKey<GetStatementOfCashFlowParams>([DOWNLOAD_CASHFLOW_STATEMENT_TAG_KEY])
 
 type UseCashflowStatementDownloadOptions = {
   startDate: Date
@@ -43,16 +42,7 @@ export function useCashflowStatementDownload({
       startDate,
       endDate,
     })),
-    ({ accessToken, apiUrl, businessId, startDate, endDate }) => getCashflowStatementCSV(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          startDate,
-          endDate,
-        },
-      })().then(({ data }) => {
+    key => fetchCashflowStatementCSV(key).then(({ data }) => {
       if (onSuccess) {
         return onSuccess(data)
       }

--- a/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/exports/csv/useCashflowStatementDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/exports/csv/useCashflowStatementDownload.ts
@@ -1,12 +1,8 @@
-import useSWRMutation from 'swr/mutation'
-
 import type { S3PresignedUrl } from '@internal-types/general'
-import type { Awaitable } from '@internal-types/utility/promises'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
+import type { MutationRequest } from '@utils/api/postAsQuery'
 import type { GetStatementOfCashFlowParams } from '@hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const getCashflowStatementCSV = getWithQuery<
   { data: S3PresignedUrl },
@@ -16,40 +12,18 @@ const getCashflowStatementCSV = getWithQuery<
   ({ businessId }) => `/v1/businesses/${businessId}/reports/cashflow-statement/exports/csv`,
 )
 
-const fetchCashflowStatementCSV = createKeyedFetcher(getCashflowStatementCSV)
+const requestCashflowStatementCSV: MutationRequest<
+  { data: S3PresignedUrl },
+  Record<string, unknown>,
+  GetStatementOfCashFlowParams
+> = (baseUrl, accessToken, options) =>
+  getCashflowStatementCSV(baseUrl, accessToken, { params: options?.params })()
 
-const DOWNLOAD_CASHFLOW_STATEMENT_TAG_KEY = '#download-cashflow-statement'
-
-const buildKey = createBuildKey<GetStatementOfCashFlowParams>([DOWNLOAD_CASHFLOW_STATEMENT_TAG_KEY])
-
-type UseCashflowStatementDownloadOptions = {
-  startDate: Date
-  endDate: Date
-  onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>
-}
-
-export function useCashflowStatementDownload({
-  startDate,
-  endDate,
-  onSuccess,
-}: UseCashflowStatementDownloadOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  return useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      startDate,
-      endDate,
-    })),
-    key => fetchCashflowStatementCSV(key).then(({ data }) => {
-      if (onSuccess) {
-        return onSuccess(data)
-      }
-    }),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
-}
+export const useCashflowStatementDownload = createMutationHook({
+  tags: ['#download-cashflow-statement'],
+  request: requestCashflowStatementCSV,
+  keyParams: ['startDate', 'endDate'],
+  argToBody: (_arg: undefined) => undefined,
+  select: ({ data }) => data,
+  swrOptions: { throwOnError: false },
+})

--- a/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow.tsx
@@ -2,10 +2,10 @@ import { endOfMonth, startOfMonth } from 'date-fns'
 import useSWR from 'swr'
 
 import type { StatementOfCashFlow } from '@internal-types/statementOfCashFlow'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
@@ -15,20 +15,19 @@ export type GetStatementOfCashFlowParams = {
   endDate: Date
 }
 
-const getStatementOfCashFlow = get<
+const getStatementOfCashFlow = getWithQuery<
   { data: StatementOfCashFlow },
   GetStatementOfCashFlowParams
 >(
-  ({ businessId, startDate, endDate }) => {
-    const parameters = toDefinedSearchParameters({ startDate, endDate })
-
-    return `/v1/businesses/${businessId}/reports/cashflow-statement?${parameters}`
-  },
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/reports/cashflow-statement`,
 )
+
+const fetchStatementOfCashFlow = createKeyedFetcher(getStatementOfCashFlow)
 
 export const STATEMENT_OF_CASH_FLOW_TAG_KEY = '#statement-of-cash-flow'
 
-const buildKey = createBuildKey<{ businessId: string, startDate: Date, endDate: Date }>([STATEMENT_OF_CASH_FLOW_TAG_KEY])
+const buildKey = createBuildKey<GetStatementOfCashFlowParams>([STATEMENT_OF_CASH_FLOW_TAG_KEY])
 
 export function useStatementOfCashFlow({
   startDate = startOfMonth(new Date()),
@@ -46,16 +45,7 @@ export function useStatementOfCashFlow({
       startDate,
       endDate,
     })),
-    ({ apiUrl, accessToken, startDate, endDate }) => getStatementOfCashFlow(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          startDate,
-          endDate,
-        },
-      })().then(({ data }) => data),
+    key => fetchStatementOfCashFlow(key).then(({ data }) => data),
   )
 
   return new SWRQueryResult(response)

--- a/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow.tsx
@@ -1,5 +1,3 @@
-import { endOfMonth, startOfMonth } from 'date-fns'
-
 import type { StatementOfCashFlow } from '@internal-types/statementOfCashFlow'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
@@ -21,20 +19,10 @@ const getStatementOfCashFlow = getWithQuery<
 
 export const STATEMENT_OF_CASH_FLOW_TAG_KEY = '#statement-of-cash-flow'
 
-const useStatementOfCashFlowQuery = createQueryHook({
+export const useStatementOfCashFlow = createQueryHook({
   tags: [STATEMENT_OF_CASH_FLOW_TAG_KEY],
   request: getStatementOfCashFlow,
   select: ({ data }) => data,
 })
-
-export function useStatementOfCashFlow({
-  startDate = startOfMonth(new Date()),
-  endDate = endOfMonth(new Date()),
-}: {
-  startDate?: Date
-  endDate?: Date
-}) {
-  return useStatementOfCashFlowQuery({ startDate, endDate })
-}
 
 export const useStatementOfCashFlowGlobalCacheActions = createResourceGlobalCacheActions<StatementOfCashFlow>(STATEMENT_OF_CASH_FLOW_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/cashflow-statement/useStatementOfCashFlow.tsx
@@ -1,13 +1,9 @@
 import { endOfMonth, startOfMonth } from 'date-fns'
-import useSWR from 'swr'
 
 import type { StatementOfCashFlow } from '@internal-types/statementOfCashFlow'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export type GetStatementOfCashFlowParams = {
   businessId: string
@@ -23,11 +19,13 @@ const getStatementOfCashFlow = getWithQuery<
   ({ businessId }) => `/v1/businesses/${businessId}/reports/cashflow-statement`,
 )
 
-const fetchStatementOfCashFlow = createKeyedFetcher(getStatementOfCashFlow)
-
 export const STATEMENT_OF_CASH_FLOW_TAG_KEY = '#statement-of-cash-flow'
 
-const buildKey = createBuildKey<GetStatementOfCashFlowParams>([STATEMENT_OF_CASH_FLOW_TAG_KEY])
+const useStatementOfCashFlowQuery = createQueryHook({
+  tags: [STATEMENT_OF_CASH_FLOW_TAG_KEY],
+  request: getStatementOfCashFlow,
+  select: ({ data }) => data,
+})
 
 export function useStatementOfCashFlow({
   startDate = startOfMonth(new Date()),
@@ -36,19 +34,7 @@ export function useStatementOfCashFlow({
   startDate?: Date
   endDate?: Date
 }) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    withLocale(buildKey({
-      ...auth,
-      businessId,
-      startDate,
-      endDate,
-    })),
-    key => fetchStatementOfCashFlow(key).then(({ data }) => data),
-  )
-
-  return new SWRQueryResult(response)
+  return useStatementOfCashFlowQuery({ startDate, endDate })
 }
 
 export const useStatementOfCashFlowGlobalCacheActions = createResourceGlobalCacheActions<StatementOfCashFlow>(STATEMENT_OF_CASH_FLOW_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
@@ -1,3 +1,5 @@
+import { Schema } from 'effect'
+
 import { ReportConfigResponseSchema } from '@schemas/reports/reportConfig'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
@@ -19,6 +21,5 @@ const getReportConfig = getWithQuery<
 export const useReportConfig = createQueryHook({
   tags: [REPORT_CONFIG_TAG_KEY],
   request: getReportConfig,
-  schema: ReportConfigResponseSchema,
-  select: ({ data }) => data,
+  schema: ReportConfigResponseSchema.pipe(Schema.pluck('data')),
 })

--- a/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
@@ -1,5 +1,3 @@
-import { Schema } from 'effect'
-
 import { ReportConfigResponseSchema } from '@schemas/reports/reportConfig'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
@@ -21,5 +19,5 @@ const getReportConfig = getWithQuery<
 export const useReportConfig = createQueryHook({
   tags: [REPORT_CONFIG_TAG_KEY],
   request: getReportConfig,
-  schema: ReportConfigResponseSchema.pipe(Schema.pluck('data')),
+  schema: ReportConfigResponseSchema,
 })

--- a/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/config/useReportConfig.ts
@@ -1,11 +1,6 @@
-import { Schema } from 'effect'
-import useSWR from 'swr'
-
-import { type ReportConfigResponse, ReportConfigResponseSchema } from '@schemas/reports/reportConfig'
-import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { ReportConfigResponseSchema } from '@schemas/reports/reportConfig'
+import { getWithQuery } from '@utils/api/getWithQuery'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const REPORT_CONFIG_TAG_KEY = '#report-config'
 
@@ -13,34 +8,17 @@ type GetReportConfigParams = {
   businessId: string
 }
 
-const getReportConfig = get<ReportConfigResponse, GetReportConfigParams>(
+const getReportConfig = getWithQuery<
+  typeof ReportConfigResponseSchema.Encoded,
+  GetReportConfigParams
+>(
+  ['businessId'],
   ({ businessId }) => `/v1/businesses/${businessId}/reports/config`,
 )
 
-const buildKey = createBuildKey<{ businessId: string }>([REPORT_CONFIG_TAG_KEY])
-
-export function useReportConfig() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    async ({ accessToken, apiUrl, businessId }) => {
-      return getReportConfig(
-        apiUrl,
-        accessToken,
-        {
-          params: {
-            businessId,
-          },
-        },
-      )()
-        .then(Schema.decodeUnknownPromise(ReportConfigResponseSchema))
-        .then(({ data }) => data)
-    },
-  )
-
-  return new SWRQueryResult(swrResponse)
-}
+export const useReportConfig = createQueryHook({
+  tags: [REPORT_CONFIG_TAG_KEY],
+  request: getReportConfig,
+  schema: ReportConfigResponseSchema,
+  select: ({ data }) => data,
+})

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
@@ -45,7 +45,7 @@ const requestProfitAndLossComparison: MutationRequest<
   },
 )
 
-const useProfitAndLossComparisonReportQuery = createQueryHook({
+export const useProfitAndLossComparisonReport = createQueryHook({
   tags: [PNL_COMPARISON_REPORT_TAG_KEY],
   request: postAsQuery(
     requestProfitAndLossComparison,
@@ -58,20 +58,5 @@ const useProfitAndLossComparisonReportQuery = createQueryHook({
   schema: ProfitAndLossComparisonResponseSchema,
   select: ({ data }) => data,
 })
-
-type UseProfitAndLossComparisonReportProps = Omit<ProfitAndLossComparisonRequestParams, 'businessId'>
-
-export function useProfitAndLossComparisonReport({
-  periods,
-  tagFilters,
-  reportingBasis,
-}: UseProfitAndLossComparisonReportProps) {
-  return useProfitAndLossComparisonReportQuery({
-    periods,
-    tagFilters,
-    reportingBasis,
-    isEnabled: Boolean(periods),
-  })
-}
 
 export const useProfitAndLossComparisonReportCacheActions = createResourceGlobalCacheActions<ProfitAndLossComparison>(PNL_COMPARISON_REPORT_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
@@ -1,5 +1,3 @@
-import { Schema } from 'effect'
-
 import { type ReportingBasis } from '@internal-types/general'
 import { type ProfitAndLossComparison, type ProfitAndLossComparisonRequestBody } from '@internal-types/profitAndLoss'
 import { post } from '@utils/api/authenticatedHttp'
@@ -16,16 +14,12 @@ type ProfitAndLossComparisonRequestParams = {
   reportingBasis?: ReportingBasis
 }
 
-const ProfitAndLossComparisonFromSelf = Schema.declare(
-  (input: unknown): input is ProfitAndLossComparison => typeof input === 'object' && input !== null,
-)
-
-const ProfitAndLossComparisonResponseSchema = Schema.Struct({
-  data: Schema.optional(ProfitAndLossComparisonFromSelf),
-})
+type ProfitAndLossComparisonResponse = {
+  data: ProfitAndLossComparison
+}
 
 const compareProfitAndLoss = post<
-  typeof ProfitAndLossComparisonResponseSchema.Encoded,
+  ProfitAndLossComparisonResponse,
   ProfitAndLossComparisonRequestBody
 >(
   ({ businessId }) =>
@@ -33,7 +27,7 @@ const compareProfitAndLoss = post<
 )
 
 const requestProfitAndLossComparison: MutationRequest<
-  typeof ProfitAndLossComparisonResponseSchema.Encoded,
+  ProfitAndLossComparisonResponse,
   ProfitAndLossComparisonRequestBody,
   ProfitAndLossComparisonRequestParams
 > = (baseUrl, accessToken, options) => compareProfitAndLoss(
@@ -55,7 +49,7 @@ export const useProfitAndLossComparisonReport = createQueryHook({
       reporting_basis: reportingBasis,
     }),
   ),
-  schema: ProfitAndLossComparisonResponseSchema.pipe(Schema.pluck('data')),
+  select: ({ data }: ProfitAndLossComparisonResponse) => data,
 })
 
 export const useProfitAndLossComparisonReportCacheActions = createResourceGlobalCacheActions<ProfitAndLossComparison>(PNL_COMPARISON_REPORT_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
@@ -1,12 +1,11 @@
-import useSWR from 'swr'
+import { Schema } from 'effect'
 
 import { type ReportingBasis } from '@internal-types/general'
 import { type ProfitAndLossComparison, type ProfitAndLossComparisonRequestBody } from '@internal-types/profitAndLoss'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
+import { type MutationRequest, postAsQuery } from '@utils/api/postAsQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const PNL_COMPARISON_REPORT_TAG_KEY = '#profit-and-loss-comparison-report'
 
@@ -17,15 +16,48 @@ type ProfitAndLossComparisonRequestParams = {
   reportingBasis?: ReportingBasis
 }
 
-const buildKey = createBuildKey<ProfitAndLossComparisonRequestParams>([PNL_COMPARISON_REPORT_TAG_KEY])
+const ProfitAndLossComparisonFromSelf = Schema.declare(
+  (input: unknown): input is ProfitAndLossComparison => typeof input === 'object' && input !== null,
+)
+
+const ProfitAndLossComparisonResponseSchema = Schema.Struct({
+  data: Schema.optional(ProfitAndLossComparisonFromSelf),
+})
 
 const compareProfitAndLoss = post<
-  { data?: ProfitAndLossComparison },
+  typeof ProfitAndLossComparisonResponseSchema.Encoded,
   ProfitAndLossComparisonRequestBody
 >(
   ({ businessId }) =>
     `/v1/businesses/${businessId}/reports/profit-and-loss-comparison`,
 )
+
+const requestProfitAndLossComparison: MutationRequest<
+  typeof ProfitAndLossComparisonResponseSchema.Encoded,
+  ProfitAndLossComparisonRequestBody,
+  ProfitAndLossComparisonRequestParams
+> = (baseUrl, accessToken, options) => compareProfitAndLoss(
+  baseUrl,
+  accessToken,
+  {
+    params: options?.params && { businessId: options.params.businessId },
+    body: options?.body,
+  },
+)
+
+const useProfitAndLossComparisonReportQuery = createQueryHook({
+  tags: [PNL_COMPARISON_REPORT_TAG_KEY],
+  request: postAsQuery(
+    requestProfitAndLossComparison,
+    ({ periods, tagFilters, reportingBasis }) => ({
+      periods: periods!,
+      tag_filters: tagFilters,
+      reporting_basis: reportingBasis,
+    }),
+  ),
+  schema: ProfitAndLossComparisonResponseSchema,
+  select: ({ data }) => data,
+})
 
 type UseProfitAndLossComparisonReportProps = Omit<ProfitAndLossComparisonRequestParams, 'businessId'>
 
@@ -34,32 +66,12 @@ export function useProfitAndLossComparisonReport({
   tagFilters,
   reportingBasis,
 }: UseProfitAndLossComparisonReportProps) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      periods,
-      tagFilters,
-      reportingBasis,
-      isEnabled: Boolean(periods),
-    })),
-    ({ accessToken, apiUrl, businessId }) => compareProfitAndLoss(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body: {
-          periods: periods!,
-          tag_filters: tagFilters,
-          reporting_basis: reportingBasis,
-        },
-      },
-    ).then(({ data }) => data),
-  )
-
-  return new SWRQueryResult(response)
+  return useProfitAndLossComparisonReportQuery({
+    periods,
+    tagFilters,
+    reportingBasis,
+    isEnabled: Boolean(periods),
+  })
 }
 
 export const useProfitAndLossComparisonReportCacheActions = createResourceGlobalCacheActions<ProfitAndLossComparison>(PNL_COMPARISON_REPORT_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
@@ -55,8 +55,7 @@ export const useProfitAndLossComparisonReport = createQueryHook({
       reporting_basis: reportingBasis,
     }),
   ),
-  schema: ProfitAndLossComparisonResponseSchema,
-  select: ({ data }) => data,
+  schema: ProfitAndLossComparisonResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export const useProfitAndLossComparisonReportCacheActions = createResourceGlobalCacheActions<ProfitAndLossComparison>(PNL_COMPARISON_REPORT_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-comparison/useProfitAndLossComparisonReport.tsx
@@ -1,7 +1,7 @@
 import { type ReportingBasis } from '@internal-types/general'
 import { type ProfitAndLossComparison, type ProfitAndLossComparisonRequestBody } from '@internal-types/profitAndLoss'
 import { post } from '@utils/api/authenticatedHttp'
-import { type MutationRequest, postAsQuery } from '@utils/api/postAsQuery'
+import { type MutationRequest, postAsQuery } from '@utils/api/getAsMutation'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-summaries/useProfitAndLossSummaries.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-summaries/useProfitAndLossSummaries.tsx
@@ -2,10 +2,10 @@ import { Schema } from 'effect'
 import useSWR from 'swr'
 
 import { type ProfitAndLossSummaries, type ProfitAndLossSummariesRequestParams, ProfitAndLossSummariesSchema } from '@schemas/reports/profitAndLoss'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
@@ -13,36 +13,26 @@ export const PNL_SUMMARIES_TAG_KEY = '#profit-and-loss-summaries'
 
 const buildKey = createBuildKey<ProfitAndLossSummariesRequestParams>([PNL_SUMMARIES_TAG_KEY])
 
-const getProfitAndLossSummaries = get<
-  { data: ProfitAndLossSummaries },
+const ProfitAndLossSummariesResponseSchema = Schema.Struct({
+  data: ProfitAndLossSummariesSchema,
+})
+
+const getProfitAndLossSummaries = getWithQuery<
+  typeof ProfitAndLossSummariesResponseSchema.Encoded,
   ProfitAndLossSummariesRequestParams
 >(
-  ({
-    businessId,
-    startYear,
-    startMonth,
-    endYear,
-    endMonth,
-    tagKey,
-    tagValues,
-    reportingBasis,
-  }) => {
-    const parameters = toDefinedSearchParameters({ startYear, startMonth, endYear, endMonth, tagKey, tagValues, reportingBasis })
-    return `/v1/businesses/${businessId}/reports/profit-and-loss-summaries?${parameters}`
-  })
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/reports/profit-and-loss-summaries`,
+)
+
+const fetchProfitAndLossSummaries = createKeyedFetcher(getProfitAndLossSummaries, ProfitAndLossSummariesResponseSchema)
 
 type UseProfitAndLossSummariesProps = Omit<ProfitAndLossSummariesRequestParams, 'businessId'> & {
   keepPreviousData?: boolean
 }
 export function useProfitAndLossSummaries({
-  startYear,
-  startMonth,
-  endYear,
-  endMonth,
-  tagKey,
-  tagValues,
-  reportingBasis,
   keepPreviousData,
+  ...params
 }: UseProfitAndLossSummariesProps) {
   const { withLocale, businessId, auth } = useBuildKeyInputs()
 
@@ -50,21 +40,9 @@ export function useProfitAndLossSummaries({
     () => withLocale(buildKey({
       ...auth,
       businessId,
-      startYear,
-      startMonth,
-      endYear,
-      endMonth,
-      tagKey,
-      tagValues,
-      reportingBasis,
+      ...params,
     })),
-    ({ accessToken, apiUrl, businessId }) => getProfitAndLossSummaries(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, startYear, startMonth, endYear, endMonth, tagKey, tagValues, reportingBasis },
-      },
-    )().then(({ data }) => Schema.decodeUnknownPromise(ProfitAndLossSummariesSchema)(data)),
+    key => fetchProfitAndLossSummaries(key).then(({ data }) => data),
     { keepPreviousData },
   )
 

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-summaries/useProfitAndLossSummaries.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-summaries/useProfitAndLossSummaries.tsx
@@ -1,17 +1,10 @@
-import useSWR from 'swr'
-
 import { type ProfitAndLossSummaries, type ProfitAndLossSummariesRequestParams, ProfitAndLossSummariesSchema } from '@schemas/reports/profitAndLoss'
 import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const PNL_SUMMARIES_TAG_KEY = '#profit-and-loss-summaries'
-
-const buildKey = createBuildKey<ProfitAndLossSummariesRequestParams>([PNL_SUMMARIES_TAG_KEY])
 
 const ProfitAndLossSummariesResponseSchema = UnwrappedDataResponseSchema(ProfitAndLossSummariesSchema)
 
@@ -23,28 +16,10 @@ const getProfitAndLossSummaries = getWithQuery<
   ({ businessId }) => `/v1/businesses/${businessId}/reports/profit-and-loss-summaries`,
 )
 
-const fetchProfitAndLossSummaries = createKeyedFetcher(getProfitAndLossSummaries, ProfitAndLossSummariesResponseSchema)
-
-type UseProfitAndLossSummariesProps = Omit<ProfitAndLossSummariesRequestParams, 'businessId'> & {
-  keepPreviousData?: boolean
-}
-export function useProfitAndLossSummaries({
-  keepPreviousData,
-  ...params
-}: UseProfitAndLossSummariesProps) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      ...params,
-    })),
-    key => fetchProfitAndLossSummaries(key),
-    { keepPreviousData },
-  )
-
-  return new SWRQueryResult(response)
-}
+export const useProfitAndLossSummaries = createQueryHook({
+  tags: [PNL_SUMMARIES_TAG_KEY],
+  request: getProfitAndLossSummaries,
+  schema: ProfitAndLossSummariesResponseSchema,
+})
 
 export const useProfitAndLossSummariesCacheActions = createResourceGlobalCacheActions<ProfitAndLossSummaries>(PNL_SUMMARIES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-summaries/useProfitAndLossSummaries.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss-summaries/useProfitAndLossSummaries.tsx
@@ -1,7 +1,7 @@
-import { Schema } from 'effect'
 import useSWR from 'swr'
 
 import { type ProfitAndLossSummaries, type ProfitAndLossSummariesRequestParams, ProfitAndLossSummariesSchema } from '@schemas/reports/profitAndLoss'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
@@ -13,9 +13,7 @@ export const PNL_SUMMARIES_TAG_KEY = '#profit-and-loss-summaries'
 
 const buildKey = createBuildKey<ProfitAndLossSummariesRequestParams>([PNL_SUMMARIES_TAG_KEY])
 
-const ProfitAndLossSummariesResponseSchema = Schema.Struct({
-  data: ProfitAndLossSummariesSchema,
-})
+const ProfitAndLossSummariesResponseSchema = UnwrappedDataResponseSchema(ProfitAndLossSummariesSchema)
 
 const getProfitAndLossSummaries = getWithQuery<
   typeof ProfitAndLossSummariesResponseSchema.Encoded,
@@ -42,7 +40,7 @@ export function useProfitAndLossSummaries({
       businessId,
       ...params,
     })),
-    key => fetchProfitAndLossSummaries(key).then(({ data }) => data),
+    key => fetchProfitAndLossSummaries(key),
     { keepPreviousData },
   )
 

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
@@ -2,33 +2,35 @@ import useSWRMutation from 'swr/mutation'
 
 import type { S3PresignedUrl } from '@internal-types/general'
 import type { Awaitable } from '@internal-types/utility/promises'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createBuildKey } from '@utils/swr/createBuildKey'
-import { type GetProfitAndLossDetailLinesParams, type PnlDetailLinesBaseParams, type PnlDetailLinesFilterParams } from '@hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
+import { type PnlDetailLinesBaseParams, type PnlDetailLinesFilterParams } from '@hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
-const getProfitAndLossDetailLinesExcel = (apiUrl: string, accessToken: string | undefined, params: GetProfitAndLossDetailLinesParams) => {
-  const { businessId, startDate, endDate, pnlStructureLineItemName, tagKey, tagValues, reportingBasis, pnlStructure } = params
-  const queryParams = toDefinedSearchParameters({
+const getProfitAndLossDetailLinesExcel = getWithQuery<
+  {
+    data?: S3PresignedUrl
+    error?: unknown
+  },
+  PnlDetailLinesBaseParams & PnlDetailLinesFilterParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/reports/profit-and-loss/lines/exports/excel`,
+  ({ startDate, endDate, pnlStructureLineItemName, tagFilter, reportingBasis, pnlStructure }) => ({
     startDate,
     endDate,
     lineItemName: pnlStructureLineItemName,
     reportingBasis,
-    tagKey,
-    tagValues,
+    tagKey: tagFilter?.key,
+    tagValues: tagFilter?.values?.join(','),
     pnlStructure,
-  })
+  }),
+)
 
-  return get<{
-    data?: S3PresignedUrl
-    error?: unknown
-  }>(({ businessId }) =>
-    `/v1/businesses/${businessId}/reports/profit-and-loss/lines/exports/excel?${queryParams.toString()}`,
-  )(apiUrl, accessToken, { params: { businessId } })
-}
+const fetchProfitAndLossDetailLinesExcel = createKeyedFetcher(getProfitAndLossDetailLinesExcel)
 
-const buildKey = createBuildKey<{ businessId: string } & PnlDetailLinesBaseParams & PnlDetailLinesFilterParams>(['#pnl-detail-lines', '#exports', '#excel'])
+const buildKey = createBuildKey<PnlDetailLinesBaseParams & PnlDetailLinesFilterParams>(['#pnl-detail-lines', '#exports', '#excel'])
 
 type UseProfitAndLossDetailLinesExportOptions = PnlDetailLinesBaseParams & PnlDetailLinesFilterParams & {
   onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>
@@ -56,25 +58,11 @@ export function useProfitAndLossDetailLinesExport({
       reportingBasis,
       pnlStructure,
     })),
-    ({ accessToken, apiUrl, businessId, startDate, endDate, pnlStructureLineItemName, tagFilter, reportingBasis, pnlStructure }) =>
-      getProfitAndLossDetailLinesExcel(
-        apiUrl,
-        accessToken,
-        {
-          businessId,
-          startDate,
-          endDate,
-          pnlStructureLineItemName,
-          tagKey: tagFilter?.key,
-          tagValues: tagFilter?.values?.join(','),
-          reportingBasis,
-          pnlStructure,
-        },
-      )().then(({ data }) => {
-        if (onSuccess && data) {
-          return onSuccess(data)
-        }
-      }),
+    key => fetchProfitAndLossDetailLinesExcel(key).then(({ data }) => {
+      if (onSuccess && data) {
+        return onSuccess(data)
+      }
+    }),
     {
       revalidate: false,
       throwOnError: false,

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
@@ -1,6 +1,6 @@
 import type { S3PresignedUrl } from '@internal-types/general'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import type { MutationRequest } from '@utils/api/postAsQuery'
+import { getAsMutation } from '@utils/api/postAsQuery'
 import { type PnlDetailLinesBaseParams, type PnlDetailLinesFilterParams } from '@hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
@@ -26,12 +26,7 @@ const getProfitAndLossDetailLinesExcel = getWithQuery<
   }),
 )
 
-const requestProfitAndLossDetailLinesExcel: MutationRequest<
-  { data?: S3PresignedUrl, error?: unknown },
-  Record<string, unknown>,
-  PnlDetailLinesExportParams
-> = (baseUrl, accessToken, options) =>
-  getProfitAndLossDetailLinesExcel(baseUrl, accessToken, { params: options?.params })()
+const requestProfitAndLossDetailLinesExcel = getAsMutation(getProfitAndLossDetailLinesExcel)
 
 export const useProfitAndLossDetailLinesExport = createMutationHook({
   tags: ['#pnl-detail-lines', '#exports', '#excel'],

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
@@ -1,6 +1,6 @@
 import type { S3PresignedUrl } from '@internal-types/general'
+import { getAsMutation } from '@utils/api/getAsMutation'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { getAsMutation } from '@utils/api/postAsQuery'
 import { type PnlDetailLinesBaseParams, type PnlDetailLinesFilterParams } from '@hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/exports/excel/useProfitAndLossDetailLinesExport.ts
@@ -1,19 +1,17 @@
-import useSWRMutation from 'swr/mutation'
-
 import type { S3PresignedUrl } from '@internal-types/general'
-import type { Awaitable } from '@internal-types/utility/promises'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
+import type { MutationRequest } from '@utils/api/postAsQuery'
 import { type PnlDetailLinesBaseParams, type PnlDetailLinesFilterParams } from '@hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
+
+type PnlDetailLinesExportParams = PnlDetailLinesBaseParams & PnlDetailLinesFilterParams
 
 const getProfitAndLossDetailLinesExcel = getWithQuery<
   {
     data?: S3PresignedUrl
     error?: unknown
   },
-  PnlDetailLinesBaseParams & PnlDetailLinesFilterParams
+  PnlDetailLinesExportParams
 >(
   ['businessId'],
   ({ businessId }) => `/v1/businesses/${businessId}/reports/profit-and-loss/lines/exports/excel`,
@@ -28,44 +26,18 @@ const getProfitAndLossDetailLinesExcel = getWithQuery<
   }),
 )
 
-const fetchProfitAndLossDetailLinesExcel = createKeyedFetcher(getProfitAndLossDetailLinesExcel)
+const requestProfitAndLossDetailLinesExcel: MutationRequest<
+  { data?: S3PresignedUrl, error?: unknown },
+  Record<string, unknown>,
+  PnlDetailLinesExportParams
+> = (baseUrl, accessToken, options) =>
+  getProfitAndLossDetailLinesExcel(baseUrl, accessToken, { params: options?.params })()
 
-const buildKey = createBuildKey<PnlDetailLinesBaseParams & PnlDetailLinesFilterParams>(['#pnl-detail-lines', '#exports', '#excel'])
-
-type UseProfitAndLossDetailLinesExportOptions = PnlDetailLinesBaseParams & PnlDetailLinesFilterParams & {
-  onSuccess?: (url: S3PresignedUrl) => Awaitable<unknown>
-}
-
-export function useProfitAndLossDetailLinesExport({
-  startDate,
-  endDate,
-  pnlStructureLineItemName,
-  tagFilter,
-  reportingBasis,
-  pnlStructure,
-  onSuccess,
-}: UseProfitAndLossDetailLinesExportOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  return useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      startDate,
-      endDate,
-      pnlStructureLineItemName,
-      tagFilter,
-      reportingBasis,
-      pnlStructure,
-    })),
-    key => fetchProfitAndLossDetailLinesExcel(key).then(({ data }) => {
-      if (onSuccess && data) {
-        return onSuccess(data)
-      }
-    }),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
-}
+export const useProfitAndLossDetailLinesExport = createMutationHook({
+  tags: ['#pnl-detail-lines', '#exports', '#excel'],
+  request: requestProfitAndLossDetailLinesExcel,
+  keyParams: ['startDate', 'endDate', 'pnlStructureLineItemName', 'tagFilter', 'reportingBasis', 'pnlStructure'],
+  argToBody: (_arg: undefined) => undefined,
+  select: ({ data }) => data,
+  swrOptions: { throwOnError: false },
+})

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
@@ -54,32 +54,13 @@ const listProfitAndLossDetailLines = getWithQuery<
   }),
 )
 
-const useProfitAndLossDetailLinesQuery = createQueryHook({
+export const useProfitAndLossDetailLines = createQueryHook({
   tags: [LIST_PNL_DETAIL_LINES_TAG_KEY],
   request: listProfitAndLossDetailLines,
   schema: PnlDetailLinesResponseSchema,
   select: ({ data }) => data,
   swrOptions: { keepPreviousData: true },
 })
-
-export function useProfitAndLossDetailLines({
-  startDate,
-  endDate,
-  pnlStructureLineItemName,
-  tagFilter,
-  reportingBasis,
-  pnlStructure,
-}: PnlDetailLinesBaseParams & PnlDetailLinesFilterParams) {
-  return useProfitAndLossDetailLinesQuery({
-    startDate,
-    endDate,
-    pnlStructureLineItemName,
-    tagFilter,
-    reportingBasis,
-    pnlStructure,
-    isEnabled: Boolean(startDate && endDate && pnlStructureLineItemName),
-  })
-}
 
 export const usePnlDetailLinesInvalidator = createResourceGlobalCacheActions<PnlDetailLinesReturn>(LIST_PNL_DETAIL_LINES_TAG_KEY)
 

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
@@ -1,14 +1,12 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
 
 import { type ReportingBasis } from '@internal-types/general'
 import { type PnlDetailLineSchema, PnlDetailLinesDataSchema } from '@schemas/reports/profitAndLoss'
 import { get } from '@utils/api/authenticatedHttp'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const LIST_PNL_DETAIL_LINES_TAG_KEY = '#list-pnl-detail-lines'
 
@@ -35,7 +33,34 @@ type PnlDetailLinesParams = PnlDetailLinesBaseParams & PnlDetailLinesFilterParam
 export type PnlDetailLine = typeof PnlDetailLineSchema.Type
 export type PnlDetailLinesReturn = typeof PnlDetailLinesDataSchema.Type
 
-const keyLoader = createBuildKey<PnlDetailLinesParams>([LIST_PNL_DETAIL_LINES_TAG_KEY])
+const PnlDetailLinesResponseSchema = Schema.Struct({
+  data: PnlDetailLinesDataSchema,
+})
+
+const listProfitAndLossDetailLines = getWithQuery<
+  typeof PnlDetailLinesResponseSchema.Encoded,
+  PnlDetailLinesParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/reports/profit-and-loss/lines`,
+  ({ startDate, endDate, pnlStructureLineItemName, tagFilter, reportingBasis, pnlStructure }) => ({
+    startDate,
+    endDate,
+    lineItemName: pnlStructureLineItemName,
+    reportingBasis,
+    tagKey: tagFilter?.key,
+    tagValues: tagFilter?.values?.join(','),
+    pnlStructure,
+  }),
+)
+
+const useProfitAndLossDetailLinesQuery = createQueryHook({
+  tags: [LIST_PNL_DETAIL_LINES_TAG_KEY],
+  request: listProfitAndLossDetailLines,
+  schema: PnlDetailLinesResponseSchema,
+  select: ({ data }) => data,
+  swrOptions: { keepPreviousData: true },
+})
 
 export function useProfitAndLossDetailLines({
   startDate,
@@ -45,50 +70,15 @@ export function useProfitAndLossDetailLines({
   reportingBasis,
   pnlStructure,
 }: PnlDetailLinesBaseParams & PnlDetailLinesFilterParams) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(
-    () => withLocale(keyLoader({
-      ...auth,
-      businessId,
-      startDate,
-      endDate,
-      pnlStructureLineItemName,
-      tagFilter,
-      reportingBasis,
-      pnlStructure,
-      isEnabled: Boolean(startDate && endDate && pnlStructureLineItemName),
-    })),
-    ({
-      accessToken,
-      apiUrl,
-      businessId,
-      startDate,
-      endDate,
-      pnlStructureLineItemName,
-      tagFilter,
-      reportingBasis,
-      pnlStructure,
-    }) => getProfitAndLossDetailLines(
-      apiUrl,
-      accessToken,
-      {
-        businessId,
-        startDate,
-        endDate,
-        pnlStructureLineItemName,
-        tagKey: tagFilter?.key,
-        tagValues: tagFilter?.values?.join(','),
-        reportingBasis,
-        pnlStructure,
-      },
-    )().then(response => response.data).then(Schema.decodeUnknownPromise(PnlDetailLinesDataSchema)),
-    {
-      keepPreviousData: true,
-    },
-  )
-
-  return new SWRQueryResult(swrResponse)
+  return useProfitAndLossDetailLinesQuery({
+    startDate,
+    endDate,
+    pnlStructureLineItemName,
+    tagFilter,
+    reportingBasis,
+    pnlStructure,
+    isEnabled: Boolean(startDate && endDate && pnlStructureLineItemName),
+  })
 }
 
 export const usePnlDetailLinesInvalidator = createResourceGlobalCacheActions<PnlDetailLinesReturn>(LIST_PNL_DETAIL_LINES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
@@ -57,8 +57,7 @@ const listProfitAndLossDetailLines = getWithQuery<
 export const useProfitAndLossDetailLines = createQueryHook({
   tags: [LIST_PNL_DETAIL_LINES_TAG_KEY],
   request: listProfitAndLossDetailLines,
-  schema: PnlDetailLinesResponseSchema,
-  select: ({ data }) => data,
+  schema: PnlDetailLinesResponseSchema.pipe(Schema.pluck('data')),
   swrOptions: { keepPreviousData: true },
 })
 

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/lines/useProfitAndLossDetailLines.tsx
@@ -1,7 +1,6 @@
-import { Schema } from 'effect'
-
 import { type ReportingBasis } from '@internal-types/general'
 import { type PnlDetailLineSchema, PnlDetailLinesDataSchema } from '@schemas/reports/profitAndLoss'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
@@ -33,9 +32,7 @@ type PnlDetailLinesParams = PnlDetailLinesBaseParams & PnlDetailLinesFilterParam
 export type PnlDetailLine = typeof PnlDetailLineSchema.Type
 export type PnlDetailLinesReturn = typeof PnlDetailLinesDataSchema.Type
 
-const PnlDetailLinesResponseSchema = Schema.Struct({
-  data: PnlDetailLinesDataSchema,
-})
+const PnlDetailLinesResponseSchema = UnwrappedDataResponseSchema(PnlDetailLinesDataSchema)
 
 const listProfitAndLossDetailLines = getWithQuery<
   typeof PnlDetailLinesResponseSchema.Encoded,
@@ -57,7 +54,7 @@ const listProfitAndLossDetailLines = getWithQuery<
 export const useProfitAndLossDetailLines = createQueryHook({
   tags: [LIST_PNL_DETAIL_LINES_TAG_KEY],
   request: listProfitAndLossDetailLines,
-  schema: PnlDetailLinesResponseSchema.pipe(Schema.pluck('data')),
+  schema: PnlDetailLinesResponseSchema,
   swrOptions: { keepPreviousData: true },
 })
 

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/useProfitAndLossReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/useProfitAndLossReport.tsx
@@ -22,8 +22,7 @@ const getProfitAndLoss = getWithQuery<
 export const useProfitAndLossReport = createQueryHook({
   tags: [PNL_REPORT_TAG_KEY],
   request: getProfitAndLoss,
-  schema: ProfitAndLossReportResponseSchema,
-  select: ({ data }) => data,
+  schema: ProfitAndLossReportResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export const useProfitAndLossReportCacheActions = createResourceGlobalCacheActions<ProfitAndLoss>(PNL_REPORT_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/useProfitAndLossReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/useProfitAndLossReport.tsx
@@ -1,60 +1,29 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
 
 import { type ProfitAndLoss, type ProfitAndLossReportRequestParams, ProfitAndLossReportSchema } from '@schemas/reports/profitAndLoss'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const PNL_REPORT_TAG_KEY = '#profit-and-loss-report'
 
-const buildKey = createBuildKey<ProfitAndLossReportRequestParams>([PNL_REPORT_TAG_KEY])
+const ProfitAndLossReportResponseSchema = Schema.Struct({
+  data: ProfitAndLossReportSchema,
+})
 
-const getProfitAndLoss = get<
-  { data: ProfitAndLoss },
+const getProfitAndLoss = getWithQuery<
+  typeof ProfitAndLossReportResponseSchema.Encoded,
   ProfitAndLossReportRequestParams
 >(
-  ({
-    businessId,
-    startDate,
-    endDate,
-    tagKey,
-    tagValues,
-    reportingBasis,
-    includeUncategorized,
-  }) => {
-    const parameters = toDefinedSearchParameters({ startDate, endDate, tagKey, tagValues, reportingBasis, includeUncategorized })
-    return `/v1/businesses/${businessId}/reports/profit-and-loss?${parameters}`
-  })
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/reports/profit-and-loss`,
+)
 
-type UseProfitAndLossReportProps = Omit<ProfitAndLossReportRequestParams, 'businessId'>
-export function useProfitAndLossReport({ startDate, endDate, tagKey, tagValues, reportingBasis, includeUncategorized }: UseProfitAndLossReportProps) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      startDate,
-      endDate,
-      tagKey,
-      tagValues,
-      reportingBasis,
-      includeUncategorized,
-    })),
-    ({ accessToken, apiUrl, businessId }) => getProfitAndLoss(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, startDate, endDate, tagKey, tagValues, reportingBasis, includeUncategorized },
-      },
-    )().then(({ data }) => Schema.decodeUnknownPromise(ProfitAndLossReportSchema)(data)),
-  )
-
-  return new SWRQueryResult(response)
-}
+export const useProfitAndLossReport = createQueryHook({
+  tags: [PNL_REPORT_TAG_KEY],
+  request: getProfitAndLoss,
+  schema: ProfitAndLossReportResponseSchema,
+  select: ({ data }) => data,
+})
 
 export const useProfitAndLossReportCacheActions = createResourceGlobalCacheActions<ProfitAndLoss>(PNL_REPORT_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/useProfitAndLossReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/profit-and-loss/useProfitAndLossReport.tsx
@@ -1,15 +1,12 @@
-import { Schema } from 'effect'
-
 import { type ProfitAndLoss, type ProfitAndLossReportRequestParams, ProfitAndLossReportSchema } from '@schemas/reports/profitAndLoss'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const PNL_REPORT_TAG_KEY = '#profit-and-loss-report'
 
-const ProfitAndLossReportResponseSchema = Schema.Struct({
-  data: ProfitAndLossReportSchema,
-})
+const ProfitAndLossReportResponseSchema = UnwrappedDataResponseSchema(ProfitAndLossReportSchema)
 
 const getProfitAndLoss = getWithQuery<
   typeof ProfitAndLossReportResponseSchema.Encoded,
@@ -22,7 +19,7 @@ const getProfitAndLoss = getWithQuery<
 export const useProfitAndLossReport = createQueryHook({
   tags: [PNL_REPORT_TAG_KEY],
   request: getProfitAndLoss,
-  schema: ProfitAndLossReportResponseSchema.pipe(Schema.pluck('data')),
+  schema: ProfitAndLossReportResponseSchema,
 })
 
 export const useProfitAndLossReportCacheActions = createResourceGlobalCacheActions<ProfitAndLoss>(PNL_REPORT_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/reports/transactions/exports/excel/useBankTransactionsDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/transactions/exports/excel/useBankTransactionsDownload.ts
@@ -2,9 +2,9 @@ import useSWRMutation from 'swr/mutation'
 
 import type { S3PresignedUrl } from '@internal-types/general'
 import { type APIError } from '@utils/api/apiError'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import type { UseBankTransactionsOptions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
@@ -20,20 +20,13 @@ type GetBankTransactionsExportParams = {
   sortBy?: string
 }
 
-const getBankTransactionsExcel = get<
+const getBankTransactionsExcel = getWithQuery<
   { data: S3PresignedUrl },
   GetBankTransactionsExportParams
->(({
-  businessId,
-  categorized,
-  direction,
-  query,
-  startDate,
-  endDate,
-  sortBy = 'date',
-  sortOrder = 'DESC',
-}: GetBankTransactionsExportParams) => {
-  const parameters = toDefinedSearchParameters({
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/reports/transactions/exports/excel`,
+  ({ categorized, direction, query, startDate, endDate, sortBy = 'date', sortOrder = 'DESC' }) => ({
     categorized,
     direction,
     q: query,
@@ -41,10 +34,10 @@ const getBankTransactionsExcel = get<
     endDate,
     sortBy,
     sortOrder,
-  })
+  }),
+)
 
-  return `/v1/businesses/${businessId}/reports/transactions/exports/excel?${parameters}`
-})
+const fetchBankTransactionsExcel = createKeyedFetcher(getBankTransactionsExcel)
 
 const buildKey = createBuildKey<{ businessId: string }>(['#bank-transactions-download-excel'])
 
@@ -62,38 +55,8 @@ export function useBankTransactionsDownload() {
         ...auth,
         businessId,
       })),
-      (
-        {
-          accessToken,
-          apiUrl,
-          businessId,
-        },
-        {
-          arg: {
-            categorized,
-            direction,
-            query,
-            startDate,
-            endDate,
-            tagFilterQueryString,
-          },
-        }: { arg: UseBankTransactionsDownloadOptions },
-      ) =>
-        getBankTransactionsExcel(
-          apiUrl,
-          accessToken,
-          {
-            params: {
-              businessId,
-              categorized,
-              query,
-              direction,
-              startDate,
-              endDate,
-              tagFilterQueryString,
-            },
-          },
-        )().then(({ data }) => data),
+      (key, { arg }: { arg: UseBankTransactionsDownloadOptions }) =>
+        fetchBankTransactionsExcel({ ...key, ...arg }).then(({ data }) => data),
       {
         revalidate: false,
         throwOnError: false,

--- a/src/hooks/api/businesses/[business-id]/reports/transactions/exports/excel/useBankTransactionsDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/transactions/exports/excel/useBankTransactionsDownload.ts
@@ -15,7 +15,8 @@ type GetBankTransactionsExportParams = {
   query?: string
   startDate?: Date
   endDate?: Date
-  tagFilterQueryString?: string
+  tagKey?: string
+  tagValues?: string
   sortOrder?: 'ASC' | 'DESC'
   sortBy?: string
 }

--- a/src/hooks/api/businesses/[business-id]/reports/transactions/exports/excel/useBankTransactionsDownload.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/transactions/exports/excel/useBankTransactionsDownload.ts
@@ -1,12 +1,8 @@
-import useSWRMutation from 'swr/mutation'
-
 import type { S3PresignedUrl } from '@internal-types/general'
-import { type APIError } from '@utils/api/apiError'
+import { getAsMutation } from '@utils/api/getAsMutation'
 import { getWithQuery } from '@utils/api/getWithQuery'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import type { UseBankTransactionsOptions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type GetBankTransactionsExportParams = {
   businessId: string
@@ -38,29 +34,15 @@ const getBankTransactionsExcel = getWithQuery<
   }),
 )
 
-const fetchBankTransactionsExcel = createKeyedFetcher(getBankTransactionsExcel)
-
-const buildKey = createBuildKey<{ businessId: string }>(['#bank-transactions-download-excel'])
+const requestBankTransactionsExcel = getAsMutation(getBankTransactionsExcel)
 
 type UseBankTransactionsDownloadOptions = UseBankTransactionsOptions
 
-export function useBankTransactionsDownload() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  return useSWRMutation<
-    S3PresignedUrl,
-    APIError,
-    () => ReturnType<typeof buildKey>,
-    UseBankTransactionsDownloadOptions>(
-      () => withLocale(buildKey({
-        ...auth,
-        businessId,
-      })),
-      (key, { arg }: { arg: UseBankTransactionsDownloadOptions }) =>
-        fetchBankTransactionsExcel({ ...key, ...arg }).then(({ data }) => data),
-      {
-        revalidate: false,
-        throwOnError: false,
-      },
-      )
-}
+export const useBankTransactionsDownload = createMutationHook({
+  tags: ['#bank-transactions-download-excel'],
+  request: requestBankTransactionsExcel,
+  argToParams: (arg: UseBankTransactionsDownloadOptions) => arg,
+  argToBody: () => undefined,
+  select: ({ data }: { data: S3PresignedUrl }) => data,
+  swrOptions: { throwOnError: false },
+})

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
@@ -1,7 +1,7 @@
-import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { type QueryParams } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
@@ -19,9 +19,7 @@ type GetUnifiedReportExcelParams = {
   route: string
 } & UnifiedReportControlParams & QueryParams
 
-const UnifiedReportExcelReturnSchema = Schema.Struct({
-  data: S3PresignedUrlSchema,
-})
+const UnifiedReportExcelReturnSchema = UnwrappedDataResponseSchema(S3PresignedUrlSchema)
 
 const getUnifiedReportExcel = getWithQuery<
   typeof UnifiedReportExcelReturnSchema.Encoded,
@@ -52,7 +50,7 @@ export function useUnifiedReportExcel({ onSuccess }: UseUnifiedReportExcelOption
       ? withLocale(buildKey({ ...auth, businessId, ...params }))
       : null,
     key => fetchUnifiedReportExcel(key)
-      .then(async ({ data }) => {
+      .then(async (data) => {
         if (onSuccess) await onSuccess(data)
         return data
       }),

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
@@ -1,16 +1,11 @@
-import useSWRMutation from 'swr/mutation'
-
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
 import { UnwrappedDataResponseSchema } from '@schemas/utils'
+import { getAsMutation } from '@utils/api/getAsMutation'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { type QueryParams } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 import {
   type UnifiedReportControlParams,
-  type UnifiedReportParams,
   useUnifiedReportParams,
 } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 
@@ -29,33 +24,30 @@ const getUnifiedReportExcel = getWithQuery<
   ({ businessId, route }) => `/v1/businesses/${businessId}/reports/unified/${route}/exports/excel`,
 )
 
-const fetchUnifiedReportExcel = createKeyedFetcher(getUnifiedReportExcel, UnifiedReportExcelReturnSchema)
+const requestUnifiedReportExcel = getAsMutation(getUnifiedReportExcel)
 
-const getTag = (report: string) => `#unified-${report}-report-excel`
+const useUnifiedReportExcelMutation = createMutationHook({
+  tags: ['#unified-report-excel'],
+  request: requestUnifiedReportExcel,
+  keyParams: ['route'],
+  argToBody: (_arg: undefined) => undefined,
+  schema: UnifiedReportExcelReturnSchema,
+  swrOptions: { throwOnError: false },
+})
 
 type UseUnifiedReportExcelOptions = {
   onSuccess?: (url: S3PresignedUrlSchemaType) => Promise<void> | void
 }
 
 export function useUnifiedReportExcel({ onSuccess }: UseUnifiedReportExcelOptions = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const params = useUnifiedReportParams()
 
-  const buildKey = createBuildKey<{ businessId: string } & UnifiedReportParams>(
-    params ? [getTag(params.route)] : [],
-  )
-
-  const rawMutationResponse = useSWRMutation(
-    () => params
-      ? withLocale(buildKey({ ...auth, businessId, ...params }))
-      : null,
-    key => fetchUnifiedReportExcel(key)
-      .then(async (data) => {
-        if (onSuccess) await onSuccess(data)
-        return data
-      }),
-    { revalidate: false, throwOnError: false },
-  )
-
-  return new SWRMutationResult(rawMutationResponse)
+  return useUnifiedReportExcelMutation({
+    ...params,
+    route: params?.route ?? '',
+    isEnabled: params !== null,
+    swrOptions: {
+      onSuccess: (data) => { void onSuccess?.(data) },
+    },
+  })
 }

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/exports/excel/useUnifiedReportExcel.ts
@@ -2,9 +2,10 @@ import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
 import { S3PresignedUrlSchema, type S3PresignedUrlSchemaType } from '@schemas/common/s3PresignedUrl'
-import { get } from '@utils/api/authenticatedHttp'
-import { type QueryParams, toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { getWithQuery } from '@utils/api/getWithQuery'
+import { type QueryParams } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import {
@@ -18,20 +19,21 @@ type GetUnifiedReportExcelParams = {
   route: string
 } & UnifiedReportControlParams & QueryParams
 
-const getUnifiedReportExcel = get<
-  { data: S3PresignedUrlSchemaType },
-  GetUnifiedReportExcelParams
->(({ businessId, route, ...restParams }) => {
-  const parameters = toDefinedSearchParameters({ ...restParams })
-
-  return `/v1/businesses/${businessId}/reports/unified/${route}/exports/excel?${parameters}`
-})
-
-const getTag = (report: string) => `#unified-${report}-report-excel`
-
 const UnifiedReportExcelReturnSchema = Schema.Struct({
   data: S3PresignedUrlSchema,
 })
+
+const getUnifiedReportExcel = getWithQuery<
+  typeof UnifiedReportExcelReturnSchema.Encoded,
+  GetUnifiedReportExcelParams
+>(
+  ['businessId', 'route'],
+  ({ businessId, route }) => `/v1/businesses/${businessId}/reports/unified/${route}/exports/excel`,
+)
+
+const fetchUnifiedReportExcel = createKeyedFetcher(getUnifiedReportExcel, UnifiedReportExcelReturnSchema)
+
+const getTag = (report: string) => `#unified-${report}-report-excel`
 
 type UseUnifiedReportExcelOptions = {
   onSuccess?: (url: S3PresignedUrlSchemaType) => Promise<void> | void
@@ -49,15 +51,11 @@ export function useUnifiedReportExcel({ onSuccess }: UseUnifiedReportExcelOption
     () => params
       ? withLocale(buildKey({ ...auth, businessId, ...params }))
       : null,
-    ({ accessToken, apiUrl, businessId, tags, ...restParams }) =>
-      getUnifiedReportExcel(apiUrl, accessToken, {
-        params: { businessId, ...restParams },
-      })()
-        .then(Schema.decodeUnknownPromise(UnifiedReportExcelReturnSchema))
-        .then(async ({ data }) => {
-          if (onSuccess) await onSuccess(data)
-          return data
-        }),
+    key => fetchUnifiedReportExcel(key)
+      .then(async ({ data }) => {
+        if (onSuccess) await onSuccess(data)
+        return data
+      }),
     { revalidate: false, throwOnError: false },
   )
 

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
@@ -1,41 +1,37 @@
-import { Schema } from 'effect'
-import useSWR from 'swr'
-
 import { UnifiedReportSchema } from '@schemas/reports/unifiedReport'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { type QueryParams } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
-import { type UnifiedReportControlParams, type UnifiedReportParams, useUnifiedReportParams } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
+import { type UnifiedReportControlParams, useUnifiedReportParams } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 
-const getTag = (report: string) => `#unified-${report}-report`
+type GetUnifiedReportParams = {
+  businessId: string
+  route: string
+} & UnifiedReportControlParams & QueryParams
+
+const UnifiedReportResponseSchema = UnwrappedDataResponseSchema(UnifiedReportSchema)
 
 const getUnifiedReport = getWithQuery<
-  { data: unknown },
-  { businessId: string, route: string } & UnifiedReportControlParams & QueryParams
+  typeof UnifiedReportResponseSchema.Encoded,
+  GetUnifiedReportParams
 >(
   ['businessId', 'route'],
   ({ businessId, route }) => `/v1/businesses/${businessId}/reports/unified/${route}`,
 )
 
-const fetchUnifiedReport = createKeyedFetcher(getUnifiedReport)
+const useUnifiedReportQuery = createQueryHook({
+  tags: ['#unified-report'],
+  request: getUnifiedReport,
+  schema: UnifiedReportResponseSchema,
+})
 
 export function useUnifiedReport() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const params = useUnifiedReportParams()
 
-  const buildKey = createBuildKey<{ businessId: string } & UnifiedReportParams>(
-    params ? [getTag(params.route)] : [],
-  )
-
-  const swrResponse = useSWR(
-    () => params
-      ? withLocale(buildKey({ ...auth, businessId, ...params }))
-      : null,
-    key => fetchUnifiedReport(key).then(({ data }) => Schema.decodeUnknownPromise(UnifiedReportSchema)(data)),
-  )
-
-  return new SWRQueryResult(swrResponse)
+  return useUnifiedReportQuery({
+    ...params,
+    route: params?.route ?? '',
+    isEnabled: params !== null,
+  })
 }

--- a/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
+++ b/src/hooks/api/businesses/[business-id]/reports/unified/report-name/useUnifiedReport.tsx
@@ -2,23 +2,25 @@ import { Schema } from 'effect'
 import useSWR from 'swr'
 
 import { UnifiedReportSchema } from '@schemas/reports/unifiedReport'
-import { get } from '@utils/api/authenticatedHttp'
-import { type QueryParams, toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import { getWithQuery } from '@utils/api/getWithQuery'
+import { type QueryParams } from '@utils/request/toDefinedSearchParameters'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 import { type UnifiedReportControlParams, type UnifiedReportParams, useUnifiedReportParams } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 
 const getTag = (report: string) => `#unified-${report}-report`
 
-const getUnifiedReport = get<
+const getUnifiedReport = getWithQuery<
   { data: unknown },
   { businessId: string, route: string } & UnifiedReportControlParams & QueryParams
->(({ businessId, route, ...restParams }) => {
-  const parameters = toDefinedSearchParameters({ ...restParams })
+>(
+  ['businessId', 'route'],
+  ({ businessId, route }) => `/v1/businesses/${businessId}/reports/unified/${route}`,
+)
 
-  return `/v1/businesses/${businessId}/reports/unified/${route}?${parameters}`
-})
+const fetchUnifiedReport = createKeyedFetcher(getUnifiedReport)
 
 export function useUnifiedReport() {
   const { withLocale, businessId, auth } = useBuildKeyInputs()
@@ -32,9 +34,7 @@ export function useUnifiedReport() {
     () => params
       ? withLocale(buildKey({ ...auth, businessId, ...params }))
       : null,
-    ({ accessToken, apiUrl, businessId, tags, ...restParams }) => getUnifiedReport(apiUrl, accessToken, {
-      params: { businessId, ...restParams },
-    })().then(({ data }) => Schema.decodeUnknownPromise(UnifiedReportSchema)(data)),
+    key => fetchUnifiedReport(key).then(({ data }) => Schema.decodeUnknownPromise(UnifiedReportSchema)(data)),
   )
 
   return new SWRQueryResult(swrResponse)

--- a/src/hooks/api/businesses/[business-id]/stripe/connect-account-link/useStripeConnectAccountLink.tsx
+++ b/src/hooks/api/businesses/[business-id]/stripe/connect-account-link/useStripeConnectAccountLink.tsx
@@ -1,10 +1,7 @@
 import { pipe, Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const STRIPE_CONNECT_ACCOUNT_LINK_TAG_KEY = '#stripe-connect-account-link'
 
@@ -27,36 +24,33 @@ const StripeConnectAccountLinkResponseSchema = Schema.Struct({
   data: StripeConnectAccountLinkDataSchema,
 })
 
+const StripeConnectAccountLinkSchema = Schema.transform(
+  StripeConnectAccountLinkResponseSchema,
+  Schema.typeSchema(StripeConnectAccountLinkDataSchema),
+  {
+    strict: true,
+    decode: ({ data }) => data,
+    encode: data => ({ data }),
+  },
+)
+
 type StripeConnectAccountLinkResponse = typeof StripeConnectAccountLinkDataSchema.Type
 
 const createStripeConnectAccountLink = post<
-  { data: StripeConnectAccountLinkResponse },
+  typeof StripeConnectAccountLinkResponseSchema.Encoded,
   never,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/stripe/connect-account-link`)
 
-const buildKey = createBuildKey<{ businessId: string }>([STRIPE_CONNECT_ACCOUNT_LINK_TAG_KEY])
-
-export function useStripeConnectAccountLink() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    ({ accessToken, apiUrl, businessId }) => {
-      return createStripeConnectAccountLink(
-        apiUrl,
-        accessToken,
-        { params: { businessId } },
-      ).then(Schema.decodeUnknownPromise(StripeConnectAccountLinkResponseSchema)).then(({ data }) => data)
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  return new SWRMutationResult(rawMutationResponse)
-}
+export const useStripeConnectAccountLink = createMutationHook<
+  typeof StripeConnectAccountLinkResponseSchema.Encoded,
+  never,
+  { businessId: string },
+  StripeConnectAccountLinkResponse,
+  never
+>({
+  tags: [STRIPE_CONNECT_ACCOUNT_LINK_TAG_KEY],
+  request: createStripeConnectAccountLink,
+  schema: StripeConnectAccountLinkSchema,
+  swrOptions: { throwOnError: true },
+})

--- a/src/hooks/api/businesses/[business-id]/stripe/connect-account-link/useStripeConnectAccountLink.tsx
+++ b/src/hooks/api/businesses/[business-id]/stripe/connect-account-link/useStripeConnectAccountLink.tsx
@@ -1,5 +1,6 @@
 import { pipe, Schema } from 'effect'
 
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
@@ -20,30 +21,18 @@ const StripeConnectAccountLinkDataSchema = Schema.Struct({
   ),
 })
 
-const StripeConnectAccountLinkResponseSchema = Schema.Struct({
-  data: StripeConnectAccountLinkDataSchema,
-})
-
-const StripeConnectAccountLinkSchema = Schema.transform(
-  StripeConnectAccountLinkResponseSchema,
-  Schema.typeSchema(StripeConnectAccountLinkDataSchema),
-  {
-    strict: true,
-    decode: ({ data }) => data,
-    encode: data => ({ data }),
-  },
-)
+const StripeConnectAccountLinkSchema = UnwrappedDataResponseSchema(StripeConnectAccountLinkDataSchema)
 
 type StripeConnectAccountLinkResponse = typeof StripeConnectAccountLinkDataSchema.Type
 
 const createStripeConnectAccountLink = post<
-  typeof StripeConnectAccountLinkResponseSchema.Encoded,
+  typeof StripeConnectAccountLinkSchema.Encoded,
   never,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/stripe/connect-account-link`)
 
 export const useStripeConnectAccountLink = createMutationHook<
-  typeof StripeConnectAccountLinkResponseSchema.Encoded,
+  typeof StripeConnectAccountLinkSchema.Encoded,
   never,
   { businessId: string },
   StripeConnectAccountLinkResponse,

--- a/src/hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus.tsx
+++ b/src/hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus.tsx
@@ -1,37 +1,17 @@
-import { Schema } from 'effect'
-import useSWR from 'swr'
-
-import { type StripeAccountStatusResponse, StripeAccountStatusResponseSchema } from '@schemas/stripeAccountStatus'
+import { StripeAccountStatusResponseSchema } from '@schemas/stripeAccountStatus'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const STRIPE_ACCOUNT_STATUS_TAG_KEY = '#stripe-account-status'
 
-const buildKey = createBuildKey<{ businessId: string }>([STRIPE_ACCOUNT_STATUS_TAG_KEY])
-
 const getStripeAccountStatus = get<
-  { data: StripeAccountStatusResponse },
+  typeof StripeAccountStatusResponseSchema.Encoded,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/stripe/status`)
 
-export function useStripeAccountStatus() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    ({ accessToken, apiUrl, businessId }) => getStripeAccountStatus(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-      },
-    )().then(Schema.decodeUnknownPromise(StripeAccountStatusResponseSchema)).then(({ data }) => data),
-  )
-
-  return new SWRQueryResult(response)
-}
+export const useStripeAccountStatus = createQueryHook({
+  tags: [STRIPE_ACCOUNT_STATUS_TAG_KEY],
+  request: getStripeAccountStatus,
+  schema: StripeAccountStatusResponseSchema,
+  select: ({ data }) => data,
+})

--- a/src/hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus.tsx
+++ b/src/hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus.tsx
@@ -1,5 +1,3 @@
-import { Schema } from 'effect'
-
 import { StripeAccountStatusResponseSchema } from '@schemas/stripeAccountStatus'
 import { get } from '@utils/api/authenticatedHttp'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
@@ -14,5 +12,5 @@ const getStripeAccountStatus = get<
 export const useStripeAccountStatus = createQueryHook({
   tags: [STRIPE_ACCOUNT_STATUS_TAG_KEY],
   request: getStripeAccountStatus,
-  schema: StripeAccountStatusResponseSchema.pipe(Schema.pluck('data')),
+  schema: StripeAccountStatusResponseSchema,
 })

--- a/src/hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus.tsx
+++ b/src/hooks/api/businesses/[business-id]/stripe/status/useStripeAccountStatus.tsx
@@ -1,3 +1,5 @@
+import { Schema } from 'effect'
+
 import { StripeAccountStatusResponseSchema } from '@schemas/stripeAccountStatus'
 import { get } from '@utils/api/authenticatedHttp'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
@@ -12,6 +14,5 @@ const getStripeAccountStatus = get<
 export const useStripeAccountStatus = createQueryHook({
   tags: [STRIPE_ACCOUNT_STATUS_TAG_KEY],
   request: getStripeAccountStatus,
-  schema: StripeAccountStatusResponseSchema,
-  select: ({ data }) => data,
+  schema: StripeAccountStatusResponseSchema.pipe(Schema.pluck('data')),
 })

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/[dimension-id]/values/useCreateTagValueDefinition.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/[dimension-id]/values/useCreateTagValueDefinition.ts
@@ -1,16 +1,12 @@
 import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
 
 import { type TagValueDefinitionSchema } from '@schemas/tag'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTagDimensionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CREATE_TAG_VALUE_DEFINITION_TAG_KEY = '#create-tag-value-definition'
-
-const buildKey = createBuildKey<{ businessId: string }>([CREATE_TAG_VALUE_DEFINITION_TAG_KEY])
 
 const createTagValueDefinition = post<
   { data: typeof TagValueDefinitionSchema.Encoded },
@@ -21,33 +17,25 @@ const createTagValueDefinition = post<
   }
 >(({ businessId, dimensionId }) => `/v1/businesses/${businessId}/tags/dimensions/${dimensionId}/values`)
 
-export function useCreateTagDimension() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
+type CreateTagValueDefinitionArg = {
+  dimensionId: string
+  value: string
+  displayName?: string
+}
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { dimensionId, value, displayName } }: { arg: { dimensionId: string, value: string, displayName?: string } },
-    ) => createTagValueDefinition(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          dimensionId,
-        },
-        body: { value, displayName },
-      },
-    ),
-  )
+const useCreateTagValueDefinitionMutation = createMutationHook({
+  tags: [CREATE_TAG_VALUE_DEFINITION_TAG_KEY],
+  request: createTagValueDefinition,
+  argToParams: ({ dimensionId }: CreateTagValueDefinitionArg) => ({ dimensionId }),
+  argToBody: ({ value, displayName }: CreateTagValueDefinitionArg) => ({ value, displayName }),
+})
+
+export function useCreateTagDimension() {
+  const mutationResponse = useCreateTagValueDefinitionMutation()
 
   const { invalidate: invalidateTagDimensions } = useTagDimensionsGlobalCacheActions()
 
-  const { trigger: originalTrigger } = mutationResponse
+  const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/key/[dimension-key]/useTagDimensionByKey.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/key/[dimension-key]/useTagDimensionByKey.ts
@@ -1,18 +1,17 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
 
 import { TagDimensionSchema } from '@schemas/tag'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const TAG_DIMENSION_BY_KEY_TAG_KEY = '#tag-dimension-by-key'
 
-const buildKey = createBuildKey<{ businessId: string, dimensionKey: string }>([TAG_DIMENSION_BY_KEY_TAG_KEY])
+const TagDimensionByKeyResponseSchema = Schema.Struct({
+  data: TagDimensionSchema,
+})
 
 const getTagDimensionByKey = get<
-  { data: unknown },
+  typeof TagDimensionByKeyResponseSchema.Encoded,
   { businessId: string, dimensionKey: string }
 >(({ businessId, dimensionKey }) => `/v1/businesses/${businessId}/tags/dimensions/key/${dimensionKey}`)
 
@@ -21,31 +20,12 @@ type UseTagDimensionByKeyParameters = {
   dimensionKey: string
 }
 
-export function useTagDimensionByKey({ isEnabled = true, dimensionKey }: UseTagDimensionByKeyParameters) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      isEnabled,
-      businessId,
-      dimensionKey,
-    })),
-    ({ accessToken, apiUrl, businessId }) => getTagDimensionByKey(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          dimensionKey,
-        },
-      },
-    )()
-      .then(({ data }) => Schema.decodeUnknownPromise(TagDimensionSchema)(data)),
-  )
-
-  return new SWRQueryResult(swrResponse)
-}
+export const useTagDimensionByKey = createQueryHook({
+  tags: [TAG_DIMENSION_BY_KEY_TAG_KEY],
+  request: getTagDimensionByKey,
+  schema: TagDimensionByKeyResponseSchema,
+  select: ({ data }) => data,
+})
 
 export function usePreloadTagDimensionByKey(parameters: UseTagDimensionByKeyParameters) {
   /*

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/key/[dimension-key]/useTagDimensionByKey.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/key/[dimension-key]/useTagDimensionByKey.ts
@@ -1,14 +1,11 @@
-import { Schema } from 'effect'
-
 import { TagDimensionSchema } from '@schemas/tag'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const TAG_DIMENSION_BY_KEY_TAG_KEY = '#tag-dimension-by-key'
 
-const TagDimensionByKeyResponseSchema = Schema.Struct({
-  data: TagDimensionSchema,
-})
+const TagDimensionByKeyResponseSchema = UnwrappedDataResponseSchema(TagDimensionSchema)
 
 const getTagDimensionByKey = get<
   typeof TagDimensionByKeyResponseSchema.Encoded,
@@ -23,7 +20,7 @@ type UseTagDimensionByKeyParameters = {
 export const useTagDimensionByKey = createQueryHook({
   tags: [TAG_DIMENSION_BY_KEY_TAG_KEY],
   request: getTagDimensionByKey,
-  schema: TagDimensionByKeyResponseSchema.pipe(Schema.pluck('data')),
+  schema: TagDimensionByKeyResponseSchema,
 })
 
 export function usePreloadTagDimensionByKey(parameters: UseTagDimensionByKeyParameters) {

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/key/[dimension-key]/useTagDimensionByKey.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/key/[dimension-key]/useTagDimensionByKey.ts
@@ -23,8 +23,7 @@ type UseTagDimensionByKeyParameters = {
 export const useTagDimensionByKey = createQueryHook({
   tags: [TAG_DIMENSION_BY_KEY_TAG_KEY],
   request: getTagDimensionByKey,
-  schema: TagDimensionByKeyResponseSchema,
-  select: ({ data }) => data,
+  schema: TagDimensionByKeyResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export function usePreloadTagDimensionByKey(parameters: UseTagDimensionByKeyParameters) {

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/useCreateTagDimension.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/useCreateTagDimension.ts
@@ -1,17 +1,13 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { type TagDimensionSchema, TagDimensionStrictnessSchema } from '@schemas/tag'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTagDimensionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const CREATE_TAG_DIMENSION_TAG_KEY = '#create-tag-dimension'
-
-const buildKey = createBuildKey<{ businessId: string }>([CREATE_TAG_DIMENSION_TAG_KEY])
 
 const CreateTagDimensionBodySchema = Schema.Struct({
   key: Schema.NonEmptyTrimmedString,
@@ -27,32 +23,19 @@ const createTagDimension = post<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/tags/dimensions`)
 
-export function useCreateTagDimension() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
+const useCreateTagDimensionMutation = createMutationHook({
+  tags: [CREATE_TAG_DIMENSION_TAG_KEY],
+  request: createTagDimension,
+  argToBody: (tagDimension: typeof CreateTagDimensionBodySchema.Type) =>
+    Schema.encodeSync(CreateTagDimensionBodySchema)(tagDimension),
+})
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: tagDimension }: { arg: typeof CreateTagDimensionBodySchema.Type },
-    ) => createTagDimension(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-        },
-        body: Schema.encodeSync(CreateTagDimensionBodySchema)(tagDimension),
-      },
-    ),
-  )
+export function useCreateTagDimension() {
+  const mutationResponse = useCreateTagDimensionMutation()
 
   const { invalidate: invalidateTagDimensions } = useTagDimensionsGlobalCacheActions()
 
-  const { trigger: originalTrigger } = mutationResponse
+  const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
@@ -1,6 +1,7 @@
 import { Schema } from 'effect'
 
 import { type TagDimension, TagDimensionSchema } from '@schemas/tag'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
@@ -9,11 +10,11 @@ export const TAG_DIMENSIONS_TAG_KEY = '#tag-dimensions'
 
 const TagDimensionsListSchema = Schema.Array(TagDimensionSchema)
 
-const TagDimensionsResponseSchema = Schema.Struct({
-  data: Schema.Struct({
+const TagDimensionsResponseSchema = UnwrappedDataResponseSchema(
+  Schema.Struct({
     dimensions: TagDimensionsListSchema,
   }).pipe(Schema.pluck('dimensions')),
-})
+)
 
 const getTagDimensions = get<
   typeof TagDimensionsResponseSchema.Encoded,
@@ -27,7 +28,7 @@ type UseTagDimensionsParameters = {
 export const useTagDimensions = createQueryHook({
   tags: [TAG_DIMENSIONS_TAG_KEY],
   request: getTagDimensions,
-  schema: TagDimensionsResponseSchema.pipe(Schema.pluck('data')),
+  schema: TagDimensionsResponseSchema,
 })
 
 export const useTagDimensionsGlobalCacheActions = createResourceGlobalCacheActions<ReadonlyArray<TagDimension>>(TAG_DIMENSIONS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
@@ -11,9 +11,7 @@ export const TAG_DIMENSIONS_TAG_KEY = '#tag-dimensions'
 const TagDimensionsListSchema = Schema.Array(TagDimensionSchema)
 
 const TagDimensionsResponseSchema = UnwrappedDataResponseSchema(
-  Schema.Struct({
-    dimensions: TagDimensionsListSchema,
-  }).pipe(Schema.pluck('dimensions')),
+  Schema.Struct({ dimensions: TagDimensionsListSchema }),
 )
 
 const getTagDimensions = get<
@@ -29,6 +27,7 @@ export const useTagDimensions = createQueryHook({
   tags: [TAG_DIMENSIONS_TAG_KEY],
   request: getTagDimensions,
   schema: TagDimensionsResponseSchema,
+  select: data => data.dimensions,
 })
 
 export const useTagDimensionsGlobalCacheActions = createResourceGlobalCacheActions<ReadonlyArray<TagDimension>>(TAG_DIMENSIONS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
@@ -12,7 +12,7 @@ const TagDimensionsListSchema = Schema.Array(TagDimensionSchema)
 const TagDimensionsResponseSchema = Schema.Struct({
   data: Schema.Struct({
     dimensions: TagDimensionsListSchema,
-  }),
+  }).pipe(Schema.pluck('dimensions')),
 })
 
 const getTagDimensions = get<
@@ -27,8 +27,7 @@ type UseTagDimensionsParameters = {
 export const useTagDimensions = createQueryHook({
   tags: [TAG_DIMENSIONS_TAG_KEY],
   request: getTagDimensions,
-  schema: TagDimensionsResponseSchema,
-  select: ({ data }) => data.dimensions,
+  schema: TagDimensionsResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export const useTagDimensionsGlobalCacheActions = createResourceGlobalCacheActions<ReadonlyArray<TagDimension>>(TAG_DIMENSIONS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
+++ b/src/hooks/api/businesses/[business-id]/tags/dimensions/useTagDimensions.ts
@@ -1,53 +1,35 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
 
 import { type TagDimension, TagDimensionSchema } from '@schemas/tag'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const TAG_DIMENSIONS_TAG_KEY = '#tag-dimensions'
 
-const buildKey = createBuildKey<{ businessId: string }>([TAG_DIMENSIONS_TAG_KEY])
+const TagDimensionsListSchema = Schema.Array(TagDimensionSchema)
+
+const TagDimensionsResponseSchema = Schema.Struct({
+  data: Schema.Struct({
+    dimensions: TagDimensionsListSchema,
+  }),
+})
 
 const getTagDimensions = get<
-  { data: unknown },
+  typeof TagDimensionsResponseSchema.Encoded,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/tags/dimensions`)
-
-const TagDimensionsListSchema = Schema.Array(TagDimensionSchema)
 
 type UseTagDimensionsParameters = {
   isEnabled?: boolean
 }
 
-export function useTagDimensions({ isEnabled = true }: UseTagDimensionsParameters = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(
-    () => withLocale(buildKey({ ...auth, businessId, isEnabled })),
-    ({ accessToken, apiUrl, businessId }) => getTagDimensions(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-        },
-      },
-    )()
-      .then(({ data }) => data)
-      .then(Schema.decodeUnknownPromise(
-        Schema.Struct({
-          dimensions: TagDimensionsListSchema,
-        }),
-      ))
-      .then(({ dimensions }) => dimensions),
-  )
-
-  return new SWRQueryResult(swrResponse)
-}
+export const useTagDimensions = createQueryHook({
+  tags: [TAG_DIMENSIONS_TAG_KEY],
+  request: getTagDimensions,
+  schema: TagDimensionsResponseSchema,
+  select: ({ data }) => data.dimensions,
+})
 
 export const useTagDimensionsGlobalCacheActions = createResourceGlobalCacheActions<ReadonlyArray<TagDimension>>(TAG_DIMENSIONS_TAG_KEY)
 

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/delete/useDeleteUploadsOnTask.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/delete/useDeleteUploadsOnTask.ts
@@ -1,14 +1,12 @@
 import { useCallback } from 'react'
 import { useSWRConfig } from 'swr'
-import useSWRMutation from 'swr/mutation'
 
 import type { BusinessTaskEncoded } from '@schemas/businessTasks/businessTask'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { BOOKKEEPING_PERIODS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const deleteUploadsOnTask = post<
   { data: BusinessTaskEncoded },
@@ -22,38 +20,24 @@ const deleteUploadsOnTask = post<
     `/v1/businesses/${businessId}/tasks/${taskId}/upload/delete`,
 )
 
-const buildKey = createBuildKey<{ businessId: string }>(['#delete-uploads-on-task'])
-
 type UseDeleteUploadsOnTaskArg = {
   taskId: string
 }
 
+const useDeleteUploadsOnTaskMutation = createMutationHook({
+  tags: ['#delete-uploads-on-task'],
+  request: deleteUploadsOnTask,
+  argToParams: (arg: UseDeleteUploadsOnTaskArg) => arg,
+  argToBody: () => undefined,
+  swrOptions: { throwOnError: false },
+})
+
 export function useDeleteUploadsOnTask() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { taskId } }: { arg: UseDeleteUploadsOnTaskArg },
-    ) => deleteUploadsOnTask(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, taskId },
-      },
-    ),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
+  const mutationResponse = useDeleteUploadsOnTaskMutation()
 
-  const { trigger: originalTrigger } = mutationResponse
+  const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/useUpdateTaskUploadDescription.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/useUpdateTaskUploadDescription.ts
@@ -1,14 +1,12 @@
 import { useCallback } from 'react'
 import { useSWRConfig } from 'swr'
-import useSWRMutation from 'swr/mutation'
 
 import type { BusinessTaskEncoded } from '@schemas/businessTasks/businessTask'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { BOOKKEEPING_PERIODS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type UpdateTaskUploadsDescriptionBody = {
   type: 'FreeResponse'
@@ -27,43 +25,28 @@ const updateTaskUploadsDescription = post<
     `/v1/businesses/${businessId}/tasks/${taskId}/upload/update-description`,
 )
 
-const buildKey = createBuildKey<{ businessId: string }>(['#update-task-upload-description'])
-
 type UseUpdateTaskUploadDescriptionArg = {
   taskId: string
   description: string
 }
 
+const useUpdateTaskUploadDescriptionMutation = createMutationHook({
+  tags: ['#update-task-upload-description'],
+  request: updateTaskUploadsDescription,
+  argToParams: ({ taskId }: UseUpdateTaskUploadDescriptionArg) => ({ taskId }),
+  argToBody: ({ description }: UseUpdateTaskUploadDescriptionArg) => ({
+    type: 'FreeResponse' as const,
+    user_response: description,
+  }),
+  swrOptions: { throwOnError: false },
+})
+
 export function useUpdateTaskUploadDescription() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { taskId, description } }: { arg: UseUpdateTaskUploadDescriptionArg },
-    ) => updateTaskUploadsDescription(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, taskId },
-        body: {
-          type: 'FreeResponse',
-          user_response: description,
-        },
-      },
-    ),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
+  const mutationResponse = useUpdateTaskUploadDescriptionMutation()
 
-  const { trigger: originalTrigger } = mutationResponse
+  const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/useUploadDocumentsForTask.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/upload/useUploadDocumentsForTask.ts
@@ -1,30 +1,34 @@
 import { useCallback } from 'react'
 import { useSWRConfig } from 'swr'
-import useSWRMutation from 'swr/mutation'
 
 import type { FileMetadata } from '@internal-types/fileUpload'
 import { postWithFormData } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { BOOKKEEPING_PERIODS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
+
+type UploadDocumentsForTaskParams = {
+  businessId: string
+  taskId: string
+}
+
+type UploadDocumentsForTaskBody = {
+  files: ReadonlyArray<File>
+  description?: string
+}
 
 function completeTaskWithUpload(
   baseUrl: string,
-  accessToken: string,
-  {
-    businessId,
-    taskId,
-    files,
-    description,
-  }: {
-    businessId: string
-    taskId: string
-    files: ReadonlyArray<File>
-    description?: string
+  accessToken: string | undefined,
+  options?: {
+    params?: UploadDocumentsForTaskParams
+    body?: UploadDocumentsForTaskBody
   },
 ) {
+  const { businessId, taskId } = options?.params ?? ({} as UploadDocumentsForTaskParams)
+  const { files, description } = options?.body ?? ({} as UploadDocumentsForTaskBody)
+
   const formData = new FormData()
   files.forEach(file => formData.append('file', file))
   if (description) {
@@ -40,43 +44,26 @@ function completeTaskWithUpload(
   )
 }
 
-const buildKey = createBuildKey<{ businessId: string }>(['#use-upload-documents-for-task'])
-
 type UseUploadDocumentsForTaskArg = {
   taskId: string
   files: ReadonlyArray<File>
   description?: string
 }
 
+const useUploadDocumentsForTaskMutation = createMutationHook({
+  tags: ['#use-upload-documents-for-task'],
+  request: completeTaskWithUpload,
+  argToParams: ({ taskId }: UseUploadDocumentsForTaskArg) => ({ taskId }),
+  argToBody: ({ files, description }: UseUploadDocumentsForTaskArg) => ({ files, description }),
+  swrOptions: { throwOnError: false },
+})
+
 export function useUploadDocumentsForTask() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { taskId, files, description } }: { arg: UseUploadDocumentsForTaskArg },
-    ) => completeTaskWithUpload(
-      apiUrl,
-      accessToken,
-      {
-        businessId,
-        taskId,
-        files,
-        description,
-      },
-    ),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
+  const mutationResponse = useUploadDocumentsForTaskMutation()
 
-  const { trigger: originalTrigger } = mutationResponse
+  const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/user-response/useSubmitResponseForTask.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/user-response/useSubmitResponseForTask.ts
@@ -1,14 +1,12 @@
 import { useCallback } from 'react'
 import { useSWRConfig } from 'swr'
-import useSWRMutation from 'swr/mutation'
 
 import type { BusinessTaskEncoded } from '@schemas/businessTasks/businessTask'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { withSWRKeyTags } from '@utils/swr/withSWRKeyTags'
 import { BOOKKEEPING_PERIODS_TAG_KEY } from '@hooks/api/businesses/[business-id]/bookkeeping/periods/useBookkeepingPeriods'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 type SubmitUserResponseForTaskBody = {
   type: 'FreeResponse'
@@ -26,46 +24,28 @@ const submitUserResponseForTask = post<
   ({ businessId, taskId }) => `/v1/businesses/${businessId}/tasks/${taskId}/user-response`,
 )
 
-const buildKey = createBuildKey<{ businessId: string }>(['#submit-user-response-for-task'])
-
 type UseSubmitUserResponseForTaskArg = {
   taskId: string
   userResponse: string
 }
 
+const useSubmitUserResponseForTaskMutation = createMutationHook({
+  tags: ['#submit-user-response-for-task'],
+  request: submitUserResponseForTask,
+  argToParams: ({ taskId }: UseSubmitUserResponseForTaskArg) => ({ taskId }),
+  argToBody: ({ userResponse }: UseSubmitUserResponseForTaskArg) => ({
+    type: 'FreeResponse' as const,
+    user_response: userResponse,
+  }),
+  swrOptions: { throwOnError: false },
+})
+
 export function useSubmitUserResponseForTask() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { mutate } = useSWRConfig()
 
-  const mutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: { taskId, userResponse } }: { arg: UseSubmitUserResponseForTaskArg },
-    ) => submitUserResponseForTask(
-      apiUrl,
-      accessToken,
-      {
-        body: {
-          type: 'FreeResponse',
-          user_response: userResponse,
-        },
-        params: {
-          businessId,
-          taskId,
-        },
-      },
-    ),
-    {
-      revalidate: false,
-      throwOnError: false,
-    },
-  )
+  const mutationResponse = useSubmitUserResponseForTaskMutation()
 
-  const { trigger: originalTrigger } = mutationResponse
+  const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner.ts
@@ -1,5 +1,3 @@
-import { Schema } from 'effect'
-
 import type { ReportingBasis } from '@internal-types/general'
 import { type TaxEstimatesBanner, TaxEstimatesBannerResponseSchema } from '@schemas/taxEstimates/banner'
 import { getWithQuery } from '@utils/api/getWithQuery'
@@ -32,7 +30,7 @@ const getTaxEstimatesBanner = getWithQuery<
 export const useTaxEstimatesBanner = createQueryHook({
   tags: [TAX_ESTIMATES_BANNER_TAG_KEY],
   request: getTaxEstimatesBanner,
-  schema: TaxEstimatesBannerResponseSchema.pipe(Schema.pluck('data')),
+  schema: TaxEstimatesBannerResponseSchema,
 })
 
 export const useTaxEstimatesBannerGlobalCacheActions = createResourceGlobalCacheActions<

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner.ts
@@ -1,3 +1,5 @@
+import { Schema } from 'effect'
+
 import type { ReportingBasis } from '@internal-types/general'
 import { type TaxEstimatesBanner, TaxEstimatesBannerResponseSchema } from '@schemas/taxEstimates/banner'
 import { getWithQuery } from '@utils/api/getWithQuery'
@@ -30,8 +32,7 @@ const getTaxEstimatesBanner = getWithQuery<
 export const useTaxEstimatesBanner = createQueryHook({
   tags: [TAX_ESTIMATES_BANNER_TAG_KEY],
   request: getTaxEstimatesBanner,
-  schema: TaxEstimatesBannerResponseSchema,
-  select: ({ data }) => data,
+  schema: TaxEstimatesBannerResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export const useTaxEstimatesBannerGlobalCacheActions = createResourceGlobalCacheActions<

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner.ts
@@ -1,77 +1,38 @@
-import { Schema } from 'effect'
-import useSWR from 'swr'
-
 import type { ReportingBasis } from '@internal-types/general'
-import { type TaxEstimatesBanner, type TaxEstimatesBannerResponse, TaxEstimatesBannerResponseSchema } from '@schemas/taxEstimates/banner'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
+import { type TaxEstimatesBanner, TaxEstimatesBannerResponseSchema } from '@schemas/taxEstimates/banner'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const TAX_ESTIMATES_BANNER_TAG_KEY = '#tax-estimates-banner'
 type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
 
-type UseTaxEstimatesBannerOptions = {
+type GetTaxEstimatesBannerParams = {
+  businessId: string
   year: number
   reportingBasis?: TaxReportingBasis
   fullYearProjection?: boolean
 }
 
-type GetTaxEstimatesBannerParams = UseTaxEstimatesBannerOptions & {
-  businessId: string
-}
-
-const getTaxEstimatesBanner = get<TaxEstimatesBannerResponse, GetTaxEstimatesBannerParams>(
-  ({ businessId, year, reportingBasis, fullYearProjection }) => {
-    const parameters = toDefinedSearchParameters({
-      year,
-      reporting_basis: reportingBasis,
-      full_year_projection: fullYearProjection,
-    })
-    return `/v1/businesses/${businessId}/tax-estimates/banner?${parameters}`
-  },
+const getTaxEstimatesBanner = getWithQuery<
+  typeof TaxEstimatesBannerResponseSchema.Encoded,
+  GetTaxEstimatesBannerParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/banner`,
+  ({ year, reportingBasis, fullYearProjection }) => ({
+    year,
+    reporting_basis: reportingBasis,
+    full_year_projection: fullYearProjection,
+  }),
 )
 
-const buildKey = createBuildKey<{
-  businessId: string
-  year: number
-  reportingBasis?: TaxReportingBasis
-  fullYearProjection?: boolean
-}>([TAX_ESTIMATES_BANNER_TAG_KEY])
-
-export function useTaxEstimatesBanner({ year, reportingBasis, fullYearProjection }: UseTaxEstimatesBannerOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      year,
-      reportingBasis,
-      fullYearProjection,
-    })),
-    async ({ accessToken, apiUrl, businessId, year, reportingBasis, fullYearProjection }) => {
-      return getTaxEstimatesBanner(
-        apiUrl,
-        accessToken,
-        {
-          params: {
-            businessId,
-            year,
-            reportingBasis,
-            fullYearProjection,
-          },
-        },
-      )()
-        .then(Schema.decodeUnknownPromise(TaxEstimatesBannerResponseSchema))
-        .then(({ data }) => data)
-    },
-  )
-
-  return new SWRQueryResult(swrResponse)
-}
+export const useTaxEstimatesBanner = createQueryHook({
+  tags: [TAX_ESTIMATES_BANNER_TAG_KEY],
+  request: getTaxEstimatesBanner,
+  schema: TaxEstimatesBannerResponseSchema,
+  select: ({ data }) => data,
+})
 
 export const useTaxEstimatesBannerGlobalCacheActions = createResourceGlobalCacheActions<
   TaxEstimatesBanner

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/banner/useTaxEstimatesBanner.ts
@@ -1,30 +1,18 @@
-import type { ReportingBasis } from '@internal-types/general'
 import { type TaxEstimatesBanner, TaxEstimatesBannerResponseSchema } from '@schemas/taxEstimates/banner'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
+import { type TaxEstimatesRequestParams, toTaxEstimatesQuery } from '@hooks/api/businesses/[business-id]/tax-estimates/taxEstimatesParams'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const TAX_ESTIMATES_BANNER_TAG_KEY = '#tax-estimates-banner'
-type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
-
-type GetTaxEstimatesBannerParams = {
-  businessId: string
-  year: number
-  reportingBasis?: TaxReportingBasis
-  fullYearProjection?: boolean
-}
 
 const getTaxEstimatesBanner = getWithQuery<
   typeof TaxEstimatesBannerResponseSchema.Encoded,
-  GetTaxEstimatesBannerParams
+  TaxEstimatesRequestParams
 >(
   ['businessId'],
   ({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/banner`,
-  ({ year, reportingBasis, fullYearProjection }) => ({
-    year,
-    reporting_basis: reportingBasis,
-    full_year_projection: fullYearProjection,
-  }),
+  toTaxEstimatesQuery,
 )
 
 export const useTaxEstimatesBanner = createQueryHook({

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails.ts
@@ -1,3 +1,5 @@
+import { Schema } from 'effect'
+
 import type { ReportingBasis } from '@internal-types/general'
 import { type TaxDetails, TaxDetailsResponseSchema } from '@schemas/taxEstimates/details'
 import { getWithQuery } from '@utils/api/getWithQuery'
@@ -29,8 +31,7 @@ const getTaxDetails = getWithQuery<
 export const useTaxDetails = createQueryHook({
   tags: [TAX_DETAILS_TAG_KEY],
   request: getTaxDetails,
-  schema: TaxDetailsResponseSchema,
-  select: ({ data }) => data,
+  schema: TaxDetailsResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export const useTaxDetailsGlobalCacheActions = createResourceGlobalCacheActions<TaxDetails>(TAX_DETAILS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails.ts
@@ -1,29 +1,18 @@
-import type { ReportingBasis } from '@internal-types/general'
 import { type TaxDetails, TaxDetailsResponseSchema } from '@schemas/taxEstimates/details'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
+import { type TaxEstimatesRequestParams, toTaxEstimatesQuery } from '@hooks/api/businesses/[business-id]/tax-estimates/taxEstimatesParams'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const TAX_DETAILS_TAG_KEY = '#tax-details'
 
-type GetTaxDetailsParams = {
-  businessId: string
-  year: number
-  reportingBasis?: ReportingBasis
-  fullYearProjection?: boolean
-}
-
 const getTaxDetails = getWithQuery<
   typeof TaxDetailsResponseSchema.Encoded,
-  GetTaxDetailsParams
+  TaxEstimatesRequestParams
 >(
   ['businessId'],
   ({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/details`,
-  ({ year, reportingBasis, fullYearProjection }) => ({
-    year,
-    reporting_basis: reportingBasis,
-    full_year_projection: fullYearProjection,
-  }),
+  toTaxEstimatesQuery,
 )
 
 export const useTaxDetails = createQueryHook({

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails.ts
@@ -1,72 +1,36 @@
-import { Schema } from 'effect'
-import useSWR from 'swr'
-
 import type { ReportingBasis } from '@internal-types/general'
-import { type TaxDetails, type TaxDetailsResponse, TaxDetailsResponseSchema } from '@schemas/taxEstimates/details'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
+import { type TaxDetails, TaxDetailsResponseSchema } from '@schemas/taxEstimates/details'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const TAX_DETAILS_TAG_KEY = '#tax-details'
-type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
 
-type UseTaxDetailsOptions = {
+type GetTaxDetailsParams = {
+  businessId: string
   year: number
   reportingBasis?: ReportingBasis
   fullYearProjection?: boolean
 }
 
-type GetTaxDetailsParams = UseTaxDetailsOptions & {
-  businessId: string
-}
-
-const getTaxDetails = get<TaxDetailsResponse, GetTaxDetailsParams>(
-  ({ businessId, year, reportingBasis, fullYearProjection }) => {
-    const parameters = toDefinedSearchParameters({ year, reporting_basis: reportingBasis, full_year_projection: fullYearProjection })
-    return `/v1/businesses/${businessId}/tax-estimates/details?${parameters}`
-  },
+const getTaxDetails = getWithQuery<
+  typeof TaxDetailsResponseSchema.Encoded,
+  GetTaxDetailsParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/details`,
+  ({ year, reportingBasis, fullYearProjection }) => ({
+    year,
+    reporting_basis: reportingBasis,
+    full_year_projection: fullYearProjection,
+  }),
 )
 
-const buildKey = createBuildKey<{
-  businessId: string
-  year: number
-  reportingBasis?: TaxReportingBasis
-  fullYearProjection?: boolean
-}>([TAX_DETAILS_TAG_KEY])
-
-export function useTaxDetails({ year, reportingBasis, fullYearProjection }: UseTaxDetailsOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      year,
-      reportingBasis,
-      fullYearProjection,
-    })),
-    async ({ accessToken, apiUrl, businessId, year, reportingBasis, fullYearProjection }) => {
-      return getTaxDetails(
-        apiUrl,
-        accessToken,
-        {
-          params: {
-            businessId,
-            year,
-            reportingBasis,
-            fullYearProjection,
-          },
-        },
-      )()
-        .then(Schema.decodeUnknownPromise(TaxDetailsResponseSchema))
-        .then(({ data }) => data)
-    },
-  )
-
-  return new SWRQueryResult(swrResponse)
-}
+export const useTaxDetails = createQueryHook({
+  tags: [TAX_DETAILS_TAG_KEY],
+  request: getTaxDetails,
+  schema: TaxDetailsResponseSchema,
+  select: ({ data }) => data,
+})
 
 export const useTaxDetailsGlobalCacheActions = createResourceGlobalCacheActions<TaxDetails>(TAX_DETAILS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails.ts
@@ -1,5 +1,3 @@
-import { Schema } from 'effect'
-
 import type { ReportingBasis } from '@internal-types/general'
 import { type TaxDetails, TaxDetailsResponseSchema } from '@schemas/taxEstimates/details'
 import { getWithQuery } from '@utils/api/getWithQuery'
@@ -31,7 +29,7 @@ const getTaxDetails = getWithQuery<
 export const useTaxDetails = createQueryHook({
   tags: [TAX_DETAILS_TAG_KEY],
   request: getTaxDetails,
-  schema: TaxDetailsResponseSchema.pipe(Schema.pluck('data')),
+  schema: TaxDetailsResponseSchema,
 })
 
 export const useTaxDetailsGlobalCacheActions = createResourceGlobalCacheActions<TaxDetails>(TAX_DETAILS_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
@@ -1,13 +1,7 @@
-import { Schema } from 'effect'
-import useSWR from 'swr'
-
 import type { ReportingBasis } from '@internal-types/general'
-import { type TaxOverviewApiResponse, TaxOverviewApiResponseSchema } from '@schemas/taxEstimates/overview'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { TaxOverviewApiResponseSchema } from '@schemas/taxEstimates/overview'
+import { getWithQuery } from '@utils/api/getWithQuery'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const TAX_OVERVIEW_TAG_KEY = '#tax-overview'
 type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
@@ -23,53 +17,31 @@ type GetTaxOverviewParams = Omit<UseTaxOverviewOptions, 'enabled'> & {
   businessId: string
 }
 
-const getTaxOverview = get<TaxOverviewApiResponse, GetTaxOverviewParams>(
-  ({ businessId, year, reportingBasis, fullYearProjection }) => {
-    const parameters = toDefinedSearchParameters({
-      year,
-      reporting_basis: reportingBasis,
-      full_year_projection: fullYearProjection,
-    })
-    return `/v1/businesses/${businessId}/tax-estimates/overview?${parameters}`
-  },
+const getTaxOverview = getWithQuery<
+  typeof TaxOverviewApiResponseSchema.Encoded,
+  GetTaxOverviewParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/overview`,
+  ({ year, reportingBasis, fullYearProjection }) => ({
+    year,
+    reporting_basis: reportingBasis,
+    full_year_projection: fullYearProjection,
+  }),
 )
 
-const buildKey = createBuildKey<{
-  businessId: string
-  year: number
-  reportingBasis?: TaxReportingBasis
-  fullYearProjection?: boolean
-}>([TAX_OVERVIEW_TAG_KEY])
+const useTaxOverviewQuery = createQueryHook({
+  tags: [TAX_OVERVIEW_TAG_KEY],
+  request: getTaxOverview,
+  schema: TaxOverviewApiResponseSchema,
+  select: ({ data }) => data,
+})
 
 export function useTaxOverview({ year, reportingBasis, fullYearProjection, enabled = true }: UseTaxOverviewOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      year,
-      reportingBasis,
-      fullYearProjection,
-      isEnabled: enabled,
-    })),
-    async ({ accessToken, apiUrl, businessId, year, reportingBasis, fullYearProjection }) => {
-      return getTaxOverview(
-        apiUrl,
-        accessToken,
-        {
-          params: {
-            businessId,
-            year,
-            reportingBasis,
-            fullYearProjection,
-          },
-        },
-      )()
-        .then(Schema.decodeUnknownPromise(TaxOverviewApiResponseSchema))
-        .then(({ data }) => data)
-    },
-  )
-
-  return new SWRQueryResult(swrResponse)
+  return useTaxOverviewQuery({
+    year,
+    reportingBasis,
+    fullYearProjection,
+    isEnabled: enabled,
+  })
 }

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
@@ -1,5 +1,3 @@
-import { Schema } from 'effect'
-
 import type { ReportingBasis } from '@internal-types/general'
 import { TaxOverviewApiResponseSchema } from '@schemas/taxEstimates/overview'
 import { getWithQuery } from '@utils/api/getWithQuery'
@@ -31,5 +29,5 @@ const getTaxOverview = getWithQuery<
 export const useTaxOverview = createQueryHook({
   tags: [TAX_OVERVIEW_TAG_KEY],
   request: getTaxOverview,
-  schema: TaxOverviewApiResponseSchema.pipe(Schema.pluck('data')),
+  schema: TaxOverviewApiResponseSchema,
 })

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
@@ -1,3 +1,5 @@
+import { Schema } from 'effect'
+
 import type { ReportingBasis } from '@internal-types/general'
 import { TaxOverviewApiResponseSchema } from '@schemas/taxEstimates/overview'
 import { getWithQuery } from '@utils/api/getWithQuery'
@@ -29,6 +31,5 @@ const getTaxOverview = getWithQuery<
 export const useTaxOverview = createQueryHook({
   tags: [TAX_OVERVIEW_TAG_KEY],
   request: getTaxOverview,
-  schema: TaxOverviewApiResponseSchema,
-  select: ({ data }) => data,
+  schema: TaxOverviewApiResponseSchema.pipe(Schema.pluck('data')),
 })

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
@@ -1,29 +1,17 @@
-import type { ReportingBasis } from '@internal-types/general'
 import { TaxOverviewApiResponseSchema } from '@schemas/taxEstimates/overview'
 import { getWithQuery } from '@utils/api/getWithQuery'
+import { type TaxEstimatesRequestParams, toTaxEstimatesQuery } from '@hooks/api/businesses/[business-id]/tax-estimates/taxEstimatesParams'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const TAX_OVERVIEW_TAG_KEY = '#tax-overview'
-type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
-
-type GetTaxOverviewParams = {
-  businessId: string
-  year: number
-  reportingBasis?: TaxReportingBasis
-  fullYearProjection?: boolean
-}
 
 const getTaxOverview = getWithQuery<
   typeof TaxOverviewApiResponseSchema.Encoded,
-  GetTaxOverviewParams
+  TaxEstimatesRequestParams
 >(
   ['businessId'],
   ({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/overview`,
-  ({ year, reportingBasis, fullYearProjection }) => ({
-    year,
-    reporting_basis: reportingBasis,
-    full_year_projection: fullYearProjection,
-  }),
+  toTaxEstimatesQuery,
 )
 
 export const useTaxOverview = createQueryHook({

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/overview/useTaxOverview.ts
@@ -6,15 +6,11 @@ import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 const TAX_OVERVIEW_TAG_KEY = '#tax-overview'
 type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
 
-type UseTaxOverviewOptions = {
+type GetTaxOverviewParams = {
+  businessId: string
   year: number
   reportingBasis?: TaxReportingBasis
   fullYearProjection?: boolean
-  enabled?: boolean
-}
-
-type GetTaxOverviewParams = Omit<UseTaxOverviewOptions, 'enabled'> & {
-  businessId: string
 }
 
 const getTaxOverview = getWithQuery<
@@ -30,18 +26,9 @@ const getTaxOverview = getWithQuery<
   }),
 )
 
-const useTaxOverviewQuery = createQueryHook({
+export const useTaxOverview = createQueryHook({
   tags: [TAX_OVERVIEW_TAG_KEY],
   request: getTaxOverview,
   schema: TaxOverviewApiResponseSchema,
   select: ({ data }) => data,
 })
-
-export function useTaxOverview({ year, reportingBasis, fullYearProjection, enabled = true }: UseTaxOverviewOptions) {
-  return useTaxOverviewQuery({
-    year,
-    reportingBasis,
-    fullYearProjection,
-    isEnabled: enabled,
-  })
-}

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments.ts
@@ -1,29 +1,18 @@
-import type { ReportingBasis } from '@internal-types/general'
 import { type TaxPaymentRow, TaxPaymentsResponseSchema } from '@schemas/taxEstimates/payments'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
+import { type TaxEstimatesRequestParams, toTaxEstimatesQuery } from '@hooks/api/businesses/[business-id]/tax-estimates/taxEstimatesParams'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const TAX_PAYMENTS_TAG_KEY = '#tax-payments'
 
-type GetTaxPaymentsParams = {
-  businessId: string
-  year: number
-  reportingBasis?: ReportingBasis
-  fullYearProjection?: boolean
-}
-
 const getTaxPayments = getWithQuery<
   typeof TaxPaymentsResponseSchema.Encoded,
-  GetTaxPaymentsParams
+  TaxEstimatesRequestParams
 >(
   ['businessId'],
   ({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/payments`,
-  ({ year, reportingBasis, fullYearProjection }) => ({
-    year,
-    reporting_basis: reportingBasis,
-    full_year_projection: fullYearProjection,
-  }),
+  toTaxEstimatesQuery,
 )
 
 export const useTaxPayments = createQueryHook({

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments.ts
@@ -1,3 +1,5 @@
+import { Schema } from 'effect'
+
 import type { ReportingBasis } from '@internal-types/general'
 import { type TaxPaymentRow, TaxPaymentsResponseSchema } from '@schemas/taxEstimates/payments'
 import { getWithQuery } from '@utils/api/getWithQuery'
@@ -29,8 +31,8 @@ const getTaxPayments = getWithQuery<
 export const useTaxPayments = createQueryHook({
   tags: [TAX_PAYMENTS_TAG_KEY],
   request: getTaxPayments,
-  schema: TaxPaymentsResponseSchema,
-  select: ({ data }) => data.data,
+  schema: TaxPaymentsResponseSchema.pipe(Schema.pluck('data')),
+  select: ({ data }) => data,
 })
 
 export const useTaxPaymentsGlobalCacheActions = createResourceGlobalCacheActions<

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments.ts
@@ -1,73 +1,37 @@
-import { Schema } from 'effect'
-import useSWR from 'swr'
-
 import type { ReportingBasis } from '@internal-types/general'
-import { type TaxPaymentRow, type TaxPaymentsResponse, TaxPaymentsResponseSchema } from '@schemas/taxEstimates/payments'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
+import { type TaxPaymentRow, TaxPaymentsResponseSchema } from '@schemas/taxEstimates/payments'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const TAX_PAYMENTS_TAG_KEY = '#tax-payments'
-type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
 
-type UseTaxPaymentsOptions = {
+type GetTaxPaymentsParams = {
+  businessId: string
   year: number
   reportingBasis?: ReportingBasis
   fullYearProjection?: boolean
 }
 
-type GetTaxPaymentsParams = UseTaxPaymentsOptions & {
-  businessId: string
-}
-
-const getTaxPayments = get<TaxPaymentsResponse, GetTaxPaymentsParams>(
-  ({ businessId, year, reportingBasis, fullYearProjection }) => {
-    const parameters = toDefinedSearchParameters({ year, reporting_basis: reportingBasis, full_year_projection: fullYearProjection })
-    return `/v1/businesses/${businessId}/tax-estimates/payments?${parameters}`
-  },
+const getTaxPayments = getWithQuery<
+  typeof TaxPaymentsResponseSchema.Encoded,
+  GetTaxPaymentsParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/payments`,
+  ({ year, reportingBasis, fullYearProjection }) => ({
+    year,
+    reporting_basis: reportingBasis,
+    full_year_projection: fullYearProjection,
+  }),
 )
 
-const buildKey = createBuildKey<{
-  businessId: string
-  year: number
-  reportingBasis?: TaxReportingBasis
-  fullYearProjection?: boolean
-}>([TAX_PAYMENTS_TAG_KEY])
-
-export function useTaxPayments({ year, reportingBasis, fullYearProjection }: UseTaxPaymentsOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      year,
-      reportingBasis,
-      fullYearProjection,
-    })),
-    async ({ accessToken, apiUrl, businessId, year, reportingBasis, fullYearProjection }) => {
-      return getTaxPayments(
-        apiUrl,
-        accessToken,
-        {
-          params: {
-            businessId,
-            year,
-            reportingBasis,
-            fullYearProjection,
-          },
-        },
-      )()
-        .then(Schema.decodeUnknownPromise(TaxPaymentsResponseSchema))
-        .then(({ data }) => data.data)
-    },
-  )
-
-  return new SWRQueryResult(swrResponse)
-}
+export const useTaxPayments = createQueryHook({
+  tags: [TAX_PAYMENTS_TAG_KEY],
+  request: getTaxPayments,
+  schema: TaxPaymentsResponseSchema,
+  select: ({ data }) => data.data,
+})
 
 export const useTaxPaymentsGlobalCacheActions = createResourceGlobalCacheActions<
   TaxPaymentRow[]

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments.ts
@@ -1,5 +1,3 @@
-import { Schema } from 'effect'
-
 import type { ReportingBasis } from '@internal-types/general'
 import { type TaxPaymentRow, TaxPaymentsResponseSchema } from '@schemas/taxEstimates/payments'
 import { getWithQuery } from '@utils/api/getWithQuery'
@@ -31,7 +29,7 @@ const getTaxPayments = getWithQuery<
 export const useTaxPayments = createQueryHook({
   tags: [TAX_PAYMENTS_TAG_KEY],
   request: getTaxPayments,
-  schema: TaxPaymentsResponseSchema.pipe(Schema.pluck('data')),
+  schema: TaxPaymentsResponseSchema,
   select: ({ data }) => data,
 })
 

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile.ts
@@ -1,40 +1,24 @@
-import { Schema } from 'effect'
-import useSWR from 'swr'
-
-import { type TaxProfile, type TaxProfileResponse, TaxProfileResponseSchema } from '@schemas/taxEstimates/profile'
+import { type TaxProfile, TaxProfileResponseSchema } from '@schemas/taxEstimates/profile'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const TAX_PROFILE_TAG_KEY = '#tax-profile'
 
-export const getTaxProfile = get<TaxProfileResponse, { businessId: string }>(
+export const getTaxProfile = get<
+  typeof TaxProfileResponseSchema.Encoded,
+  { businessId: string }
+>(
   ({ businessId }) => {
     return `/v1/businesses/${businessId}/tax-estimates/profile`
   },
 )
 
-const buildKey = createBuildKey<{ businessId: string }>([TAX_PROFILE_TAG_KEY])
-
-export function useTaxProfile() {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(
-    () => withLocale(buildKey({ ...auth, businessId })),
-    async ({ accessToken, apiUrl, businessId }) => {
-      return getTaxProfile(
-        apiUrl,
-        accessToken,
-        { params: { businessId } },
-      )()
-        .then(Schema.decodeUnknownPromise(TaxProfileResponseSchema))
-        .then(({ data }) => data)
-    },
-  )
-
-  return new SWRQueryResult(swrResponse)
-}
+export const useTaxProfile = createQueryHook({
+  tags: [TAX_PROFILE_TAG_KEY],
+  request: getTaxProfile,
+  schema: TaxProfileResponseSchema,
+  select: ({ data }) => data,
+})
 
 export const useTaxProfileGlobalCacheActions = createResourceGlobalCacheActions<TaxProfile>(TAX_PROFILE_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile.ts
@@ -1,3 +1,5 @@
+import { Schema } from 'effect'
+
 import { type TaxProfile, TaxProfileResponseSchema } from '@schemas/taxEstimates/profile'
 import { get } from '@utils/api/authenticatedHttp'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
@@ -17,8 +19,7 @@ export const getTaxProfile = get<
 export const useTaxProfile = createQueryHook({
   tags: [TAX_PROFILE_TAG_KEY],
   request: getTaxProfile,
-  schema: TaxProfileResponseSchema,
-  select: ({ data }) => data,
+  schema: TaxProfileResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export const useTaxProfileGlobalCacheActions = createResourceGlobalCacheActions<TaxProfile>(TAX_PROFILE_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile.ts
@@ -1,5 +1,3 @@
-import { Schema } from 'effect'
-
 import { type TaxProfile, TaxProfileResponseSchema } from '@schemas/taxEstimates/profile'
 import { get } from '@utils/api/authenticatedHttp'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
@@ -19,7 +17,7 @@ export const getTaxProfile = get<
 export const useTaxProfile = createQueryHook({
   tags: [TAX_PROFILE_TAG_KEY],
   request: getTaxProfile,
-  schema: TaxProfileResponseSchema.pipe(Schema.pluck('data')),
+  schema: TaxProfileResponseSchema,
 })
 
 export const useTaxProfileGlobalCacheActions = createResourceGlobalCacheActions<TaxProfile>(TAX_PROFILE_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useUpsertTaxProfile.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useUpsertTaxProfile.ts
@@ -1,16 +1,12 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
-import { type TaxProfileRequest, type TaxProfileResponse, TaxProfileResponseSchema } from '@schemas/taxEstimates/profile'
+import { type TaxProfileRequest, TaxProfileResponseSchema } from '@schemas/taxEstimates/profile'
 import { patch, post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTaxDetailsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/tax-estimates/details/useTaxDetails'
 import { useTaxPaymentsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/tax-estimates/payments/useTaxPayments'
 import { useTaxProfileGlobalCacheActions } from '@hooks/api/businesses/[business-id]/tax-estimates/profile/useTaxProfile'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPSERT_TAX_PROFILE_TAG_KEY = '#upsert-tax-profile'
 
@@ -20,52 +16,45 @@ export enum UpsertTaxProfileMode {
 }
 
 export const createTaxProfile = post<
-  TaxProfileResponse,
+  typeof TaxProfileResponseSchema.Encoded,
   TaxProfileRequest,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/profile`)
 
 export const updateTaxProfile = patch<
-  TaxProfileResponse,
+  typeof TaxProfileResponseSchema.Encoded,
   TaxProfileRequest,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/profile`)
 
-const buildKey = createBuildKey<{ businessId: string }>([UPSERT_TAX_PROFILE_TAG_KEY])
+const useCreateTaxProfileMutation = createMutationHook({
+  tags: [UPSERT_TAX_PROFILE_TAG_KEY],
+  request: createTaxProfile,
+  schema: TaxProfileResponseSchema,
+  swrOptions: { throwOnError: true },
+})
 
-function getRequestFn(mode: UpsertTaxProfileMode) {
-  return mode === UpsertTaxProfileMode.Update ? updateTaxProfile : createTaxProfile
-}
+const useUpdateTaxProfileMutation = createMutationHook({
+  tags: [UPSERT_TAX_PROFILE_TAG_KEY],
+  request: updateTaxProfile,
+  schema: TaxProfileResponseSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseUpsertTaxProfileProps = {
   mode: UpsertTaxProfileMode
 }
 export function useUpsertTaxProfile({ mode }: UseUpsertTaxProfileProps) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { overwriteCache: overwriteTaxProfile } = useTaxProfileGlobalCacheActions()
   const { forceReload: forceReloadTaxPayments } = useTaxPaymentsGlobalCacheActions()
   const { forceReload: forceReloadTaxDetails } = useTaxDetailsGlobalCacheActions()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    async ({ accessToken, apiUrl, businessId }, { arg }: { arg: TaxProfileRequest }) => {
-      const request = getRequestFn(mode)
+  const createMutationResponse = useCreateTaxProfileMutation()
+  const updateMutationResponse = useUpdateTaxProfileMutation()
 
-      return request(apiUrl, accessToken, {
-        params: { businessId },
-        body: arg,
-      }).then(Schema.decodeUnknownPromise(TaxProfileResponseSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = mode === UpsertTaxProfileMode.Update
+    ? updateMutationResponse
+    : createMutationResponse
 
   const originalTrigger = mutationResponse.trigger
 

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useUpsertTaxProfile.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/profile/useUpsertTaxProfile.ts
@@ -62,7 +62,7 @@ export function useUpsertTaxProfile({ mode }: UseUpsertTaxProfileProps) {
     async (...triggerParameters: Parameters<typeof originalTrigger>) => {
       const triggerResult = await originalTrigger(...triggerParameters)
 
-      void overwriteTaxProfile(triggerResult.data)
+      void overwriteTaxProfile(triggerResult)
       void forceReloadTaxPayments()
       void forceReloadTaxDetails()
 

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
@@ -1,30 +1,18 @@
-import type { ReportingBasis } from '@internal-types/general'
 import { type TaxSummary, TaxSummaryResponseSchema } from '@schemas/taxEstimates/summary'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
+import { type TaxEstimatesRequestParams, toTaxEstimatesQuery } from '@hooks/api/businesses/[business-id]/tax-estimates/taxEstimatesParams'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const TAX_SUMMARY_TAG_KEY = '#tax-summary'
-type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
-
-type GetTaxSummaryParams = {
-  businessId: string
-  year: number
-  reportingBasis?: TaxReportingBasis
-  fullYearProjection?: boolean
-}
 
 const getTaxSummary = getWithQuery<
   typeof TaxSummaryResponseSchema.Encoded,
-  GetTaxSummaryParams
+  TaxEstimatesRequestParams
 >(
   ['businessId'],
   ({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/summary`,
-  ({ year, reportingBasis, fullYearProjection }) => ({
-    year,
-    reporting_basis: reportingBasis,
-    full_year_projection: fullYearProjection,
-  }),
+  toTaxEstimatesQuery,
 )
 
 export const useTaxSummary = createQueryHook({

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
@@ -1,14 +1,8 @@
-import { Schema } from 'effect'
-import useSWR from 'swr'
-
 import type { ReportingBasis } from '@internal-types/general'
-import { type TaxSummary, type TaxSummaryResponse, TaxSummaryResponseSchema } from '@schemas/taxEstimates/summary'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
+import { type TaxSummary, TaxSummaryResponseSchema } from '@schemas/taxEstimates/summary'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const TAX_SUMMARY_TAG_KEY = '#tax-summary'
 type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
@@ -24,51 +18,33 @@ type GetTaxSummaryParams = Omit<UseTaxSummaryOptions, 'enabled'> & {
   businessId: string
 }
 
-const getTaxSummary = get<TaxSummaryResponse, GetTaxSummaryParams>(
-  ({ businessId, year, reportingBasis, fullYearProjection }) => {
-    const parameters = toDefinedSearchParameters({ year, reporting_basis: reportingBasis, full_year_projection: fullYearProjection })
-    return `/v1/businesses/${businessId}/tax-estimates/summary?${parameters}`
-  },
+const getTaxSummary = getWithQuery<
+  typeof TaxSummaryResponseSchema.Encoded,
+  GetTaxSummaryParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/tax-estimates/summary`,
+  ({ year, reportingBasis, fullYearProjection }) => ({
+    year,
+    reporting_basis: reportingBasis,
+    full_year_projection: fullYearProjection,
+  }),
 )
 
-const buildKey = createBuildKey<{
-  businessId: string
-  year: number
-  reportingBasis?: TaxReportingBasis
-  fullYearProjection?: boolean
-}>([TAX_SUMMARY_TAG_KEY])
+const useTaxSummaryQuery = createQueryHook({
+  tags: [TAX_SUMMARY_TAG_KEY],
+  request: getTaxSummary,
+  schema: TaxSummaryResponseSchema,
+  select: ({ data }) => data,
+})
 
 export function useTaxSummary({ year, reportingBasis, fullYearProjection, enabled = true }: UseTaxSummaryOptions) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      year,
-      reportingBasis,
-      fullYearProjection,
-      isEnabled: enabled,
-    })),
-    async ({ accessToken, apiUrl, businessId, year, reportingBasis, fullYearProjection }) => {
-      return getTaxSummary(
-        apiUrl,
-        accessToken,
-        {
-          params: {
-            businessId,
-            year,
-            reportingBasis,
-            fullYearProjection,
-          },
-        },
-      )()
-        .then(Schema.decodeUnknownPromise(TaxSummaryResponseSchema))
-        .then(({ data }) => data)
-    },
-  )
-
-  return new SWRQueryResult(swrResponse)
+  return useTaxSummaryQuery({
+    year,
+    reportingBasis,
+    fullYearProjection,
+    isEnabled: enabled,
+  })
 }
 
 export const useTaxSummaryGlobalCacheActions = createResourceGlobalCacheActions<

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
@@ -7,15 +7,11 @@ import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 const TAX_SUMMARY_TAG_KEY = '#tax-summary'
 type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
 
-type UseTaxSummaryOptions = {
+type GetTaxSummaryParams = {
+  businessId: string
   year: number
   reportingBasis?: TaxReportingBasis
   fullYearProjection?: boolean
-  enabled?: boolean
-}
-
-type GetTaxSummaryParams = Omit<UseTaxSummaryOptions, 'enabled'> & {
-  businessId: string
 }
 
 const getTaxSummary = getWithQuery<
@@ -31,21 +27,12 @@ const getTaxSummary = getWithQuery<
   }),
 )
 
-const useTaxSummaryQuery = createQueryHook({
+export const useTaxSummary = createQueryHook({
   tags: [TAX_SUMMARY_TAG_KEY],
   request: getTaxSummary,
   schema: TaxSummaryResponseSchema,
   select: ({ data }) => data,
 })
-
-export function useTaxSummary({ year, reportingBasis, fullYearProjection, enabled = true }: UseTaxSummaryOptions) {
-  return useTaxSummaryQuery({
-    year,
-    reportingBasis,
-    fullYearProjection,
-    isEnabled: enabled,
-  })
-}
 
 export const useTaxSummaryGlobalCacheActions = createResourceGlobalCacheActions<
   TaxSummary

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
@@ -1,3 +1,5 @@
+import { Schema } from 'effect'
+
 import type { ReportingBasis } from '@internal-types/general'
 import { type TaxSummary, TaxSummaryResponseSchema } from '@schemas/taxEstimates/summary'
 import { getWithQuery } from '@utils/api/getWithQuery'
@@ -30,8 +32,7 @@ const getTaxSummary = getWithQuery<
 export const useTaxSummary = createQueryHook({
   tags: [TAX_SUMMARY_TAG_KEY],
   request: getTaxSummary,
-  schema: TaxSummaryResponseSchema,
-  select: ({ data }) => data,
+  schema: TaxSummaryResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export const useTaxSummaryGlobalCacheActions = createResourceGlobalCacheActions<

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/summary/useTaxSummary.ts
@@ -1,5 +1,3 @@
-import { Schema } from 'effect'
-
 import type { ReportingBasis } from '@internal-types/general'
 import { type TaxSummary, TaxSummaryResponseSchema } from '@schemas/taxEstimates/summary'
 import { getWithQuery } from '@utils/api/getWithQuery'
@@ -32,7 +30,7 @@ const getTaxSummary = getWithQuery<
 export const useTaxSummary = createQueryHook({
   tags: [TAX_SUMMARY_TAG_KEY],
   request: getTaxSummary,
-  schema: TaxSummaryResponseSchema.pipe(Schema.pluck('data')),
+  schema: TaxSummaryResponseSchema,
 })
 
 export const useTaxSummaryGlobalCacheActions = createResourceGlobalCacheActions<

--- a/src/hooks/api/businesses/[business-id]/tax-estimates/taxEstimatesParams.ts
+++ b/src/hooks/api/businesses/[business-id]/tax-estimates/taxEstimatesParams.ts
@@ -1,0 +1,19 @@
+import type { ReportingBasis } from '@internal-types/general'
+import { type QueryParams } from '@utils/request/toDefinedSearchParameters'
+
+export type TaxReportingBasis = Exclude<ReportingBasis, 'CASH_COLLECTED'>
+
+export type TaxEstimatesRequestParams = {
+  businessId: string
+  year: number
+  reportingBasis?: TaxReportingBasis
+  fullYearProjection?: boolean
+}
+
+export const toTaxEstimatesQuery = (
+  { year, reportingBasis, fullYearProjection }: TaxEstimatesRequestParams,
+): QueryParams => ({
+  year,
+  reporting_basis: reportingBasis,
+  full_year_projection: fullYearProjection,
+})

--- a/src/hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary.ts
@@ -31,8 +31,7 @@ const getTimeTrackingSummary = getWithQuery<
 export const useTimeTrackingSummary = createQueryHook({
   tags: [TIME_TRACKING_SUMMARY_TAG_KEY],
   request: getTimeTrackingSummary,
-  schema: TimeTrackingSummaryResponseSchema,
-  select: ({ data }) => data,
+  schema: TimeTrackingSummaryResponseSchema.pipe(Schema.pluck('data')),
 })
 
 export const useTimeTrackingSummaryGlobalCacheActions = createResourceGlobalCacheActions<

--- a/src/hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary.ts
@@ -1,13 +1,10 @@
-import { Schema } from 'effect'
-
 import { type TimeEntrySummary, TimeEntrySummarySchema } from '@schemas/timeTracking'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
-const TimeTrackingSummaryResponseSchema = Schema.Struct({
-  data: TimeEntrySummarySchema,
-})
+const TimeTrackingSummaryResponseSchema = UnwrappedDataResponseSchema(TimeEntrySummarySchema)
 
 export const TIME_TRACKING_SUMMARY_TAG_KEY = '#time-tracking-summary'
 
@@ -31,7 +28,7 @@ const getTimeTrackingSummary = getWithQuery<
 export const useTimeTrackingSummary = createQueryHook({
   tags: [TIME_TRACKING_SUMMARY_TAG_KEY],
   request: getTimeTrackingSummary,
-  schema: TimeTrackingSummaryResponseSchema.pipe(Schema.pluck('data')),
+  schema: TimeTrackingSummaryResponseSchema,
 })
 
 export const useTimeTrackingSummaryGlobalCacheActions = createResourceGlobalCacheActions<

--- a/src/hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary.ts
@@ -1,13 +1,9 @@
 import { Schema } from 'effect'
-import useSWR from 'swr'
 
 import { type TimeEntrySummary, TimeEntrySummarySchema } from '@schemas/timeTracking'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createBuildKey } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 const TimeTrackingSummaryResponseSchema = Schema.Struct({
   data: TimeEntrySummarySchema,
@@ -22,44 +18,22 @@ export type TimeTrackingSummaryFilterParams = {
   endDate?: Date
 }
 
-const buildKey = createBuildKey<{ businessId: string } & TimeTrackingSummaryFilterParams>([TIME_TRACKING_SUMMARY_TAG_KEY])
+type GetTimeTrackingSummaryParams = { businessId: string } & TimeTrackingSummaryFilterParams
 
-const getTimeTrackingSummary = get<
+const getTimeTrackingSummary = getWithQuery<
   typeof TimeTrackingSummaryResponseSchema.Encoded,
-  { businessId: string } & TimeTrackingSummaryFilterParams
->(({ businessId, customerId, serviceId, startDate, endDate }) => {
-  const parameters = toDefinedSearchParameters({
-    customerId,
-    serviceId,
-    startDate,
-    endDate,
-  }).toString()
-  const baseUrl = `/v1/businesses/${businessId}/time-tracking/time-entries/summary`
-  return parameters ? `${baseUrl}?${parameters}` : baseUrl
+  GetTimeTrackingSummaryParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/time-tracking/time-entries/summary`,
+)
+
+export const useTimeTrackingSummary = createQueryHook({
+  tags: [TIME_TRACKING_SUMMARY_TAG_KEY],
+  request: getTimeTrackingSummary,
+  schema: TimeTrackingSummaryResponseSchema,
+  select: ({ data }) => data,
 })
-
-export function useTimeTrackingSummary(filterParams: TimeTrackingSummaryFilterParams = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      ...filterParams,
-    })),
-    ({ accessToken, apiUrl, businessId, customerId, serviceId, startDate, endDate }) => getTimeTrackingSummary(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId, customerId, serviceId, startDate, endDate },
-      },
-    )()
-      .then(Schema.decodeUnknownPromise(TimeTrackingSummaryResponseSchema))
-      .then(({ data }) => data),
-  )
-
-  return new SWRQueryResult(response)
-}
 
 export const useTimeTrackingSummaryGlobalCacheActions = createResourceGlobalCacheActions<
   TimeEntrySummary

--- a/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/[time-entry-id]/useDeleteTimeEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/[time-entry-id]/useDeleteTimeEntry.ts
@@ -1,59 +1,36 @@
 import { useCallback } from 'react'
-import useSWRMutation from 'swr/mutation'
 
 import { del } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTimeTrackingSummaryGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary'
 import { useTimeEntriesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/time-entries/useListTimeEntries'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const DELETE_TIME_ENTRY_TAG_KEY = '#delete-time-entry'
 
 const deleteTimeEntry = del<
   Record<string, never>,
   Record<string, never>,
-  { businessId: string, timeEntryId: string }
+  { businessId: string, timeEntryId?: string }
 >(({ businessId, timeEntryId }) => `/v1/businesses/${businessId}/time-tracking/time-entries/${timeEntryId}`)
 
-const buildKey = createBuildKey<{ businessId: string, timeEntryId: string }>([DELETE_TIME_ENTRY_TAG_KEY])
+const useDeleteTimeEntryMutation = createMutationHook({
+  tags: [DELETE_TIME_ENTRY_TAG_KEY],
+  request: deleteTimeEntry,
+  keyParams: ['timeEntryId'],
+  argToBody: (_arg: never) => undefined,
+  swrOptions: { throwOnError: true },
+})
 
 type UseDeleteTimeEntryProps = {
   timeEntryId: string | undefined
 }
 
 export const useDeleteTimeEntry = ({ timeEntryId }: UseDeleteTimeEntryProps) => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const rawMutationResponse = useSWRMutation(
-    () => {
-      if (!timeEntryId) {
-        return undefined
-      }
-
-      return withLocale(buildKey({
-        ...auth,
-        businessId,
-        timeEntryId,
-      }))
-    },
-    (
-      { accessToken, apiUrl, businessId, timeEntryId },
-    ) => {
-      return deleteTimeEntry(
-        apiUrl,
-        accessToken,
-        { params: { businessId, timeEntryId } },
-      )
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useDeleteTimeEntryMutation({
+    timeEntryId,
+    isEnabled: Boolean(timeEntryId),
+  })
 
   const { forceReload: forceReloadTimeEntries } = useTimeEntriesGlobalCacheActions()
   const { invalidate: invalidateTimeTrackingSummary } = useTimeTrackingSummaryGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useListTimeEntries.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useListTimeEntries.ts
@@ -1,15 +1,8 @@
-import { Schema } from 'effect'
-import useSWRInfinite from 'swr/infinite'
-
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { type TimeEntry, TimeEntrySchema } from '@schemas/timeTracking'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
+import { getWithQuery } from '@utils/api/getWithQuery'
 import { createInfiniteQueryGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
-import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createInfiniteQueryHook } from '@hooks/utils/swr/createInfiniteQueryHook'
 
 export const LIST_TIME_ENTRIES_TAG_KEY = '#list-time-entries'
 
@@ -27,96 +20,26 @@ export type ListTimeEntriesFilterParams = {
 }
 
 const ListTimeEntriesResponseSchema = PaginatedResponseSchema(TimeEntrySchema)
-type ListTimeEntriesResponse = typeof ListTimeEntriesResponseSchema.Type
 
-const keyLoader = createInfiniteKeyLoader<
-  { businessId: string } & ListTimeEntriesFilterParams,
-  ListTimeEntriesResponse
->([LIST_TIME_ENTRIES_TAG_KEY])
+type ListTimeEntriesParams = {
+  businessId: string
+  cursor?: string
+  limit?: number
+} & ListTimeEntriesFilterParams
 
-const listTimeEntries = get<
+const listTimeEntries = getWithQuery<
   typeof ListTimeEntriesResponseSchema.Encoded,
-  {
-    businessId: string
-    cursor?: string | null
-    limit?: number
-    customerId?: string
-    serviceId?: string
-    startDate?: Date
-    endDate?: Date
-    includeDeleted?: boolean
-    status?: 'ACTIVE' | 'COMPLETED' | 'RECORDED'
-    billable?: boolean
-    hasCustomer?: boolean
-    sortBy?: string
-    sortOrder?: 'ASC' | 'DESC'
-  }
->(({ businessId, cursor, limit, customerId, serviceId, startDate, endDate, includeDeleted, status, billable, hasCustomer, sortBy, sortOrder }) => {
-  const parameters = toDefinedSearchParameters({
-    cursor,
-    limit,
-    customerId,
-    serviceId,
-    startDate,
-    endDate,
-    includeDeleted,
-    status,
-    billable,
-    hasCustomer,
-    sortBy,
-    sortOrder,
-  })
-  const baseUrl = `/v1/businesses/${businessId}/time-tracking/time-entries`
-  const query = parameters.toString()
-  return query ? `${baseUrl}?${query}` : baseUrl
+  ListTimeEntriesParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/time-tracking/time-entries`,
+)
+
+export const useListTimeEntries = createInfiniteQueryHook({
+  tags: [LIST_TIME_ENTRIES_TAG_KEY],
+  request: listTimeEntries,
+  schema: ListTimeEntriesResponseSchema,
+  keyDefaults: { limit: 200 },
 })
-
-export function useListTimeEntries(filterParams: ListTimeEntriesFilterParams = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWRInfinite(
-    (_index, previousPageData: ListTimeEntriesResponse | null) => withLocale(keyLoader(
-      previousPageData,
-      {
-        ...auth,
-        businessId,
-        ...filterParams,
-      },
-    )),
-    ({
-      accessToken, apiUrl, businessId, cursor, customerId, serviceId,
-      startDate, endDate, includeDeleted, status, billable, hasCustomer, sortBy, sortOrder,
-    }) => listTimeEntries(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          cursor,
-          limit: 200,
-          customerId,
-          serviceId,
-          startDate,
-          endDate,
-          includeDeleted,
-          status,
-          billable,
-          hasCustomer,
-          sortBy,
-          sortOrder,
-        },
-      },
-    )().then(Schema.decodeUnknownPromise(ListTimeEntriesResponseSchema)),
-    {
-      keepPreviousData: true,
-      revalidateFirstPage: false,
-      initialSize: 1,
-    },
-  )
-
-  usePreserveInfiniteSize(swrResponse)
-
-  return useSWRInfiniteResult(swrResponse)
-}
 
 export const useTimeEntriesGlobalCacheActions = createInfiniteQueryGlobalCacheActions<TimeEntry>(LIST_TIME_ENTRIES_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useUpsertTimeEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useUpsertTimeEntry.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { TimeEntrySchema, type UpsertTimeEntryEncoded } from '@schemas/timeTracking'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { patch, post } from '@utils/api/authenticatedHttp'
 import type { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
@@ -20,9 +20,7 @@ type CreateTimeEntryBody = UpsertTimeEntryEncoded
 type UpdateTimeEntryBody = Partial<UpsertTimeEntryEncoded>
 type UpsertTimeEntryBody = CreateTimeEntryBody | UpdateTimeEntryBody
 
-const UpsertTimeEntryReturnSchema = Schema.Struct({
-  data: TimeEntrySchema,
-})
+const UpsertTimeEntryReturnSchema = UnwrappedDataResponseSchema(TimeEntrySchema)
 
 type UpsertTimeEntryReturn = typeof UpsertTimeEntryReturnSchema.Type
 type UpsertTimeEntryReturnEncoded = typeof UpsertTimeEntryReturnSchema.Encoded
@@ -85,7 +83,7 @@ export function useUpsertTimeEntry(props: UseUpsertTimeEntryProps) {
       const triggerResult = await originalTrigger(...triggerParameters)
 
       if (mode === UpsertTimeEntryMode.Update) {
-        void patchTimeEntryByKey(triggerResult.data)
+        void patchTimeEntryByKey(triggerResult)
       }
       else {
         void forceReloadTimeEntries()

--- a/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useUpsertTimeEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useUpsertTimeEntry.ts
@@ -1,15 +1,13 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { TimeEntrySchema, type UpsertTimeEntryEncoded } from '@schemas/timeTracking'
 import { patch, post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
+import type { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTimeTrackingSummaryGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary'
 import { useTimeEntriesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/time-entries/useListTimeEntries'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const UPSERT_TIME_ENTRY_TAG_KEY = '#upsert-time-entry'
 
@@ -22,25 +20,50 @@ type CreateTimeEntryBody = UpsertTimeEntryEncoded
 type UpdateTimeEntryBody = Partial<UpsertTimeEntryEncoded>
 type UpsertTimeEntryBody = CreateTimeEntryBody | UpdateTimeEntryBody
 
-const createTimeEntry = post<
-  UpsertTimeEntryReturn,
-  CreateTimeEntryBody,
-  { businessId: string }
->(({ businessId }) => `/v1/businesses/${businessId}/time-tracking/time-entries`)
-
-const updateTimeEntry = patch<
-  UpsertTimeEntryReturn,
-  UpdateTimeEntryBody,
-  { businessId: string, timeEntryId: string }
->(({ businessId, timeEntryId }) => `/v1/businesses/${businessId}/time-tracking/time-entries/${timeEntryId}`)
-
-const buildKey = createBuildKey<{ businessId: string, timeEntryId?: string }>([UPSERT_TIME_ENTRY_TAG_KEY])
-
 const UpsertTimeEntryReturnSchema = Schema.Struct({
   data: TimeEntrySchema,
 })
 
 type UpsertTimeEntryReturn = typeof UpsertTimeEntryReturnSchema.Type
+type UpsertTimeEntryReturnEncoded = typeof UpsertTimeEntryReturnSchema.Encoded
+
+const createTimeEntry = post<UpsertTimeEntryReturnEncoded, CreateTimeEntryBody>(
+  ({ businessId }) => `/v1/businesses/${businessId}/time-tracking/time-entries`,
+)
+
+const updateTimeEntry = patch<UpsertTimeEntryReturnEncoded, UpdateTimeEntryBody>(
+  ({ businessId, timeEntryId }) => `/v1/businesses/${businessId}/time-tracking/time-entries/${timeEntryId}`,
+)
+
+type UpsertTimeEntryParams = { businessId: string, timeEntryId?: string }
+
+const upsertTimeEntry = (
+  baseUrl: string,
+  accessToken: string | undefined,
+  options?: { params?: UpsertTimeEntryParams, body?: UpsertTimeEntryBody },
+): Promise<UpsertTimeEntryReturnEncoded> => {
+  const { params, body } = options ?? {}
+
+  if (params?.timeEntryId !== undefined) {
+    return updateTimeEntry(baseUrl, accessToken, {
+      params: { businessId: params.businessId, timeEntryId: params.timeEntryId },
+      body,
+    })
+  }
+
+  return createTimeEntry(baseUrl, accessToken, {
+    params: { businessId: params?.businessId },
+    body: body as CreateTimeEntryBody,
+  })
+}
+
+const useUpsertTimeEntryMutation = createMutationHook({
+  tags: [UPSERT_TIME_ENTRY_TAG_KEY],
+  request: upsertTimeEntry,
+  keyParams: ['timeEntryId'],
+  schema: UpsertTimeEntryReturnSchema,
+  swrOptions: { throwOnError: true },
+})
 
 type UseUpsertTimeEntryCreateProps = { mode: UpsertTimeEntryMode.Create }
 type UseUpsertTimeEntryUpdateProps = { mode: UpsertTimeEntryMode.Update, timeEntryId: string }
@@ -50,44 +73,10 @@ export function useUpsertTimeEntry(props: UseUpsertTimeEntryCreateProps): SWRMut
 export function useUpsertTimeEntry(props: UseUpsertTimeEntryUpdateProps): SWRMutationResult<UpsertTimeEntryReturn, UpdateTimeEntryBody>
 export function useUpsertTimeEntry(props: UseUpsertTimeEntryProps): SWRMutationResult<UpsertTimeEntryReturn, UpsertTimeEntryBody>
 export function useUpsertTimeEntry(props: UseUpsertTimeEntryProps) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
   const { mode } = props
   const timeEntryId = mode === UpsertTimeEntryMode.Update ? props.timeEntryId : undefined
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-      timeEntryId,
-    })),
-    (
-      { accessToken, apiUrl, businessId, timeEntryId },
-      { arg: body }: { arg: UpsertTimeEntryBody },
-    ) => {
-      if (mode === UpsertTimeEntryMode.Create) {
-        return createTimeEntry(apiUrl, accessToken, {
-          params: { businessId },
-          body: body as CreateTimeEntryBody,
-        }).then(Schema.decodeUnknownPromise(UpsertTimeEntryReturnSchema))
-      }
-
-      if (timeEntryId === undefined) {
-        throw new Error('timeEntryId is required for update mode')
-      }
-
-      return updateTimeEntry(apiUrl, accessToken, {
-        params: { businessId, timeEntryId },
-        body: body,
-      }).then(Schema.decodeUnknownPromise(UpsertTimeEntryReturnSchema))
-    },
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useUpsertTimeEntryMutation({ timeEntryId })
 
   const { patchByKey: patchTimeEntryByKey, forceReload: forceReloadTimeEntries } = useTimeEntriesGlobalCacheActions()
   const { invalidate: invalidateTimeTrackingSummary } = useTimeTrackingSummaryGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useUpsertTimeEntry.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/time-entries/useUpsertTimeEntry.ts
@@ -31,35 +31,24 @@ const createTimeEntry = post<UpsertTimeEntryReturnEncoded, CreateTimeEntryBody>(
   ({ businessId }) => `/v1/businesses/${businessId}/time-tracking/time-entries`,
 )
 
-const updateTimeEntry = patch<UpsertTimeEntryReturnEncoded, UpdateTimeEntryBody>(
+const updateTimeEntry = patch<
+  UpsertTimeEntryReturnEncoded,
+  UpdateTimeEntryBody,
+  { businessId: string, timeEntryId: string }
+>(
   ({ businessId, timeEntryId }) => `/v1/businesses/${businessId}/time-tracking/time-entries/${timeEntryId}`,
 )
 
-type UpsertTimeEntryParams = { businessId: string, timeEntryId?: string }
-
-const upsertTimeEntry = (
-  baseUrl: string,
-  accessToken: string | undefined,
-  options?: { params?: UpsertTimeEntryParams, body?: UpsertTimeEntryBody },
-): Promise<UpsertTimeEntryReturnEncoded> => {
-  const { params, body } = options ?? {}
-
-  if (params?.timeEntryId !== undefined) {
-    return updateTimeEntry(baseUrl, accessToken, {
-      params: { businessId: params.businessId, timeEntryId: params.timeEntryId },
-      body,
-    })
-  }
-
-  return createTimeEntry(baseUrl, accessToken, {
-    params: { businessId: params?.businessId },
-    body: body as CreateTimeEntryBody,
-  })
-}
-
-const useUpsertTimeEntryMutation = createMutationHook({
+const useCreateTimeEntry = createMutationHook({
   tags: [UPSERT_TIME_ENTRY_TAG_KEY],
-  request: upsertTimeEntry,
+  request: createTimeEntry,
+  schema: UpsertTimeEntryReturnSchema,
+  swrOptions: { throwOnError: true },
+})
+
+const useUpdateTimeEntry = createMutationHook({
+  tags: [UPSERT_TIME_ENTRY_TAG_KEY],
+  request: updateTimeEntry,
   keyParams: ['timeEntryId'],
   schema: UpsertTimeEntryReturnSchema,
   swrOptions: { throwOnError: true },
@@ -76,7 +65,15 @@ export function useUpsertTimeEntry(props: UseUpsertTimeEntryProps) {
   const { mode } = props
   const timeEntryId = mode === UpsertTimeEntryMode.Update ? props.timeEntryId : undefined
 
-  const mutationResponse = useUpsertTimeEntryMutation({ timeEntryId })
+  const createResponse = useCreateTimeEntry()
+  const updateResponse = useUpdateTimeEntry({
+    timeEntryId: timeEntryId ?? '',
+    isEnabled: timeEntryId !== undefined,
+  })
+
+  const mutationResponse = (
+    mode === UpsertTimeEntryMode.Create ? createResponse : updateResponse
+  ) as SWRMutationResult<UpsertTimeEntryReturn, UpsertTimeEntryBody>
 
   const { patchByKey: patchTimeEntryByKey, forceReload: forceReloadTimeEntries } = useTimeEntriesGlobalCacheActions()
   const { invalidate: invalidateTimeTrackingSummary } = useTimeTrackingSummaryGlobalCacheActions()

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker.ts
@@ -1,20 +1,21 @@
 import { pipe, Schema } from 'effect'
 
 import { type TimeEntry, TimeEntrySchema } from '@schemas/timeTracking'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { get } from '@utils/api/authenticatedHttp'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const ACTIVE_TIME_TRACKER_TAG_KEY = '#active-time-tracker'
 
-const ActiveTimeTrackerResponseSchema = Schema.Struct({
-  data: Schema.Struct({
+const ActiveTimeTrackerResponseSchema = UnwrappedDataResponseSchema(
+  Schema.Struct({
     timeEntry: pipe(
       Schema.propertySignature(Schema.NullishOr(TimeEntrySchema)),
       Schema.fromKey('time_entry'),
     ),
   }),
-})
+)
 
 const getActiveTimeTracker = get<
   typeof ActiveTimeTrackerResponseSchema.Encoded,
@@ -25,7 +26,7 @@ export const useActiveTimeTracker = createQueryHook({
   tags: [ACTIVE_TIME_TRACKER_TAG_KEY],
   request: getActiveTimeTracker,
   schema: ActiveTimeTrackerResponseSchema,
-  select: ({ data }) => data.timeEntry ?? null,
+  select: data => data.timeEntry ?? null,
 })
 
 export const useActiveTimeTrackerGlobalCacheActions = createResourceGlobalCacheActions<TimeEntry | null>(ACTIVE_TIME_TRACKER_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker.ts
@@ -1,12 +1,9 @@
 import { pipe, Schema } from 'effect'
-import useSWR from 'swr'
 
 import { type TimeEntry, TimeEntrySchema } from '@schemas/timeTracking'
 import { get } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
 import { createResourceGlobalCacheActions } from '@utils/swr/createGlobalCacheActions'
-import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 
 export const ACTIVE_TIME_TRACKER_TAG_KEY = '#active-time-tracker'
 
@@ -24,28 +21,11 @@ const getActiveTimeTracker = get<
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/time-tracking/tracker/active`)
 
-const buildKey = createBuildKey<{ businessId: string }>([ACTIVE_TIME_TRACKER_TAG_KEY])
-
-export function useActiveTimeTracker(): SWRQueryResult<TimeEntry | null> {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const response = useSWR(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    ({ accessToken, apiUrl, businessId }) => getActiveTimeTracker(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-      },
-    )()
-      .then(Schema.decodeUnknownPromise(ActiveTimeTrackerResponseSchema))
-      .then(({ data }) => data.timeEntry ?? null),
-  )
-
-  return new SWRQueryResult(response)
-}
+export const useActiveTimeTracker = createQueryHook({
+  tags: [ACTIVE_TIME_TRACKER_TAG_KEY],
+  request: getActiveTimeTracker,
+  schema: ActiveTimeTrackerResponseSchema,
+  select: ({ data }) => data.timeEntry ?? null,
+})
 
 export const useActiveTimeTrackerGlobalCacheActions = createResourceGlobalCacheActions<TimeEntry | null>(ACTIVE_TIME_TRACKER_TAG_KEY)

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStartTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStartTimeTracker.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { Schema } from 'effect'
 
 import { type StartTrackerEncoded, TimeEntrySchema } from '@schemas/timeTracking'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useActiveTimeTrackerGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker'
@@ -11,9 +11,7 @@ const START_TIME_TRACKER_TAG_KEY = '#start-time-tracker'
 
 type StartTimeTrackerBody = StartTrackerEncoded
 
-const StartTimeTrackerResponseSchema = Schema.Struct({
-  data: TimeEntrySchema,
-})
+const StartTimeTrackerResponseSchema = UnwrappedDataResponseSchema(TimeEntrySchema)
 
 const startTimeTracker = post<
   typeof StartTimeTrackerResponseSchema.Encoded,

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStartTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStartTimeTracker.ts
@@ -1,14 +1,11 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { type StartTrackerEncoded, TimeEntrySchema } from '@schemas/timeTracking'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useActiveTimeTrackerGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const START_TIME_TRACKER_TAG_KEY = '#start-time-tracker'
 
@@ -18,43 +15,23 @@ const StartTimeTrackerResponseSchema = Schema.Struct({
   data: TimeEntrySchema,
 })
 
-type StartTimeTrackerResponse = typeof StartTimeTrackerResponseSchema.Type
-
 const startTimeTracker = post<
-  StartTimeTrackerResponse,
+  typeof StartTimeTrackerResponseSchema.Encoded,
   StartTimeTrackerBody,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/time-tracking/tracker/start`)
 
-const buildKey = createBuildKey<{ businessId: string }>([START_TIME_TRACKER_TAG_KEY])
+const useStartTimeTrackerMutation = createMutationHook({
+  tags: [START_TIME_TRACKER_TAG_KEY],
+  request: startTimeTracker,
+  schema: StartTimeTrackerResponseSchema,
+  swrOptions: { throwOnError: true },
+})
 
 export const useStartTimeTracker = () => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { invalidate: invalidateActiveTimeTracker } = useActiveTimeTrackerGlobalCacheActions()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    (
-      { accessToken, apiUrl, businessId },
-      { arg: body }: { arg: StartTimeTrackerBody },
-    ) => startTimeTracker(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body,
-      },
-    ).then(Schema.decodeUnknownPromise(StartTimeTrackerResponseSchema)),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useStartTimeTrackerMutation()
   const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStopTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStopTimeTracker.ts
@@ -1,16 +1,13 @@
 import { useCallback } from 'react'
 import { Schema } from 'effect'
-import useSWRMutation from 'swr/mutation'
 
 import { type StopTrackerEncoded } from '@schemas/timeTracking'
 import { post } from '@utils/api/authenticatedHttp'
-import { createBuildKey } from '@utils/swr/createBuildKey'
-import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTimeTrackingSummaryGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary'
 import { useTimeEntriesGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/time-entries/useListTimeEntries'
 import { useActiveTimeTrackerGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/tracker/useActiveTimeTracker'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const STOP_TIME_TRACKER_TAG_KEY = '#stop-time-tracker'
 
@@ -20,43 +17,27 @@ const StopTimeTrackerResponseSchema = Schema.Struct({
   }),
 })
 
-type StopTimeTrackerResponse = typeof StopTimeTrackerResponseSchema.Type
 type StopTimeTrackerBody = StopTrackerEncoded
 
 const stopTimeTracker = post<
-  StopTimeTrackerResponse,
+  typeof StopTimeTrackerResponseSchema.Encoded,
   StopTimeTrackerBody,
   { businessId: string }
 >(({ businessId }) => `/v1/businesses/${businessId}/time-tracking/tracker/stop`)
 
-const buildKey = createBuildKey<{ businessId: string }>([STOP_TIME_TRACKER_TAG_KEY])
+const useStopTimeTrackerMutation = createMutationHook({
+  tags: [STOP_TIME_TRACKER_TAG_KEY],
+  request: stopTimeTracker,
+  schema: StopTimeTrackerResponseSchema,
+  swrOptions: { throwOnError: true },
+})
 
 export const useStopTimeTracker = () => {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
   const { forceReload: forceReloadTimeEntries } = useTimeEntriesGlobalCacheActions()
   const { invalidate: invalidateTimeTrackingSummary } = useTimeTrackingSummaryGlobalCacheActions()
   const { invalidate: invalidateActiveTimeTracker } = useActiveTimeTrackerGlobalCacheActions()
 
-  const rawMutationResponse = useSWRMutation(
-    () => withLocale(buildKey({
-      ...auth,
-      businessId,
-    })),
-    ({ accessToken, apiUrl, businessId }, { arg: body }: { arg: StopTimeTrackerBody }) => stopTimeTracker(
-      apiUrl,
-      accessToken,
-      {
-        params: { businessId },
-        body,
-      },
-    ).then(Schema.decodeUnknownPromise(StopTimeTrackerResponseSchema)),
-    {
-      revalidate: false,
-      throwOnError: true,
-    },
-  )
-
-  const mutationResponse = new SWRMutationResult(rawMutationResponse)
+  const mutationResponse = useStopTimeTrackerMutation()
   const originalTrigger = mutationResponse.trigger
 
   const stableProxiedTrigger = useCallback(

--- a/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStopTimeTracker.ts
+++ b/src/hooks/api/businesses/[business-id]/time-tracking/tracker/useStopTimeTracker.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import { Schema } from 'effect'
 
 import { type StopTrackerEncoded } from '@schemas/timeTracking'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 import { post } from '@utils/api/authenticatedHttp'
 import { withStableTrigger } from '@utils/swr/withStableTrigger'
 import { useTimeTrackingSummaryGlobalCacheActions } from '@hooks/api/businesses/[business-id]/time-tracking/summary/useTimeTrackingSummary'
@@ -11,11 +12,11 @@ import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
 const STOP_TIME_TRACKER_TAG_KEY = '#stop-time-tracker'
 
-const StopTimeTrackerResponseSchema = Schema.Struct({
-  data: Schema.Struct({
+const StopTimeTrackerResponseSchema = UnwrappedDataResponseSchema(
+  Schema.Struct({
     id: Schema.UUID,
   }),
-})
+)
 
 type StopTimeTrackerBody = StopTrackerEncoded
 

--- a/src/hooks/api/businesses/[business-id]/useBusiness.ts
+++ b/src/hooks/api/businesses/[business-id]/useBusiness.ts
@@ -1,28 +1,29 @@
-import { Schema } from 'effect'
 import useSWR from 'swr'
 
-import { type Business, BusinessResponseSchema } from '@schemas/business'
+import { BusinessResponseSchema } from '@schemas/business'
 import { get } from '@utils/api/authenticatedHttp'
 import { createBuildKey } from '@utils/swr/createBuildKey'
+import { createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
 import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
 import { useAuth } from '@hooks/utils/auth/useAuth'
 
 export const BUSINESS_TAG_KEY = '#business'
 
-const getBusiness = get<{ data: Business }>(
-  ({ businessId }) => `/v1/businesses/${businessId}`,
-)
+const getBusiness = get<
+  typeof BusinessResponseSchema.Encoded,
+  { businessId: string }
+>(({ businessId }) => `/v1/businesses/${businessId}`)
 
 const buildKey = createBuildKey<{ businessId: string }>([BUSINESS_TAG_KEY])
+
+const fetchBusiness = createKeyedFetcher(getBusiness, BusinessResponseSchema)
 
 export function useBusiness({ businessId }: { businessId: string }) {
   const { data: auth } = useAuth()
 
   const swrResponse = useSWR(
     () => buildKey({ ...auth, businessId }),
-    ({ accessToken, apiUrl, businessId }) =>
-      getBusiness(apiUrl, accessToken, { params: { businessId } })()
-        .then(Schema.decodeUnknownPromise(BusinessResponseSchema)),
+    fetchBusiness,
   )
 
   return new SWRQueryResult(swrResponse)

--- a/src/hooks/api/businesses/[business-id]/vendors/useListVendors.ts
+++ b/src/hooks/api/businesses/[business-id]/vendors/useListVendors.ts
@@ -1,100 +1,41 @@
-import { Schema } from 'effect'
-import useSWRInfinite from 'swr/infinite'
-
 import { PaginatedResponseSchema } from '@schemas/common/pagination'
 import { VendorSchema } from '@schemas/vendor'
-import { get } from '@utils/api/authenticatedHttp'
-import { toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
-import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
-import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
-import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
-import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+import { getWithQuery } from '@utils/api/getWithQuery'
+import { createInfiniteQueryHook } from '@hooks/utils/swr/createInfiniteQueryHook'
 
 const ListVendorsRawResultSchema = PaginatedResponseSchema(VendorSchema)
-type ListVendorsRawResult = typeof ListVendorsRawResultSchema.Type
 
-type ListVendorsBaseParams = {
+type ListVendorsPaginatedParams = {
   businessId: string
-}
-type ListVendorsPaginatedParams = ListVendorsBaseParams & {
   cursor?: string
   limit?: number
   query?: string
 }
 
-const listVendors = get<
-  Record<string, unknown>,
+const listVendors = getWithQuery<
+  typeof ListVendorsRawResultSchema.Encoded,
   ListVendorsPaginatedParams
->(({
-  businessId,
-  cursor,
-  limit,
-  query,
-}) => {
-  const parameters = toDefinedSearchParameters({
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/vendors`,
+  ({ cursor, limit, query }) => ({
     cursor,
     identityStatus: 'IDENTIFIED',
     limit,
     q: query,
-  })
-
-  return `/v1/businesses/${businessId}/vendors?${parameters}`
-})
+  }),
+)
 
 export const VENDORS_TAG_KEY = '#vendors'
 
-const keyLoader = createInfiniteKeyLoader<
-  { businessId: string, query?: string },
-  ListVendorsRawResult
->([VENDORS_TAG_KEY])
+export const useListVendors = createInfiniteQueryHook({
+  tags: [VENDORS_TAG_KEY],
+  request: listVendors,
+  schema: ListVendorsRawResultSchema,
+  keyDefaults: { limit: 100 },
+})
 
-type UseListVendorsParameters = {
-  query?: string
-  isEnabled?: boolean
-}
-
-export function useListVendors({ query, isEnabled = true }: UseListVendorsParameters = {}) {
-  const { withLocale, businessId, auth } = useBuildKeyInputs()
-
-  const swrResponse = useSWRInfinite(
-    (_index, previousPageData: ListVendorsRawResult | null) => withLocale(keyLoader(
-      previousPageData,
-      {
-        ...auth,
-        businessId,
-        query,
-        isEnabled,
-      },
-    )),
-    ({
-      accessToken,
-      apiUrl,
-      businessId,
-      cursor,
-      query,
-    }) => listVendors(
-      apiUrl,
-      accessToken,
-      {
-        params: {
-          businessId,
-          cursor,
-          limit: 100,
-          query,
-        },
-      },
-    )().then(Schema.decodeUnknownPromise(ListVendorsRawResultSchema)),
-    {
-      keepPreviousData: true,
-      revalidateFirstPage: false,
-      initialSize: 1,
-    },
-  )
-
-  usePreserveInfiniteSize(swrResponse)
-
-  return useSWRInfiniteResult(swrResponse)
-}
+type UseListVendorsParameters = Parameters<typeof useListVendors>[0]
 
 export function usePreloadVendors(parameters?: UseListVendorsParameters) {
   /*

--- a/src/hooks/features/bankTransactions/useAugmentedBankTransactions.tsx
+++ b/src/hooks/features/bankTransactions/useAugmentedBankTransactions.tsx
@@ -13,13 +13,14 @@ import { usePollBankTransactions } from '@hooks/features/bankTransactions/usePol
 import { useBankTransactionsFiltersContext } from '@contexts/BankTransactionsFiltersContext/BankTransactionsFiltersContext'
 import { CategorizationRulesContext } from '@contexts/CategorizationRulesContext/CategorizationRulesContext'
 
-const tagFilterToQueryString = (tagFilter: TagFilterInput): string => {
+const tagFilterToParams = (tagFilter: TagFilterInput): Pick<UseBankTransactionsOptions, 'tagKey' | 'tagValues'> => {
   if (tagFilter != 'None' && tagFilter.tagValues.length > 0) {
-    return `tag_key=${tagFilter.tagKey}&tag_values=${tagFilter.tagValues.join(
-      ',',
-    )}&`
+    return {
+      tagKey: tagFilter.tagKey,
+      tagValues: tagFilter.tagValues.join(','),
+    }
   }
-  return ''
+  return {}
 }
 
 export function bankTransactionFiltersToHookOptions(
@@ -39,7 +40,7 @@ export function bankTransactionFiltersToHookOptions(
     query: filters?.query,
     startDate: filters?.dateRange?.startDate,
     endDate: filters?.dateRange?.endDate,
-    tagFilterQueryString: filters?.tagFilter ? tagFilterToQueryString(filters.tagFilter) : undefined,
+    ...(filters?.tagFilter ? tagFilterToParams(filters.tagFilter) : undefined),
   }
 }
 

--- a/src/hooks/features/linkedAccounts/usePollPlaidHostedLinkStatus.ts
+++ b/src/hooks/features/linkedAccounts/usePollPlaidHostedLinkStatus.ts
@@ -43,7 +43,7 @@ export function usePollPlaidHostedLinkStatus({ onSuccess, enabled }: UsePollPlai
     isFatalError,
   })
 
-  const { data, mutate } = usePlaidHostedLinkStatus(pollingConfig, enabled)
+  const { data, mutate } = usePlaidHostedLinkStatus({ isEnabled: enabled, swrOptions: pollingConfig })
 
   // Clear a previous session's cached status; polling fetches the current one.
   useEffect(() => {

--- a/src/hooks/features/profitAndLoss/useProfitAndLossComparison.tsx
+++ b/src/hooks/features/profitAndLoss/useProfitAndLossComparison.tsx
@@ -226,6 +226,7 @@ export function useProfitAndLossComparison({
     periods,
     tagFilters,
     reportingBasis,
+    isEnabled: Boolean(periods),
   })
 
   const getProfitAndLossComparisonCsv = (

--- a/src/hooks/features/profitAndLoss/useProfitAndLossLTM.tsx
+++ b/src/hooks/features/profitAndLoss/useProfitAndLossLTM.tsx
@@ -73,7 +73,7 @@ export const useProfitAndLossLTM = ({ tagFilter, reportingBasis, chartWindow }: 
     tagKey: tagFilter?.key,
     tagValues: tagFilter?.values?.join(','),
     reportingBasis,
-    keepPreviousData: true,
+    swrOptions: { keepPreviousData: true },
   })
 
   const [delayedMonths, setDelayedMonths] = useState(data?.months)

--- a/src/hooks/legacy/useChartOfAccounts.tsx
+++ b/src/hooks/legacy/useChartOfAccounts.tsx
@@ -9,7 +9,10 @@ type Props = {
 
 export const useChartOfAccounts = ({ withDates = false }: Props = {}) => {
   const { startDate, endDate } = useGlobalDateRange({ dateSelectionMode: 'month' })
-  const { data, isLoading, isValidating, isError, mutate } = useLedgerBalances(withDates, startDate, endDate)
+  const { data, isLoading, isValidating, isError, mutate } = useLedgerBalances({
+    startDate: withDates ? startDate : undefined,
+    endDate: withDates ? endDate : undefined,
+  })
 
   const refetch = useCallback(async () => {
     await mutate()

--- a/src/hooks/legacy/useLedgerAccounts.tsx
+++ b/src/hooks/legacy/useLedgerAccounts.tsx
@@ -74,7 +74,7 @@ export const useLedgerAccounts: UseLedgerAccounts = () => {
 
   return {
     data,
-    entryData: entryData?.data,
+    entryData,
     isLoading: shouldFetch ? paginationIsLoading : false,
     isLoadingEntry,
     isValidating: shouldFetch ? paginationIsValidating : false,

--- a/src/hooks/legacy/useLedgerAccounts.tsx
+++ b/src/hooks/legacy/useLedgerAccounts.tsx
@@ -43,6 +43,7 @@ export const useLedgerAccounts: UseLedgerAccounts = () => {
     sort_by: 'entry_at',
     sort_order: 'DESC',
     limit: 150,
+    isEnabled: Boolean(selectedAccountId),
   })
 
   // Only use the data when accountId is available
@@ -62,7 +63,7 @@ export const useLedgerAccounts: UseLedgerAccounts = () => {
     mutate: mutateEntryData,
     isLoading: isLoadingEntry,
     isError: isErrorEntry,
-  } = useLedgerAccountsEntry({ entryId: selectedEntryId })
+  } = useLedgerAccountsEntry({ entryId: selectedEntryId, isEnabled: Boolean(selectedEntryId) })
 
   const refetch = () => mutate()
 

--- a/src/hooks/utils/swr/createInfiniteQueryHook.ts
+++ b/src/hooks/utils/swr/createInfiniteQueryHook.ts
@@ -1,0 +1,67 @@
+import { type Schema } from 'effect'
+import useSWRInfinite, { type SWRInfiniteConfiguration } from 'swr/infinite'
+
+import type { PaginatedResponse } from '@schemas/common/pagination'
+import { createInfiniteKeyLoader } from '@utils/swr/createBuildKey'
+import { type AuthenticatedRequest, createKeyedFetcher } from '@utils/swr/createKeyedFetcher'
+import { usePreserveInfiniteSize } from '@utils/swr/usePreserveInfiniteSize'
+import { useSWRInfiniteResult } from '@utils/swr/useSWRInfiniteResult'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+
+type BusinessScopedParams = { businessId: string }
+
+type InfiniteQueryHookOptions = { isEnabled?: boolean }
+
+/*
+ * Business-scoped cursor-paginated `useSWRInfinite` hook factory; `businessId`, `cursor`,
+ * auth, and locale are injected, so the returned hook takes the request params minus those.
+ * `keyDefaults` bakes constants (e.g. a fixed page size) into the key and the request.
+ */
+export function createInfiniteQueryHook<
+  TParams extends BusinessScopedParams & { cursor?: string },
+  TEncoded,
+  TDecoded extends PaginatedResponse<unknown>,
+>(config: {
+  tags: ReadonlyArray<string>
+  request: AuthenticatedRequest<TEncoded, TParams>
+  schema: Schema.Schema<TDecoded, TEncoded>
+  keyDefaults?: Partial<Omit<TParams, 'businessId' | 'cursor'>>
+  swrOptions?: SWRInfiniteConfiguration
+  isLocalized?: boolean
+}) {
+  const { tags, request, schema, keyDefaults, swrOptions, isLocalized = true } = config
+
+  const keyLoader = createInfiniteKeyLoader<TParams, TDecoded>(tags)
+  const fetcher = createKeyedFetcher(request, schema)
+
+  return function useInfiniteQuery(params?: Omit<TParams, 'businessId' | 'cursor'> & InfiniteQueryHookOptions) {
+    const { withLocale, businessId, auth } = useBuildKeyInputs()
+
+    const swrResponse = useSWRInfinite<TDecoded>(
+      (_index: number, previousPageData: TDecoded | null) => {
+        const key = keyLoader(
+          previousPageData,
+          {
+            ...auth,
+            businessId,
+            ...keyDefaults,
+            ...params,
+          } as Parameters<typeof keyLoader>[1],
+        )
+
+        return isLocalized ? withLocale(key) : key
+      },
+      fetcher,
+      {
+        keepPreviousData: true,
+        revalidateFirstPage: false,
+        initialSize: 1,
+        ...swrOptions,
+      },
+    )
+
+    usePreserveInfiniteSize(swrResponse)
+
+    return useSWRInfiniteResult(swrResponse)
+  }
+}

--- a/src/hooks/utils/swr/createInfiniteQueryHook.ts
+++ b/src/hooks/utils/swr/createInfiniteQueryHook.ts
@@ -10,7 +10,10 @@ import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 type BusinessScopedParams = { businessId: string }
 
-type InfiniteQueryHookOptions = { isEnabled?: boolean }
+type InfiniteQueryHookOptions = {
+  isEnabled?: boolean
+  swrOptions?: SWRInfiniteConfiguration
+}
 
 /*
  * Business-scoped cursor-paginated `useSWRInfinite` hook factory; `businessId`, `cursor`,
@@ -37,6 +40,8 @@ export function createInfiniteQueryHook<
   return function useInfiniteQuery(params?: Omit<TParams, 'businessId' | 'cursor'> & InfiniteQueryHookOptions) {
     const { withLocale, businessId, auth } = useBuildKeyInputs()
 
+    const { swrOptions: callSwrOptions, ...keyInputs } = params ?? ({} as InfiniteQueryHookOptions)
+
     const swrResponse = useSWRInfinite<TDecoded>(
       (_index: number, previousPageData: TDecoded | null) => {
         const key = keyLoader(
@@ -45,7 +50,7 @@ export function createInfiniteQueryHook<
             ...auth,
             businessId,
             ...keyDefaults,
-            ...params,
+            ...keyInputs,
           } as Parameters<typeof keyLoader>[1],
         )
 
@@ -57,6 +62,7 @@ export function createInfiniteQueryHook<
         revalidateFirstPage: false,
         initialSize: 1,
         ...swrOptions,
+        ...callSwrOptions,
       },
     )
 

--- a/src/hooks/utils/swr/createInfiniteQueryHook.ts
+++ b/src/hooks/utils/swr/createInfiniteQueryHook.ts
@@ -15,21 +15,22 @@ type InfiniteQueryHookOptions = {
   swrOptions?: SWRInfiniteConfiguration
 }
 
-/*
- * Business-scoped cursor-paginated `useSWRInfinite` hook factory; `businessId`, `cursor`,
- * auth, and locale are injected, so the returned hook takes the request params minus those.
- * `keyDefaults` bakes constants (e.g. a fixed page size) into the key and the request.
- */
 export function createInfiniteQueryHook<
   TParams extends BusinessScopedParams & { cursor?: string },
   TEncoded,
   TDecoded extends PaginatedResponse<unknown>,
 >(config: {
+  /** Marks this hook's cache entries so global cache actions (invalidate, patch, force-reload) can find them. */
   tags: ReadonlyArray<string>
+  /** The HTTP call for one page. Receives the hook-call params, plus the injected auth, `businessId`, and page `cursor`. */
   request: AuthenticatedRequest<TEncoded, TParams>
+  /** Decodes one raw page; must produce a `PaginatedResponse` so the next page's cursor can be read. */
   schema: Schema.Schema<TDecoded, TEncoded>
+  /** Params fixed for every caller (e.g. a page size); baked into each page's key and request. */
   keyDefaults?: Partial<Omit<TParams, 'businessId' | 'cursor'>>
+  /** Default SWR-infinite behavior for every caller. A caller's own `swrOptions` win, key by key. */
   swrOptions?: SWRInfiniteConfiguration
+  /** Whether the locale is part of the cache key (switching locale refetches). True by default. */
   isLocalized?: boolean
 }) {
   const { tags, request, schema, keyDefaults, swrOptions, isLocalized = true } = config

--- a/src/hooks/utils/swr/createMutationHook.ts
+++ b/src/hooks/utils/swr/createMutationHook.ts
@@ -1,0 +1,73 @@
+import { Schema } from 'effect'
+import useSWRMutation from 'swr/mutation'
+
+import { createBuildKey } from '@utils/swr/createBuildKey'
+import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+
+type BusinessScopedParams = { businessId: string }
+
+type MutationRequest<TReturn, TBody, TParams> = (
+  baseUrl: string,
+  accessToken: string | undefined,
+  options?: { params?: TParams, body?: TBody },
+) => Promise<TReturn>
+
+/*
+ * Business-scoped `useSWRMutation` hook factory. The trigger argument is the request body
+ * by default; `argToBody`/`argToParams` split it when parts belong in the URL instead.
+ */
+export function createMutationHook<
+  TEncoded,
+  TBody extends Record<string, unknown> = Record<string, unknown>,
+  TParams extends BusinessScopedParams = BusinessScopedParams,
+  TDecoded = TEncoded,
+  TArg = TBody,
+>(config: {
+  tags: ReadonlyArray<string>
+  request: MutationRequest<TEncoded, TBody, TParams>
+  argToParams?: (arg: TArg) => Omit<TParams, 'businessId'>
+  argToBody?: (arg: TArg) => TBody | undefined
+  schema?: Schema.Schema<TDecoded, TEncoded>
+  swrOptions?: { revalidate?: boolean, throwOnError?: boolean }
+  isLocalized?: boolean
+}) {
+  const { tags, request, argToParams, argToBody, schema, swrOptions, isLocalized = true } = config
+
+  const buildKey = createBuildKey<BusinessScopedParams>(tags)
+
+  return function useMutation() {
+    const { withLocale, businessId, auth } = useBuildKeyInputs()
+
+    const rawMutationResponse = useSWRMutation(
+      () => {
+        const key = buildKey({ ...auth, businessId })
+        return isLocalized ? withLocale(key) : key
+      },
+      (
+        { accessToken, apiUrl, businessId }: { accessToken: string, apiUrl: string, businessId: string },
+        { arg }: { arg: TArg },
+      ): Promise<TDecoded> => {
+        const response = request(apiUrl, accessToken, {
+          params: {
+            businessId,
+            ...(argToParams ? argToParams(arg) : undefined),
+          } as TParams,
+          body: argToBody ? argToBody(arg) : arg as unknown as TBody,
+        })
+
+        if (schema) {
+          return response.then(Schema.decodeUnknownPromise(schema))
+        }
+
+        return response as Promise<unknown> as Promise<TDecoded>
+      },
+      {
+        revalidate: false,
+        ...swrOptions,
+      },
+    )
+
+    return new SWRMutationResult(rawMutationResponse)
+  }
+}

--- a/src/hooks/utils/swr/createMutationHook.ts
+++ b/src/hooks/utils/swr/createMutationHook.ts
@@ -1,21 +1,25 @@
 import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
+import type { MutationRequest } from '@utils/api/postAsQuery'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 type BusinessScopedParams = { businessId: string }
 
-type MutationRequest<TReturn, TBody, TParams> = (
-  baseUrl: string,
-  accessToken: string | undefined,
-  options?: { params?: TParams, body?: TBody },
-) => Promise<TReturn>
+type MutationSWROptions<TData> = {
+  revalidate?: boolean
+  throwOnError?: boolean
+  onSuccess?: (data: TData) => void
+  onError?: (error: unknown) => void
+}
 
 /*
  * Business-scoped `useSWRMutation` hook factory. The trigger argument is the request body
  * by default; `argToBody`/`argToParams` split it when parts belong in the URL instead.
+ * `keyParams` names the request params that scope the SWR key (and mutation state) to an
+ * entity; the returned hook takes them alongside `isEnabled` and per-call `swrOptions`.
  */
 export function createMutationHook<
   TEncoded,
@@ -23,48 +27,65 @@ export function createMutationHook<
   TParams extends BusinessScopedParams = BusinessScopedParams,
   TDecoded = TEncoded,
   TArg = TBody,
+  const TKeyKeys extends ReadonlyArray<Exclude<keyof TParams, 'businessId'>> = readonly [],
+  TData = TDecoded,
 >(config: {
   tags: ReadonlyArray<string>
   request: MutationRequest<TEncoded, TBody, TParams>
-  argToParams?: (arg: TArg) => Omit<TParams, 'businessId'>
-  argToBody?: (arg: TArg) => TBody | undefined
+  keyParams?: TKeyKeys
+  argToParams?: (arg: TArg, keyParams: BusinessScopedParams & Pick<TParams, TKeyKeys[number]>) => Partial<Omit<TParams, 'businessId'>>
+  argToBody?: (arg: TArg, keyParams: BusinessScopedParams & Pick<TParams, TKeyKeys[number]>) => TBody | undefined
   schema?: Schema.Schema<TDecoded, TEncoded>
-  swrOptions?: { revalidate?: boolean, throwOnError?: boolean }
+  select?: (decoded: TDecoded) => TData
+  swrOptions?: MutationSWROptions<TData>
   isLocalized?: boolean
 }) {
-  const { tags, request, argToParams, argToBody, schema, swrOptions, isLocalized = true } = config
+  const { tags, request, argToParams, argToBody, schema, select, swrOptions, isLocalized = true } = config
 
-  const buildKey = createBuildKey<BusinessScopedParams>(tags)
+  type KeyParams = BusinessScopedParams & Pick<TParams, TKeyKeys[number]>
 
-  return function useMutation() {
+  const buildKey = createBuildKey<KeyParams>(tags)
+
+  type UseMutationOptions = Pick<TParams, TKeyKeys[number]> & {
+    isEnabled?: boolean
+    swrOptions?: MutationSWROptions<TData>
+  }
+
+  return function useMutation(options?: UseMutationOptions) {
     const { withLocale, businessId, auth } = useBuildKeyInputs()
+
+    const { swrOptions: callSwrOptions, ...keyInputs } = options ?? ({} as UseMutationOptions)
 
     const rawMutationResponse = useSWRMutation(
       () => {
-        const key = buildKey({ ...auth, businessId })
+        const key = buildKey({ ...auth, businessId, ...keyInputs } as Parameters<typeof buildKey>[0])
         return isLocalized ? withLocale(key) : key
       },
       (
-        { accessToken, apiUrl, businessId }: { accessToken: string, apiUrl: string, businessId: string },
+        key: { accessToken: string, apiUrl: string } & KeyParams,
         { arg }: { arg: TArg },
-      ): Promise<TDecoded> => {
+      ): Promise<TData> => {
+        const { accessToken, apiUrl, ...rest } = key
+        const keyParams = rest as unknown as KeyParams
+
         const response = request(apiUrl, accessToken, {
           params: {
-            businessId,
-            ...(argToParams ? argToParams(arg) : undefined),
+            ...keyParams,
+            ...(argToParams ? argToParams(arg, keyParams) : undefined),
           } as TParams,
-          body: argToBody ? argToBody(arg) : arg as unknown as TBody,
+          body: argToBody ? argToBody(arg, keyParams) : arg as unknown as TBody,
         })
 
-        if (schema) {
-          return response.then(Schema.decodeUnknownPromise(schema))
-        }
+        const decoded = schema
+          ? response.then(Schema.decodeUnknownPromise(schema))
+          : response as Promise<unknown> as Promise<TDecoded>
 
-        return response as Promise<unknown> as Promise<TDecoded>
+        return select ? decoded.then(select) : decoded as Promise<unknown> as Promise<TData>
       },
       {
         revalidate: false,
         ...swrOptions,
+        ...callSwrOptions,
       },
     )
 

--- a/src/hooks/utils/swr/createMutationHook.ts
+++ b/src/hooks/utils/swr/createMutationHook.ts
@@ -15,12 +15,6 @@ type MutationSWROptions<TData> = {
   onError?: (error: unknown) => void
 }
 
-/*
- * Business-scoped `useSWRMutation` hook factory. The trigger argument is the request body
- * by default; `argToBody`/`argToParams` split it when parts belong in the URL instead.
- * `keyParams` names the request params that scope the SWR key (and mutation state) to an
- * entity; the returned hook takes them alongside `isEnabled` and per-call `swrOptions`.
- */
 export function createMutationHook<
   TEncoded,
   TBody extends Record<string, unknown> = Record<string, unknown>,
@@ -30,14 +24,26 @@ export function createMutationHook<
   const TKeyKeys extends ReadonlyArray<Exclude<keyof TParams, 'businessId'>> = readonly [],
   TData = TDecoded,
 >(config: {
+  /** Marks this mutation's key so global cache actions (invalidate, patch, force-reload) can find it. */
   tags: ReadonlyArray<string>
+  /** The HTTP call to make when triggered. Receives the assembled params and body, plus the injected auth and `businessId`. */
   request: MutationRequest<TEncoded, TBody, TParams>
+  /** Params that pin the mutation to one entity (e.g. an id). Callers pass these when creating the hook, not when triggering. */
   keyParams?: TKeyKeys
+  /** Pulls URL params out of the trigger argument, for when it mixes routing info (e.g. an id) with payload. */
   argToParams?: (arg: TArg, keyParams: BusinessScopedParams & Pick<TParams, TKeyKeys[number]>) => Partial<Omit<TParams, 'businessId'>>
+  /**
+   * Builds the body from the trigger argument; without it, the whole argument is the body.
+   * `argToBody: (_arg: undefined) => undefined` makes `trigger()` take no argument and send no body.
+   */
   argToBody?: (arg: TArg, keyParams: BusinessScopedParams & Pick<TParams, TKeyKeys[number]>) => TBody | undefined
+  /** Decodes the raw response. Leave out for endpoints without a schema — the response is used as-is. */
   schema?: Schema.Schema<TDecoded, TEncoded>
+  /** Reshapes the decoded response into what `trigger` resolves with (and what `onSuccess` receives). */
   select?: (decoded: TDecoded) => TData
+  /** Default mutation behavior for every caller. A caller's own `swrOptions` win, key by key. */
   swrOptions?: MutationSWROptions<TData>
+  /** Whether the locale is part of the mutation key, mirroring the query keys it relates to. True by default. */
   isLocalized?: boolean
 }) {
   const { tags, request, argToParams, argToBody, schema, select, swrOptions, isLocalized = true } = config

--- a/src/hooks/utils/swr/createMutationHook.ts
+++ b/src/hooks/utils/swr/createMutationHook.ts
@@ -1,7 +1,7 @@
 import { Schema } from 'effect'
 import useSWRMutation from 'swr/mutation'
 
-import type { MutationRequest } from '@utils/api/postAsQuery'
+import type { MutationRequest } from '@utils/api/getAsMutation'
 import { createBuildKey } from '@utils/swr/createBuildKey'
 import { SWRMutationResult } from '@utils/swr/SWRResponseTypes'
 import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'

--- a/src/hooks/utils/swr/createQueryHook.ts
+++ b/src/hooks/utils/swr/createQueryHook.ts
@@ -1,0 +1,64 @@
+import { type Schema } from 'effect'
+import useSWR, { type SWRConfiguration } from 'swr'
+
+import { createBuildKey } from '@utils/swr/createBuildKey'
+import { type AuthenticatedRequest, createKeyedFetcher, type SWRKeyContext } from '@utils/swr/createKeyedFetcher'
+import { SWRQueryResult } from '@utils/swr/SWRResponseTypes'
+import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
+
+type BusinessScopedParams = { businessId: string }
+
+type QueryHookOptions = { isEnabled?: boolean }
+
+/*
+ * Business-scoped `useSWR` hook factory; `businessId`, auth, and locale are injected,
+ * so the returned hook takes the request params minus `businessId`.
+ */
+export function createQueryHook<
+  TParams extends BusinessScopedParams,
+  TEncoded,
+  TDecoded,
+  TData = TDecoded,
+>(config: {
+  tags: ReadonlyArray<string>
+  request: AuthenticatedRequest<TEncoded, TParams>
+  schema: Schema.Schema<TDecoded, TEncoded>
+  select?: (decoded: TDecoded) => TData
+  swrOptions?: SWRConfiguration
+  isLocalized?: boolean
+}) {
+  const { tags, request, schema, select, swrOptions, isLocalized = true } = config
+
+  const buildKey = createBuildKey<TParams>(tags)
+  const decodingFetcher = createKeyedFetcher(request, schema)
+
+  const fetcher = (key: SWRKeyContext & TParams): Promise<TData> => {
+    const decoded = decodingFetcher(key)
+
+    if (select) {
+      return decoded.then(select)
+    }
+
+    return decoded as Promise<unknown> as Promise<TData>
+  }
+
+  return function useQuery(params?: Omit<TParams, 'businessId'> & QueryHookOptions) {
+    const { withLocale, businessId, auth } = useBuildKeyInputs()
+
+    const swrResponse = useSWR<TData>(
+      () => {
+        const key = buildKey({
+          ...auth,
+          businessId,
+          ...params,
+        } as Parameters<typeof buildKey>[0])
+
+        return isLocalized ? withLocale(key) : key
+      },
+      fetcher,
+      swrOptions,
+    )
+
+    return new SWRQueryResult(swrResponse)
+  }
+}

--- a/src/hooks/utils/swr/createQueryHook.ts
+++ b/src/hooks/utils/swr/createQueryHook.ts
@@ -13,21 +13,23 @@ type QueryHookOptions = {
   swrOptions?: SWRConfiguration
 }
 
-/*
- * Business-scoped `useSWR` hook factory; `businessId`, auth, and locale are injected,
- * so the returned hook takes the request params minus `businessId`.
- */
 export function createQueryHook<
   TParams extends BusinessScopedParams,
   TEncoded,
   TDecoded = TEncoded,
   TData = TDecoded,
 >(config: {
+  /** Marks this hook's cache entries so global cache actions (invalidate, patch, force-reload) can find them. */
   tags: ReadonlyArray<string>
+  /** The HTTP call to make. Receives every param the hook was called with, plus the injected auth and `businessId`. */
   request: AuthenticatedRequest<TEncoded, TParams>
+  /** Decodes the raw response. Leave out for endpoints without a schema — the response is used as-is. */
   schema?: Schema.Schema<TDecoded, TEncoded>
+  /** Reshapes the decoded response into the hook's `data` — e.g. unwrap an envelope or pick one field. */
   select?: (decoded: TDecoded) => TData
+  /** Default SWR behavior for every caller. A caller's own `swrOptions` win, key by key. */
   swrOptions?: SWRConfiguration
+  /** Whether the locale is part of the cache key (switching locale refetches). True by default. */
   isLocalized?: boolean
 }) {
   const { tags, request, schema, select, swrOptions, isLocalized = true } = config

--- a/src/hooks/utils/swr/createQueryHook.ts
+++ b/src/hooks/utils/swr/createQueryHook.ts
@@ -20,12 +20,12 @@ type QueryHookOptions = {
 export function createQueryHook<
   TParams extends BusinessScopedParams,
   TEncoded,
-  TDecoded,
+  TDecoded = TEncoded,
   TData = TDecoded,
 >(config: {
   tags: ReadonlyArray<string>
   request: AuthenticatedRequest<TEncoded, TParams>
-  schema: Schema.Schema<TDecoded, TEncoded>
+  schema?: Schema.Schema<TDecoded, TEncoded>
   select?: (decoded: TDecoded) => TData
   swrOptions?: SWRConfiguration
   isLocalized?: boolean

--- a/src/hooks/utils/swr/createQueryHook.ts
+++ b/src/hooks/utils/swr/createQueryHook.ts
@@ -8,7 +8,10 @@ import { useBuildKeyInputs } from '@hooks/utils/swr/useBuildKeyInputs'
 
 type BusinessScopedParams = { businessId: string }
 
-type QueryHookOptions = { isEnabled?: boolean }
+type QueryHookOptions = {
+  isEnabled?: boolean
+  swrOptions?: SWRConfiguration
+}
 
 /*
  * Business-scoped `useSWR` hook factory; `businessId`, auth, and locale are injected,
@@ -45,18 +48,20 @@ export function createQueryHook<
   return function useQuery(params?: Omit<TParams, 'businessId'> & QueryHookOptions) {
     const { withLocale, businessId, auth } = useBuildKeyInputs()
 
+    const { swrOptions: callSwrOptions, ...keyInputs } = params ?? ({} as QueryHookOptions)
+
     const swrResponse = useSWR<TData>(
       () => {
         const key = buildKey({
           ...auth,
           businessId,
-          ...params,
+          ...keyInputs,
         } as Parameters<typeof buildKey>[0])
 
         return isLocalized ? withLocale(key) : key
       },
       fetcher,
-      swrOptions,
+      { ...swrOptions, ...callSwrOptions },
     )
 
     return new SWRQueryResult(swrResponse)

--- a/src/schemas/bookkeepingConfiguration.ts
+++ b/src/schemas/bookkeepingConfiguration.ts
@@ -78,9 +78,3 @@ export const BookkeepingConfigurationSchema = Schema.Struct({
 })
 
 export type BookkeepingConfiguration = typeof BookkeepingConfigurationSchema.Type
-
-export const BookkeepingConfigurationResponseSchema = Schema.Struct({
-  data: BookkeepingConfigurationSchema,
-})
-
-export type BookkeepingConfigurationResponse = typeof BookkeepingConfigurationResponseSchema.Type

--- a/src/schemas/bookkeepingStatus.ts
+++ b/src/schemas/bookkeepingStatus.ts
@@ -11,7 +11,7 @@ const TransformedBookkeepingStatusSchema = createTransformedEnumSchema(
   BookkeepingStatus.NOT_PURCHASED,
 )
 
-const BookkeepingStatusDataSchema = Schema.Struct({
+export const BookkeepingStatusDataSchema = Schema.Struct({
   status: TransformedBookkeepingStatusSchema,
 
   showEmbeddedOnboarding: pipe(
@@ -26,9 +26,3 @@ const BookkeepingStatusDataSchema = Schema.Struct({
 })
 
 export type BookkeepingStatusData = typeof BookkeepingStatusDataSchema.Type
-
-export const BookkeepingStatusResponseSchema = Schema.Struct({
-  data: BookkeepingStatusDataSchema,
-})
-
-export type BookkeepingStatusResponse = typeof BookkeepingStatusResponseSchema.Type

--- a/src/schemas/reports/reportConfig.ts
+++ b/src/schemas/reports/reportConfig.ts
@@ -1,7 +1,7 @@
 import { pipe, Schema } from 'effect'
 
 import { TagDimensionSchema, TagValueDefinitionSchema } from '@schemas/tag'
-import { createTransformedEnumSchema } from '@schemas/utils'
+import { createTransformedEnumSchema, UnwrappedDataResponseSchema } from '@schemas/utils'
 
 export enum ReportControl {
   Date = 'date',
@@ -64,7 +64,7 @@ export const ReportGroupSchema = Schema.Struct({
 })
 export type ReportGroup = typeof ReportGroupSchema.Type
 
-export const ReportConfigResponseSchema = Schema.Struct({
-  data: Schema.Array(ReportGroupSchema),
-})
+export const ReportConfigResponseSchema = UnwrappedDataResponseSchema(
+  Schema.Array(ReportGroupSchema),
+)
 export type ReportConfigResponse = typeof ReportConfigResponseSchema.Type

--- a/src/schemas/stripeAccountStatus.ts
+++ b/src/schemas/stripeAccountStatus.ts
@@ -1,5 +1,7 @@
 import { pipe, Schema } from 'effect'
 
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
+
 export enum StripeAccountStatus {
   NotCreated = 'not_created',
   Incomplete = 'incomplete',
@@ -30,7 +32,5 @@ const StripeAccountStatusDataSchema = Schema.Struct({
   ),
 })
 
-export const StripeAccountStatusResponseSchema = Schema.Struct({
-  data: StripeAccountStatusDataSchema,
-})
+export const StripeAccountStatusResponseSchema = UnwrappedDataResponseSchema(StripeAccountStatusDataSchema)
 export type StripeAccountStatusResponse = typeof StripeAccountStatusDataSchema.Type

--- a/src/schemas/taxEstimates/banner.ts
+++ b/src/schemas/taxEstimates/banner.ts
@@ -2,7 +2,7 @@ import { pipe, Schema } from 'effect'
 
 import { CalendarDateSchema } from '@schemas/common/calendarDateFromSelf'
 import { TaxOverviewDeadlineStatus } from '@schemas/taxEstimates/overview'
-import { createTransformedEnumSchema } from '@schemas/utils'
+import { createTransformedEnumSchema, UnwrappedDataResponseSchema } from '@schemas/utils'
 
 const TransformedTaxOverviewDeadlineStatusSchema = createTransformedEnumSchema(
   Schema.Enums(TaxOverviewDeadlineStatus),
@@ -92,8 +92,6 @@ const TaxEstimatesBannerSchema = Schema.Struct({
 
 export type TaxEstimatesBanner = typeof TaxEstimatesBannerSchema.Type
 
-export const TaxEstimatesBannerResponseSchema = Schema.Struct({
-  data: TaxEstimatesBannerSchema,
-})
+export const TaxEstimatesBannerResponseSchema = UnwrappedDataResponseSchema(TaxEstimatesBannerSchema)
 
 export type TaxEstimatesBannerResponse = typeof TaxEstimatesBannerResponseSchema.Type

--- a/src/schemas/taxEstimates/details.ts
+++ b/src/schemas/taxEstimates/details.ts
@@ -7,6 +7,7 @@ import {
   UnifiedCellValueUnknownSchema,
 } from '@schemas/reports/unifiedReport'
 import { TransformedTaxSummaryStateSchema } from '@schemas/taxEstimates/summary'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 
 const TaxDetailsValueSchema = Schema.Union(
   UnifiedCellValueCurrencySchema,
@@ -63,8 +64,6 @@ const TaxDetailsSchema = Schema.Struct({
 
 export type TaxDetails = typeof TaxDetailsSchema.Type
 
-export const TaxDetailsResponseSchema = Schema.Struct({
-  data: TaxDetailsSchema,
-})
+export const TaxDetailsResponseSchema = UnwrappedDataResponseSchema(TaxDetailsSchema)
 
 export type TaxDetailsResponse = typeof TaxDetailsResponseSchema.Type

--- a/src/schemas/taxEstimates/overview.ts
+++ b/src/schemas/taxEstimates/overview.ts
@@ -1,6 +1,6 @@
 import { pipe, Schema } from 'effect'
 
-import { createTransformedEnumSchema } from '@schemas/utils'
+import { createTransformedEnumSchema, UnwrappedDataResponseSchema } from '@schemas/utils'
 
 import { type TaxSummarySectionType } from './summary'
 
@@ -41,9 +41,7 @@ const TaxOverviewApiDataSchema = Schema.Struct({
 
 export type TaxOverviewApiData = typeof TaxOverviewApiDataSchema.Type
 
-export const TaxOverviewApiResponseSchema = Schema.Struct({
-  data: TaxOverviewApiDataSchema,
-})
+export const TaxOverviewApiResponseSchema = UnwrappedDataResponseSchema(TaxOverviewApiDataSchema)
 
 export type TaxOverviewApiResponse = typeof TaxOverviewApiResponseSchema.Type
 

--- a/src/schemas/taxEstimates/payments.ts
+++ b/src/schemas/taxEstimates/payments.ts
@@ -1,5 +1,7 @@
 import { pipe, Schema } from 'effect'
 
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
+
 const taxPaymentBreakdownFields = {
   rowKey: pipe(
     Schema.propertySignature(Schema.String),
@@ -46,11 +48,11 @@ const TaxPaymentsRowSchema = Schema.Struct({
 
 export type TaxPaymentRow = typeof TaxPaymentsRowSchema.Type
 
-export const TaxPaymentsResponseSchema = Schema.Struct({
-  data: Schema.Struct({
+export const TaxPaymentsResponseSchema = UnwrappedDataResponseSchema(
+  Schema.Struct({
     type: Schema.Literal('US_Tax_Payments'),
     data: Schema.Array(TaxPaymentsRowSchema),
   }),
-})
+)
 
 export type TaxPaymentsResponse = typeof TaxPaymentsResponseSchema.Type

--- a/src/schemas/taxEstimates/profile.ts
+++ b/src/schemas/taxEstimates/profile.ts
@@ -2,6 +2,7 @@ import { pipe, Schema } from 'effect'
 
 import { US_STATE_VALUES } from '@internal-types/location'
 import { FilingStatusSchema } from '@schemas/taxEstimates/filingStatus'
+import { UnwrappedDataResponseSchema } from '@schemas/utils'
 
 const USStateCodeSchema = Schema.Literal(...US_STATE_VALUES)
 
@@ -97,9 +98,7 @@ export const TaxProfileSchema = Schema.Struct({
 
 export type TaxProfile = typeof TaxProfileSchema.Type
 
-export const TaxProfileResponseSchema = Schema.Struct({
-  data: TaxProfileSchema,
-})
+export const TaxProfileResponseSchema = UnwrappedDataResponseSchema(TaxProfileSchema)
 
 export type TaxProfileResponse = typeof TaxProfileResponseSchema.Type
 

--- a/src/schemas/taxEstimates/summary.ts
+++ b/src/schemas/taxEstimates/summary.ts
@@ -1,6 +1,6 @@
 import { pipe, Schema } from 'effect'
 
-import { createTransformedEnumSchema } from '@schemas/utils'
+import { createTransformedEnumSchema, UnwrappedDataResponseSchema } from '@schemas/utils'
 
 const TaxSummarySectionTypeSchema = Schema.Literal('federal', 'state')
 
@@ -56,8 +56,6 @@ const TaxSummarySchema = Schema.Struct({
 
 export type TaxSummary = typeof TaxSummarySchema.Type
 
-export const TaxSummaryResponseSchema = Schema.Struct({
-  data: TaxSummarySchema,
-})
+export const TaxSummaryResponseSchema = UnwrappedDataResponseSchema(TaxSummarySchema)
 
 export type TaxSummaryResponse = typeof TaxSummaryResponseSchema.Type

--- a/src/schemas/utils.ts
+++ b/src/schemas/utils.ts
@@ -1,5 +1,18 @@
 import { Schema } from 'effect/index'
 
+export const UnwrappedDataResponseSchema = <A, I, R>(
+  dataSchema: Schema.Schema<A, I, R>,
+) =>
+  Schema.transform(
+    Schema.Struct({ data: dataSchema }),
+    Schema.typeSchema(dataSchema),
+    {
+      strict: true,
+      decode: ({ data }) => data,
+      encode: data => ({ data }),
+    },
+  )
+
 // Helper function to create transformed enum schemas with safe defaults.
 export const createTransformedEnumSchema = <T extends Record<string, string>>(
   enumSchema: Schema.Schema<T[keyof T], T[keyof T]>,

--- a/src/utils/api/getAsMutation.ts
+++ b/src/utils/api/getAsMutation.ts
@@ -6,10 +6,6 @@ export type MutationRequest<TReturn, TBody, TParams> = (
   options?: { params?: TParams, body?: TBody },
 ) => Promise<TReturn>
 
-/*
- * Adapts a POST-backed read endpoint into the thunk shape `createKeyedFetcher` and the
- * query hook factories expect, deriving the request body from the params.
- */
 export function postAsQuery<TReturn, TBody, TParams>(
   request: MutationRequest<TReturn, TBody, TParams>,
   toBody: (params: TParams) => TBody,
@@ -22,8 +18,12 @@ export function postAsQuery<TReturn, TBody, TParams>(
 }
 
 /*
- * Adapts a GET-backed request into the shape `createMutationHook` expects, for
- * endpoints (e.g. report exports) that are triggered imperatively rather than on render.
+ * Adapts a GET-shaped endpoint that semantically acts (e.g. report exports that generate
+ * a file and mint a fresh presigned URL per call) into the mutation pipeline, so it only
+ * runs on `trigger()` and is never cached or revalidated.
+ *
+ * Assign the result to a `const` before passing it to `createMutationHook`; inlined in the
+ * config object, TypeScript fails to infer the factory's type params from it.
  */
 export function getAsMutation<TReturn, TParams>(
   request: AuthenticatedRequest<TReturn, TParams>,

--- a/src/utils/api/getWithQuery.ts
+++ b/src/utils/api/getWithQuery.ts
@@ -1,0 +1,35 @@
+import { get } from '@utils/api/authenticatedHttp'
+import { type QueryParams, toDefinedSearchParameters } from '@utils/request/toDefinedSearchParameters'
+import type { AuthenticatedRequest } from '@utils/swr/createKeyedFetcher'
+
+/*
+ * Named path params go into the URL; all remaining params become search params.
+ * `transformQuery` replaces that default for renames, constants, or flattening.
+ */
+export function getWithQuery<
+  TReturn extends Record<string, unknown>,
+  TParams extends Record<string, unknown>,
+>(
+  pathParamKeys: ReadonlyArray<keyof TParams>,
+  buildPath: (params: TParams) => string,
+  transformQuery?: (params: TParams) => QueryParams,
+): AuthenticatedRequest<TReturn, TParams> {
+  const buildUrl = (params: TParams) => {
+    const query = transformQuery
+      ? transformQuery(params)
+      : Object.fromEntries(
+        Object.entries(params).filter(
+          ([key]) => !(pathParamKeys as ReadonlyArray<string>).includes(key),
+        ),
+      ) as QueryParams
+
+    const path = buildPath(params)
+    const queryString = toDefinedSearchParameters(query).toString()
+
+    return queryString ? `${path}?${queryString}` : path
+  }
+
+  // TParams may be richer than `get`'s serializable-params constraint (e.g. nested
+  // filter objects handled by transformQuery), so the builder is cast at the boundary.
+  return get<TReturn>(buildUrl as (params: QueryParams) => string) as AuthenticatedRequest<TReturn, TParams>
+}

--- a/src/utils/api/postAsQuery.ts
+++ b/src/utils/api/postAsQuery.ts
@@ -20,3 +20,14 @@ export function postAsQuery<TReturn, TBody, TParams>(
       body: toBody(options?.params as TParams),
     })
 }
+
+/*
+ * Adapts a GET-backed request into the shape `createMutationHook` expects, for
+ * endpoints (e.g. report exports) that are triggered imperatively rather than on render.
+ */
+export function getAsMutation<TReturn, TParams>(
+  request: AuthenticatedRequest<TReturn, TParams>,
+): MutationRequest<TReturn, Record<string, unknown>, TParams> {
+  return (baseUrl, accessToken, options) =>
+    request(baseUrl, accessToken, { params: options?.params })()
+}

--- a/src/utils/api/postAsQuery.ts
+++ b/src/utils/api/postAsQuery.ts
@@ -1,0 +1,22 @@
+import type { AuthenticatedRequest } from '@utils/swr/createKeyedFetcher'
+
+export type MutationRequest<TReturn, TBody, TParams> = (
+  baseUrl: string,
+  accessToken: string | undefined,
+  options?: { params?: TParams, body?: TBody },
+) => Promise<TReturn>
+
+/*
+ * Adapts a POST-backed read endpoint into the thunk shape `createKeyedFetcher` and the
+ * query hook factories expect, deriving the request body from the params.
+ */
+export function postAsQuery<TReturn, TBody, TParams>(
+  request: MutationRequest<TReturn, TBody, TParams>,
+  toBody: (params: TParams) => TBody,
+): AuthenticatedRequest<TReturn, TParams> {
+  return (baseUrl, accessToken, options) => () =>
+    request(baseUrl, accessToken, {
+      params: options?.params,
+      body: toBody(options?.params as TParams),
+    })
+}

--- a/src/utils/swr/SWRResponseTypes.ts
+++ b/src/utils/swr/SWRResponseTypes.ts
@@ -136,4 +136,8 @@ export class SWRMutationResult<Data, ExtraArg = never> {
   get isError() {
     return this.swrResponse.error !== undefined
   }
+
+  get reset() {
+    return this.swrResponse.reset
+  }
 }

--- a/src/utils/swr/createGlobalCacheActions.ts
+++ b/src/utils/swr/createGlobalCacheActions.ts
@@ -30,11 +30,18 @@ export function createResourceGlobalCacheActions<TResource>(tagKey: string) {
       [patchCache],
     )
 
+    const patchCacheResource = useCallback(
+      (transformResource: (resource?: TResource) => TResource | undefined, options?: PatchOptions) =>
+        patchCache<TResource | undefined>(matchesTag, transformResource, options),
+      [patchCache],
+    )
+
     return useMemo(() => ({
       invalidate: invalidateResource,
       forceReload: forceReloadResource,
       overwriteCache: overwriteCacheResource,
-    }), [invalidateResource, forceReloadResource, overwriteCacheResource])
+      patchCache: patchCacheResource,
+    }), [invalidateResource, forceReloadResource, overwriteCacheResource, patchCacheResource])
   }
 }
 

--- a/src/utils/swr/createKeyedFetcher.ts
+++ b/src/utils/swr/createKeyedFetcher.ts
@@ -1,0 +1,36 @@
+import { Schema } from 'effect'
+
+export type AuthenticatedRequest<TReturn, TParams> = (
+  baseUrl: string,
+  accessToken: string | undefined,
+  options?: { params?: TParams },
+) => () => Promise<TReturn>
+
+export type SWRKeyContext = {
+  accessToken: string
+  apiUrl: string
+  tags: ReadonlyArray<string>
+}
+
+/*
+ * Keys built by `createBuildKey`/`createInfiniteKeyLoader` are the request params plus
+ * `accessToken`/`apiUrl`/`tags`; the fetcher strips the context and forwards the rest.
+ */
+export function createKeyedFetcher<
+  TReturn,
+  TParams extends Record<string, unknown>,
+  TDecoded = TReturn,
+>(
+  request: AuthenticatedRequest<TReturn, TParams>,
+  schema?: Schema.Schema<TDecoded, TReturn>,
+) {
+  return ({ accessToken, apiUrl, tags: _tags, ...params }: SWRKeyContext & TParams): Promise<TDecoded> => {
+    const response = request(apiUrl, accessToken, { params: params as unknown as TParams })()
+
+    if (schema) {
+      return response.then(Schema.decodeUnknownPromise(schema))
+    }
+
+    return response as Promise<unknown> as Promise<TDecoded>
+  }
+}


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Wide refactor across bank transactions, invoices, categorization, and cache invalidation paths; behavior depends on consistent response unwrapping and hook return-shape changes throughout the app.
> 
> **Overview**
> Introduces **`createQueryHook`**, **`createMutationHook`**, and **`createInfiniteQueryHook`** and migrates a large set of business-scoped API hooks off hand-rolled `useSWR` / `useSWRMutation` wiring (keys, fetchers, decode). Hooks now declare tags, HTTP requests, **`UnwrappedDataResponseSchema`** decoding, and optional `select` / `swrOptions` in one place.
> 
> **Mutation and query return shapes change at the UI boundary:** `trigger` resolves to the decoded entity (not `{ data: ... }`), so forms and modals pass `result` / `upsertedInvoice` directly into `onSuccess`. Download/export hooks move success handlers into **`swrOptions.onSuccess`** and use **`isError`** where applicable. Paginated list hooks expose **`flattenedData`** (e.g. catalog services) instead of nested `data.data`.
> 
> **Call-site adjustments** include categorization-rule upsert taking create/update **mode at hook init** with a plain body on `trigger`, bulk match-or-categorize exposing **`response.trigger`**, ledger download props **`startDate` / `endDate`**, P&amp;L detail lines gated with **`isEnabled`** and no longer passing `businessId` from context, and **`BankAccountsProvider`** deriving sync/disconnect counts from list data while passing polling via **`swrOptions`**. Bank transaction listing moves tag filtering to **`tagKey` / `tagValues`** query params via **`getWithQuery`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9d0c36551451de087d671d99df4d9719303dca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->