### PR TITLE
fix: do not import React Aria components from deep links

### DIFF
--- a/src/components/NestedNavigation/TreeNavigation/TreeNavigationGroup.tsx
+++ b/src/components/NestedNavigation/TreeNavigation/TreeNavigationGroup.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement } from 'react'
 import { ChevronRight } from 'lucide-react'
+import { Collection as ReactAriaCollection } from 'react-aria-components'
 import { Button as ReactAriaButton } from 'react-aria-components/Button'
-import { Collection as ReactAriaCollection } from 'react-aria-components/Collection'
 
 import { HStack } from '@ui/Stack/Stack'
 import { TreeItem, TreeItemContent } from '@ui/Tree/Tree'

--- a/src/providers/I18nProvider/LayerI18nProvider.tsx
+++ b/src/providers/I18nProvider/LayerI18nProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useRef } from 'react'
-import { I18nProvider as AriaI18nProvider } from 'react-aria-components/I18nProvider'
+import { I18nProvider as ReactAriaI18nProvider } from 'react-aria-components'
 import { I18nextProvider } from 'react-i18next'
 import { IntlProvider } from 'react-intl'
 
@@ -31,9 +31,9 @@ export function LayerI18nProvider({ children, locale = DEFAULT_LOCALE }: LayerI1
     <LocaleContext.Provider value={locale}>
       <I18nextProvider i18n={i18next}>
         <IntlProvider locale={locale} defaultLocale={DEFAULT_LOCALE} messages={EMPTY_MESSAGES}>
-          <AriaI18nProvider locale={locale}>
+          <ReactAriaI18nProvider locale={locale}>
             {children}
-          </AriaI18nProvider>
+          </ReactAriaI18nProvider>
         </IntlProvider>
       </I18nextProvider>
     </LocaleContext.Provider>


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path-only changes with no logic or API changes; very low risk.
> 
> **Overview**
> Stops using **deep subpath imports** for React Aria (`react-aria-components/Collection`, `react-aria-components/I18nProvider`) and pulls **`Collection`** and **`I18nProvider`** from the main `react-aria-components` entry instead.
> 
> In **`TreeNavigationGroup`**, only the `Collection` import path changes; **`Button`** still comes from `react-aria-components/Button`. In **`LayerI18nProvider`**, the provider is renamed to **`ReactAriaI18nProvider`** for consistency with other React Aria imports—behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f488235be84a56d75fa2048e9cccd9c89b6995e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->