### PR TITLE
feat: add `showTitle` prop to `UnifiedReports`

### DIFF
--- a/src/components/ReportsNavigation/ReportsMobileSelectionDrawer.tsx
+++ b/src/components/ReportsNavigation/ReportsMobileSelectionDrawer.tsx
@@ -4,7 +4,10 @@ import { useTranslation } from 'react-i18next'
 import { useReportConfig } from '@hooks/api/businesses/[business-id]/reports/config/useReportConfig'
 import { useBaseUnifiedReport } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { MobileSelectionDrawerWithTrigger } from '@ui/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger'
+import { HStack } from '@ui/Stack/Stack'
 import { ReportComboBoxOption } from '@components/ReportsNavigation/reportComboBoxOption'
+
+import './reportsMobileSelectionDrawer.scss'
 
 export function ReportsMobileSelectionDrawer() {
   const { t } = useTranslation()
@@ -36,16 +39,18 @@ export function ReportsMobileSelectionDrawer() {
   }, [setBaseReport])
 
   return (
-    <MobileSelectionDrawerWithTrigger<ReportComboBoxOption>
-      ariaLabel={t('reports:label.reports_navigation', 'Reports navigation')}
-      heading={t('reports:label.select_report', 'Select report')}
-      groups={groups}
-      selectedValue={selectedValue}
-      onSelectedValueChange={onSelectedValueChange}
-      isLoading={isLoading}
-      isError={isError}
-      isSearchable
-      searchPlaceholder={t('reports:action.search_reports', 'Search reports')}
-    />
+    <HStack className='Layer__ReportsMobileSelectionDrawer'>
+      <MobileSelectionDrawerWithTrigger<ReportComboBoxOption>
+        ariaLabel={t('reports:label.reports_navigation', 'Reports navigation')}
+        heading={t('reports:label.select_report', 'Select report')}
+        groups={groups}
+        selectedValue={selectedValue}
+        onSelectedValueChange={onSelectedValueChange}
+        isLoading={isLoading}
+        isError={isError}
+        isSearchable
+        searchPlaceholder={t('reports:action.search_reports', 'Search reports')}
+      />
+    </HStack>
   )
 }

--- a/src/components/ReportsNavigation/reportsMobileSelectionDrawer.scss
+++ b/src/components/ReportsNavigation/reportsMobileSelectionDrawer.scss
@@ -1,0 +1,4 @@
+.Layer__ReportsMobileSelectionDrawer {
+  inline-size: 100%;
+  max-inline-size: 16rem;
+}

--- a/src/components/UnifiedReports/UnifiedReportControls.tsx
+++ b/src/components/UnifiedReports/UnifiedReportControls.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 
 import { ReportControl } from '@schemas/reports/reportConfig'
 import { useElementSize } from '@hooks/utils/size/useElementSize'
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import {
   hasControl,
   useBaseUnifiedReport,
@@ -14,6 +15,7 @@ import { CombinedDateRangeSelection } from '@components/DateSelection/CombinedDa
 import { CombinedDateSelection } from '@components/DateSelection/CombinedDateSelection'
 import { DateGroupByComboBox } from '@components/DateSelection/DateGroupByComboBox'
 import { GlobalYearPicker } from '@components/GlobalYearPicker/GlobalYearPicker'
+import { UnifiedReportHeaderButtons } from '@components/UnifiedReports/UnifiedReportHeaderButtons'
 import { UnifiedReportReportingBasisControl } from '@components/UnifiedReports/UnifiedReportReportingBasisControl'
 import { UnifiedReportTagControl } from '@components/UnifiedReports/UnifiedReportTagControl'
 
@@ -43,6 +45,7 @@ export const UnifiedReportControls = () => {
   const { groupBy, setGroupBy } = useUnifiedReportGroupByParam()
   const { reportingBasis, setReportingBasis } = useUnifiedReportReportingBasisParam()
   const dateSelectionMode = useUnifiedReportDateSelectionMode()
+  const { isDesktop } = useSizeClass()
   const [size, setSize] = useState(3)
 
   const containerRef = useElementSize<HTMLDivElement>((size) => {
@@ -58,6 +61,17 @@ export const UnifiedReportControls = () => {
 
   return (
     <VStack ref={containerRef} className='Layer__UnifiedReports__ControlsContainer'>
+      {!isDesktop && (
+        <Stack
+          direction='row'
+          pi='lg'
+          pbs='lg'
+          gap='xs'
+          className='Layer__UnifiedReports__ControlsActions'
+        >
+          <UnifiedReportHeaderButtons variant='Mobile' />
+        </Stack>
+      )}
       <Stack
         direction='row'
         pb='md'

--- a/src/components/UnifiedReports/UnifiedReportControls.tsx
+++ b/src/components/UnifiedReports/UnifiedReportControls.tsx
@@ -10,7 +10,7 @@ import {
   useUnifiedReportGroupByParam,
   useUnifiedReportReportingBasisParam,
 } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
-import { Stack, VStack } from '@ui/Stack/Stack'
+import { HStack, VStack } from '@ui/Stack/Stack'
 import { CombinedDateRangeSelection } from '@components/DateSelection/CombinedDateRangeSelection'
 import { CombinedDateSelection } from '@components/DateSelection/CombinedDateSelection'
 import { DateGroupByComboBox } from '@components/DateSelection/DateGroupByComboBox'
@@ -62,18 +62,16 @@ export const UnifiedReportControls = () => {
   return (
     <VStack ref={containerRef} className='Layer__UnifiedReports__ControlsContainer'>
       {!isDesktop && (
-        <Stack
-          direction='row'
+        <HStack
           pi='lg'
           pbs='lg'
           gap='xs'
           className='Layer__UnifiedReports__ControlsActions'
         >
           <UnifiedReportHeaderButtons variant='Mobile' />
-        </Stack>
+        </HStack>
       )}
-      <Stack
-        direction='row'
+      <HStack
         pb='md'
         pi='lg'
         gap='xs'
@@ -93,7 +91,7 @@ export const UnifiedReportControls = () => {
             )}
           </div>
         )}
-      </Stack>
+      </HStack>
     </VStack>
   )
 }

--- a/src/components/UnifiedReports/UnifiedReportDetailHeader.tsx
+++ b/src/components/UnifiedReports/UnifiedReportDetailHeader.tsx
@@ -1,24 +1,36 @@
+import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { useDetailUnifiedReport } from '@providers/UnifiedReportStore/UnifiedReportStoreProvider'
 import { BackButton } from '@ui/Button/BackButton'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { UnifiedReportDetailBreadcrumb } from '@components/UnifiedReports/UnifiedReportDetailBreadcrumb'
+import { UnifiedReportDownloadButton } from '@components/UnifiedReports/UnifiedReportDownloadButton'
 
 import './unifiedReportDetailHeader.scss'
 
 export const UnifiedReportDetailHeader = () => {
   const { detailReportConfig, closeDetailReport } = useDetailUnifiedReport()
+  const { isDesktop } = useSizeClass()
 
   if (!detailReportConfig) return null
   const { column } = detailReportConfig
 
   return (
-    <HStack gap='sm' pb='lg' pis='lg' align='center' className='Layer__UnifiedReports__DetailHeader'>
-      <BackButton onPress={closeDetailReport} />
-      <VStack gap='3xs'>
-        <UnifiedReportDetailBreadcrumb />
-        <Span size='sm' variant='subtle'>{column.displayName}</Span>
-      </VStack>
+    <HStack
+      pb='lg'
+      pi='lg'
+      align='center'
+      justify='space-between'
+      className='Layer__UnifiedReports__DetailHeader'
+    >
+      <HStack gap='sm' align='center'>
+        <BackButton onPress={closeDetailReport} />
+        <VStack gap='3xs'>
+          <UnifiedReportDetailBreadcrumb />
+          <Span size='sm' variant='subtle'>{column.displayName}</Span>
+        </VStack>
+      </HStack>
+      <UnifiedReportDownloadButton icon={!isDesktop} />
     </HStack>
   )
 }

--- a/src/components/UnifiedReports/UnifiedReportHeaderButtons.tsx
+++ b/src/components/UnifiedReports/UnifiedReportHeaderButtons.tsx
@@ -21,13 +21,16 @@ export const UnifiedReportHeaderButtons = ({ variant }: UnifiedReportHeaderButto
   return (
     <HStack
       gap='xs'
+      justify={isMobile ? 'space-between' : 'end'}
       className={classNames('Layer__UnifiedReports__HeaderButtons', {
         'Layer__UnifiedReports__HeaderButtons--mobile': isMobile,
       })}
     >
       {isMobile && <ReportsMobileSelectionDrawer />}
-      <ExpandableDataTableToggleButton icon={isMobile} />
-      <UnifiedReportDownloadButton icon={isMobile} />
+      <HStack gap='xs'>
+        <ExpandableDataTableToggleButton icon={isMobile} />
+        <UnifiedReportDownloadButton icon={isMobile} />
+      </HStack>
     </HStack>
   )
 }

--- a/src/components/UnifiedReports/UnifiedReports.tsx
+++ b/src/components/UnifiedReports/UnifiedReports.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
@@ -7,7 +6,6 @@ import { UnifiedReportStoreProvider } from '@providers/UnifiedReportStore/Unifie
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { ExpandableDataTableProvider } from '@components/ExpandableDataTable/ExpandableDataTableProvider'
 import { ReportsNavigationSidebar } from '@components/ReportsNavigation/ReportsNavigationSidebar'
-import { UnifiedReportHeaderButtons } from '@components/UnifiedReports/UnifiedReportHeaderButtons'
 import { UnifiedReportTable } from '@components/UnifiedReports/UnifiedReportTable'
 import { UnifiedReportTableHeader } from '@components/UnifiedReports/UnifiedReportTableHeader'
 import { View } from '@components/View/View'
@@ -19,20 +17,18 @@ export type UnifiedReportNavigationVariant = 'sidebar' | 'menu'
 type UnifiedReportProps = {
   dateSelectionMode?: DateSelectionMode
   navigationVariant?: UnifiedReportNavigationVariant
+  showTitle?: boolean
 }
 
-const UnifiedReportContent = ({ navigationVariant = 'sidebar' }: Pick<UnifiedReportProps, 'navigationVariant'>) => {
+const UnifiedReportContent = ({
+  navigationVariant = 'sidebar',
+  showTitle = true,
+}: Pick<UnifiedReportProps, 'navigationVariant' | 'showTitle'>) => {
   const { t } = useTranslation()
   const { isDesktop } = useSizeClass()
 
-  const header = useMemo(() => {
-    if (isDesktop) return null
-
-    return <UnifiedReportHeaderButtons />
-  }, [isDesktop])
-
   return (
-    <View title={t('reports:label.reports', 'Reports')} viewClassName='Layer__UnifiedReports' header={header}>
+    <View title={t('reports:label.reports', 'Reports')} showHeader={showTitle} viewClassName='Layer__UnifiedReports'>
       <HStack className='Layer__UnifiedReports__Body'>
         {isDesktop && navigationVariant === 'sidebar' && (
           <VStack className='Layer__UnifiedReports__Sidebar'>
@@ -48,11 +44,11 @@ const UnifiedReportContent = ({ navigationVariant = 'sidebar' }: Pick<UnifiedRep
   )
 }
 
-export const UnifiedReports = ({ dateSelectionMode, navigationVariant }: UnifiedReportProps) => {
+export const UnifiedReports = ({ dateSelectionMode, navigationVariant, showTitle = true }: UnifiedReportProps) => {
   return (
     <UnifiedReportStoreProvider dateSelectionMode={dateSelectionMode}>
       <ExpandableDataTableProvider>
-        <UnifiedReportContent navigationVariant={navigationVariant} />
+        <UnifiedReportContent navigationVariant={navigationVariant} showTitle={showTitle} />
       </ExpandableDataTableProvider>
     </UnifiedReportStoreProvider>
   )

--- a/src/components/UnifiedReports/unifiedReportHeaderButtons.scss
+++ b/src/components/UnifiedReports/unifiedReportHeaderButtons.scss
@@ -1,13 +1,12 @@
 .Layer__UnifiedReports__HeaderButtons {
-  justify-content: flex-end;
   min-width: 15rem;
   max-width: 24rem;
+}
 
-  &--mobile {
-    width: 100%;
-    min-width: 0;
-    max-width: none;
-  }
+.Layer__UnifiedReports__HeaderButtons--mobile {
+  width: 100%;
+  min-width: 0;
+  max-width: none;
 }
 
 @container unified-reports (max-width: 500px) {


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and prop wiring for reports; no auth, data, or API changes.
> 
> **Overview**
> Adds a **`showTitle`** prop (default `true`) on `UnifiedReports` so embedders can hide the outer **Reports** page header via `View`’s `showHeader`, instead of putting mobile actions in that header slot.
> 
> **Mobile chrome** is reorganized: report picker, expand, and download move from the `View` header into **`UnifiedReportControls`** (non-desktop only). **`UnifiedReportHeaderButtons`** uses `space-between` on mobile (picker vs. action group) with SCSS tweaks; the mobile report drawer gets a **16rem max width** wrapper.
> 
> **Detail view**: **`UnifiedReportDetailHeader`** lays out back/breadcrumb on the left and **`UnifiedReportDownloadButton`** on the right (icon-only when not desktop).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 973c7f1a6ee0f04a3bc4ee8f9a4bb96abd178738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->