### PR TITLE
[bugfix] Fix export type error

### DIFF
--- a/src/schemas/categorization.ts
+++ b/src/schemas/categorization.ts
@@ -130,7 +130,7 @@ export interface NestedAccountCategorization extends Schema.Struct.Type<typeof n
   subCategories?: NestedApiCategorization[] | null
 }
 
-interface NestedAccountCategorizationEncoded extends Schema.Struct.Encoded<typeof nestedAccountCategorizationFields> {
+export interface NestedAccountCategorizationEncoded extends Schema.Struct.Encoded<typeof nestedAccountCategorizationFields> {
   subCategories?: NestedApiCategorizationEncoded[] | null
 }
 
@@ -138,7 +138,7 @@ export interface NestedOptionalCategorization extends Schema.Struct.Type<typeof 
   subCategories?: NestedApiCategorization[] | null
 }
 
-interface NestedOptionalCategorizationEncoded extends Schema.Struct.Encoded<typeof nestedOptionalCategorizationFields> {
+export interface NestedOptionalCategorizationEncoded extends Schema.Struct.Encoded<typeof nestedOptionalCategorizationFields> {
   subCategories?: NestedApiCategorizationEncoded[] | null
 }
 
@@ -146,12 +146,12 @@ export interface NestedExclusionCategorization extends Schema.Struct.Type<typeof
   subCategories?: NestedApiCategorization[] | null
 }
 
-interface NestedExclusionCategorizationEncoded extends Schema.Struct.Encoded<typeof nestedExclusionCategorizationFields> {
+export interface NestedExclusionCategorizationEncoded extends Schema.Struct.Encoded<typeof nestedExclusionCategorizationFields> {
   subCategories?: NestedApiCategorizationEncoded[] | null
 }
 
 export type NestedApiCategorization = NestedAccountCategorization | NestedOptionalCategorization | NestedExclusionCategorization
-type NestedApiCategorizationEncoded = NestedAccountCategorizationEncoded | NestedOptionalCategorizationEncoded | NestedExclusionCategorizationEncoded
+export type NestedApiCategorizationEncoded = NestedAccountCategorizationEncoded | NestedOptionalCategorizationEncoded | NestedExclusionCategorizationEncoded
 
 export const NestedAccountCategorizationSchema = Schema.Struct({
   ...nestedAccountCategorizationFields,


### PR DESCRIPTION
## Description

### The error:

Happening on `main` when running `npm run dev`

> src/hooks/api/businesses/[business-id]/categories/useCategories.ts:15:14 - error TS4023: Exported variable 'getCategories' has or is using name 'NestedOptionalCategorizationEncoded' from external module "/Users/jeffreyzhou/Github/layer-react/src/schemas/categorization" but cannot be named.

<img width="996" height="269" alt="image" src="https://github.com/user-attachments/assets/858dd769-85f9-4097-a1c4-71050b84f31b" />


### The fix:

The new Effect Schema commit (a5d5e192f and follow-ups) added nested categorization types to categorization.ts, but only exported the decoded-side interfaces — the Encoded counterparts (NestedAccountCategorizationEncoded, NestedOptionalCategorizationEncoded, NestedExclusionCategorizationEncoded, and the NestedApiCategorizationEncoded union) were left module-private.

Since useCategories.ts:15 exports getCategories typed with typeof CategoriesResponseSchema.Encoded, the `dev:types` half of `npm run dev` has to write that type into a .d.ts file by name. 

It couldn't reference the un-exported interfaces, which is exactly what TS4023 ("has or is using name ... but cannot be named") means. It slipped through because plain tsc --noEmit doesn't catch it — it only shows up when declarations are emitted.