### PR TITLE
fix: checkbox not center aligned in invoices form `isTaxable` field

### DIFF
--- a/src/components/ui/Checkbox/Checkbox.tsx
+++ b/src/components/ui/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { forwardRef, useMemo, type ComponentRef } from 'react'
 import classNames from 'classnames'
 import { Check, Minus } from 'lucide-react'
 import {
@@ -33,7 +33,7 @@ type CheckboxWithTooltipProps = CheckboxProps & {
   tooltip?: string
 }
 
-export function Checkbox({ children, className, variant = 'default', size = 'sm', isIndeterminate, ...props }: CheckboxProps) {
+export const Checkbox = forwardRef<ComponentRef<typeof ReactAriaCheckbox>, CheckboxProps>(function Checkbox({ children, className, variant = 'default', size = 'sm', isIndeterminate, ...props }, ref) {
   const dataProperties = useMemo(() => toDataProperties({
     size,
     variant,
@@ -44,6 +44,7 @@ export function Checkbox({ children, className, variant = 'default', size = 'sm'
     <ReactAriaCheckbox
       {...dataProperties}
       {...props}
+      ref={ref}
       isIndeterminate={isIndeterminate}
       className={classNames(CLASS_NAME, className)}
     >
@@ -59,7 +60,7 @@ export function Checkbox({ children, className, variant = 'default', size = 'sm'
       ))}
     </ReactAriaCheckbox>
   )
-}
+})
 
 export function CheckboxWithTooltip({ tooltip, ...props }: CheckboxWithTooltipProps) {
   return (

--- a/src/components/ui/Checkbox/Checkbox.tsx
+++ b/src/components/ui/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo, type ComponentRef } from 'react'
+import { type ComponentRef, forwardRef, useMemo } from 'react'
 import classNames from 'classnames'
 import { Check, Minus } from 'lucide-react'
 import {

--- a/src/components/ui/Checkbox/Checkbox.tsx
+++ b/src/components/ui/Checkbox/Checkbox.tsx
@@ -63,13 +63,11 @@ export function Checkbox({ children, className, variant = 'default', size = 'sm'
 
 export function CheckboxWithTooltip({ tooltip, ...props }: CheckboxWithTooltipProps) {
   return (
-    <div className='Layer__checkbox-wrapper'>
-      <Tooltip isDisabled={!tooltip}>
-        <TooltipTrigger variant='fit-content'>
-          <Checkbox {...props} />
-        </TooltipTrigger>
-        <TooltipContent>{tooltip}</TooltipContent>
-      </Tooltip>
-    </div>
+    <Tooltip isDisabled={!tooltip}>
+      <TooltipTrigger variant='fit-content' asChild>
+        <Checkbox {...props} />
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
   )
 }


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI composition change in Checkbox/CheckboxWithTooltip with no auth, data, or API impact.
> 
> **Overview**
> Fixes misaligned checkboxes (e.g. invoices form `isTaxable`) by changing how tooltipped checkboxes are composed in the DOM.
> 
> **`Checkbox`** is now a `forwardRef` component that passes `ref` through to `ReactAriaCheckbox`, so parent/tooltip code can attach a ref to the real control.
> 
> **`CheckboxWithTooltip`** drops the extra `Layer__checkbox-wrapper` div and uses `TooltipTrigger` with `asChild`, so the checkbox is the tooltip reference element instead of being wrapped in an extra block-level container that broke vertical alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e5ce05b038ef993d5ca3018db6da703746e33b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->