### PR TITLE
LAY-2342 Journal Date Filter [3/n] [refactor] Extract prop-driven date range selection components

### DIFF
--- a/src/components/DatePicker/DateRangePicker.test.tsx
+++ b/src/components/DatePicker/DateRangePicker.test.tsx
@@ -1,19 +1,21 @@
-import { useCallback, useState } from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
-import { IntlProvider } from 'react-intl'
+import { type ReactElement, useCallback, useState } from 'react'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import { type DateRange } from '@utils/date/dateRange'
 import { DateRangePicker } from '@components/DatePicker/DateRangePicker'
 
-vi.mock('@hooks/utils/dates/useBusinessDatePickerBounds', () => {
-  const bounds = { minDate: null, maxDate: new Date(2027, 0, 1) }
-  return { useBusinessDatePickerBounds: () => bounds }
-})
+import { LayerTestProvider } from '@test-utils/LayerTestProvider'
 
 const INITIAL_RANGE: DateRange = {
   startDate: new Date(2026, 0, 1),
   endDate: new Date(2026, 0, 31),
+}
+
+const UPDATED_RANGE: DateRange = {
+  startDate: new Date(2026, 1, 1),
+  endDate: new Date(2026, 1, 28),
 }
 
 function PlainStateParent({ onSetDateRange }: { onSetDateRange: (range: DateRange) => void }) {
@@ -24,12 +26,21 @@ function PlainStateParent({ onSetDateRange }: { onSetDateRange: (range: DateRang
     setRange(next)
   }, [onSetDateRange])
 
-  return (
-    <IntlProvider locale='en'>
-      <DateRangePicker dateRange={range} setDateRange={setDateRange} />
-    </IntlProvider>
-  )
+  return <DateRangePicker dateRange={range} setDateRange={setDateRange} />
 }
+
+const renderDateRangePicker = (ui: ReactElement) => {
+  const user = userEvent.setup()
+
+  return {
+    user,
+    ...render(ui, { wrapper: LayerTestProvider }),
+  }
+}
+
+const getDaySegment = (pickerName: string) =>
+  within(screen.getByRole('group', { name: pickerName }))
+    .getByRole('spinbutton', { name: /day/i })
 
 describe('DateRangePicker', () => {
   it('does not re-render endlessly with a plain useState parent', () => {
@@ -40,46 +51,36 @@ describe('DateRangePicker', () => {
       }
     })
 
-    render(<PlainStateParent onSetDateRange={onSetDateRange} />)
+    renderDateRangePicker(<PlainStateParent onSetDateRange={onSetDateRange} />)
 
     // The picker starts in sync with the incoming range, so mounting should
     // not push any update back to the parent.
+    expect(screen.getByRole('group', { name: 'Start date' })).toBeInTheDocument()
     expect(onSetDateRange).not.toHaveBeenCalled()
   })
 
   it('does not echo an externally-updated range back to the parent', () => {
     const setDateRange = vi.fn()
 
-    const { rerender } = render(
-      <IntlProvider locale='en'>
-        <DateRangePicker dateRange={INITIAL_RANGE} setDateRange={setDateRange} />
-      </IntlProvider>,
+    const { rerender } = renderDateRangePicker(
+      <DateRangePicker dateRange={INITIAL_RANGE} setDateRange={setDateRange} />,
     )
 
-    rerender(
-      <IntlProvider locale='en'>
-        <DateRangePicker
-          dateRange={{ startDate: new Date(2026, 1, 1), endDate: new Date(2026, 1, 28) }}
-          setDateRange={setDateRange}
-        />
-      </IntlProvider>,
-    )
+    rerender(<DateRangePicker dateRange={UPDATED_RANGE} setDateRange={setDateRange} />)
 
     expect(setDateRange).not.toHaveBeenCalled()
   })
 
-  it('still propagates local edits to the parent', () => {
+  it('still propagates local edits to the parent', async () => {
     const onSetDateRange = vi.fn()
 
-    render(<PlainStateParent onSetDateRange={onSetDateRange} />)
+    const { user } = renderDateRangePicker(<PlainStateParent onSetDateRange={onSetDateRange} />)
 
     // Bump the day segment of the start date field
-    const daySegment = screen
-      .getAllByRole('spinbutton')
-      .find(segment => segment.getAttribute('data-type') === 'day')
+    const daySegment = getDaySegment('Start date')
 
-    expect(daySegment).toBeDefined()
-    fireEvent.keyDown(daySegment!, { key: 'ArrowUp' })
+    await user.click(daySegment)
+    await user.keyboard('{ArrowUp}')
 
     expect(onSetDateRange).toHaveBeenCalledTimes(1)
     expect(onSetDateRange).toHaveBeenLastCalledWith({

--- a/src/components/DatePicker/DateRangePicker.test.tsx
+++ b/src/components/DatePicker/DateRangePicker.test.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useState } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { IntlProvider } from 'react-intl'
+import { describe, expect, it, vi } from 'vitest'
+
+import { type DateRange } from '@utils/date/dateRange'
+import { DateRangePicker } from '@components/DatePicker/DateRangePicker'
+
+vi.mock('@hooks/utils/dates/useGlobalDatePickerBounds', () => {
+  const bounds = { minDate: null, maxDate: new Date(2027, 0, 1) }
+  return { useGlobalDatePickerBounds: () => bounds }
+})
+
+const INITIAL_RANGE: DateRange = {
+  startDate: new Date(2026, 0, 1),
+  endDate: new Date(2026, 0, 31),
+}
+
+function PlainStateParent({ onSetDateRange }: { onSetDateRange: (range: DateRange) => void }) {
+  const [range, setRange] = useState(INITIAL_RANGE)
+
+  const setDateRange = useCallback((next: DateRange) => {
+    onSetDateRange(next)
+    setRange(next)
+  }, [onSetDateRange])
+
+  return (
+    <IntlProvider locale='en'>
+      <DateRangePicker dateRange={range} setDateRange={setDateRange} />
+    </IntlProvider>
+  )
+}
+
+describe('DateRangePicker', () => {
+  it('does not re-render endlessly with a plain useState parent', () => {
+    const onSetDateRange = vi.fn((_range: DateRange) => {
+      // Circuit-breaker so a regression fails fast instead of hanging the run
+      if (onSetDateRange.mock.calls.length > 25) {
+        throw new Error('render loop detected: setDateRange called more than 25 times')
+      }
+    })
+
+    render(<PlainStateParent onSetDateRange={onSetDateRange} />)
+
+    // The picker starts in sync with the incoming range, so mounting should
+    // not push any update back to the parent.
+    expect(onSetDateRange).not.toHaveBeenCalled()
+  })
+
+  it('does not echo an externally-updated range back to the parent', () => {
+    const setDateRange = vi.fn()
+
+    const { rerender } = render(
+      <IntlProvider locale='en'>
+        <DateRangePicker dateRange={INITIAL_RANGE} setDateRange={setDateRange} />
+      </IntlProvider>,
+    )
+
+    rerender(
+      <IntlProvider locale='en'>
+        <DateRangePicker
+          dateRange={{ startDate: new Date(2026, 1, 1), endDate: new Date(2026, 1, 28) }}
+          setDateRange={setDateRange}
+        />
+      </IntlProvider>,
+    )
+
+    expect(setDateRange).not.toHaveBeenCalled()
+  })
+
+  it('still propagates local edits to the parent', () => {
+    const onSetDateRange = vi.fn()
+
+    render(<PlainStateParent onSetDateRange={onSetDateRange} />)
+
+    // Bump the day segment of the start date field
+    const daySegment = screen
+      .getAllByRole('spinbutton')
+      .find(segment => segment.getAttribute('data-type') === 'day')
+
+    expect(daySegment).toBeDefined()
+    fireEvent.keyDown(daySegment!, { key: 'ArrowUp' })
+
+    expect(onSetDateRange).toHaveBeenCalledTimes(1)
+    expect(onSetDateRange).toHaveBeenLastCalledWith({
+      startDate: new Date(2026, 0, 2),
+      endDate: INITIAL_RANGE.endDate,
+    })
+  })
+})

--- a/src/components/DatePicker/DateRangePicker.test.tsx
+++ b/src/components/DatePicker/DateRangePicker.test.tsx
@@ -6,9 +6,9 @@ import { describe, expect, it, vi } from 'vitest'
 import { type DateRange } from '@utils/date/dateRange'
 import { DateRangePicker } from '@components/DatePicker/DateRangePicker'
 
-vi.mock('@hooks/utils/dates/useGlobalDatePickerBounds', () => {
+vi.mock('@hooks/utils/dates/useBusinessDatePickerBounds', () => {
   const bounds = { minDate: null, maxDate: new Date(2027, 0, 1) }
-  return { useGlobalDatePickerBounds: () => bounds }
+  return { useBusinessDatePickerBounds: () => bounds }
 })
 
 const INITIAL_RANGE: DateRange = {

--- a/src/components/DatePicker/DateRangePicker.test.tsx
+++ b/src/components/DatePicker/DateRangePicker.test.tsx
@@ -45,16 +45,12 @@ const getDaySegment = (pickerName: string) =>
 describe('DateRangePicker', () => {
   it('does not re-render endlessly with a plain useState parent', () => {
     const onSetDateRange = vi.fn((_range: DateRange) => {
-      // Circuit-breaker so a regression fails fast instead of hanging the run
       if (onSetDateRange.mock.calls.length > 25) {
         throw new Error('render loop detected: setDateRange called more than 25 times')
       }
     })
 
     renderDateRangePicker(<PlainStateParent onSetDateRange={onSetDateRange} />)
-
-    // The picker starts in sync with the incoming range, so mounting should
-    // not push any update back to the parent.
     expect(screen.getByRole('group', { name: 'Start date' })).toBeInTheDocument()
     expect(onSetDateRange).not.toHaveBeenCalled()
   })
@@ -78,7 +74,6 @@ describe('DateRangePicker', () => {
 
     // Bump the day segment of the start date field
     const daySegment = getDaySegment('Start date')
-
     await user.click(daySegment)
     await user.keyboard('{ArrowUp}')
 

--- a/src/components/DatePicker/DateRangePicker.tsx
+++ b/src/components/DatePicker/DateRangePicker.tsx
@@ -1,19 +1,18 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { type DateRange } from '@utils/date/dateRange'
+import { type DateRange, isSameDateRange } from '@utils/date/dateRange'
 import { useGlobalDatePickerBounds } from '@hooks/utils/dates/useGlobalDatePickerBounds'
 import { DatePicker } from '@components/DatePicker/DatePicker'
 import { useDatePickerState } from '@components/DatePicker/useDatePickerState'
 
 type DateRangePickerProps = {
-  startDate: Date
-  endDate: Date
+  dateRange: DateRange
   setDateRange: (range: DateRange) => void
   showLabels?: boolean
 }
 
-export const DateRangePicker = ({ startDate, endDate, setDateRange, showLabels = false }: DateRangePickerProps) => {
+export const DateRangePicker = ({ dateRange, setDateRange, showLabels = false }: DateRangePickerProps) => {
   const { t } = useTranslation()
   const { minDate, maxDate } = useGlobalDatePickerBounds()
 
@@ -26,7 +25,7 @@ export const DateRangePicker = ({ startDate, endDate, setDateRange, showLabels =
     errorText: startDateErrorText,
     onBlur: onBlurStartDate,
   } = useDatePickerState({
-    date: startDate,
+    date: dateRange.startDate,
     minDate,
     maxDate,
   })
@@ -40,15 +39,23 @@ export const DateRangePicker = ({ startDate, endDate, setDateRange, showLabels =
     errorText: endDateErrorText,
     onBlur: onBlurEndDate,
   } = useDatePickerState({
-    date: endDate,
+    date: dateRange.endDate,
     minDate,
     maxDate,
   })
+
+  const dateRangeRef = useRef(dateRange)
+
+  useEffect(() => {
+    dateRangeRef.current = dateRange
+  }, [dateRange])
 
   useEffect(() => {
     if (startDateInvalid || endDateInvalid || !localStartDate || !localEndDate) return
 
     const next = { startDate: localStartDate.toDate(), endDate: localEndDate.toDate() }
+
+    if (isSameDateRange(next, dateRangeRef.current)) return
 
     setDateRange(next)
   }, [startDateInvalid, endDateInvalid, localStartDate, localEndDate, setDateRange])

--- a/src/components/DatePicker/DateRangePicker.tsx
+++ b/src/components/DatePicker/DateRangePicker.tsx
@@ -1,0 +1,84 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useGlobalDatePickerBounds } from '@hooks/utils/dates/useGlobalDatePickerBounds'
+import { type DateRange } from '@providers/DateStoreProvider/internal/types'
+import { DatePicker } from '@components/DatePicker/DatePicker'
+import { useDatePickerState } from '@components/DatePicker/useDatePickerState'
+
+type DateRangePickerProps = {
+  startDate: Date
+  endDate: Date
+  setDateRange: (range: DateRange) => void
+  showLabels?: boolean
+}
+
+export const DateRangePicker = ({ startDate, endDate, setDateRange, showLabels = false }: DateRangePickerProps) => {
+  const { t } = useTranslation()
+  const { minDate, maxDate } = useGlobalDatePickerBounds()
+
+  const {
+    localDate: localStartDate,
+    onChange: onChangeStartDate,
+    minDateZdt: minStartDate,
+    maxDateZdt: maxStartDate,
+    isInvalid: startDateInvalid,
+    errorText: startDateErrorText,
+    onBlur: onBlurStartDate,
+  } = useDatePickerState({
+    date: startDate,
+    minDate,
+    maxDate,
+  })
+
+  const {
+    localDate: localEndDate,
+    onChange: onChangeEndDate,
+    minDateZdt: minEndDate,
+    maxDateZdt: maxEndDate,
+    isInvalid: endDateInvalid,
+    errorText: endDateErrorText,
+    onBlur: onBlurEndDate,
+  } = useDatePickerState({
+    date: endDate,
+    minDate,
+    maxDate,
+  })
+
+  useEffect(() => {
+    if (startDateInvalid || endDateInvalid || !localStartDate || !localEndDate) return
+
+    const next = { startDate: localStartDate.toDate(), endDate: localEndDate.toDate() }
+
+    setDateRange(next)
+  }, [startDateInvalid, endDateInvalid, localStartDate, localEndDate, setDateRange])
+
+  return (
+    <>
+      <DatePicker
+        label={t('date:label.start_date', 'Start date')}
+        date={localStartDate}
+        onChange={onChangeStartDate}
+        minDate={minStartDate}
+        maxDate={maxStartDate}
+        isInvalid={startDateInvalid}
+        errorText={startDateErrorText}
+        onBlur={onBlurStartDate}
+        slotProps={{ Label: { size: 'sm', pbe: '3xs' } }}
+        showLabel={showLabels}
+      />
+      <DatePicker
+        label={t('date:label.end_date', 'End date')}
+        date={localEndDate}
+        onChange={onChangeEndDate}
+        minDate={minEndDate}
+        maxDate={maxEndDate}
+        isInvalid={endDateInvalid}
+        errorText={endDateErrorText}
+        onBlur={onBlurEndDate}
+        slotProps={{ Label: { size: 'sm', pbe: '3xs' } }}
+        showLabel={showLabels}
+      />
+    </>
+  )
+}

--- a/src/components/DatePicker/DateRangePicker.tsx
+++ b/src/components/DatePicker/DateRangePicker.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { type DateRange, isSameDateRange } from '@utils/date/dateRange'
-import { useGlobalDatePickerBounds } from '@hooks/utils/dates/useGlobalDatePickerBounds'
+import { useBusinessDatePickerBounds } from '@hooks/utils/dates/useBusinessDatePickerBounds'
 import { DatePicker } from '@components/DatePicker/DatePicker'
 import { useDatePickerState } from '@components/DatePicker/useDatePickerState'
 
@@ -14,7 +14,7 @@ type DateRangePickerProps = {
 
 export const DateRangePicker = ({ dateRange, setDateRange, showLabels = false }: DateRangePickerProps) => {
   const { t } = useTranslation()
-  const { minDate, maxDate } = useGlobalDatePickerBounds()
+  const { minDate, maxDate } = useBusinessDatePickerBounds()
 
   const {
     localDate: localStartDate,

--- a/src/components/DatePicker/DateRangePicker.tsx
+++ b/src/components/DatePicker/DateRangePicker.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useGlobalDatePickerBounds } from '@hooks/utils/dates/useGlobalDatePickerBounds'
-import { type DateRange } from '@providers/DateStoreProvider/internal/types'
+import { type DateRange } from '@utils/date/dateRange'
 import { DatePicker } from '@components/DatePicker/DatePicker'
 import { useDatePickerState } from '@components/DatePicker/useDatePickerState'
 

--- a/src/components/DatePicker/DateRangePicker.tsx
+++ b/src/components/DatePicker/DateRangePicker.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useGlobalDatePickerBounds } from '@hooks/utils/dates/useGlobalDatePickerBounds'
 import { type DateRange } from '@utils/date/dateRange'
+import { useGlobalDatePickerBounds } from '@hooks/utils/dates/useGlobalDatePickerBounds'
 import { DatePicker } from '@components/DatePicker/DatePicker'
 import { useDatePickerState } from '@components/DatePicker/useDatePickerState'
 

--- a/src/components/DateSelection/DateRangeSelection.tsx
+++ b/src/components/DateSelection/DateRangeSelection.tsx
@@ -4,7 +4,7 @@ import { type DateRange } from '@utils/date/dateRange'
 import { DateRangePicker } from '@components/DatePicker/DateRangePicker'
 import { DateSelectionComboBox } from '@components/DateSelection/DateSelectionComboBox'
 
-import './globalDateRangeSelection.scss'
+import './dateRangeSelection.scss'
 
 type DateRangeSelectionProps = {
   dateRange: DateRange
@@ -21,8 +21,8 @@ export const DateRangeSelection = ({
 }: DateRangeSelectionProps) => {
   return (
     <div
-      className={classNames('Layer__GlobalDateRangeSelection', {
-        'Layer__GlobalDateRangeSelection--compact': isCompact,
+      className={classNames('Layer__DateRangeSelection', {
+        'Layer__DateRangeSelection--compact': isCompact,
       })}
     >
       <DateSelectionComboBox

--- a/src/components/DateSelection/DateRangeSelection.tsx
+++ b/src/components/DateSelection/DateRangeSelection.tsx
@@ -1,0 +1,44 @@
+import classNames from 'classnames'
+
+import { type DateRange } from '@providers/DateStoreProvider/internal/types'
+import { DateRangePicker } from '@components/DatePicker/DateRangePicker'
+import { DateSelectionComboBox } from '@components/DateSelection/DateSelectionComboBox'
+
+import './globalDateRangeSelection.scss'
+
+type DateRangeSelectionProps = {
+  startDate: Date
+  endDate: Date
+  setDateRange: (range: DateRange) => void
+  showLabels?: boolean
+  isCompact?: boolean
+}
+
+export const DateRangeSelection = ({
+  startDate,
+  endDate,
+  setDateRange,
+  showLabels = false,
+  isCompact = false,
+}: DateRangeSelectionProps) => {
+  return (
+    <div
+      className={classNames('Layer__GlobalDateRangeSelection', {
+        'Layer__GlobalDateRangeSelection--compact': isCompact,
+      })}
+    >
+      <DateSelectionComboBox
+        startDate={startDate}
+        endDate={endDate}
+        setDateRange={setDateRange}
+        showLabel={showLabels}
+      />
+      <DateRangePicker
+        startDate={startDate}
+        endDate={endDate}
+        setDateRange={setDateRange}
+        showLabels={showLabels}
+      />
+    </div>
+  )
+}

--- a/src/components/DateSelection/DateRangeSelection.tsx
+++ b/src/components/DateSelection/DateRangeSelection.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 
-import { type DateRange } from '@providers/DateStoreProvider/internal/types'
+import { type DateRange } from '@utils/date/dateRange'
 import { DateRangePicker } from '@components/DatePicker/DateRangePicker'
 import { DateSelectionComboBox } from '@components/DateSelection/DateSelectionComboBox'
 

--- a/src/components/DateSelection/DateRangeSelection.tsx
+++ b/src/components/DateSelection/DateRangeSelection.tsx
@@ -7,16 +7,14 @@ import { DateSelectionComboBox } from '@components/DateSelection/DateSelectionCo
 import './globalDateRangeSelection.scss'
 
 type DateRangeSelectionProps = {
-  startDate: Date
-  endDate: Date
+  dateRange: DateRange
   setDateRange: (range: DateRange) => void
   showLabels?: boolean
   isCompact?: boolean
 }
 
 export const DateRangeSelection = ({
-  startDate,
-  endDate,
+  dateRange,
   setDateRange,
   showLabels = false,
   isCompact = false,
@@ -28,14 +26,12 @@ export const DateRangeSelection = ({
       })}
     >
       <DateSelectionComboBox
-        startDate={startDate}
-        endDate={endDate}
+        dateRange={dateRange}
         setDateRange={setDateRange}
         showLabel={showLabels}
       />
       <DateRangePicker
-        startDate={startDate}
-        endDate={endDate}
+        dateRange={dateRange}
         setDateRange={setDateRange}
         showLabels={showLabels}
       />

--- a/src/components/DateSelection/DateSelectionComboBox.tsx
+++ b/src/components/DateSelection/DateSelectionComboBox.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { getActivationDate } from '@utils/business'
 import { DatePreset, presetForDateRange, rangeForPreset } from '@utils/date/dateRangePresets'
-import { type DateRange } from '@providers/DateStoreProvider/internal/types'
+import { type DateRange } from '@utils/date/dateRange'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { ComboBox } from '@ui/ComboBox/ComboBox'
 import { VStack } from '@ui/Stack/Stack'

--- a/src/components/DateSelection/DateSelectionComboBox.tsx
+++ b/src/components/DateSelection/DateSelectionComboBox.tsx
@@ -2,7 +2,7 @@ import { useCallback, useId, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { getActivationDate } from '@utils/business'
-import { useGlobalDateRange, useGlobalDateRangeActions } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
+import { type DateRange } from '@providers/DateStoreProvider/internal/types'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { ComboBox } from '@ui/ComboBox/ComboBox'
 import { VStack } from '@ui/Stack/Stack'
@@ -14,13 +14,19 @@ type DateSelectionOption = {
   value: DatePreset
 }
 
-export const DateSelectionComboBox = ({ showLabel = false }: { showLabel?: boolean }) => {
+type DateSelectionComboBoxProps = {
+  startDate: Date
+  endDate: Date
+  setDateRange: (range: DateRange) => void
+  showLabel?: boolean
+}
+
+export const DateSelectionComboBox = ({ startDate, endDate, setDateRange, showLabel = false }: DateSelectionComboBoxProps) => {
   const { t } = useTranslation()
   const [lastPreset, setLastPreset] = useState<DatePreset | null>(null)
   const { business } = useLayerContext()
 
-  const dateRange = useGlobalDateRange({ dateSelectionMode: 'full' })
-  const { setDateRange } = useGlobalDateRangeActions()
+  const dateRange = useMemo(() => ({ startDate, endDate }), [startDate, endDate])
 
   const selectedPreset = presetForDateRange(dateRange, lastPreset, getActivationDate(business))
 

--- a/src/components/DateSelection/DateSelectionComboBox.tsx
+++ b/src/components/DateSelection/DateSelectionComboBox.tsx
@@ -2,8 +2,8 @@ import { useCallback, useId, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { getActivationDate } from '@utils/business'
-import { DatePreset, presetForDateRange, rangeForPreset } from '@utils/date/dateRangePresets'
 import { type DateRange } from '@utils/date/dateRange'
+import { DatePreset, presetForDateRange, rangeForPreset } from '@utils/date/dateRangePresets'
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { ComboBox } from '@ui/ComboBox/ComboBox'
 import { VStack } from '@ui/Stack/Stack'
@@ -15,18 +15,15 @@ type DateSelectionOption = {
 }
 
 type DateSelectionComboBoxProps = {
-  startDate: Date
-  endDate: Date
+  dateRange: DateRange
   setDateRange: (range: DateRange) => void
   showLabel?: boolean
 }
 
-export const DateSelectionComboBox = ({ startDate, endDate, setDateRange, showLabel = false }: DateSelectionComboBoxProps) => {
+export const DateSelectionComboBox = ({ dateRange, setDateRange, showLabel = false }: DateSelectionComboBoxProps) => {
   const { t } = useTranslation()
   const [lastPreset, setLastPreset] = useState<DatePreset | null>(null)
   const { business } = useLayerContext()
-
-  const dateRange = useMemo(() => ({ startDate, endDate }), [startDate, endDate])
 
   const selectedPreset = presetForDateRange(dateRange, lastPreset, getActivationDate(business))
 

--- a/src/components/DateSelection/GlobalDateRangeSelection.tsx
+++ b/src/components/DateSelection/GlobalDateRangeSelection.tsx
@@ -1,9 +1,5 @@
-import classNames from 'classnames'
-
-import { DateSelectionComboBox } from '@components/DateSelection/DateSelectionComboBox'
-import { GlobalDateRangePicker } from '@components/GlobalDateRangePicker/GlobalDateRangePicker'
-
-import './globalDateRangeSelection.scss'
+import { useGlobalDateRange, useGlobalDateRangeActions } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
+import { DateRangeSelection } from '@components/DateSelection/DateRangeSelection'
 
 type GlobalDateRangeSelectionProps = {
   showLabels?: boolean
@@ -11,14 +7,16 @@ type GlobalDateRangeSelectionProps = {
 }
 
 export const GlobalDateRangeSelection = ({ showLabels = false, isCompact = false }: GlobalDateRangeSelectionProps) => {
+  const { startDate, endDate } = useGlobalDateRange({ dateSelectionMode: 'full' })
+  const { setDateRange } = useGlobalDateRangeActions()
+
   return (
-    <div
-      className={classNames('Layer__GlobalDateRangeSelection', {
-        'Layer__GlobalDateRangeSelection--compact': isCompact,
-      })}
-    >
-      <DateSelectionComboBox showLabel={showLabels} />
-      <GlobalDateRangePicker showLabels={showLabels} />
-    </div>
+    <DateRangeSelection
+      startDate={startDate}
+      endDate={endDate}
+      setDateRange={setDateRange}
+      showLabels={showLabels}
+      isCompact={isCompact}
+    />
   )
 }

--- a/src/components/DateSelection/GlobalDateRangeSelection.tsx
+++ b/src/components/DateSelection/GlobalDateRangeSelection.tsx
@@ -7,13 +7,12 @@ type GlobalDateRangeSelectionProps = {
 }
 
 export const GlobalDateRangeSelection = ({ showLabels = false, isCompact = false }: GlobalDateRangeSelectionProps) => {
-  const { startDate, endDate } = useGlobalDateRange({ dateSelectionMode: 'full' })
+  const dateRange = useGlobalDateRange({ dateSelectionMode: 'full' })
   const { setDateRange } = useGlobalDateRangeActions()
 
   return (
     <DateRangeSelection
-      startDate={startDate}
-      endDate={endDate}
+      dateRange={dateRange}
       setDateRange={setDateRange}
       showLabels={showLabels}
       isCompact={isCompact}

--- a/src/components/DateSelection/GlobalDateSelection.tsx
+++ b/src/components/DateSelection/GlobalDateSelection.tsx
@@ -12,7 +12,7 @@ type GlobalDateSelectionProps = {
 }
 
 export const GlobalDateSelection = ({ showLabels = false, isCompact = false }: GlobalDateSelectionProps) => {
-  const { startDate, endDate } = useGlobalDateRange({ dateSelectionMode: 'full' })
+  const dateRange = useGlobalDateRange({ dateSelectionMode: 'full' })
   const { setDateRange } = useGlobalDateRangeActions()
 
   return (
@@ -22,8 +22,7 @@ export const GlobalDateSelection = ({ showLabels = false, isCompact = false }: G
       })}
     >
       <DateSelectionComboBox
-        startDate={startDate}
-        endDate={endDate}
+        dateRange={dateRange}
         setDateRange={setDateRange}
         showLabel={showLabels}
       />

--- a/src/components/DateSelection/GlobalDateSelection.tsx
+++ b/src/components/DateSelection/GlobalDateSelection.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames'
 
+import { useGlobalDateRange, useGlobalDateRangeActions } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
 import { DateSelectionComboBox } from '@components/DateSelection/DateSelectionComboBox'
 import { GlobalDatePicker } from '@components/GlobalDatePicker/GlobalDatePicker'
 
@@ -11,13 +12,21 @@ type GlobalDateSelectionProps = {
 }
 
 export const GlobalDateSelection = ({ showLabels = false, isCompact = false }: GlobalDateSelectionProps) => {
+  const { startDate, endDate } = useGlobalDateRange({ dateSelectionMode: 'full' })
+  const { setDateRange } = useGlobalDateRangeActions()
+
   return (
     <div
       className={classNames('Layer__GlobalDateSelection', {
         'Layer__GlobalDateSelection--compact': isCompact,
       })}
     >
-      <DateSelectionComboBox showLabel={showLabels} />
+      <DateSelectionComboBox
+        startDate={startDate}
+        endDate={endDate}
+        setDateRange={setDateRange}
+        showLabel={showLabels}
+      />
       <GlobalDatePicker showLabel={showLabels} />
     </div>
   )

--- a/src/components/DateSelection/dateRangeSelection.scss
+++ b/src/components/DateSelection/dateRangeSelection.scss
@@ -1,4 +1,4 @@
-.Layer__GlobalDateRangeSelection {
+.Layer__DateRangeSelection {
   display: grid;
   grid-template-columns: repeat(3, minmax(10rem, 1fr));
   gap: var(--spacing-xs);

--- a/src/components/GlobalDatePicker/GlobalDatePicker.tsx
+++ b/src/components/GlobalDatePicker/GlobalDatePicker.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useGlobalDatePickerBounds } from '@hooks/utils/dates/useGlobalDatePickerBounds'
+import { useBusinessDatePickerBounds } from '@hooks/utils/dates/useBusinessDatePickerBounds'
 import { useGlobalDate, useGlobalDateActions } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
 import { DatePicker } from '@components/DatePicker/DatePicker'
 import { useDatePickerState } from '@components/DatePicker/useDatePickerState'
@@ -10,7 +10,7 @@ export const GlobalDatePicker = ({ showLabel = false }: { showLabel?: boolean })
   const { t } = useTranslation()
   const { date } = useGlobalDate({ dateSelectionMode: 'full' })
   const { setDate: setGlobalDate } = useGlobalDateActions()
-  const { minDate, maxDate } = useGlobalDatePickerBounds()
+  const { minDate, maxDate } = useBusinessDatePickerBounds()
 
   const setDate = useCallback((date: Date) => {
     setGlobalDate({ date })

--- a/src/components/GlobalDateRangePicker/GlobalDateRangePicker.tsx
+++ b/src/components/GlobalDateRangePicker/GlobalDateRangePicker.tsx
@@ -1,79 +1,16 @@
-import { useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
-
-import { useGlobalDatePickerBounds } from '@hooks/utils/dates/useGlobalDatePickerBounds'
 import { useGlobalDateRange, useGlobalDateRangeActions } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
-import { DatePicker } from '@components/DatePicker/DatePicker'
-import { useDatePickerState } from '@components/DatePicker/useDatePickerState'
+import { DateRangePicker } from '@components/DatePicker/DateRangePicker'
 
 export const GlobalDateRangePicker = ({ showLabels = false }: { showLabels?: boolean }) => {
-  const { t } = useTranslation()
-  const { startDate: globalStartDate, endDate: globalEndDate } = useGlobalDateRange({ dateSelectionMode: 'full' })
-  const { setDateRange: setGlobalDateRange } = useGlobalDateRangeActions()
-  const { minDate, maxDate } = useGlobalDatePickerBounds()
-
-  const {
-    localDate: localStartDate,
-    onChange: onChangeStartDate,
-    minDateZdt: minStartDate,
-    maxDateZdt: maxStartDate,
-    isInvalid: startDateInvalid,
-    errorText: startDateErrorText,
-    onBlur: onBlurStartDate,
-  } = useDatePickerState({
-    date: globalStartDate,
-    minDate,
-    maxDate,
-  })
-
-  const {
-    localDate: localEndDate,
-    onChange: onChangeEndDate,
-    minDateZdt: minEndDate,
-    maxDateZdt: maxEndDate,
-    isInvalid: endDateInvalid,
-    errorText: endDateErrorText,
-    onBlur: onBlurEndDate,
-  } = useDatePickerState({
-    date: globalEndDate,
-    minDate,
-    maxDate,
-  })
-
-  useEffect(() => {
-    if (startDateInvalid || endDateInvalid || !localStartDate || !localEndDate) return
-
-    const next = { startDate: localStartDate.toDate(), endDate: localEndDate.toDate() }
-
-    setGlobalDateRange(next)
-  }, [startDateInvalid, endDateInvalid, localStartDate, localEndDate, setGlobalDateRange])
+  const { startDate, endDate } = useGlobalDateRange({ dateSelectionMode: 'full' })
+  const { setDateRange } = useGlobalDateRangeActions()
 
   return (
-    <>
-      <DatePicker
-        label={t('date:label.start_date', 'Start date')}
-        date={localStartDate}
-        onChange={onChangeStartDate}
-        minDate={minStartDate}
-        maxDate={maxStartDate}
-        isInvalid={startDateInvalid}
-        errorText={startDateErrorText}
-        onBlur={onBlurStartDate}
-        slotProps={{ Label: { size: 'sm', pbe: '3xs' } }}
-        showLabel={showLabels}
-      />
-      <DatePicker
-        label={t('date:label.end_date', 'End date')}
-        date={localEndDate}
-        onChange={onChangeEndDate}
-        minDate={minEndDate}
-        maxDate={maxEndDate}
-        isInvalid={endDateInvalid}
-        errorText={endDateErrorText}
-        onBlur={onBlurEndDate}
-        slotProps={{ Label: { size: 'sm', pbe: '3xs' } }}
-        showLabel={showLabels}
-      />
-    </>
+    <DateRangePicker
+      startDate={startDate}
+      endDate={endDate}
+      setDateRange={setDateRange}
+      showLabels={showLabels}
+    />
   )
 }

--- a/src/components/GlobalDateRangePicker/GlobalDateRangePicker.tsx
+++ b/src/components/GlobalDateRangePicker/GlobalDateRangePicker.tsx
@@ -2,13 +2,12 @@ import { useGlobalDateRange, useGlobalDateRangeActions } from '@providers/DateSt
 import { DateRangePicker } from '@components/DatePicker/DateRangePicker'
 
 export const GlobalDateRangePicker = ({ showLabels = false }: { showLabels?: boolean }) => {
-  const { startDate, endDate } = useGlobalDateRange({ dateSelectionMode: 'full' })
+  const dateRange = useGlobalDateRange({ dateSelectionMode: 'full' })
   const { setDateRange } = useGlobalDateRangeActions()
 
   return (
     <DateRangePicker
-      startDate={startDate}
-      endDate={endDate}
+      dateRange={dateRange}
       setDateRange={setDateRange}
       showLabels={showLabels}
     />

--- a/src/components/GlobalMonthPicker/GlobalMonthPicker.tsx
+++ b/src/components/GlobalMonthPicker/GlobalMonthPicker.tsx
@@ -3,7 +3,7 @@ import { type ZonedDateTime } from '@internationalized/date'
 import { useTranslation } from 'react-i18next'
 
 import { convertDateToZonedDateTime } from '@utils/time/timeUtils'
-import { useGlobalDatePickerBounds } from '@hooks/utils/dates/useGlobalDatePickerBounds'
+import { useBusinessDatePickerBounds } from '@hooks/utils/dates/useBusinessDatePickerBounds'
 import { useGlobalDate, useGlobalDateRangeActions } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
 import { MonthPicker } from '@components/MonthPicker/MonthPicker'
 
@@ -14,7 +14,7 @@ type GlobalMonthPickerProps = {
 
 export const GlobalMonthPicker = ({ truncateMonth, showLabel = false }: GlobalMonthPickerProps) => {
   const { t } = useTranslation()
-  const { minDate, maxDate } = useGlobalDatePickerBounds()
+  const { minDate, maxDate } = useBusinessDatePickerBounds()
   const { setMonth } = useGlobalDateRangeActions()
   const { date } = useGlobalDate({ dateSelectionMode: 'month' })
 

--- a/src/components/GlobalYearPicker/GlobalYearPicker.tsx
+++ b/src/components/GlobalYearPicker/GlobalYearPicker.tsx
@@ -2,12 +2,12 @@ import { useCallback, useMemo } from 'react'
 import { getYear } from 'date-fns'
 
 import { convertDateToZonedDateTime } from '@utils/time/timeUtils'
-import { useGlobalDatePickerBounds } from '@hooks/utils/dates/useGlobalDatePickerBounds'
+import { useBusinessDatePickerBounds } from '@hooks/utils/dates/useBusinessDatePickerBounds'
 import { useGlobalDateRange, useGlobalDateRangeActions } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
 import { YearPicker } from '@components/YearPicker/YearPicker'
 
 export const GlobalYearPicker = () => {
-  const { minDate, maxDate } = useGlobalDatePickerBounds()
+  const { minDate, maxDate } = useBusinessDatePickerBounds()
   const { setYear } = useGlobalDateRangeActions()
   const { startDate } = useGlobalDateRange({ dateSelectionMode: 'year' })
 

--- a/src/components/TimeTrackingStats/timeTrackingStats.scss
+++ b/src/components/TimeTrackingStats/timeTrackingStats.scss
@@ -17,7 +17,7 @@
   min-inline-size: 0;
   container: time-tracking-stats-dates / inline-size;
 
-  .Layer__GlobalDateRangeSelection {
+  .Layer__DateRangeSelection {
     inline-size: 100%;
   }
 }
@@ -96,12 +96,12 @@
     flex-basis: auto;
     inline-size: 100%;
 
-    .Layer__GlobalDateRangeSelection {
+    .Layer__DateRangeSelection {
       grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
       inline-size: 100%;
       min-inline-size: 0;
 
-      &.Layer__GlobalDateRangeSelection--mobile {
+      &.Layer__DateRangeSelection--mobile {
         grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
       }
 
@@ -113,8 +113,8 @@
 }
 
 @container time-tracking-stats (max-width: 430px) {
-  .Layer__TimeTrackingStats__DateSelection .Layer__GlobalDateRangeSelection,
-  .Layer__TimeTrackingStats__DateSelection .Layer__GlobalDateRangeSelection.Layer__GlobalDateRangeSelection--mobile {
+  .Layer__TimeTrackingStats__DateSelection .Layer__DateRangeSelection,
+  .Layer__TimeTrackingStats__DateSelection .Layer__DateRangeSelection.Layer__DateRangeSelection--mobile {
     grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/src/hooks/utils/dates/useBusinessDatePickerBounds.ts
+++ b/src/hooks/utils/dates/useBusinessDatePickerBounds.ts
@@ -3,7 +3,7 @@ import { endOfDay, startOfDay } from 'date-fns'
 
 import { useBusinessActivationDate } from '@hooks/features/business/useBusinessActivationDate'
 
-export function useGlobalDatePickerBounds(): { minDate: Date | null, maxDate: Date } {
+export function useBusinessDatePickerBounds(): { minDate: Date | null, maxDate: Date } {
   const rawActivationDate = useBusinessActivationDate()
 
   const minDate = useMemo(() => rawActivationDate ? startOfDay(rawActivationDate) : null, [rawActivationDate])

--- a/src/utils/date/dateRange.ts
+++ b/src/utils/date/dateRange.ts
@@ -1,8 +1,12 @@
-import { endOfDay, max, min } from 'date-fns'
+import { endOfDay, isEqual, max, min } from 'date-fns'
 
 export type DateSelectionMode = 'full' | 'month' | 'year'
 
 export type DateRange = { startDate: Date, endDate: Date }
+
+export function isSameDateRange(a: DateRange, b: DateRange) {
+  return isEqual(a.startDate, b.startDate) && isEqual(a.endDate, b.endDate)
+}
 
 export function clampToAfterActivationDate(date: Date | number, activationDate: Date) {
   return max([date, activationDate])


### PR DESCRIPTION
## Description

This PR decouples date-range UI from the global date store by introducing prop-driven `DateRangePicker` and `DateRangeSelection`, and refactoring `DateSelectionComboBox` to accept `dateRange` and `setDateRange` props instead of calling global hooks internally.

GlobalDateRangeSelection, GlobalDateRangePicker, and GlobalDateSelection become thin wrappers that inject the global store hooks, so the public API and behavior are unchanged while the presentational components can be bound to any date store.

## Changes
This is to prepare for introducing date pickers that use a different date context than the global date context.

## How this has been tested?
Manually QA'd existing local date picker functionality with local demo finguard deployment, and ensured that date selection worked as expected.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors shared date-filter UI used in multiple surfaces; behavior is intended to be unchanged via wrappers, but incorrect sync logic could affect reporting and time-tracking date selection.
> 
> **Overview**
> Introduces **prop-driven** `DateRangePicker` and `DateRangeSelection` so preset combo + start/end pickers can bind to any `dateRange` / `setDateRange` source, not only the global date store. `DateSelectionComboBox` is updated the same way (drops internal global hooks).
> 
> `GlobalDateRangeSelection`, `GlobalDateRangePicker`, and `GlobalDateSelection` stay as thin wrappers that wire global store hooks into those components, preserving existing entry points. `GlobalDateRangePicker` delegates to the shared `DateRangePicker` instead of duplicating dual-picker logic.
> 
> `DateRangePicker` only calls `setDateRange` when local start/end values differ from the current range (`isSameDateRange` + a ref), avoiding render loops and not re-echoing parent-driven prop updates; vitest covers those cases. `useGlobalDatePickerBounds` is renamed to **`useBusinessDatePickerBounds`** across global pickers. Layout SCSS targets `Layer__DateRangeSelection` instead of the old global-specific class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62be756cb63bc3aa71d21a5212ae73b2a70121d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->