### PR TITLE
LAY-2342 Journal Date Filter [2/n] Move Journal and CoA action buttons to the title bar

### DIFF
--- a/src/components/ChartOfAccountsTable/ChartOfAccountsTableHeader.tsx
+++ b/src/components/ChartOfAccountsTable/ChartOfAccountsTableHeader.tsx
@@ -41,45 +41,41 @@ export const ChartOfAccountsTableHeader = ({
   const addAccountLabel = stringOverrides?.addAccountButtonText || t('chartOfAccounts:action.add_account', 'Add Account')
 
   return (
-    <>
-      <Header asHeader rounded>
-        <HeaderRow>
-          <HeaderCol>
-            <Heading level={asWidget ? 3 : 2} size={asWidget ? 'md' : 'lg'}>
-              {stringOverrides?.headerText || t('chartOfAccounts:label.chart_of_accounts', 'Chart of Accounts')}
-            </Heading>
-          </HeaderCol>
-          <HeaderCol>
-            {withExpandAllButton && <ExpandableDataTableToggleButton />}
-            <AccountBalancesDownloadButton
+    <Header asHeader sticky rounded>
+      <HeaderRow>
+        <HeaderCol>
+          <Heading level={asWidget ? 3 : 2} size={asWidget ? 'md' : 'lg'}>
+            {stringOverrides?.headerText || t('chartOfAccounts:label.chart_of_accounts', 'Chart of Accounts')}
+          </Heading>
+        </HeaderCol>
+        <HeaderCol>
+          {withExpandAllButton && <ExpandableDataTableToggleButton />}
+          <AccountBalancesDownloadButton
+            icon={!isDesktop}
+          />
+          {showAddAccountButton && (
+            <Button
+              onPress={() => onAddAccount()}
               icon={!isDesktop}
-            />
-            {showAddAccountButton && (
-              <Button
-                onPress={() => onAddAccount()}
-                icon={!isDesktop}
-                aria-label={!isDesktop ? addAccountLabel : undefined}
-              >
-                {isDesktop ? addAccountLabel : <CirclePlus size={14} />}
-              </Button>
-            )}
-          </HeaderCol>
-        </HeaderRow>
-      </Header>
-      <Header sticky>
-        <HeaderRow>
-          <HeaderCol>
-            {withDateControl && <GlobalMonthPicker />}
-          </HeaderCol>
-          <HeaderCol className='Layer__chart-of-accounts__actions'>
-            <SearchField
-              label={t('chartOfAccounts:label.search_accounts', 'Search accounts')}
-              value={inputValue}
-              onChange={onSearchChange}
-            />
-          </HeaderCol>
-        </HeaderRow>
-      </Header>
-    </>
+              aria-label={!isDesktop ? addAccountLabel : undefined}
+            >
+              {isDesktop ? addAccountLabel : <CirclePlus size={14} />}
+            </Button>
+          )}
+        </HeaderCol>
+      </HeaderRow>
+      <HeaderRow>
+        <HeaderCol>
+          {withDateControl && <GlobalMonthPicker />}
+        </HeaderCol>
+        <HeaderCol className='Layer__chart-of-accounts__actions'>
+          <SearchField
+            label={t('chartOfAccounts:label.search_accounts', 'Search accounts')}
+            value={inputValue}
+            onChange={onSearchChange}
+          />
+        </HeaderCol>
+      </HeaderRow>
+    </Header>
   )
 }

--- a/src/components/ChartOfAccountsTable/ChartOfAccountsTableHeader.tsx
+++ b/src/components/ChartOfAccountsTable/ChartOfAccountsTableHeader.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { Button } from '@ui/Button/Button'
-import { HStack } from '@ui/Stack/Stack'
 import { Heading } from '@ui/Typography/Heading'
 import { AccountBalancesDownloadButton } from '@components/ChartOfAccounts/download/AccountBalancesDownloadButton'
 import { type ChartOfAccountsTableStringOverrides } from '@components/ChartOfAccountsTable/ChartOfAccountsTableWithPanel'
@@ -50,24 +49,8 @@ export const ChartOfAccountsTableHeader = ({
               {stringOverrides?.headerText || t('chartOfAccounts:label.chart_of_accounts', 'Chart of Accounts')}
             </Heading>
           </HeaderCol>
-        </HeaderRow>
-      </Header>
-      <Header sticky>
-        <HeaderRow>
           <HeaderCol>
-            {(withDateControl || withExpandAllButton) && (
-              <HStack align='center' gap='xs'>
-                {withDateControl && <GlobalMonthPicker />}
-                {withExpandAllButton && <ExpandableDataTableToggleButton />}
-              </HStack>
-            )}
-          </HeaderCol>
-          <HeaderCol className='Layer__chart-of-accounts__actions'>
-            <SearchField
-              label={t('chartOfAccounts:label.search_accounts', 'Search accounts')}
-              value={inputValue}
-              onChange={onSearchChange}
-            />
+            {withExpandAllButton && <ExpandableDataTableToggleButton />}
             <AccountBalancesDownloadButton
               icon={!isDesktop}
             />
@@ -80,6 +63,20 @@ export const ChartOfAccountsTableHeader = ({
                 {isDesktop ? addAccountLabel : <CirclePlus size={14} />}
               </Button>
             )}
+          </HeaderCol>
+        </HeaderRow>
+      </Header>
+      <Header sticky>
+        <HeaderRow>
+          <HeaderCol>
+            {withDateControl && <GlobalMonthPicker />}
+          </HeaderCol>
+          <HeaderCol className='Layer__chart-of-accounts__actions'>
+            <SearchField
+              label={t('chartOfAccounts:label.search_accounts', 'Search accounts')}
+              value={inputValue}
+              onChange={onSearchChange}
+            />
           </HeaderCol>
         </HeaderRow>
       </Header>

--- a/src/components/Journal/Journal.tsx
+++ b/src/components/Journal/Journal.tsx
@@ -61,12 +61,11 @@ const JournalTableView = ({
   asWidget?: boolean
   stringOverrides?: JournalStringOverrides
 }) => {
-  const { view, containerRef } = useElementViewSize<HTMLDivElement>()
+  const { containerRef } = useElementViewSize<HTMLDivElement>()
 
   return (
     <Container name='journal' ref={containerRef} asWidget={asWidget}>
       <JournalTableWithPanel
-        view={view}
         containerRef={containerRef}
         stringOverrides={stringOverrides?.journalTable}
       />

--- a/src/components/JournalTable/JournalTableWithPanel.tsx
+++ b/src/components/JournalTable/JournalTableWithPanel.tsx
@@ -19,6 +19,7 @@ const COMPONENT_NAME = 'journal-table'
 
 export interface JournalTableStringOverrides {
   componentTitle?: string
+  /** @deprecated The sub-header row was removed; this override no longer renders. */
   componentSubtitle?: string
   addEntryButton?: string
   idColumnHeader?: string
@@ -62,15 +63,6 @@ export const JournalTableWithPanel = ({
           <HeaderCol>
             <Heading level={2} size='md'>
               {stringOverrides?.componentTitle || t('generalLedger:label.journal', 'Journal')}
-            </Heading>
-          </HeaderCol>
-        </HeaderRow>
-      </Header>
-      <Header>
-        <HeaderRow>
-          <HeaderCol>
-            <Heading level={3} size='sm'>
-              {stringOverrides?.componentSubtitle || t('generalLedger:label.entries', 'Entries')}
             </Heading>
           </HeaderCol>
           <HeaderCol>

--- a/src/components/JournalTable/JournalTableWithPanel.tsx
+++ b/src/components/JournalTable/JournalTableWithPanel.tsx
@@ -2,7 +2,7 @@ import { type RefObject, useContext } from 'react'
 import { CirclePlus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { type View } from '@internal-types/general'
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { useJournalNavigation } from '@providers/JournalStore/JournalStoreProvider'
 import { JournalContext } from '@contexts/JournalContext/JournalContext'
 import { Button } from '@ui/Button/Button'
@@ -34,13 +34,12 @@ export interface JournalTableStringOverrides {
 export const JournalTableWithPanel = ({
   containerRef,
   stringOverrides,
-  view,
 }: {
-  view: View
   containerRef: RefObject<HTMLDivElement>
   stringOverrides?: JournalTableStringOverrides
 }) => {
   const { t } = useTranslation()
+  const { isDesktop } = useSizeClass()
   const { toCreateEntry } = useJournalNavigation()
   const addEntryLabel = stringOverrides?.addEntryButton || t('generalLedger:action.add_entry', 'Add Entry')
 
@@ -67,14 +66,14 @@ export const JournalTableWithPanel = ({
           </HeaderCol>
           <HeaderCol>
             <JournalEntriesDownloadButton
-              icon={['mobile', 'tablet'].includes(view)}
+              icon={!isDesktop}
             />
             <Button
               onPress={() => toCreateEntry()}
-              icon={view === 'mobile'}
-              aria-label={view === 'mobile' ? addEntryLabel : undefined}
+              icon={!isDesktop}
+              aria-label={!isDesktop ? addEntryLabel : undefined}
             >
-              {view === 'mobile' ? <CirclePlus size={14} /> : addEntryLabel}
+              {isDesktop ? addEntryLabel : <CirclePlus size={14} />}
             </Button>
           </HeaderCol>
         </HeaderRow>


### PR DESCRIPTION
## Description

Reorganizes Journal and Chart of Accounts headers to free space for upcoming date-range filters.

### Changes:

- Moves quick action buttons (Add new, Download CSV, Expand All) into the title bar.
- Keeps Chart of Accounts filtering controls (month picker + search) in a separate row.
- Removes the Journal “Entries” sub-header row and deprecates the `componentSubtitle` string override.

The general UI philosophy we have aligned on for these Ledger views in the short term is:
- Main header row: Title + quick action buttons
- Secondary header row: filter options (date, search)

## Screenshots

### Before - Chart Of Accounts
<img width="1262" height="646" alt="image" src="https://github.com/user-attachments/assets/69d6b723-4591-44b3-b837-9b98d271f1ae" />

### After - Chart Of Accounts
<img width="1264" height="695" alt="image" src="https://github.com/user-attachments/assets/27acaae9-2a5d-46f9-b182-30a2b707eb46" />


### Before - Journal
<img width="1256" height="640" alt="image" src="https://github.com/user-attachments/assets/3ff93785-2eca-4106-9e5a-734c672d3e25" />


### After - Journal
<img width="1268" height="590" alt="image" src="https://github.com/user-attachments/assets/eac39809-95c8-4bbd-956a-788b8e6bbf64" />

## How this has been tested?
This was tested via a local deployment of demo finguard.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only header layout and responsive button styling; no ledger, auth, or data-path changes.
> 
> **Overview**
> Reorganizes **Chart of Accounts** and **Journal** headers so the main row is **title + quick actions** (download, add, expand-all on CoA) and filters stay on a **second row** (month picker + search on CoA), freeing vertical space for upcoming date-range filters.
> 
> **Chart of Accounts** collapses the separate title and sticky toolbars into one `Header` with two `HeaderRow`s: expand-all moves next to download/add on the title row; month picker and search remain below.
> 
> **Journal** drops the “Entries” sub-header, puts download and **Add Entry** on the title row, and stops passing container `view` into the table—responsive icon vs label buttons now use `useSizeClass` (`isDesktop`) instead of `view === 'mobile'`. `componentSubtitle` on `JournalTableStringOverrides` is **deprecated** and no longer rendered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91287672dab094b05e46f5dc7d58bbb03b1ddd31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->