### PR TITLE
Hiding button and adding a new optional callback

### DIFF
--- a/src/components/LinkAccounts/LinkAccounts.tsx
+++ b/src/components/LinkAccounts/LinkAccounts.tsx
@@ -15,12 +15,17 @@ import './linkAccounts.scss'
 
 type LinkAccountsProps = {
   onComplete?: () => Awaitable<void>
+  onPlaidConnectionSuccess?: () => Awaitable<void>
   plaidHostedLinkConfig?: PlaidHostedLinkConfig
+  showDoneLinkingButton?: boolean
 }
 
-export function LinkAccounts({ plaidHostedLinkConfig, ...props }: LinkAccountsProps) {
+export function LinkAccounts({ plaidHostedLinkConfig, onPlaidConnectionSuccess, ...props }: LinkAccountsProps) {
   return (
-    <LinkedAccountsProvider plaidHostedLinkConfig={plaidHostedLinkConfig}>
+    <LinkedAccountsProvider
+      plaidHostedLinkConfig={plaidHostedLinkConfig}
+      onPlaidConnectionSuccess={onPlaidConnectionSuccess}
+    >
       <LinkAccountsContent {...props} />
     </LinkedAccountsProvider>
   )
@@ -28,7 +33,8 @@ export function LinkAccounts({ plaidHostedLinkConfig, ...props }: LinkAccountsPr
 
 function LinkAccountsContent({
   onComplete,
-}: LinkAccountsProps) {
+  showDoneLinkingButton = true,
+}: Omit<LinkAccountsProps, 'onPlaidConnectionSuccess' | 'plaidHostedLinkConfig'>) {
   const { t } = useTranslation()
   const { data: linkedAccounts, loadingStatus } = useBankAccountsContext()
 
@@ -52,7 +58,7 @@ function LinkAccountsContent({
         Footer={null}
         onComplete={onComplete}
       >
-        <LinkAccountsLinkStep />
+        <LinkAccountsLinkStep showDoneLinkingButton={showDoneLinkingButton} />
         {hideConfirmationStep ? null : <LinkAccountsConfirmationStep />}
       </Wizard>
     </section>

--- a/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
+++ b/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
@@ -23,7 +23,11 @@ import { Separator } from '@components/Separator/Separator'
 import { ConditionalList } from '@components/utility/ConditionalList'
 import { useWizard } from '@components/Wizard/Wizard'
 
-export function LinkAccountsLinkStep() {
+type LinkAccountsLinkStepProps = {
+  showDoneLinkingButton?: boolean
+}
+
+export function LinkAccountsLinkStep({ showDoneLinkingButton = true }: LinkAccountsLinkStepProps) {
   const { t } = useTranslation()
   const { formatNumber } = useIntlFormatter()
   const { isLinking, addConnection } = useContext(LinkedAccountsContext)
@@ -121,7 +125,7 @@ export function LinkAccountsLinkStep() {
           </BasicLinkedAccountContainer>
         )}
       </ConditionalList>
-      {effectiveAccounts.length > 0
+      {showDoneLinkingButton && effectiveAccounts.length > 0
         ? (
           <>
             <Separator mbs='lg' mbe='lg' />

--- a/src/hooks/features/linkedAccounts/usePlaidLinkModal.ts
+++ b/src/hooks/features/linkedAccounts/usePlaidLinkModal.ts
@@ -18,7 +18,7 @@ type UsePlaidLinkModalOptions = {
   linkMode: LinkMode
   /** Called after the connection set changes, so the caller can refresh accounts. */
   onSuccess: () => Awaitable<void>
-  onConnectionSuccess?: () => Awaitable<void>
+  onAddConnectionSuccess?: () => Awaitable<void>
   /** Updates the active link mode; reset to 'add' when a flow completes or the modal exits. */
   setLinkMode: (mode: LinkMode) => void
 }
@@ -32,7 +32,7 @@ export function usePlaidLinkModal({
   linkToken,
   linkMode,
   onSuccess,
-  onConnectionSuccess,
+  onAddConnectionSuccess,
   setLinkMode,
 }: UsePlaidLinkModalOptions) {
   const { usePlaidSandbox } = useEnvironment()
@@ -47,7 +47,7 @@ export function usePlaidLinkModal({
   const { trigger: triggerUpdateConnectionStatus } = useUpdateConnectionStatus()
 
   const [isLinking, setIsLinking] = useState(false)
-  const handleConnectionSuccess = onConnectionSuccess ?? onSuccess
+  const handleAddConnectionSuccess = onAddConnectionSuccess ?? onSuccess
 
   /**
    * When the user has finished entering credentials, send the resulting
@@ -65,7 +65,7 @@ export function usePlaidLinkModal({
       })
         .then(
           // Only refresh once the link has actually persisted.
-          () => handleConnectionSuccess(),
+          () => handleAddConnectionSuccess(),
           () => addToast({
             content: t('linkedAccounts:error.connect_account', 'We couldn’t connect your account. Please try again.'),
             type: 'error',
@@ -76,7 +76,7 @@ export function usePlaidLinkModal({
           resetAccountConfirmation()
         })
     },
-    [triggerExchangePlaidPublicToken, handleConnectionSuccess, addToast, t, preloadAccountConfirmation, resetAccountConfirmation],
+    [triggerExchangePlaidPublicToken, handleAddConnectionSuccess, addToast, t, preloadAccountConfirmation, resetAccountConfirmation],
   )
 
   const { open: plaidLinkStart, ready: plaidLinkReady } = usePlaidLink({

--- a/src/hooks/features/linkedAccounts/usePlaidLinkModal.ts
+++ b/src/hooks/features/linkedAccounts/usePlaidLinkModal.ts
@@ -18,6 +18,7 @@ type UsePlaidLinkModalOptions = {
   linkMode: LinkMode
   /** Called after the connection set changes, so the caller can refresh accounts. */
   onSuccess: () => Awaitable<void>
+  onConnectionSuccess?: () => Awaitable<void>
   /** Updates the active link mode; reset to 'add' when a flow completes or the modal exits. */
   setLinkMode: (mode: LinkMode) => void
 }
@@ -31,6 +32,7 @@ export function usePlaidLinkModal({
   linkToken,
   linkMode,
   onSuccess,
+  onConnectionSuccess,
   setLinkMode,
 }: UsePlaidLinkModalOptions) {
   const { usePlaidSandbox } = useEnvironment()
@@ -45,6 +47,7 @@ export function usePlaidLinkModal({
   const { trigger: triggerUpdateConnectionStatus } = useUpdateConnectionStatus()
 
   const [isLinking, setIsLinking] = useState(false)
+  const handleConnectionSuccess = onConnectionSuccess ?? onSuccess
 
   /**
    * When the user has finished entering credentials, send the resulting
@@ -62,7 +65,7 @@ export function usePlaidLinkModal({
       })
         .then(
           // Only refresh once the link has actually persisted.
-          () => onSuccess(),
+          () => handleConnectionSuccess(),
           () => addToast({
             content: t('linkedAccounts:error.connect_account', 'We couldn’t connect your account. Please try again.'),
             type: 'error',
@@ -73,7 +76,7 @@ export function usePlaidLinkModal({
           resetAccountConfirmation()
         })
     },
-    [triggerExchangePlaidPublicToken, onSuccess, addToast, t, preloadAccountConfirmation, resetAccountConfirmation],
+    [triggerExchangePlaidPublicToken, handleConnectionSuccess, addToast, t, preloadAccountConfirmation, resetAccountConfirmation],
   )
 
   const { open: plaidLinkStart, ready: plaidLinkReady } = usePlaidLink({

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { type AccountSource } from '@internal-types/linkedAccounts'
+import type { Awaitable } from '@internal-types/utility/promises'
 import { type PlaidHostedLinkConfig, toCreatePlaidLinkParams } from '@schemas/linkedAccounts/plaid'
 import { useUnlinkBankAccount } from '@hooks/api/businesses/[business-id]/bank-accounts/useUnlinkBankAccount'
 import { useBankTransactionsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-transactions/useBankTransactions'
@@ -17,6 +18,7 @@ import { useBankAccountsContext } from '@contexts/BankAccountsContext/BankAccoun
 import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 
 type UseLinkedAccountsOptions = {
+  onPlaidConnectionSuccess?: () => Awaitable<void>
   plaidHostedLinkConfig?: PlaidHostedLinkConfig
 }
 
@@ -55,7 +57,7 @@ const usePlaidOnlyAction = <Args extends unknown[]>(
     [operation, action],
   )
 
-export const useLinkedAccounts: UseLinkedAccounts = ({ plaidHostedLinkConfig } = {}) => {
+export const useLinkedAccounts: UseLinkedAccounts = ({ onPlaidConnectionSuccess, plaidHostedLinkConfig } = {}) => {
   const { addToast } = useLayerContext()
   const { t } = useTranslation()
 
@@ -80,16 +82,35 @@ export const useLinkedAccounts: UseLinkedAccounts = ({ plaidHostedLinkConfig } =
     ])
   }, [refetch, forceReloadBankTransactions])
 
+  const notifyPlaidConnectionSuccess = useCallback(async () => {
+    if (!onPlaidConnectionSuccess) return
+
+    try {
+      await onPlaidConnectionSuccess()
+    }
+    catch (error) {
+      console.error('onPlaidConnectionSuccess failed', error)
+    }
+  }, [onPlaidConnectionSuccess])
+
+  const handlePlaidConnectionSuccess = useCallback(async () => {
+    await Promise.all([
+      refetchAccountsAndTransactions(),
+      notifyPlaidConnectionSuccess(),
+    ])
+  }, [refetchAccountsAndTransactions, notifyPlaidConnectionSuccess])
+
   const { isLinking } = usePlaidLinkModal({
     linkToken,
     linkMode,
     setLinkMode,
     onSuccess: refetchAccountsAndTransactions,
+    onConnectionSuccess: handlePlaidConnectionSuccess,
   })
 
   const { isFailed: isHostedLinkError } = usePollPlaidHostedLinkStatus({
     enabled: plaidHostedLinkConfig != null,
-    onSuccess: refetchAccountsAndTransactions,
+    onSuccess: handlePlaidConnectionSuccess,
   })
 
   /**

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -82,23 +82,14 @@ export const useLinkedAccounts: UseLinkedAccounts = ({ onPlaidConnectionSuccess,
     ])
   }, [refetch, forceReloadBankTransactions])
 
-  const notifyPlaidConnectionSuccess = useCallback(async () => {
-    if (!onPlaidConnectionSuccess) return
-
-    try {
-      await onPlaidConnectionSuccess()
-    }
-    catch (error) {
-      console.error('onPlaidConnectionSuccess failed', error)
-    }
-  }, [onPlaidConnectionSuccess])
-
   const handlePlaidConnectionSuccess = useCallback(async () => {
     await Promise.all([
       refetchAccountsAndTransactions(),
-      notifyPlaidConnectionSuccess(),
+      Promise.resolve(onPlaidConnectionSuccess?.()).catch((error: unknown) => {
+        console.error('onPlaidConnectionSuccess failed', error)
+      }),
     ])
-  }, [refetchAccountsAndTransactions, notifyPlaidConnectionSuccess])
+  }, [refetchAccountsAndTransactions, onPlaidConnectionSuccess])
 
   const { isLinking } = usePlaidLinkModal({
     linkToken,

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -83,14 +83,8 @@ export const useLinkedAccounts: UseLinkedAccounts = ({ onPlaidConnectionSuccess,
   }, [refetch, forceReloadBankTransactions])
 
   const handlePlaidConnectionSuccess = useCallback(async () => {
-    try {
-      await refetchAccountsAndTransactions()
-    }
-    finally {
-      await Promise.resolve(onPlaidConnectionSuccess?.()).catch((error: unknown) => {
-        console.error('onPlaidConnectionSuccess failed', error)
-      })
-    }
+    await refetchAccountsAndTransactions().catch(() => undefined)
+    await onPlaidConnectionSuccess?.()
   }, [refetchAccountsAndTransactions, onPlaidConnectionSuccess])
 
   const { isLinking } = usePlaidLinkModal({

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -97,7 +97,7 @@ export const useLinkedAccounts: UseLinkedAccounts = ({ onPlaidConnectionSuccess,
 
   const { isFailed: isHostedLinkError } = usePollPlaidHostedLinkStatus({
     enabled: plaidHostedLinkConfig != null,
-    onSuccess: handlePlaidConnectionSuccess,
+    onSuccess: refetchAccountsAndTransactions,
   })
 
   /**

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -98,7 +98,7 @@ export const useLinkedAccounts: UseLinkedAccounts = ({ onPlaidConnectionSuccess,
     linkMode,
     setLinkMode,
     onSuccess: refetchAccountsAndTransactions,
-    onConnectionSuccess: handlePlaidConnectionSuccess,
+    onAddConnectionSuccess: handlePlaidConnectionSuccess,
   })
 
   const { isFailed: isHostedLinkError } = usePollPlaidHostedLinkStatus({

--- a/src/hooks/legacy/useLinkedAccounts.ts
+++ b/src/hooks/legacy/useLinkedAccounts.ts
@@ -83,12 +83,14 @@ export const useLinkedAccounts: UseLinkedAccounts = ({ onPlaidConnectionSuccess,
   }, [refetch, forceReloadBankTransactions])
 
   const handlePlaidConnectionSuccess = useCallback(async () => {
-    await Promise.all([
-      refetchAccountsAndTransactions(),
-      Promise.resolve(onPlaidConnectionSuccess?.()).catch((error: unknown) => {
+    try {
+      await refetchAccountsAndTransactions()
+    }
+    finally {
+      await Promise.resolve(onPlaidConnectionSuccess?.()).catch((error: unknown) => {
         console.error('onPlaidConnectionSuccess failed', error)
-      }),
-    ])
+      })
+    }
   }, [refetchAccountsAndTransactions, onPlaidConnectionSuccess])
 
   const { isLinking } = usePlaidLinkModal({

--- a/src/providers/LinkedAccountsProvider/LinkedAccountsProvider.tsx
+++ b/src/providers/LinkedAccountsProvider/LinkedAccountsProvider.tsx
@@ -1,15 +1,21 @@
 import { type PropsWithChildren } from 'react'
 
+import type { Awaitable } from '@internal-types/utility/promises'
 import { type PlaidHostedLinkConfig } from '@schemas/linkedAccounts/plaid'
 import { useLinkedAccounts } from '@hooks/legacy/useLinkedAccounts'
 import { LinkedAccountsContext } from '@contexts/LinkedAccountsContext/LinkedAccountsContext'
 
 type LinkedAccountsProviderProps = PropsWithChildren<{
+  onPlaidConnectionSuccess?: () => Awaitable<void>
   plaidHostedLinkConfig?: PlaidHostedLinkConfig
 }>
 
-export function LinkedAccountsProvider({ children, plaidHostedLinkConfig }: LinkedAccountsProviderProps) {
-  const linkedAccountsContextData = useLinkedAccounts({ plaidHostedLinkConfig })
+export function LinkedAccountsProvider({
+  children,
+  onPlaidConnectionSuccess,
+  plaidHostedLinkConfig,
+}: LinkedAccountsProviderProps) {
+  const linkedAccountsContextData = useLinkedAccounts({ onPlaidConnectionSuccess, plaidHostedLinkConfig })
 
   return (
     <LinkedAccountsContext.Provider value={linkedAccountsContextData}>


### PR DESCRIPTION
## Summary
- Add `onPlaidConnectionSuccess` to `LinkAccounts` so consumers can track successful Plaid add-link flows.
- Add `showDoneLinkingButton` to optionally hide the “I’m done linking my banks” button.

## Review
- Start with `LinkAccounts.tsx` for the new public props.
- Check `useLinkedAccounts.ts` for callback ordering and hosted-link success handling.
- Check `usePlaidLinkModal.ts` for the add-only `onAddConnectionSuccess` path.
- Check `LinkAccountsLinkStep.tsx` for the button visibility gate.

## Testing
- `npm run typecheck`
- focused ESLint on touched files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible API and UI toggles on the link-accounts flow; repair and hosted-link polling behavior is unchanged.
> 
> **Overview**
> **`LinkAccounts`** gains two optional props: **`onPlaidConnectionSuccess`** (runs after a successful **add** Plaid link once accounts/transactions are refetched) and **`showDoneLinkingButton`** (defaults to showing the wizard CTA).
> 
> The callback is threaded through **`LinkedAccountsProvider`** / **`useLinkedAccounts`** into **`usePlaidLinkModal`** via a new **`onAddConnectionSuccess`** hook so **repair/update** flows still use the existing **`onSuccess`** refresh only. **`LinkAccountsLinkStep`** gates the “I’m done linking my banks” button on **`showDoneLinkingButton`** when at least one account is listed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84e433b76005b3ca6051b69be8a20269db0f614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->