### PR TITLE
test: polling config

### DIFF
--- a/src/hooks/utils/swr/usePollingConfig.test.tsx
+++ b/src/hooks/utils/swr/usePollingConfig.test.tsx
@@ -1,0 +1,365 @@
+import { type PropsWithChildren } from 'react'
+import { act, renderHook } from '@testing-library/react'
+import useSWR, { SWRConfig } from 'swr'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePollingConfig } from '@hooks/utils/swr/usePollingConfig'
+
+type PollData = { status: 'pending' | 'done', version?: number }
+const PENDING: PollData = { status: 'pending' }
+const DONE: PollData = { status: 'done' }
+
+const DEFAULT_INTERVAL = 2000
+const DEFAULT_MAX_DURATION = 2 * 60 * 1000
+
+type PollingOptions = Parameters<typeof usePollingConfig<PollData>>[0]
+
+const defaultShouldContinue = (data?: PollData) => data?.status === 'pending'
+
+const renderPollingConfig = (overrides: Partial<PollingOptions> = {}) => {
+  const opts: PollingOptions = { shouldContinue: defaultShouldContinue, ...overrides }
+  return renderHook(() => usePollingConfig(opts))
+}
+
+type Result = ReturnType<typeof renderPollingConfig>['result']
+
+/** `refreshInterval` is a function in this hook; call it with the latest data. */
+const callRefresh = (result: Result, data?: PollData) =>
+  (result.current.refreshInterval as (d?: PollData) => number)(data)
+
+const callSuccess = (result: Result, data: PollData) => {
+  act(() => result.current.onSuccess?.(data, 'key', {} as never))
+}
+
+/** Invoke `onErrorRetry` with sensible defaults; overrides for retryCount. */
+const callErrorRetry = (
+  result: Result,
+  revalidate: ReturnType<typeof vi.fn>,
+  { error = new Error('boom'), retryCount = 0 }: { error?: unknown, retryCount?: number } = {},
+) =>
+  result.current.onErrorRetry?.(
+    error,
+    'key',
+    {} as never,
+    revalidate as never,
+    { retryCount } as never,
+  )
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(0)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('usePollingConfig', () => {
+  describe('refreshInterval', () => {
+    it('returns 0 when shouldContinue is false', () => {
+      const { result } = renderPollingConfig()
+      expect(callRefresh(result, DONE)).toBe(0)
+    })
+
+    it('starts polling from idle and returns the default interval', () => {
+      const { result } = renderPollingConfig()
+      expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
+    })
+
+    it('returns a custom numeric interval', () => {
+      const { result } = renderPollingConfig({ intervalMs: 500 })
+      expect(callRefresh(result, PENDING)).toBe(500)
+    })
+
+    it('evaluates a function interval on each call', () => {
+      const intervalMs = vi.fn(() => 1234)
+      const { result } = renderPollingConfig({ intervalMs })
+      expect(callRefresh(result, PENDING)).toBe(1234)
+      expect(intervalMs).toHaveBeenCalled()
+    })
+
+    it('stops (returns 0) once the max duration deadline passes', () => {
+      const { result } = renderPollingConfig()
+
+      expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL) // idle -> active, deadline set
+
+      vi.setSystemTime(DEFAULT_MAX_DURATION)
+      expect(callRefresh(result, PENDING)).toBe(0) // deadline reached -> stopped
+    })
+
+    it('stays stopped on later calls even while shouldContinue is true', () => {
+      const { result } = renderPollingConfig()
+      callRefresh(result, PENDING)
+      vi.setSystemTime(DEFAULT_MAX_DURATION)
+      expect(callRefresh(result, PENDING)).toBe(0)
+      expect(callRefresh(result, PENDING)).toBe(0)
+    })
+  })
+
+  describe('onErrorRetry', () => {
+    it('schedules a retry after the interval when under the cap', () => {
+      const revalidate = vi.fn()
+      const { result } = renderPollingConfig({ intervalMs: 500 })
+
+      callErrorRetry(result, revalidate, { retryCount: 0 })
+      expect(revalidate).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(500)
+      expect(revalidate).toHaveBeenCalledWith({ retryCount: 0 })
+    })
+
+    it('does not retry and stops on a fatal error', () => {
+      const revalidate = vi.fn()
+      const isFatalError = vi.fn(() => true)
+      const { result } = renderPollingConfig({ isFatalError })
+
+      callErrorRetry(result, revalidate)
+      vi.advanceTimersByTime(DEFAULT_INTERVAL)
+
+      expect(revalidate).not.toHaveBeenCalled()
+      expect(callRefresh(result, PENDING)).toBe(0) // stopped
+    })
+
+    it('stops once max error retries are reached', () => {
+      const revalidate = vi.fn()
+      const { result } = renderPollingConfig({ maxErrorRetries: 3 })
+
+      callErrorRetry(result, revalidate, { retryCount: 3 })
+      vi.advanceTimersByTime(DEFAULT_INTERVAL)
+
+      expect(revalidate).not.toHaveBeenCalled()
+      expect(callRefresh(result, PENDING)).toBe(0)
+    })
+
+    it('stops when the polling deadline has passed', () => {
+      const revalidate = vi.fn()
+      const { result } = renderPollingConfig()
+
+      vi.setSystemTime(DEFAULT_MAX_DURATION)
+      callErrorRetry(result, revalidate)
+      vi.advanceTimersByTime(DEFAULT_INTERVAL)
+
+      expect(revalidate).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op once the session is stopped', () => {
+      const revalidate = vi.fn()
+      const { result } = renderPollingConfig({ isFatalError: () => true })
+
+      callErrorRetry(result, revalidate) // fatal -> stopped
+      callErrorRetry(result, revalidate, { error: new Error('again'), retryCount: 0 })
+      vi.advanceTimersByTime(DEFAULT_INTERVAL)
+
+      expect(revalidate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('onSuccess', () => {
+    it('calls onPoll with the latest data on every success', () => {
+      const onPoll = vi.fn()
+      const { result } = renderPollingConfig({ onPoll })
+
+      callSuccess(result, PENDING)
+
+      expect(onPoll).toHaveBeenCalledWith(PENDING)
+    })
+
+    it('restarts a fresh (idle) session and revives refreshInterval identity', () => {
+      const { result } = renderPollingConfig()
+      const before = result.current.refreshInterval
+
+      callSuccess(result, PENDING)
+
+      expect(result.current.refreshInterval).not.toBe(before) // nonce bumped
+      expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL) // active
+    })
+
+    it('fires onComplete once when the poll completes (default: shouldContinue false)', () => {
+      const onComplete = vi.fn()
+      const { result } = renderPollingConfig({ onComplete })
+
+      callSuccess(result, DONE)
+      callSuccess(result, DONE)
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith(DONE)
+    })
+
+    it('uses a custom shouldComplete predicate', () => {
+      const onComplete = vi.fn()
+      const shouldComplete = vi.fn((d: PollData) => d.version === 2)
+      const { result } = renderPollingConfig({ onComplete, shouldComplete })
+
+      callSuccess(result, { status: 'pending', version: 1 })
+      expect(onComplete).not.toHaveBeenCalled()
+
+      callSuccess(result, { status: 'pending', version: 2 })
+      expect(onComplete).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not revive a stopped session without progress (default rising edge)', () => {
+      const { result } = renderPollingConfig()
+
+      // idle -> active via a poll, then let the deadline stop it.
+      callSuccess(result, PENDING)
+      vi.setSystemTime(DEFAULT_MAX_DURATION)
+      expect(callRefresh(result, PENDING)).toBe(0) // stopped
+      const stopped = result.current.refreshInterval
+
+      // Another "still pending" poll is not progress (prev was already pending).
+      callSuccess(result, PENDING)
+
+      expect(result.current.refreshInterval).toBe(stopped) // no restart
+      expect(callRefresh(result, PENDING)).toBe(0)
+    })
+
+    it('revives a stopped session when shouldRestartPolling reports progress', () => {
+      const shouldRestartPolling = vi.fn(
+        (prev: PollData | undefined, next: PollData) => prev?.version !== next.version,
+      )
+      const { result } = renderPollingConfig({ shouldRestartPolling })
+
+      callSuccess(result, { status: 'pending', version: 1 })
+      vi.setSystemTime(DEFAULT_MAX_DURATION)
+      expect(callRefresh(result, PENDING)).toBe(0) // stopped
+
+      callSuccess(result, { status: 'pending', version: 2 })
+
+      expect(shouldRestartPolling).toHaveBeenLastCalledWith({ status: 'pending', version: 1 }, { status: 'pending', version: 2 })
+      expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL) // revived
+    })
+
+    it('extends the deadline on progress (shouldRestartPolling) while active', () => {
+      const shouldRestartPolling = (prev: PollData | undefined, next: PollData) => prev?.version !== next.version
+      const { result } = renderPollingConfig({ shouldRestartPolling })
+
+      callSuccess(result, { status: 'pending', version: 1 }) // active, deadline = 120000
+
+      vi.setSystemTime(DEFAULT_MAX_DURATION - 1000)
+      callSuccess(result, { status: 'pending', version: 2 }) // extends to 239000
+
+      vi.setSystemTime(DEFAULT_MAX_DURATION + 1000) // past original deadline, before extended
+      expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
+    })
+
+    it('treats maxDurationMs as a hard cap by default (still-pending polls are not progress)', () => {
+      const { result } = renderPollingConfig()
+
+      callSuccess(result, { status: 'pending', version: 1 }) // active, deadline = 120000
+
+      // A steady stream of still-pending polls does not extend the deadline.
+      vi.setSystemTime(DEFAULT_MAX_DURATION - 1000)
+      callSuccess(result, { status: 'pending', version: 2 })
+
+      vi.setSystemTime(DEFAULT_MAX_DURATION)
+      expect(callRefresh(result, PENDING)).toBe(0)
+    })
+  })
+
+  describe('return value', () => {
+    it('is a stable { refreshInterval, onErrorRetry, onSuccess } across renders', () => {
+      const opts: PollingOptions = { shouldContinue: defaultShouldContinue }
+      const { result, rerender } = renderHook(() => usePollingConfig(opts))
+
+      const first = result.current
+      expect(Object.keys(first).sort()).toEqual(['onErrorRetry', 'onSuccess', 'refreshInterval'])
+
+      rerender()
+      expect(result.current).toBe(first)
+    })
+  })
+
+  describe('when driving useSWR', () => {
+    const INTERVAL = 1000
+
+    const swrWrapper = ({ children }: PropsWithChildren) => (
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>
+    )
+
+    const renderPolledSWR = (
+      key: string,
+      fetcher: () => Promise<PollData>,
+      overrides: Partial<PollingOptions> = {},
+    ) =>
+      renderHook(
+        () => {
+          const config = usePollingConfig<PollData>({
+            shouldContinue: defaultShouldContinue,
+            intervalMs: INTERVAL,
+            ...overrides,
+          })
+          return useSWR(key, fetcher, config)
+        },
+        { wrapper: swrWrapper },
+      )
+
+    const advance = async (ms: number) => {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ms)
+      })
+    }
+
+    it('polls on the interval while pending and stops once done, completing once', async () => {
+      let response: PollData = PENDING
+      const fetcher = vi.fn(() => Promise.resolve(response))
+      const onComplete = vi.fn()
+
+      renderPolledSWR('poll-lifecycle', fetcher, { onComplete })
+
+      await advance(0) // mount fetch
+      expect(fetcher).toHaveBeenCalledTimes(1)
+
+      await advance(INTERVAL)
+      expect(fetcher).toHaveBeenCalledTimes(2)
+
+      response = DONE
+      await advance(INTERVAL)
+      expect(fetcher).toHaveBeenCalledTimes(3)
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith(DONE)
+
+      // Terminal data halts the loop: no further fetches.
+      await advance(INTERVAL * 5)
+      expect(fetcher).toHaveBeenCalledTimes(3)
+      expect(onComplete).toHaveBeenCalledTimes(1)
+    })
+
+    it('revives the dead polling loop when a refetch reports a new pending session', async () => {
+      let response: PollData = DONE
+      const fetcher = vi.fn(() => Promise.resolve(response))
+
+      const { result } = renderPolledSWR('poll-revival', fetcher)
+
+      await advance(0) // mount fetch returns done -> loop never starts
+      await advance(INTERVAL * 3)
+      expect(fetcher).toHaveBeenCalledTimes(1)
+
+      // A new session begins: an external refetch observes pending data...
+      response = PENDING
+      await act(async () => {
+        await result.current.mutate()
+      })
+      expect(fetcher).toHaveBeenCalledTimes(2)
+
+      // ...and the restart nonce revives SWR's polling loop.
+      await advance(INTERVAL)
+      expect(fetcher).toHaveBeenCalledTimes(3)
+    })
+
+    it('halts polling at the max duration while data is still pending', async () => {
+      const fetcher = vi.fn(() => Promise.resolve(PENDING))
+
+      renderPolledSWR('poll-deadline', fetcher, { maxDurationMs: INTERVAL * 3 })
+
+      await advance(0) // mount fetch
+      await advance(INTERVAL * 10)
+
+      const haltedCount = fetcher.mock.calls.length
+      expect(haltedCount).toBeLessThan(6) // capped well below the 10 ticks elapsed
+
+      await advance(INTERVAL * 5)
+      expect(fetcher).toHaveBeenCalledTimes(haltedCount) // no further polls
+    })
+  })
+})

--- a/src/hooks/utils/swr/usePollingConfig.test.tsx
+++ b/src/hooks/utils/swr/usePollingConfig.test.tsx
@@ -31,7 +31,6 @@ const callSuccess = (result: Result, data: PollData) => {
   act(() => result.current.onSuccess?.(data, 'key', {} as never))
 }
 
-/** Invoke `onErrorRetry` with sensible defaults; overrides for retryCount. */
 const callErrorRetry = (
   result: Result,
   revalidate: ReturnType<typeof vi.fn>,
@@ -56,13 +55,13 @@ afterEach(() => {
 })
 
 describe('usePollingConfig', () => {
-  describe('session lifecycle', () => {
-    it('refreshInterval returns 0 when shouldContinue is false', () => {
+  describe('refreshInterval', () => {
+    it('returns 0 when shouldContinue is false', () => {
       const { result } = renderPollingConfig()
       expect(callRefresh(result, DONE)).toBe(0)
     })
 
-    it('transitions idle -> active and schedules polling while shouldContinue is true', () => {
+    it('transitions idle -> active and returns the default interval while shouldContinue is true', () => {
       const { result } = renderPollingConfig()
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
     })
@@ -74,39 +73,7 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, undefined)).toBe(DEFAULT_INTERVAL)
     })
 
-    it('transitions active -> stopped and returns 0 once maxDurationMs elapses', () => {
-      const { result } = renderPollingConfig()
-
-      expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL) // idle -> active, deadline set
-
-      vi.setSystemTime(DEFAULT_MAX_DURATION)
-      expect(callRefresh(result, PENDING)).toBe(0) // deadline reached -> stopped
-    })
-
-    it('remains stopped on subsequent calls even while shouldContinue is true', () => {
-      const { result } = renderPollingConfig()
-      callRefresh(result, PENDING)
-      vi.setSystemTime(DEFAULT_MAX_DURATION)
-      expect(callRefresh(result, PENDING)).toBe(0)
-      expect(callRefresh(result, PENDING)).toBe(0)
-    })
-
-    it('treats maxDurationMs as a hard cap by default, since still-pending polls are not progress', () => {
-      const { result } = renderPollingConfig()
-
-      callSuccess(result, { status: 'pending', version: 1 }) // active, deadline = 120000
-
-      // A steady stream of still-pending polls does not extend the deadline.
-      vi.setSystemTime(DEFAULT_MAX_DURATION - 1000)
-      callSuccess(result, { status: 'pending', version: 2 })
-
-      vi.setSystemTime(DEFAULT_MAX_DURATION)
-      expect(callRefresh(result, PENDING)).toBe(0)
-    })
-  })
-
-  describe('interval configuration', () => {
-    it('uses a numeric intervalMs override', () => {
+    it('returns a numeric intervalMs override', () => {
       const { result } = renderPollingConfig({ intervalMs: 500 })
       expect(callRefresh(result, PENDING)).toBe(500)
     })
@@ -117,9 +84,26 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(1234)
       expect(intervalMs).toHaveBeenCalled()
     })
+
+    it('transitions active -> stopped and returns 0 once maxDurationMs elapses', () => {
+      const { result } = renderPollingConfig()
+
+      expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
+
+      vi.setSystemTime(DEFAULT_MAX_DURATION)
+      expect(callRefresh(result, PENDING)).toBe(0)
+    })
+
+    it('remains stopped on subsequent calls even while shouldContinue is true', () => {
+      const { result } = renderPollingConfig()
+      callRefresh(result, PENDING)
+      vi.setSystemTime(DEFAULT_MAX_DURATION)
+      expect(callRefresh(result, PENDING)).toBe(0)
+      expect(callRefresh(result, PENDING)).toBe(0)
+    })
   })
 
-  describe('error retries', () => {
+  describe('onErrorRetry', () => {
     it('schedules revalidate after one interval, preserving retryCount, while under maxErrorRetries', () => {
       const revalidate = vi.fn()
       const { result } = renderPollingConfig({ intervalMs: 500 })
@@ -149,7 +133,7 @@ describe('usePollingConfig', () => {
       vi.advanceTimersByTime(DEFAULT_INTERVAL)
 
       expect(revalidate).not.toHaveBeenCalled()
-      expect(callRefresh(result, PENDING)).toBe(0) // stopped
+      expect(callRefresh(result, PENDING)).toBe(0)
     })
 
     it('stops the session without retrying when isFatalError matches', () => {
@@ -161,7 +145,7 @@ describe('usePollingConfig', () => {
       vi.advanceTimersByTime(DEFAULT_INTERVAL)
 
       expect(revalidate).not.toHaveBeenCalled()
-      expect(callRefresh(result, PENDING)).toBe(0) // stopped
+      expect(callRefresh(result, PENDING)).toBe(0)
     })
 
     it('stops retrying once the polling deadline has passed', () => {
@@ -179,7 +163,7 @@ describe('usePollingConfig', () => {
       const revalidate = vi.fn()
       const { result } = renderPollingConfig({ isFatalError: () => true })
 
-      callErrorRetry(result, revalidate) // fatal -> stopped
+      callErrorRetry(result, revalidate)
       callErrorRetry(result, revalidate, { error: new Error('again'), retryCount: 1 })
       vi.advanceTimersByTime(DEFAULT_INTERVAL)
 
@@ -187,30 +171,37 @@ describe('usePollingConfig', () => {
     })
   })
 
-  describe('revival of a halted polling loop', () => {
-    it('restarts an idle session on success, bumping refreshInterval identity so SWR revives its polling loop', () => {
+  describe('onSuccess', () => {
+    it('invokes onPoll with every successful payload', () => {
+      const onPoll = vi.fn()
+      const { result } = renderPollingConfig({ onPoll })
+
+      callSuccess(result, PENDING)
+
+      expect(onPoll).toHaveBeenCalledWith(PENDING)
+    })
+
+    it('restarts an idle session, bumping refreshInterval identity so SWR revives its polling loop', () => {
       const { result } = renderPollingConfig()
       const before = result.current.refreshInterval
 
       callSuccess(result, PENDING)
 
-      expect(result.current.refreshInterval).not.toBe(before) // nonce bumped
-      expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL) // active
+      expect(result.current.refreshInterval).not.toBe(before)
+      expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
     })
 
     it('does not revive a stopped session when shouldContinue was already true (no rising edge)', () => {
       const { result } = renderPollingConfig()
 
-      // idle -> active via a poll, then let the deadline stop it.
       callSuccess(result, PENDING)
       vi.setSystemTime(DEFAULT_MAX_DURATION)
-      expect(callRefresh(result, PENDING)).toBe(0) // stopped
+      expect(callRefresh(result, PENDING)).toBe(0)
       const stopped = result.current.refreshInterval
 
-      // Another "still pending" poll is not progress (prev was already pending).
       callSuccess(result, PENDING)
 
-      expect(result.current.refreshInterval).toBe(stopped) // no restart
+      expect(result.current.refreshInterval).toBe(stopped)
       expect(callRefresh(result, PENDING)).toBe(0)
     })
 
@@ -219,10 +210,10 @@ describe('usePollingConfig', () => {
 
       callSuccess(result, PENDING)
       vi.setSystemTime(DEFAULT_MAX_DURATION)
-      expect(callRefresh(result, PENDING)).toBe(0) // capped -> stopped
+      expect(callRefresh(result, PENDING)).toBe(0)
 
-      callSuccess(result, DONE) // the stuck session finally terminates
-      callSuccess(result, PENDING) // a new session begins: the rising edge revives polling
+      callSuccess(result, DONE)
+      callSuccess(result, PENDING)
 
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
     })
@@ -235,43 +226,44 @@ describe('usePollingConfig', () => {
 
       callSuccess(result, { status: 'pending', version: 1 })
       vi.setSystemTime(DEFAULT_MAX_DURATION)
-      expect(callRefresh(result, PENDING)).toBe(0) // stopped
+      expect(callRefresh(result, PENDING)).toBe(0)
 
       callSuccess(result, { status: 'pending', version: 2 })
 
       expect(shouldRestartPolling).toHaveBeenLastCalledWith({ status: 'pending', version: 1 }, { status: 'pending', version: 2 })
-      expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL) // revived
+      expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
     })
 
     it('extends the deadline when shouldRestartPolling reports progress while active', () => {
       const shouldRestartPolling = (prev: PollData | undefined, next: PollData) => prev?.version !== next.version
       const { result } = renderPollingConfig({ shouldRestartPolling })
 
-      callSuccess(result, { status: 'pending', version: 1 }) // active, deadline = 120000
+      callSuccess(result, { status: 'pending', version: 1 })
 
       vi.setSystemTime(DEFAULT_MAX_DURATION - 1000)
-      callSuccess(result, { status: 'pending', version: 2 }) // extends to 239000
+      callSuccess(result, { status: 'pending', version: 2 })
 
       vi.setSystemTime(DEFAULT_MAX_DURATION + 1000) // past original deadline, before extended
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
     })
-  })
 
-  describe('poll and completion callbacks', () => {
-    it('invokes onPoll with every successful payload', () => {
-      const onPoll = vi.fn()
-      const { result } = renderPollingConfig({ onPoll })
+    it('treats maxDurationMs as a hard cap by default, since still-pending polls are not progress', () => {
+      const { result } = renderPollingConfig()
 
-      callSuccess(result, PENDING)
+      callSuccess(result, { status: 'pending', version: 1 })
 
-      expect(onPoll).toHaveBeenCalledWith(PENDING)
+      vi.setSystemTime(DEFAULT_MAX_DURATION - 1000)
+      callSuccess(result, { status: 'pending', version: 2 })
+
+      vi.setSystemTime(DEFAULT_MAX_DURATION)
+      expect(callRefresh(result, PENDING)).toBe(0)
     })
 
     it('calls onComplete exactly once when an active session ends (default completion)', () => {
       const onComplete = vi.fn()
       const { result } = renderPollingConfig({ onComplete })
 
-      callSuccess(result, PENDING) // start the session
+      callSuccess(result, PENDING)
       callSuccess(result, DONE)
       callSuccess(result, DONE)
 
@@ -292,11 +284,11 @@ describe('usePollingConfig', () => {
       const onComplete = vi.fn()
       const { result } = renderPollingConfig({ onComplete })
 
-      callSuccess(result, PENDING) // session 1
-      callSuccess(result, DONE) // completes (1)
+      callSuccess(result, PENDING)
+      callSuccess(result, DONE)
       expect(callRefresh(result, DONE)).toBe(0) // natural end -> idle
-      callSuccess(result, PENDING) // session 2 restarts, re-arming completion
-      callSuccess(result, DONE) // completes (2)
+      callSuccess(result, PENDING)
+      callSuccess(result, DONE)
 
       expect(onComplete).toHaveBeenCalledTimes(2)
     })
@@ -329,9 +321,18 @@ describe('usePollingConfig', () => {
 
   describe('when driving useSWR', () => {
     const INTERVAL = 1000
+    /** Mirrors DEFAULT_SWR_CONFIG's global 10-minute refresh, which LayerProvider applies app-wide. */
+    const GLOBAL_REFRESH_INTERVAL = 10 * 60 * 1000
 
+    /*
+     * The global refreshInterval is deliberately included: real consumers rely on the
+     * hook-level polling function overriding it, so every test here also defends that
+     * precedence — polls must arrive at INTERVAL, not the global cadence.
+     */
     const swrWrapper = ({ children }: PropsWithChildren) => (
-      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, refreshInterval: GLOBAL_REFRESH_INTERVAL }}>
+        {children}
+      </SWRConfig>
     )
 
     const renderPolledSWR = (
@@ -364,7 +365,7 @@ describe('usePollingConfig', () => {
 
       renderPolledSWR('poll-lifecycle', fetcher, { onComplete })
 
-      await advance(0) // mount fetch
+      await advance(0)
       expect(fetcher).toHaveBeenCalledTimes(1)
 
       await advance(INTERVAL)
@@ -376,7 +377,6 @@ describe('usePollingConfig', () => {
       expect(onComplete).toHaveBeenCalledTimes(1)
       expect(onComplete).toHaveBeenCalledWith(DONE)
 
-      // Terminal data halts the loop: no further fetches.
       await advance(INTERVAL * 5)
       expect(fetcher).toHaveBeenCalledTimes(3)
       expect(onComplete).toHaveBeenCalledTimes(1)
@@ -409,14 +409,14 @@ describe('usePollingConfig', () => {
 
       renderPolledSWR('poll-deadline', fetcher, { maxDurationMs: INTERVAL * 3 })
 
-      await advance(0) // mount fetch
+      await advance(0)
       await advance(INTERVAL * 10)
 
       const haltedCount = fetcher.mock.calls.length
       expect(haltedCount).toBeLessThan(6) // capped well below the 10 ticks elapsed
 
       await advance(INTERVAL * 5)
-      expect(fetcher).toHaveBeenCalledTimes(haltedCount) // no further polls
+      expect(fetcher).toHaveBeenCalledTimes(haltedCount)
     })
 
     it('retries a failing fetch at the interval, then gives up after maxErrorRetries retries', async () => {
@@ -424,14 +424,14 @@ describe('usePollingConfig', () => {
 
       renderPolledSWR('poll-errors', fetcher, { maxErrorRetries: 3 })
 
-      await advance(0) // mount fetch fails
+      await advance(0)
       expect(fetcher).toHaveBeenCalledTimes(1)
 
       await advance(INTERVAL * 10)
       expect(fetcher).toHaveBeenCalledTimes(4) // initial attempt + 3 retries
 
       await advance(INTERVAL * 5)
-      expect(fetcher).toHaveBeenCalledTimes(4) // gave up
+      expect(fetcher).toHaveBeenCalledTimes(4)
     })
   })
 })

--- a/src/hooks/utils/swr/usePollingConfig.test.tsx
+++ b/src/hooks/utils/swr/usePollingConfig.test.tsx
@@ -321,14 +321,9 @@ describe('usePollingConfig', () => {
 
   describe('when driving useSWR', () => {
     const INTERVAL = 1000
-    /** Mirrors DEFAULT_SWR_CONFIG's global 10-minute refresh, which LayerProvider applies app-wide. */
+    /** DEFAULT_SWR_CONFIG's app-wide refresh; the hook-level polling function must override it. */
     const GLOBAL_REFRESH_INTERVAL = 10 * 60 * 1000
 
-    /*
-     * The global refreshInterval is deliberately included: real consumers rely on the
-     * hook-level polling function overriding it, so every test here also defends that
-     * precedence — polls must arrive at INTERVAL, not the global cadence.
-     */
     const swrWrapper = ({ children }: PropsWithChildren) => (
       <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, refreshInterval: GLOBAL_REFRESH_INTERVAL }}>
         {children}
@@ -388,18 +383,16 @@ describe('usePollingConfig', () => {
 
       const { result } = renderPolledSWR('poll-revival', fetcher)
 
-      await advance(0) // mount fetch returns done -> loop never starts
+      await advance(0)
       await advance(INTERVAL * 3)
       expect(fetcher).toHaveBeenCalledTimes(1)
 
-      // A new session begins: an external refetch observes pending data...
       response = PENDING
       await act(async () => {
         await result.current.mutate()
       })
       expect(fetcher).toHaveBeenCalledTimes(2)
 
-      // ...and the restart nonce revives SWR's polling loop.
       await advance(INTERVAL)
       expect(fetcher).toHaveBeenCalledTimes(3)
     })

--- a/src/hooks/utils/swr/usePollingConfig.test.tsx
+++ b/src/hooks/utils/swr/usePollingConfig.test.tsx
@@ -35,7 +35,7 @@ const callSuccess = (result: Result, data: PollData) => {
 const callErrorRetry = (
   result: Result,
   revalidate: ReturnType<typeof vi.fn>,
-  { error = new Error('boom'), retryCount = 0 }: { error?: unknown, retryCount?: number } = {},
+  { error = new Error('boom'), retryCount = 1 }: { error?: unknown, retryCount?: number } = {},
 ) =>
   result.current.onErrorRetry?.(
     error,
@@ -56,30 +56,25 @@ afterEach(() => {
 })
 
 describe('usePollingConfig', () => {
-  describe('refreshInterval', () => {
-    it('returns 0 when shouldContinue is false', () => {
+  describe('session lifecycle', () => {
+    it('refreshInterval returns 0 when shouldContinue is false', () => {
       const { result } = renderPollingConfig()
       expect(callRefresh(result, DONE)).toBe(0)
     })
 
-    it('transitions idle -> active and returns the default interval while shouldContinue is true', () => {
+    it('transitions idle -> active and schedules polling while shouldContinue is true', () => {
       const { result } = renderPollingConfig()
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
     })
 
-    it('returns a numeric intervalMs override', () => {
-      const { result } = renderPollingConfig({ intervalMs: 500 })
-      expect(callRefresh(result, PENDING)).toBe(500)
+    it('starts polling before any data arrives when shouldContinue accepts undefined', () => {
+      const { result } = renderPollingConfig({
+        shouldContinue: data => data === undefined || data.status === 'pending',
+      })
+      expect(callRefresh(result, undefined)).toBe(DEFAULT_INTERVAL)
     })
 
-    it('invokes a function-form intervalMs on each scheduling call', () => {
-      const intervalMs = vi.fn(() => 1234)
-      const { result } = renderPollingConfig({ intervalMs })
-      expect(callRefresh(result, PENDING)).toBe(1234)
-      expect(intervalMs).toHaveBeenCalled()
-    })
-
-    it('returns 0 and transitions active -> stopped once maxDurationMs elapses', () => {
+    it('transitions active -> stopped and returns 0 once maxDurationMs elapses', () => {
       const { result } = renderPollingConfig()
 
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL) // idle -> active, deadline set
@@ -95,18 +90,66 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(0)
       expect(callRefresh(result, PENDING)).toBe(0)
     })
+
+    it('treats maxDurationMs as a hard cap by default, since still-pending polls are not progress', () => {
+      const { result } = renderPollingConfig()
+
+      callSuccess(result, { status: 'pending', version: 1 }) // active, deadline = 120000
+
+      // A steady stream of still-pending polls does not extend the deadline.
+      vi.setSystemTime(DEFAULT_MAX_DURATION - 1000)
+      callSuccess(result, { status: 'pending', version: 2 })
+
+      vi.setSystemTime(DEFAULT_MAX_DURATION)
+      expect(callRefresh(result, PENDING)).toBe(0)
+    })
   })
 
-  describe('onErrorRetry', () => {
+  describe('interval configuration', () => {
+    it('uses a numeric intervalMs override', () => {
+      const { result } = renderPollingConfig({ intervalMs: 500 })
+      expect(callRefresh(result, PENDING)).toBe(500)
+    })
+
+    it('invokes a function-form intervalMs on each scheduling call', () => {
+      const intervalMs = vi.fn(() => 1234)
+      const { result } = renderPollingConfig({ intervalMs })
+      expect(callRefresh(result, PENDING)).toBe(1234)
+      expect(intervalMs).toHaveBeenCalled()
+    })
+  })
+
+  describe('error retries', () => {
     it('schedules revalidate after one interval, preserving retryCount, while under maxErrorRetries', () => {
       const revalidate = vi.fn()
       const { result } = renderPollingConfig({ intervalMs: 500 })
 
-      callErrorRetry(result, revalidate, { retryCount: 0 })
+      callErrorRetry(result, revalidate, { retryCount: 1 })
       expect(revalidate).not.toHaveBeenCalled()
 
       vi.advanceTimersByTime(500)
-      expect(revalidate).toHaveBeenCalledWith({ retryCount: 0 })
+      expect(revalidate).toHaveBeenCalledWith({ retryCount: 1 })
+    })
+
+    it('still retries when retryCount equals maxErrorRetries (SWR retryCount is 1-based)', () => {
+      const revalidate = vi.fn()
+      const { result } = renderPollingConfig({ maxErrorRetries: 3 })
+
+      callErrorRetry(result, revalidate, { retryCount: 3 })
+      vi.advanceTimersByTime(DEFAULT_INTERVAL)
+
+      expect(revalidate).toHaveBeenCalledWith({ retryCount: 3 })
+    })
+
+    it('stops retrying once retryCount exceeds maxErrorRetries', () => {
+      const revalidate = vi.fn()
+      const { result } = renderPollingConfig({ maxErrorRetries: 3 })
+
+      callErrorRetry(result, revalidate, { retryCount: 4 })
+      vi.advanceTimersByTime(DEFAULT_INTERVAL)
+
+      expect(revalidate).not.toHaveBeenCalled()
+      expect(callRefresh(result, PENDING)).toBe(0) // stopped
     })
 
     it('stops the session without retrying when isFatalError matches', () => {
@@ -119,17 +162,6 @@ describe('usePollingConfig', () => {
 
       expect(revalidate).not.toHaveBeenCalled()
       expect(callRefresh(result, PENDING)).toBe(0) // stopped
-    })
-
-    it('stops retrying once retryCount reaches maxErrorRetries', () => {
-      const revalidate = vi.fn()
-      const { result } = renderPollingConfig({ maxErrorRetries: 3 })
-
-      callErrorRetry(result, revalidate, { retryCount: 3 })
-      vi.advanceTimersByTime(DEFAULT_INTERVAL)
-
-      expect(revalidate).not.toHaveBeenCalled()
-      expect(callRefresh(result, PENDING)).toBe(0)
     })
 
     it('stops retrying once the polling deadline has passed', () => {
@@ -148,23 +180,14 @@ describe('usePollingConfig', () => {
       const { result } = renderPollingConfig({ isFatalError: () => true })
 
       callErrorRetry(result, revalidate) // fatal -> stopped
-      callErrorRetry(result, revalidate, { error: new Error('again'), retryCount: 0 })
+      callErrorRetry(result, revalidate, { error: new Error('again'), retryCount: 1 })
       vi.advanceTimersByTime(DEFAULT_INTERVAL)
 
       expect(revalidate).not.toHaveBeenCalled()
     })
   })
 
-  describe('onSuccess', () => {
-    it('invokes onPoll with every successful payload', () => {
-      const onPoll = vi.fn()
-      const { result } = renderPollingConfig({ onPoll })
-
-      callSuccess(result, PENDING)
-
-      expect(onPoll).toHaveBeenCalledWith(PENDING)
-    })
-
+  describe('revival of a halted polling loop', () => {
     it('restarts an idle session on success, bumping refreshInterval identity so SWR revives its polling loop', () => {
       const { result } = renderPollingConfig()
       const before = result.current.refreshInterval
@@ -173,29 +196,6 @@ describe('usePollingConfig', () => {
 
       expect(result.current.refreshInterval).not.toBe(before) // nonce bumped
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL) // active
-    })
-
-    it('calls onComplete exactly once when shouldContinue goes false (default completion)', () => {
-      const onComplete = vi.fn()
-      const { result } = renderPollingConfig({ onComplete })
-
-      callSuccess(result, DONE)
-      callSuccess(result, DONE)
-
-      expect(onComplete).toHaveBeenCalledTimes(1)
-      expect(onComplete).toHaveBeenCalledWith(DONE)
-    })
-
-    it('defers completion to a custom shouldComplete predicate', () => {
-      const onComplete = vi.fn()
-      const shouldComplete = vi.fn((d: PollData) => d.version === 2)
-      const { result } = renderPollingConfig({ onComplete, shouldComplete })
-
-      callSuccess(result, { status: 'pending', version: 1 })
-      expect(onComplete).not.toHaveBeenCalled()
-
-      callSuccess(result, { status: 'pending', version: 2 })
-      expect(onComplete).toHaveBeenCalledTimes(1)
     })
 
     it('does not revive a stopped session when shouldContinue was already true (no rising edge)', () => {
@@ -212,6 +212,19 @@ describe('usePollingConfig', () => {
 
       expect(result.current.refreshInterval).toBe(stopped) // no restart
       expect(callRefresh(result, PENDING)).toBe(0)
+    })
+
+    it('revives a stopped session on the default rising edge (terminal, then pending again)', () => {
+      const { result } = renderPollingConfig()
+
+      callSuccess(result, PENDING)
+      vi.setSystemTime(DEFAULT_MAX_DURATION)
+      expect(callRefresh(result, PENDING)).toBe(0) // capped -> stopped
+
+      callSuccess(result, DONE) // the stuck session finally terminates
+      callSuccess(result, PENDING) // a new session begins: the rising edge revives polling
+
+      expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
     })
 
     it('revives a stopped session when shouldRestartPolling reports progress', () => {
@@ -242,22 +255,66 @@ describe('usePollingConfig', () => {
       vi.setSystemTime(DEFAULT_MAX_DURATION + 1000) // past original deadline, before extended
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
     })
+  })
 
-    it('treats maxDurationMs as a hard cap by default, since still-pending polls are not progress', () => {
-      const { result } = renderPollingConfig()
+  describe('poll and completion callbacks', () => {
+    it('invokes onPoll with every successful payload', () => {
+      const onPoll = vi.fn()
+      const { result } = renderPollingConfig({ onPoll })
 
-      callSuccess(result, { status: 'pending', version: 1 }) // active, deadline = 120000
+      callSuccess(result, PENDING)
 
-      // A steady stream of still-pending polls does not extend the deadline.
-      vi.setSystemTime(DEFAULT_MAX_DURATION - 1000)
+      expect(onPoll).toHaveBeenCalledWith(PENDING)
+    })
+
+    it('calls onComplete exactly once when an active session ends (default completion)', () => {
+      const onComplete = vi.fn()
+      const { result } = renderPollingConfig({ onComplete })
+
+      callSuccess(result, PENDING) // start the session
+      callSuccess(result, DONE)
+      callSuccess(result, DONE)
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith(DONE)
+    })
+
+    it('does not fire default completion when the first fetch is already terminal (no session ran)', () => {
+      const onComplete = vi.fn()
+      const { result } = renderPollingConfig({ onComplete })
+
+      callSuccess(result, DONE)
+
+      expect(onComplete).not.toHaveBeenCalled()
+    })
+
+    it('re-arms completion per session: a restarted session completes again', () => {
+      const onComplete = vi.fn()
+      const { result } = renderPollingConfig({ onComplete })
+
+      callSuccess(result, PENDING) // session 1
+      callSuccess(result, DONE) // completes (1)
+      expect(callRefresh(result, DONE)).toBe(0) // natural end -> idle
+      callSuccess(result, PENDING) // session 2 restarts, re-arming completion
+      callSuccess(result, DONE) // completes (2)
+
+      expect(onComplete).toHaveBeenCalledTimes(2)
+    })
+
+    it('defers completion to a custom shouldComplete predicate', () => {
+      const onComplete = vi.fn()
+      const shouldComplete = vi.fn((d: PollData) => d.version === 2)
+      const { result } = renderPollingConfig({ onComplete, shouldComplete })
+
+      callSuccess(result, { status: 'pending', version: 1 })
+      expect(onComplete).not.toHaveBeenCalled()
+
       callSuccess(result, { status: 'pending', version: 2 })
-
-      vi.setSystemTime(DEFAULT_MAX_DURATION)
-      expect(callRefresh(result, PENDING)).toBe(0)
+      expect(onComplete).toHaveBeenCalledTimes(1)
     })
   })
 
-  describe('return value', () => {
+  describe('returned config', () => {
     it('returns the same { refreshInterval, onErrorRetry, onSuccess } object across re-renders', () => {
       const opts: PollingOptions = { shouldContinue: defaultShouldContinue }
       const { result, rerender } = renderHook(() => usePollingConfig(opts))
@@ -360,6 +417,21 @@ describe('usePollingConfig', () => {
 
       await advance(INTERVAL * 5)
       expect(fetcher).toHaveBeenCalledTimes(haltedCount) // no further polls
+    })
+
+    it('retries a failing fetch at the interval, then gives up after maxErrorRetries retries', async () => {
+      const fetcher = vi.fn(() => Promise.reject(new Error('boom')))
+
+      renderPolledSWR('poll-errors', fetcher, { maxErrorRetries: 3 })
+
+      await advance(0) // mount fetch fails
+      expect(fetcher).toHaveBeenCalledTimes(1)
+
+      await advance(INTERVAL * 10)
+      expect(fetcher).toHaveBeenCalledTimes(4) // initial attempt + 3 retries
+
+      await advance(INTERVAL * 5)
+      expect(fetcher).toHaveBeenCalledTimes(4) // gave up
     })
   })
 })

--- a/src/hooks/utils/swr/usePollingConfig.test.tsx
+++ b/src/hooks/utils/swr/usePollingConfig.test.tsx
@@ -62,24 +62,24 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, DONE)).toBe(0)
     })
 
-    it('starts polling from idle and returns the default interval', () => {
+    it('transitions idle -> active and returns the default interval while shouldContinue is true', () => {
       const { result } = renderPollingConfig()
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
     })
 
-    it('returns a custom numeric interval', () => {
+    it('respects a custom numeric interval', () => {
       const { result } = renderPollingConfig({ intervalMs: 500 })
       expect(callRefresh(result, PENDING)).toBe(500)
     })
 
-    it('evaluates a function interval on each call', () => {
+    it('supports a function that computes the interval per poll', () => {
       const intervalMs = vi.fn(() => 1234)
       const { result } = renderPollingConfig({ intervalMs })
       expect(callRefresh(result, PENDING)).toBe(1234)
       expect(intervalMs).toHaveBeenCalled()
     })
 
-    it('stops (returns 0) once the max duration deadline passes', () => {
+    it('stops polling once the max duration has elapsed', () => {
       const { result } = renderPollingConfig()
 
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL) // idle -> active, deadline set
@@ -88,7 +88,7 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(0) // deadline reached -> stopped
     })
 
-    it('stays stopped on later calls even while shouldContinue is true', () => {
+    it('remains stopped on subsequent calls even while shouldContinue is true', () => {
       const { result } = renderPollingConfig()
       callRefresh(result, PENDING)
       vi.setSystemTime(DEFAULT_MAX_DURATION)
@@ -98,7 +98,7 @@ describe('usePollingConfig', () => {
   })
 
   describe('onErrorRetry', () => {
-    it('schedules a retry after the interval when under the cap', () => {
+    it('retries after one interval while under the retry limit', () => {
       const revalidate = vi.fn()
       const { result } = renderPollingConfig({ intervalMs: 500 })
 
@@ -109,7 +109,7 @@ describe('usePollingConfig', () => {
       expect(revalidate).toHaveBeenCalledWith({ retryCount: 0 })
     })
 
-    it('does not retry and stops on a fatal error', () => {
+    it('gives up immediately on a fatal error', () => {
       const revalidate = vi.fn()
       const isFatalError = vi.fn(() => true)
       const { result } = renderPollingConfig({ isFatalError })
@@ -121,7 +121,7 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(0) // stopped
     })
 
-    it('stops once max error retries are reached', () => {
+    it('gives up after the maximum number of retries', () => {
       const revalidate = vi.fn()
       const { result } = renderPollingConfig({ maxErrorRetries: 3 })
 
@@ -132,7 +132,7 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(0)
     })
 
-    it('stops when the polling deadline has passed', () => {
+    it('gives up once the max polling duration has elapsed', () => {
       const revalidate = vi.fn()
       const { result } = renderPollingConfig()
 
@@ -143,7 +143,7 @@ describe('usePollingConfig', () => {
       expect(revalidate).not.toHaveBeenCalled()
     })
 
-    it('is a no-op once the session is stopped', () => {
+    it('does nothing once polling has already stopped', () => {
       const revalidate = vi.fn()
       const { result } = renderPollingConfig({ isFatalError: () => true })
 
@@ -156,7 +156,7 @@ describe('usePollingConfig', () => {
   })
 
   describe('onSuccess', () => {
-    it('calls onPoll with the latest data on every success', () => {
+    it('notifies onPoll with each successful result', () => {
       const onPoll = vi.fn()
       const { result } = renderPollingConfig({ onPoll })
 
@@ -165,7 +165,7 @@ describe('usePollingConfig', () => {
       expect(onPoll).toHaveBeenCalledWith(PENDING)
     })
 
-    it('restarts a fresh (idle) session and revives refreshInterval identity', () => {
+    it('restarts an idle session on success, bumping refreshInterval identity so SWR revives its polling loop', () => {
       const { result } = renderPollingConfig()
       const before = result.current.refreshInterval
 
@@ -175,7 +175,7 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL) // active
     })
 
-    it('fires onComplete once when the poll completes (default: shouldContinue false)', () => {
+    it('calls onComplete exactly once when shouldContinue goes false (default completion)', () => {
       const onComplete = vi.fn()
       const { result } = renderPollingConfig({ onComplete })
 
@@ -186,7 +186,7 @@ describe('usePollingConfig', () => {
       expect(onComplete).toHaveBeenCalledWith(DONE)
     })
 
-    it('uses a custom shouldComplete predicate', () => {
+    it('defers completion to a custom shouldComplete predicate', () => {
       const onComplete = vi.fn()
       const shouldComplete = vi.fn((d: PollData) => d.version === 2)
       const { result } = renderPollingConfig({ onComplete, shouldComplete })
@@ -198,7 +198,7 @@ describe('usePollingConfig', () => {
       expect(onComplete).toHaveBeenCalledTimes(1)
     })
 
-    it('does not revive a stopped session without progress (default rising edge)', () => {
+    it('does not revive a stopped session when shouldContinue was already true (no rising edge)', () => {
       const { result } = renderPollingConfig()
 
       // idle -> active via a poll, then let the deadline stop it.
@@ -214,7 +214,7 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(0)
     })
 
-    it('revives a stopped session when shouldRestartPolling reports progress', () => {
+    it('restarts a stopped session when shouldRestartPolling sees progress', () => {
       const shouldRestartPolling = vi.fn(
         (prev: PollData | undefined, next: PollData) => prev?.version !== next.version,
       )
@@ -230,7 +230,7 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL) // revived
     })
 
-    it('extends the deadline on progress (shouldRestartPolling) while active', () => {
+    it('extends the deadline when shouldRestartPolling reports progress while active', () => {
       const shouldRestartPolling = (prev: PollData | undefined, next: PollData) => prev?.version !== next.version
       const { result } = renderPollingConfig({ shouldRestartPolling })
 
@@ -243,7 +243,7 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
     })
 
-    it('treats maxDurationMs as a hard cap by default (still-pending polls are not progress)', () => {
+    it('treats maxDurationMs as a hard cap by default, since still-pending polls are not progress', () => {
       const { result } = renderPollingConfig()
 
       callSuccess(result, { status: 'pending', version: 1 }) // active, deadline = 120000
@@ -258,7 +258,7 @@ describe('usePollingConfig', () => {
   })
 
   describe('return value', () => {
-    it('is a stable { refreshInterval, onErrorRetry, onSuccess } across renders', () => {
+    it('returns the same { refreshInterval, onErrorRetry, onSuccess } object across re-renders', () => {
       const opts: PollingOptions = { shouldContinue: defaultShouldContinue }
       const { result, rerender } = renderHook(() => usePollingConfig(opts))
 
@@ -300,7 +300,7 @@ describe('usePollingConfig', () => {
       })
     }
 
-    it('polls on the interval while pending and stops once done, completing once', async () => {
+    it('polls at the interval until shouldContinue goes false, then halts and completes once', async () => {
       let response: PollData = PENDING
       const fetcher = vi.fn(() => Promise.resolve(response))
       const onComplete = vi.fn()
@@ -325,7 +325,7 @@ describe('usePollingConfig', () => {
       expect(onComplete).toHaveBeenCalledTimes(1)
     })
 
-    it('revives the dead polling loop when a refetch reports a new pending session', async () => {
+    it('resumes polling when a refetch finds a new pending session after the loop has died', async () => {
       let response: PollData = DONE
       const fetcher = vi.fn(() => Promise.resolve(response))
 
@@ -347,7 +347,7 @@ describe('usePollingConfig', () => {
       expect(fetcher).toHaveBeenCalledTimes(3)
     })
 
-    it('halts polling at the max duration while data is still pending', async () => {
+    it('halts at maxDurationMs while shouldContinue is still true', async () => {
       const fetcher = vi.fn(() => Promise.resolve(PENDING))
 
       renderPolledSWR('poll-deadline', fetcher, { maxDurationMs: INTERVAL * 3 })

--- a/src/hooks/utils/swr/usePollingConfig.test.tsx
+++ b/src/hooks/utils/swr/usePollingConfig.test.tsx
@@ -426,5 +426,53 @@ describe('usePollingConfig', () => {
       await advance(INTERVAL * 5)
       expect(fetcher).toHaveBeenCalledTimes(4)
     })
+
+    it('recovers from a transient error and resumes polling at the interval', async () => {
+      let failuresRemaining = 1
+      const fetcher = vi.fn(() =>
+        failuresRemaining-- > 0 ? Promise.reject(new Error('boom')) : Promise.resolve(PENDING),
+      )
+
+      renderPolledSWR('poll-recovery', fetcher)
+
+      await advance(0) // mount fetch fails
+      expect(fetcher).toHaveBeenCalledTimes(1)
+
+      await advance(INTERVAL) // retry succeeds with pending data
+      expect(fetcher).toHaveBeenCalledTimes(2)
+
+      await advance(INTERVAL) // polling has resumed
+      expect(fetcher).toHaveBeenCalledTimes(3)
+    })
+
+    it('revives a cap-stopped loop only on a rising edge, not on still-pending refetches', async () => {
+      let response: PollData = PENDING
+      const fetcher = vi.fn(() => Promise.resolve(response))
+
+      const { result } = renderPolledSWR('poll-stopped-revival', fetcher, { maxDurationMs: INTERVAL * 2 })
+
+      await advance(0)
+      await advance(INTERVAL * 5) // cap halts the loop
+      const haltedCount = fetcher.mock.calls.length
+
+      await act(async () => {
+        await result.current.mutate()
+      })
+      await advance(INTERVAL * 3)
+      expect(fetcher).toHaveBeenCalledTimes(haltedCount + 1) // refetch ran, but no polling revived
+
+      response = DONE
+      await act(async () => {
+        await result.current.mutate()
+      })
+      response = PENDING
+      await act(async () => {
+        await result.current.mutate()
+      })
+      const revivedBase = fetcher.mock.calls.length
+
+      await advance(INTERVAL)
+      expect(fetcher.mock.calls.length).toBeGreaterThan(revivedBase) // rising edge restarted the loop
+    })
   })
 })

--- a/src/hooks/utils/swr/usePollingConfig.test.tsx
+++ b/src/hooks/utils/swr/usePollingConfig.test.tsx
@@ -67,19 +67,19 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL)
     })
 
-    it('respects a custom numeric interval', () => {
+    it('returns a numeric intervalMs override', () => {
       const { result } = renderPollingConfig({ intervalMs: 500 })
       expect(callRefresh(result, PENDING)).toBe(500)
     })
 
-    it('supports a function that computes the interval per poll', () => {
+    it('invokes a function-form intervalMs on each scheduling call', () => {
       const intervalMs = vi.fn(() => 1234)
       const { result } = renderPollingConfig({ intervalMs })
       expect(callRefresh(result, PENDING)).toBe(1234)
       expect(intervalMs).toHaveBeenCalled()
     })
 
-    it('stops polling once the max duration has elapsed', () => {
+    it('returns 0 and transitions active -> stopped once maxDurationMs elapses', () => {
       const { result } = renderPollingConfig()
 
       expect(callRefresh(result, PENDING)).toBe(DEFAULT_INTERVAL) // idle -> active, deadline set
@@ -98,7 +98,7 @@ describe('usePollingConfig', () => {
   })
 
   describe('onErrorRetry', () => {
-    it('retries after one interval while under the retry limit', () => {
+    it('schedules revalidate after one interval, preserving retryCount, while under maxErrorRetries', () => {
       const revalidate = vi.fn()
       const { result } = renderPollingConfig({ intervalMs: 500 })
 
@@ -109,7 +109,7 @@ describe('usePollingConfig', () => {
       expect(revalidate).toHaveBeenCalledWith({ retryCount: 0 })
     })
 
-    it('gives up immediately on a fatal error', () => {
+    it('stops the session without retrying when isFatalError matches', () => {
       const revalidate = vi.fn()
       const isFatalError = vi.fn(() => true)
       const { result } = renderPollingConfig({ isFatalError })
@@ -121,7 +121,7 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(0) // stopped
     })
 
-    it('gives up after the maximum number of retries', () => {
+    it('stops retrying once retryCount reaches maxErrorRetries', () => {
       const revalidate = vi.fn()
       const { result } = renderPollingConfig({ maxErrorRetries: 3 })
 
@@ -132,7 +132,7 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(0)
     })
 
-    it('gives up once the max polling duration has elapsed', () => {
+    it('stops retrying once the polling deadline has passed', () => {
       const revalidate = vi.fn()
       const { result } = renderPollingConfig()
 
@@ -143,7 +143,7 @@ describe('usePollingConfig', () => {
       expect(revalidate).not.toHaveBeenCalled()
     })
 
-    it('does nothing once polling has already stopped', () => {
+    it('is a no-op when the session is already stopped', () => {
       const revalidate = vi.fn()
       const { result } = renderPollingConfig({ isFatalError: () => true })
 
@@ -156,7 +156,7 @@ describe('usePollingConfig', () => {
   })
 
   describe('onSuccess', () => {
-    it('notifies onPoll with each successful result', () => {
+    it('invokes onPoll with every successful payload', () => {
       const onPoll = vi.fn()
       const { result } = renderPollingConfig({ onPoll })
 
@@ -214,7 +214,7 @@ describe('usePollingConfig', () => {
       expect(callRefresh(result, PENDING)).toBe(0)
     })
 
-    it('restarts a stopped session when shouldRestartPolling sees progress', () => {
+    it('revives a stopped session when shouldRestartPolling reports progress', () => {
       const shouldRestartPolling = vi.fn(
         (prev: PollData | undefined, next: PollData) => prev?.version !== next.version,
       )
@@ -325,7 +325,7 @@ describe('usePollingConfig', () => {
       expect(onComplete).toHaveBeenCalledTimes(1)
     })
 
-    it('resumes polling when a refetch finds a new pending session after the loop has died', async () => {
+    it('revives the dead SWR polling loop when a refetch surfaces a new pending session', async () => {
       let response: PollData = DONE
       const fetcher = vi.fn(() => Promise.resolve(response))
 

--- a/src/hooks/utils/swr/usePollingConfig.ts
+++ b/src/hooks/utils/swr/usePollingConfig.ts
@@ -83,7 +83,8 @@ export function usePollingConfig<TData>({
     (error, _key, _config, revalidate, { retryCount }) => {
       if (isStopped(phaseRef)) return
 
-      const isAtMaxRetries = retryCount >= maxErrorRetries
+      // SWR passes a 1-based retryCount, so `>` yields exactly `maxErrorRetries` retries.
+      const isAtMaxRetries = retryCount > maxErrorRetries
       const isPastPollingDeadline = Date.now() >= pollingEndTimestampRef.current
 
       if (isFatalError?.(error) || isAtMaxRetries || isPastPollingDeadline) {
@@ -117,7 +118,14 @@ export function usePollingConfig<TData>({
 
     previousDataRef.current = nextData
 
-    const completed = shouldComplete ? shouldComplete(nextData) : !shouldContinue(nextData)
+    /*
+     * Default completion means an actual session ended: data that is already terminal on
+     * the first fetch (phase still Idle) is "nothing to poll", not "finished". A custom
+     * `shouldComplete` is an explicit definition of done, so it applies regardless.
+     */
+    const completed = shouldComplete
+      ? shouldComplete(nextData)
+      : !isIdle(phaseRef) && !shouldContinue(nextData)
     if (!hasCompletedRef.current && completed) {
       hasCompletedRef.current = true
       void onComplete?.(nextData)


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small logic changes to shared SWR polling used by bank accounts and Plaid flows; tests mitigate regressions but retry/completion semantics affect production polling behavior.
> 
> **Overview**
> Adds a large **Vitest** suite for `usePollingConfig`, covering `refreshInterval`, error retries, `onSuccess` session lifecycle, and integration with **SWR** (fake timers, revival after cap/stop, retry limits).
> 
> **`usePollingConfig` behavior fixes:** error retry cutoff now uses `retryCount > maxErrorRetries` so SWR’s 1-based `retryCount` allows exactly `maxErrorRetries` retries. Default **`onComplete`** only runs after an active polling session ends (`!isIdle`), so an initial fetch that is already terminal no longer counts as “completed.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35eab696422eeb09ca962c70deaec90861a0f68e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->