### PR TITLE
fix: connect bank button stretching full width in VStack

### DIFF
--- a/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
+++ b/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
@@ -42,7 +42,7 @@ export function LinkAccountsLinkStep() {
         Empty={(
           <ElevatedLoadingSpinnerContainer>
             {isLinking && <ElevatedLoadingSpinner />}
-            <VStack gap='xl' pbe='md'>
+            <VStack gap='xl' pbe='md' align='start'>
               <P status='disabled'>
                 {t('linkedAccounts:label.connect_bank_accounts_and_credit_cards', 'Connect your bank accounts and credit cards to automatically import your business transactions.')}
               </P>


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single layout prop on an empty-state container; no logic, auth, or data changes.
> 
> **Overview**
> Fixes the **Connect my bank** button stretching to full width when the linked-accounts wizard shows the empty state (no accounts yet).
> 
> Adds `align='start'` to the empty-state `VStack` in `LinkAccountsLinkStep` so flex children align to the start of the cross axis instead of stretching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92c38e7c1e26de70658a786b9d214d00f3f13e21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->