### PR TITLE
ci: add build job gating the publish path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run build
+      run: npm run build
+
+    - name: Validate build artifacts
+      run: |
+        # Assert every entrypoint declared in package.json exists and is non-empty.
+        artifacts=(
+          dist/cjs/index.cjs   # main / require
+          dist/esm/index.mjs   # module / import
+          dist/index.d.ts      # types
+          dist/index.css       # style / ./index.css export
+        )
+        missing=0
+        for f in "${artifacts[@]}"; do
+          if [ ! -s "$f" ]; then
+            echo "::error::Missing or empty build artifact: $f"
+            missing=1
+          fi
+        done
+        if [ "$missing" -ne 0 ]; then exit 1; fi
+        echo "All expected build artifacts present."


### PR DESCRIPTION
## Scope
Adds a `build` CI job that runs on PRs to `main`. Closes a real gap: the package's **build/publish path had no PR-time gate**, so declaration-emit and bundling errors (e.g. `TS4023 "cannot be named"`) only surfaced at release time via the `prepack` hook.

`build.yml`:
- Runs `npm run build` — vite esm + cjs, then `build:types` (`tsc -p tsconfig.dts.json` → `tsc-alias` → rollup `.d.ts` bundling).
- Validates the four published entrypoints declared in `package.json` exist and are non-empty: `dist/cjs/index.cjs`, `dist/esm/index.mjs`, `dist/index.d.ts`, `dist/index.css`.

Net change: **one new file** (`.github/workflows/build.yml`).

## Context
The TS4023 error that motivated this was fixed independently on `main` in #1556, so no source change is included here — this PR is purely the CI gate that would have caught it pre-merge.

## Verification
- Confirmed the build job reproduces the 3 TS4023 errors when the fix is absent.
- Confirmed a successful build emits all four validated artifacts.