### PR TITLE
feat: add LinkAccounts story with mocked Plaid link and confirm flow

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,4 @@
 import { join } from 'node:path'
-
 import { type StorybookConfig } from '@storybook/react-vite'
 
 const config: StorybookConfig = {

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,8 +13,7 @@ const config: StorybookConfig = {
       tsconfigPaths: true,
       alias: {
         ...viteConfig.resolve?.alias,
-        // Plaid's hosted iframe can't run in Storybook; swap the SDK for a mock
-        // that fakes a successful link so the connect flow is demoable end-to-end.
+        // Plaid's hosted iframe can't run in Storybook; the mock fakes a successful link.
         'react-plaid-link': join(process.cwd(), '.storybook/mocks/react-plaid-link.ts'),
       },
     },

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,17 @@
 import { join } from 'node:path'
 import { type StorybookConfig } from '@storybook/react-vite'
+import { type Alias, type AliasOptions } from 'vite'
+
+// Plaid's hosted iframe can't run in Storybook; the mock fakes a successful link.
+const PLAID_LINK_ALIAS = {
+  find: 'react-plaid-link',
+  replacement: join(process.cwd(), '.storybook/mocks/react-plaid-link.ts'),
+}
+
+const withPlaidLinkAlias = (alias: AliasOptions | undefined): AliasOptions =>
+  Array.isArray(alias)
+    ? [...(alias as readonly Alias[]), PLAID_LINK_ALIAS]
+    : { ...alias, [PLAID_LINK_ALIAS.find]: PLAID_LINK_ALIAS.replacement }
 
 const config: StorybookConfig = {
   framework: '@storybook/react-vite',
@@ -10,11 +22,7 @@ const config: StorybookConfig = {
     resolve: {
       ...viteConfig.resolve,
       tsconfigPaths: true,
-      alias: {
-        ...viteConfig.resolve?.alias,
-        // Plaid's hosted iframe can't run in Storybook; the mock fakes a successful link.
-        'react-plaid-link': join(process.cwd(), '.storybook/mocks/react-plaid-link.ts'),
-      },
+      alias: withPlaidLinkAlias(viteConfig.resolve?.alias),
     },
   }),
 }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path'
+
 import { type StorybookConfig } from '@storybook/react-vite'
 
 const config: StorybookConfig = {
@@ -9,6 +11,12 @@ const config: StorybookConfig = {
     resolve: {
       ...viteConfig.resolve,
       tsconfigPaths: true,
+      alias: {
+        ...viteConfig.resolve?.alias,
+        // Plaid's hosted iframe can't run in Storybook; swap the SDK for a mock
+        // that fakes a successful link so the connect flow is demoable end-to-end.
+        'react-plaid-link': join(process.cwd(), '.storybook/mocks/react-plaid-link.ts'),
+      },
     },
   }),
 }

--- a/.storybook/mocks/react-plaid-link.ts
+++ b/.storybook/mocks/react-plaid-link.ts
@@ -1,12 +1,5 @@
 import { useCallback, useMemo, useRef } from 'react'
 
-/**
- * Storybook stand-in for `react-plaid-link` (aliased via `.storybook/main.ts`);
- * `open()` fakes a successful link. Like the real SDK, `open` is stable per
- * token (a per-render identity would loop the open effect) but changes with the
- * token (which is what opens the next session).
- */
-
 type MockPlaidLinkConfig = {
   token?: string | null
   onSuccess?: (publicToken: string, metadata: unknown) => void

--- a/.storybook/mocks/react-plaid-link.ts
+++ b/.storybook/mocks/react-plaid-link.ts
@@ -1,14 +1,10 @@
 import { useCallback, useMemo, useRef } from 'react'
 
 /**
- * Storybook stand-in for `react-plaid-link` (aliased via `.storybook/main.ts`):
- * Plaid's hosted iframe can't run here, so `open()` fakes a successful link by
- * invoking `onSuccess` after a short delay.
- *
- * Like the real SDK, `open` keeps a stable identity per token - a new identity
- * each render would loop `usePlaidLinkModal`'s open effect, while it must change
- * with the token to open the next session ("Link another bank"). Callbacks are
- * read through a ref so `open` only tracks the token without going stale.
+ * Storybook stand-in for `react-plaid-link` (aliased via `.storybook/main.ts`);
+ * `open()` fakes a successful link. Like the real SDK, `open` is stable per
+ * token (a per-render identity would loop the open effect) but changes with the
+ * token (which is what opens the next session).
  */
 
 type MockPlaidLinkConfig = {

--- a/.storybook/mocks/react-plaid-link.ts
+++ b/.storybook/mocks/react-plaid-link.ts
@@ -1,0 +1,49 @@
+import { useCallback, useMemo, useRef } from 'react'
+
+/**
+ * Storybook stand-in for `react-plaid-link` (aliased via `.storybook/main.ts`):
+ * Plaid's hosted iframe can't run here, so `open()` fakes a successful link by
+ * invoking `onSuccess` after a short delay.
+ *
+ * Like the real SDK, `open` keeps a stable identity per token - a new identity
+ * each render would loop `usePlaidLinkModal`'s open effect, while it must change
+ * with the token to open the next session ("Link another bank"). Callbacks are
+ * read through a ref so `open` only tracks the token without going stale.
+ */
+
+type MockPlaidLinkConfig = {
+  token?: string | null
+  onSuccess?: (publicToken: string, metadata: unknown) => void
+  onExit?: (error: unknown, metadata: unknown) => void
+}
+
+const MOCK_SUCCESS_METADATA = {
+  institution: { name: 'Mock Bank', institution_id: 'ins_mock' },
+  accounts: [],
+  link_session_id: 'mock-link-session',
+  transfer_status: null,
+  public_token: 'public-sandbox-mock-token',
+}
+
+const FAKE_LINK_DELAY_MS = 800
+
+export function usePlaidLink(config: MockPlaidLinkConfig) {
+  const configRef = useRef(config)
+  configRef.current = config
+
+  const token = config.token ?? null
+  const ready = token != null
+
+  const open = useCallback(() => {
+    if (token == null) return
+    window.setTimeout(() => {
+      configRef.current.onSuccess?.('public-sandbox-mock-token', MOCK_SUCCESS_METADATA)
+    }, FAKE_LINK_DELAY_MS)
+  }, [token])
+
+  const exit = useCallback(() => {
+    configRef.current.onExit?.(null, MOCK_SUCCESS_METADATA)
+  }, [])
+
+  return useMemo(() => ({ open, ready, exit, error: null }), [open, ready, exit])
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,7 @@ export default tsEslint.config(
         projectService: {
           allowDefaultProject: [
             '.storybook/main.ts',
+            '.storybook/mocks/react-plaid-link.ts',
             '.storybook/preview.tsx',
             'eslint.config.mjs',
             'i18next.config.ts',

--- a/src/components/LinkAccounts/LinkAccounts.stories.tsx
+++ b/src/components/LinkAccounts/LinkAccounts.stories.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useState } from 'react'
+import { type Meta, type StoryObj } from '@storybook/react-vite'
+
+import { useBankAccountsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
+import { LinkAccounts } from '@components/LinkAccounts/LinkAccounts'
+
+import { bankAccountStore } from '@msw/api/businesses/[business-id]/bank-accounts/store'
+
+// The store's default seed is already-linked accounts; this flow links new ones.
+const clearBankAccounts = () => {
+  bankAccountStore.all().forEach(({ id }) => bankAccountStore.deleteById(id))
+}
+
+// Completing the wizard empties the store and remounts the component (via key),
+// so the flow restarts from the "Connect my bank" step and can be run repeatedly.
+// The SWR cache is overwritten too: the remount's revalidation is deduped away
+// (the confirm step refetched moments earlier), so the cleared store alone would
+// leave the just-confirmed accounts on screen.
+function RestartingLinkAccounts() {
+  const [iteration, setIteration] = useState(0)
+  const { overwriteCache } = useBankAccountsGlobalCacheActions()
+
+  const handleComplete = useCallback(() => {
+    clearBankAccounts()
+    void overwriteCache([], { withRevalidate: false })
+    setIteration(previous => previous + 1)
+  }, [overwriteCache])
+
+  return <LinkAccounts key={iteration} onComplete={handleComplete} />
+}
+
+const meta = {
+  title: 'Components/LinkAccounts',
+  component: LinkAccounts,
+  render: () => <RestartingLinkAccounts />,
+  argTypes: {
+    onComplete: { table: { disable: true } },
+    plaidHostedLinkConfig: { table: { disable: true } },
+  },
+  // Mirrors how a host app mounts LinkAccounts: a padded page with a max-width card.
+  decorators: [
+    Story => (
+      <div
+        className='LinkAccountsPage'
+        style={{ display: 'grid', paddingBlockStart: '2rem', paddingBlockEnd: '4rem', paddingInline: '3rem' }}
+      >
+        <div
+          className='LinkAccountsContainer'
+          style={{
+            display: 'grid',
+            minInlineSize: '40rem',
+            maxInlineSize: '80rem',
+            padding: '1rem',
+            borderRadius: '1rem',
+            border: '1px solid rgb(0 0 0 / 10%)',
+          }}
+        >
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof LinkAccounts>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/**
+ * Full flow: "Connect my bank" runs the fake Plaid link (SDK mocked via
+ * `.storybook/mocks/react-plaid-link.ts`), then the found accounts move into
+ * the confirm/exclude step. Completing the wizard restarts the flow.
+ */
+export const Default: Story = {
+  loaders: [clearBankAccounts],
+}

--- a/src/components/LinkAccounts/LinkAccounts.stories.tsx
+++ b/src/components/LinkAccounts/LinkAccounts.stories.tsx
@@ -6,16 +6,13 @@ import { LinkAccounts } from '@components/LinkAccounts/LinkAccounts'
 
 import { bankAccountStore } from '@msw/api/businesses/[business-id]/bank-accounts/store'
 
-// The store's default seed is already-linked accounts; this flow links new ones.
 const clearBankAccounts = () => {
   bankAccountStore.all().forEach(({ id }) => bankAccountStore.deleteById(id))
 }
 
-// Completing the wizard empties the store and remounts the component (via key),
-// so the flow restarts from the "Connect my bank" step and can be run repeatedly.
-// The SWR cache is overwritten too: the remount's revalidation is deduped away
-// (the confirm step refetched moments earlier), so the cleared store alone would
-// leave the just-confirmed accounts on screen.
+// Completing the wizard resets everything and remounts, restarting the flow.
+// The SWR cache must be wiped too: the remount's revalidation is deduped away
+// after the confirm step's own refetch.
 function RestartingLinkAccounts() {
   const [iteration, setIteration] = useState(0)
   const { overwriteCache } = useBankAccountsGlobalCacheActions()
@@ -66,11 +63,6 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-/**
- * Full flow: "Connect my bank" runs the fake Plaid link (SDK mocked via
- * `.storybook/mocks/react-plaid-link.ts`), then the found accounts move into
- * the confirm/exclude step. Completing the wizard restarts the flow.
- */
 export const Default: Story = {
   loaders: [clearBankAccounts],
 }

--- a/src/components/LinkAccounts/LinkAccounts.stories.tsx
+++ b/src/components/LinkAccounts/LinkAccounts.stories.tsx
@@ -10,9 +10,6 @@ const clearBankAccounts = () => {
   bankAccountStore.all().forEach(({ id }) => bankAccountStore.deleteById(id))
 }
 
-// Completing the wizard resets everything and remounts, restarting the flow.
-// The SWR cache must be wiped too: the remount's revalidation is deduped away
-// after the confirm step's own refetch.
 function RestartingLinkAccounts() {
   const [iteration, setIteration] = useState(0)
   const { overwriteCache } = useBankAccountsGlobalCacheActions()
@@ -39,7 +36,7 @@ const meta = {
     Story => (
       <div
         className='LinkAccountsPage'
-        style={{ display: 'grid', paddingBlockStart: '2rem', paddingBlockEnd: '4rem', paddingInline: '3rem' }}
+        style={{ display: 'grid', paddingBlock: '2rem', paddingInline: '3rem' }}
       >
         <div
           className='LinkAccountsContainer'

--- a/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
+++ b/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
@@ -37,11 +37,11 @@ export function LinkAccountsLinkStep() {
 
   return (
     <>
-      <ConditionalList
-        list={effectiveAccounts}
-        Empty={(
-          <ElevatedLoadingSpinnerContainer>
-            {isLinking && <ElevatedLoadingSpinner />}
+      <ElevatedLoadingSpinnerContainer>
+        {isLinking && <ElevatedLoadingSpinner />}
+        <ConditionalList
+          list={effectiveAccounts}
+          Empty={(
             <VStack gap='xl' pbe='md' align='start'>
               <P status='disabled'>
                 {t('linkedAccounts:label.connect_bank_accounts_and_credit_cards', 'Connect your bank accounts and credit cards to automatically import your business transactions.')}
@@ -56,11 +56,8 @@ export function LinkAccountsLinkStep() {
                 </Button>
               </LinkAccountDemoTooltip>
             </VStack>
-          </ElevatedLoadingSpinnerContainer>
-        )}
-        Container={({ children }) => (
-          <ElevatedLoadingSpinnerContainer>
-            {isLinking && <ElevatedLoadingSpinner />}
+          )}
+          Container={({ children }) => (
             <VStack>
               <VStack gap='2xs' pbe='md'>
                 <Heading level={3} size='sm'>
@@ -96,31 +93,31 @@ export function LinkAccountsLinkStep() {
                 />
               </VStack>
             </VStack>
-          </ElevatedLoadingSpinnerContainer>
-        )}
-        isError={isError}
-        Error={(
-          <DataState
-            status={DataStateStatus.failed}
-            title={t('linkedAccounts:error.load_accounts', 'Failed to load accounts')}
-            description={t('common:error.please_try_again_later', 'Please try again later')}
-            onRefresh={() => { void refetch() }}
-          />
-        )}
-        isLoading={loadingStatus === 'loading' || loadingStatus === 'initial'}
-        Loading={<Loader />}
-      >
-        {({ item: bankAccount }) => (
-          <BasicLinkedAccountContainer key={bankAccount.id} isSelected>
-            <BasicLinkedAccountContent account={{
-              externalAccountName: getBankAccountDisplayName(bankAccount),
-              mask: bankAccount.mask,
-              institution: getBankAccountInstitution(bankAccount),
-            }}
+          )}
+          isError={isError}
+          Error={(
+            <DataState
+              status={DataStateStatus.failed}
+              title={t('linkedAccounts:error.load_accounts', 'Failed to load accounts')}
+              description={t('common:error.please_try_again_later', 'Please try again later')}
+              onRefresh={() => { void refetch() }}
             />
-          </BasicLinkedAccountContainer>
-        )}
-      </ConditionalList>
+          )}
+          isLoading={loadingStatus === 'loading' || loadingStatus === 'initial'}
+          Loading={<Loader />}
+        >
+          {({ item: bankAccount }) => (
+            <BasicLinkedAccountContainer key={bankAccount.id} isSelected>
+              <BasicLinkedAccountContent account={{
+                externalAccountName: getBankAccountDisplayName(bankAccount),
+                mask: bankAccount.mask,
+                institution: getBankAccountInstitution(bankAccount),
+              }}
+              />
+            </BasicLinkedAccountContainer>
+          )}
+        </ConditionalList>
+      </ElevatedLoadingSpinnerContainer>
       {effectiveAccounts.length > 0
         ? (
           <>

--- a/src/fixtures/bankAccounts/arbitrary.ts
+++ b/src/fixtures/bankAccounts/arbitrary.ts
@@ -15,11 +15,8 @@ export const accountNameKindArbitrary = (fc: typeof FastCheck) =>
 export const balanceTimestampArbitrary = (fc: typeof FastCheck) =>
   amountArbitrary(fc).map(balance => ({ balance }))
 
-/**
- * Exactly one connection per account: the account's display details are
- * mirrored onto every connection, so surfaces that render a row per connection
- * (e.g. the link-accounts confirmation step) would show duplicates otherwise.
- */
+// Exactly one connection per account - the same display details are mirrored
+// onto every connection, so per-connection surfaces would show duplicate rows.
 export const externalAccountsArbitrary = (fc: typeof FastCheck) =>
   fc.array(Arbitrary.make(externalAccountConnectionSchema), { minLength: 1, maxLength: 1 })
 

--- a/src/fixtures/bankAccounts/arbitrary.ts
+++ b/src/fixtures/bankAccounts/arbitrary.ts
@@ -15,8 +15,13 @@ export const accountNameKindArbitrary = (fc: typeof FastCheck) =>
 export const balanceTimestampArbitrary = (fc: typeof FastCheck) =>
   amountArbitrary(fc).map(balance => ({ balance }))
 
+/**
+ * Exactly one connection per account: the account's display details are
+ * mirrored onto every connection, so surfaces that render a row per connection
+ * (e.g. the link-accounts confirmation step) would show duplicates otherwise.
+ */
 export const externalAccountsArbitrary = (fc: typeof FastCheck) =>
-  fc.array(Arbitrary.make(externalAccountConnectionSchema), { minLength: 1, maxLength: 2 })
+  fc.array(Arbitrary.make(externalAccountConnectionSchema), { minLength: 1, maxLength: 1 })
 
 export const isDisconnectedArbitrary = (fc: typeof FastCheck) =>
   fc.oneof(

--- a/src/fixtures/bankAccounts/generator.ts
+++ b/src/fixtures/bankAccounts/generator.ts
@@ -1,3 +1,4 @@
+import { markAccountNeedingConfirmation } from '@fixtures/bankAccounts/mocks'
 import { schema } from '@fixtures/bankAccounts/schema'
 import { createGenerator } from '@fixtures/utils/createGenerator'
 
@@ -6,3 +7,11 @@ const generate = createGenerator(schema, {
 })
 
 export const generator = () => generate({ numRuns: 5 })
+
+/**
+ * Randomly generates bank accounts flagged as needing confirmation - what a
+ * fake Plaid link session "finds". Same seed, same accounts; vary the seed to
+ * produce fresh banks per link session.
+ */
+export const generateAccountsNeedingConfirmation = (count: number, seed: number) =>
+  generate({ numRuns: count, seed }).map(markAccountNeedingConfirmation)

--- a/src/fixtures/bankAccounts/generator.ts
+++ b/src/fixtures/bankAccounts/generator.ts
@@ -8,10 +8,5 @@ const generate = createGenerator(schema, {
 
 export const generator = () => generate({ numRuns: 5 })
 
-/**
- * Randomly generates bank accounts flagged as needing confirmation - what a
- * fake Plaid link session "finds". Same seed, same accounts; vary the seed to
- * produce fresh banks per link session.
- */
 export const generateAccountsNeedingConfirmation = (count: number, seed: number) =>
   generate({ numRuns: count, seed }).map(markAccountNeedingConfirmation)

--- a/src/fixtures/bankAccounts/mocks.ts
+++ b/src/fixtures/bankAccounts/mocks.ts
@@ -1,4 +1,5 @@
 import { type BankAccount } from '@schemas/bankAccounts/bankAccount'
+import { type ExternalAccountConnection } from '@schemas/bankAccounts/externalAccountConnection'
 
 import { createFixtureFactory } from '@fixtures/utils/createFixtureFactory'
 
@@ -39,3 +40,84 @@ const baseBankAccount: BankAccount = {
 
 export const { make: makeBankAccount, makeMany: makeBankAccounts } =
   createFixtureFactory(baseBankAccount)
+
+type MirroredBankAccountOptions = {
+  id: string
+  externalAccountId: string
+  name: string
+  institution: string
+  mask: string
+  balance: number
+  externalAccountOverrides?: Partial<ExternalAccountConnection>
+}
+
+/**
+ * A bank account whose display details (name, institution, mask) are mirrored
+ * into its single external connection - the usual shape for a freshly linked
+ * Plaid account, where the connection is the source of those details.
+ */
+export function makeBankAccountWithMirroredExternalAccount({
+  id,
+  externalAccountId,
+  name,
+  institution,
+  mask,
+  balance,
+  externalAccountOverrides,
+}: MirroredBankAccountOptions): BankAccount {
+  const mirroredInstitution = { name: institution, logo: null }
+
+  return makeBankAccount({
+    id,
+    accountName: name,
+    institution: mirroredInstitution,
+    notifyWhenDisconnected: false,
+    mask,
+    latestBalanceTimestamp: { balance },
+    currentLedgerBalance: balance,
+    externalAccounts: [
+      {
+        id: externalAccountId,
+        externalAccountSource: 'PLAID',
+        externalAccountName: name,
+        mask,
+        institution: mirroredInstitution,
+        notifications: [],
+        connectionNeedsRepairAsOf: null,
+        reconnectWithNewCredentials: false,
+        connectionExternalId: null,
+        userCreated: false,
+        isSyncing: false,
+        ...externalAccountOverrides,
+      },
+    ],
+  })
+}
+
+/**
+ * A bank account whose single external connection carries a `CONFIRM_RELEVANT`
+ * notification - see `markAccountNeedingConfirmation`.
+ */
+export function makeAccountNeedingConfirmation(
+  options: Omit<MirroredBankAccountOptions, 'externalAccountOverrides'>,
+): BankAccount {
+  return markAccountNeedingConfirmation(makeBankAccountWithMirroredExternalAccount(options))
+}
+
+/**
+ * Flags every external connection on the account with the `CONFIRM_RELEVANT`
+ * notification - the flag `getAccountsNeedingConfirmation` looks for to surface
+ * the "which accounts do you use for your business?" confirm/exclude step.
+ */
+export function markAccountNeedingConfirmation(account: BankAccount): BankAccount {
+  return {
+    ...account,
+    externalAccounts: account.externalAccounts.map(externalAccount => ({
+      ...externalAccount,
+      notifications: [
+        ...externalAccount.notifications.filter(({ type }) => type !== 'CONFIRM_RELEVANT'),
+        { type: 'CONFIRM_RELEVANT' },
+      ],
+    })),
+  }
+}

--- a/src/fixtures/bankAccounts/mocks.ts
+++ b/src/fixtures/bankAccounts/mocks.ts
@@ -51,11 +51,6 @@ type MirroredBankAccountOptions = {
   externalAccountOverrides?: Partial<ExternalAccountConnection>
 }
 
-/**
- * A bank account whose display details (name, institution, mask) are mirrored
- * into its single external connection - the usual shape for a freshly linked
- * Plaid account, where the connection is the source of those details.
- */
 export function makeBankAccountWithMirroredExternalAccount({
   id,
   externalAccountId,
@@ -94,21 +89,13 @@ export function makeBankAccountWithMirroredExternalAccount({
   })
 }
 
-/**
- * A bank account whose single external connection carries a `CONFIRM_RELEVANT`
- * notification - see `markAccountNeedingConfirmation`.
- */
 export function makeAccountNeedingConfirmation(
   options: Omit<MirroredBankAccountOptions, 'externalAccountOverrides'>,
 ): BankAccount {
   return markAccountNeedingConfirmation(makeBankAccountWithMirroredExternalAccount(options))
 }
 
-/**
- * Flags every external connection on the account with the `CONFIRM_RELEVANT`
- * notification - the flag `getAccountsNeedingConfirmation` looks for to surface
- * the "which accounts do you use for your business?" confirm/exclude step.
- */
+/** Adds the `CONFIRM_RELEVANT` notification `getAccountsNeedingConfirmation` looks for. */
 export function markAccountNeedingConfirmation(account: BankAccount): BankAccount {
   return {
     ...account,

--- a/src/fixtures/generated/bankAccounts.gen.ts
+++ b/src/fixtures/generated/bankAccounts.gen.ts
@@ -13,10 +13,10 @@ export const bankAccounts = [
     "isDisconnected": false,
     "externalAccounts": [
       {
-        "id": "35975309-4e2e-4773-a358-6ece4da4d075",
+        "id": "ffffffee-fff7-5fff-9c86-5097ffffffe3",
         "externalAccountSource": "PLAID",
         "externalAccountName": "American Express Business Savings",
-        "mask": "4717",
+        "mask": "9995",
         "institution": {
           "name": "American Express",
           "logo": null
@@ -30,10 +30,10 @@ export const bankAccounts = [
       }
     ],
     "latestBalanceTimestamp": {
-      "balance": 1001500
+      "balance": 2499900
     },
-    "currentLedgerBalance": 51200,
-    "mask": "4717",
+    "currentLedgerBalance": 1084600,
+    "mask": "9995",
     "notifications": []
   },
   {
@@ -47,10 +47,10 @@ export const bankAccounts = [
     "isDisconnected": false,
     "externalAccounts": [
       {
-        "id": "d046606e-ffe6-5fff-bfff-fff500000004",
+        "id": "cdc54d3e-606e-4046-bfff-ffe8ffffffe9",
         "externalAccountSource": "PLAID",
         "externalAccountName": "American Express Business Savings",
-        "mask": "3709",
+        "mask": "9988",
         "institution": {
           "name": "American Express",
           "logo": null
@@ -64,10 +64,10 @@ export const bankAccounts = [
       }
     ],
     "latestBalanceTimestamp": {
-      "balance": 1784600
+      "balance": 50000
     },
-    "currentLedgerBalance": 2498600,
-    "mask": "3709",
+    "currentLedgerBalance": 50600,
+    "mask": "9988",
     "notifications": []
   },
   {
@@ -81,10 +81,10 @@ export const bankAccounts = [
     "isDisconnected": false,
     "externalAccounts": [
       {
-        "id": "43eb3c88-9683-434c-a57a-3668100b93e1",
+        "id": "00000003-001c-1000-bfff-ffe8fffffff4",
         "externalAccountSource": "PLAID",
         "externalAccountName": "Capital One Business Credit Card",
-        "mask": "0004",
+        "mask": "0008",
         "institution": {
           "name": "Capital One",
           "logo": null
@@ -98,10 +98,10 @@ export const bankAccounts = [
       }
     ],
     "latestBalanceTimestamp": {
-      "balance": 2498800
+      "balance": 78100
     },
-    "currentLedgerBalance": 2205500,
-    "mask": "0004",
+    "currentLedgerBalance": 2499900,
+    "mask": "0008",
     "notifications": []
   },
   {
@@ -115,10 +115,10 @@ export const bankAccounts = [
     "isDisconnected": false,
     "externalAccounts": [
       {
-        "id": "5bc417dd-7d76-16e9-b88b-382e8bcdeda9",
+        "id": "00000016-001e-1000-bfff-fff500000009",
         "externalAccountSource": "PLAID",
         "externalAccountName": "Capital One Business Credit Card",
-        "mask": "6068",
+        "mask": "0006",
         "institution": {
           "name": "Capital One",
           "logo": null
@@ -132,10 +132,10 @@ export const bankAccounts = [
       }
     ],
     "latestBalanceTimestamp": {
-      "balance": 2061500
+      "balance": 51100
     },
-    "currentLedgerBalance": 50000,
-    "mask": "6068",
+    "currentLedgerBalance": 2416500,
+    "mask": "0006",
     "notifications": []
   },
   {
@@ -149,10 +149,10 @@ export const bankAccounts = [
     "isDisconnected": false,
     "externalAccounts": [
       {
-        "id": "9453594d-305f-50c5-92af-87ca851fd344",
+        "id": "0000001f-fff1-5fff-bfff-fff6b4f4186a",
         "externalAccountSource": "PLAID",
         "externalAccountName": "Chase Business Checking",
-        "mask": "9994",
+        "mask": "0010",
         "institution": {
           "name": "Chase",
           "logo": null
@@ -166,10 +166,10 @@ export const bankAccounts = [
       }
     ],
     "latestBalanceTimestamp": {
-      "balance": 50600
+      "balance": 2499300
     },
-    "currentLedgerBalance": 51300,
-    "mask": "9994",
+    "currentLedgerBalance": 600000,
+    "mask": "0010",
     "notifications": []
   }
 ] as (typeof schema.Type)[]

--- a/src/msw/api/businesses/[business-id]/bank-accounts/get.ts
+++ b/src/msw/api/businesses/[business-id]/bank-accounts/get.ts
@@ -2,8 +2,8 @@ import { Schema } from 'effect'
 
 import { type BankAccount, BankAccountSchema } from '@schemas/bankAccounts/bankAccount'
 
+import { bankAccountStore } from '@msw/api/businesses/[business-id]/bank-accounts/store'
 import { createMockEndpoint } from '@msw/utils/createMockEndpoint'
-import { bankAccounts as defaultBankAccounts } from '@fixtures/generated/bankAccounts.gen'
 
 const encodeBankAccount = Schema.encodeSync(BankAccountSchema)
 
@@ -14,5 +14,5 @@ const toResponse = (bankAccounts: readonly BankAccount[]) => ({
 export const get = createMockEndpoint<readonly BankAccount[], ReturnType<typeof toResponse>>({
   method: 'get',
   path: '*/v1/businesses/:businessId/bank-accounts',
-  resolve: ({ override: bankAccounts = defaultBankAccounts }) => toResponse(bankAccounts),
+  resolve: ({ override: bankAccounts = bankAccountStore.all() }) => toResponse(bankAccounts),
 })

--- a/src/msw/api/businesses/[business-id]/bank-accounts/store.ts
+++ b/src/msw/api/businesses/[business-id]/bank-accounts/store.ts
@@ -1,4 +1,6 @@
+import { type BankAccount } from '@schemas/bankAccounts/bankAccount'
+
 import { createMockStore } from '@msw/utils/createMockStore'
 import { bankAccounts } from '@fixtures/generated/bankAccounts.gen'
 
-export const bankAccountStore = createMockStore(() => bankAccounts)
+export const bankAccountStore = createMockStore<BankAccount>(() => bankAccounts)

--- a/src/msw/api/businesses/[business-id]/bank-accounts/store.ts
+++ b/src/msw/api/businesses/[business-id]/bank-accounts/store.ts
@@ -1,0 +1,4 @@
+import { createMockStore } from '@msw/utils/createMockStore'
+import { bankAccounts } from '@fixtures/generated/bankAccounts.gen'
+
+export const bankAccountStore = createMockStore(() => bankAccounts)

--- a/src/msw/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm/post.ts
+++ b/src/msw/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm/post.ts
@@ -1,0 +1,38 @@
+import { bankAccountStore } from '@msw/api/businesses/[business-id]/bank-accounts/store'
+import { apiData } from '@msw/utils/apiResponse'
+import { createMockEndpoint } from '@msw/utils/createMockEndpoint'
+
+/**
+ * Confirming an external account clears its `CONFIRM_RELEVANT` notification on
+ * the owning bank account, so the next bank-accounts fetch no longer reports it
+ * as needing confirmation.
+ */
+export const post = createMockEndpoint({
+  method: 'post',
+  path: '*/v1/businesses/:businessId/external-accounts/:accountId/confirm',
+  resolve: ({ params }) => {
+    const accountId = String(params.accountId)
+
+    const owner = bankAccountStore
+      .all()
+      .find(account => account.externalAccounts.some(({ id }) => id === accountId))
+
+    if (owner) {
+      bankAccountStore.save({
+        ...owner,
+        externalAccounts: owner.externalAccounts.map(externalAccount =>
+          externalAccount.id === accountId
+            ? {
+              ...externalAccount,
+              notifications: externalAccount.notifications.filter(
+                ({ type }) => type !== 'CONFIRM_RELEVANT',
+              ),
+            }
+            : externalAccount,
+        ),
+      })
+    }
+
+    return apiData({})
+  },
+})

--- a/src/msw/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm/post.ts
+++ b/src/msw/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm/post.ts
@@ -2,11 +2,6 @@ import { bankAccountStore } from '@msw/api/businesses/[business-id]/bank-account
 import { apiData } from '@msw/utils/apiResponse'
 import { createMockEndpoint } from '@msw/utils/createMockEndpoint'
 
-/**
- * Confirming an external account clears its `CONFIRM_RELEVANT` notification on
- * the owning bank account, so the next bank-accounts fetch no longer reports it
- * as needing confirmation.
- */
 export const post = createMockEndpoint({
   method: 'post',
   path: '*/v1/businesses/:businessId/external-accounts/:accountId/confirm',

--- a/src/msw/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude/post.ts
+++ b/src/msw/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude/post.ts
@@ -2,10 +2,6 @@ import { bankAccountStore } from '@msw/api/businesses/[business-id]/bank-account
 import { apiData } from '@msw/utils/apiResponse'
 import { createMockEndpoint } from '@msw/utils/createMockEndpoint'
 
-/**
- * Excluding an external account removes its owning bank account from the store,
- * so the next bank-accounts fetch no longer includes it.
- */
 export const post = createMockEndpoint({
   method: 'post',
   path: '*/v1/businesses/:businessId/external-accounts/:accountId/exclude',

--- a/src/msw/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude/post.ts
+++ b/src/msw/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude/post.ts
@@ -1,0 +1,23 @@
+import { bankAccountStore } from '@msw/api/businesses/[business-id]/bank-accounts/store'
+import { apiData } from '@msw/utils/apiResponse'
+import { createMockEndpoint } from '@msw/utils/createMockEndpoint'
+
+/**
+ * Excluding an external account removes its owning bank account from the store,
+ * so the next bank-accounts fetch no longer includes it.
+ */
+export const post = createMockEndpoint({
+  method: 'post',
+  path: '*/v1/businesses/:businessId/external-accounts/:accountId/exclude',
+  resolve: ({ params }) => {
+    const accountId = String(params.accountId)
+
+    const owner = bankAccountStore
+      .all()
+      .find(account => account.externalAccounts.some(({ id }) => id === accountId))
+
+    if (owner) bankAccountStore.deleteById(owner.id)
+
+    return apiData({})
+  },
+})

--- a/src/msw/api/businesses/[business-id]/external-accounts/handlers.ts
+++ b/src/msw/api/businesses/[business-id]/external-accounts/handlers.ts
@@ -1,0 +1,9 @@
+import { type RequestHandler } from 'msw'
+
+import { post as confirmExternalAccount } from '@msw/api/businesses/[business-id]/external-accounts/[external-account-id]/confirm/post'
+import { post as excludeExternalAccount } from '@msw/api/businesses/[business-id]/external-accounts/[external-account-id]/exclude/post'
+
+export const externalAccountsHandlers: RequestHandler[] = [
+  confirmExternalAccount.handler,
+  excludeExternalAccount.handler,
+]

--- a/src/msw/api/businesses/[business-id]/handlers.ts
+++ b/src/msw/api/businesses/[business-id]/handlers.ts
@@ -6,9 +6,11 @@ import { catalogHandlers } from '@msw/api/businesses/[business-id]/catalog/handl
 import { categoriesHandlers } from '@msw/api/businesses/[business-id]/categories/handlers'
 import { customAccountsHandlers } from '@msw/api/businesses/[business-id]/custom-accounts/handlers'
 import { customersHandlers } from '@msw/api/businesses/[business-id]/customers/handlers'
+import { externalAccountsHandlers } from '@msw/api/businesses/[business-id]/external-accounts/handlers'
 import { get as getBusiness } from '@msw/api/businesses/[business-id]/get'
 import { ledgerHandlers } from '@msw/api/businesses/[business-id]/ledger/handlers'
 import { mileageHandlers } from '@msw/api/businesses/[business-id]/mileage/handlers'
+import { plaidHandlers } from '@msw/api/businesses/[business-id]/plaid/handlers'
 import { timeTrackingHandlers } from '@msw/api/businesses/[business-id]/time-tracking/handlers'
 import { vendorsHandlers } from '@msw/api/businesses/[business-id]/vendors/handlers'
 
@@ -16,6 +18,8 @@ export const businessHandlers: RequestHandler[] = [
   getBusiness.handler,
   ...accountingConfigurationHandlers,
   ...bankAccountsHandlers,
+  ...externalAccountsHandlers,
+  ...plaidHandlers,
   ...categoriesHandlers,
   ...customAccountsHandlers,
   ...customersHandlers,

--- a/src/msw/api/businesses/[business-id]/plaid/handlers.ts
+++ b/src/msw/api/businesses/[business-id]/plaid/handlers.ts
@@ -1,0 +1,9 @@
+import { type RequestHandler } from 'msw'
+
+import { post as exchangePlaidPublicToken } from '@msw/api/businesses/[business-id]/plaid/link/exchange/post'
+import { post as createPlaidLink } from '@msw/api/businesses/[business-id]/plaid/link/post'
+
+export const plaidHandlers: RequestHandler[] = [
+  createPlaidLink.handler,
+  exchangePlaidPublicToken.handler,
+]

--- a/src/msw/api/businesses/[business-id]/plaid/link/exchange/post.ts
+++ b/src/msw/api/businesses/[business-id]/plaid/link/exchange/post.ts
@@ -9,10 +9,6 @@ const FIRST_LINK_ACCOUNT_COUNT = 3
 // offset past the generated-fixture seed to avoid reproducing seeded ids.
 let linkSessionSeed = 1000
 
-/**
- * A fake Plaid link session "finds" randomly generated accounts needing
- * confirmation: a few on the first session, one more on each additional one.
- */
 export const post = createMockEndpoint({
   method: 'post',
   path: '*/v1/businesses/:businessId/plaid/link/exchange',

--- a/src/msw/api/businesses/[business-id]/plaid/link/exchange/post.ts
+++ b/src/msw/api/businesses/[business-id]/plaid/link/exchange/post.ts
@@ -1,0 +1,29 @@
+import { bankAccountStore } from '@msw/api/businesses/[business-id]/bank-accounts/store'
+import { apiData } from '@msw/utils/apiResponse'
+import { createMockEndpoint } from '@msw/utils/createMockEndpoint'
+import { generateAccountsNeedingConfirmation } from '@fixtures/bankAccounts/generator'
+
+const FIRST_LINK_ACCOUNT_COUNT = 3
+
+// Advanced per generated account so each link session finds fresh banks;
+// offset past the generated-fixture seed to avoid reproducing seeded ids.
+let linkSessionSeed = 1000
+
+/**
+ * A fake Plaid link session "finds" randomly generated accounts needing
+ * confirmation: a few on the first session, one more on each additional one.
+ */
+export const post = createMockEndpoint({
+  method: 'post',
+  path: '*/v1/businesses/:businessId/plaid/link/exchange',
+  resolve: () => {
+    const count = bankAccountStore.all().length === 0 ? FIRST_LINK_ACCOUNT_COUNT : 1
+
+    generateAccountsNeedingConfirmation(count, linkSessionSeed)
+      .forEach(account => bankAccountStore.save(account))
+
+    linkSessionSeed += count
+
+    return apiData({})
+  },
+})

--- a/src/msw/api/businesses/[business-id]/plaid/link/post.ts
+++ b/src/msw/api/businesses/[business-id]/plaid/link/post.ts
@@ -1,0 +1,20 @@
+import { apiData } from '@msw/utils/apiResponse'
+import { createMockEndpoint } from '@msw/utils/createMockEndpoint'
+
+// Unique per request, like the real backend: the link modal only reopens for a
+// new session when the token actually changes.
+let linkTokenSequence = 0
+
+/**
+ * Issues a placeholder link token; the SDK is mocked in Storybook
+ * (`.storybook/mocks/react-plaid-link.ts`), so it is never sent to Plaid.
+ */
+export const post = createMockEndpoint({
+  method: 'post',
+  path: '*/v1/businesses/:businessId/plaid/link',
+  resolve: () => apiData({
+    type: 'Link_Token',
+    link_token: `link-sandbox-mock-token-${++linkTokenSequence}`,
+    hosted_link: null,
+  }),
+})

--- a/src/msw/api/businesses/[business-id]/plaid/link/post.ts
+++ b/src/msw/api/businesses/[business-id]/plaid/link/post.ts
@@ -1,14 +1,10 @@
 import { apiData } from '@msw/utils/apiResponse'
 import { createMockEndpoint } from '@msw/utils/createMockEndpoint'
 
-// Unique per request, like the real backend: the link modal only reopens for a
-// new session when the token actually changes.
+// Unique per request, like the real backend: the link modal only reopens when
+// the token actually changes.
 let linkTokenSequence = 0
 
-/**
- * Issues a placeholder link token; the SDK is mocked in Storybook
- * (`.storybook/mocks/react-plaid-link.ts`), so it is never sent to Plaid.
- */
 export const post = createMockEndpoint({
   method: 'post',
   path: '*/v1/businesses/:businessId/plaid/link',


### PR DESCRIPTION
## Scope

Adds a Storybook story for `LinkAccounts` covering the full link → confirm/exclude experience, backed by global MSW mocks rather than story-local handlers.

### Storybook
- `.storybook/mocks/react-plaid-link.ts` — vite-aliased stand-in for the Plaid SDK; `open()` fakes a successful link session. `open` keeps a stable identity per token (avoids an exchange/refetch loop) and changes with the token (so "Link another bank" opens a new session).
- `LinkAccounts.stories.tsx` — single `Default` story wrapped in a demo-finguard-style page/card; completing the wizard clears the store + SWR cache and remounts, restarting the flow.

### MSW (global, following the mileage-tracking conventions)
- Stateful `bankAccountStore` backing the bank-accounts GET (same generated-fixture seed as before).
- New endpoints: `plaid/link` (unique token per request), `plaid/link/exchange` (generates random accounts needing confirmation — 3 on first session, one more per additional session), `external-accounts/:id/confirm` (clears the `CONFIRM_RELEVANT` notification), `external-accounts/:id/exclude` (removes the account).

### Fixtures
- `makeBankAccountWithMirroredExternalAccount` / `makeAccountNeedingConfirmation` / `markAccountNeedingConfirmation` helpers.
- `generateAccountsNeedingConfirmation(count, seed)` samples the existing bank-account arbitrary at runtime.
- The arbitrary now generates exactly one external connection per account (per-connection surfaces rendered duplicate rows otherwise); `bankAccounts.gen.ts` regenerated.

### Product fix
- `LinkAccountsLinkStep`: the loading spinner restarted mid-link because the inline `ConditionalList` `Container` is a new component type each render, remounting its subtree when the refetch lands. The spinner overlay is hoisted outside the `ConditionalList` so it spins continuously.

## Verification
- Storybook builds; story registered as `components-linkaccounts--default`
- Click-through: connect → fake Plaid → found accounts → link another bank (adds one more) → confirm/exclude multiple → completion restarts the flow
- `fixtures:check` passes; ESLint clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Storybook/MSW/fixtures and a small UI structure fix in the link step; no production Plaid or API client behavior is altered beyond smoother loading UX during link.
> 
> **Overview**
> Adds a **Storybook** path for the full **LinkAccounts** flow (connect → confirm/exclude → restart) by aliasing `react-plaid-link` to a mock that simulates a successful link after a short delay, and wiring **global MSW** mocks for Plaid link/exchange plus external-account confirm/exclude.
> 
> **MSW** now uses a shared **`bankAccountStore`** for bank-accounts GET and mutating handlers: Plaid exchange seeds accounts needing `CONFIRM_RELEVANT` (three on first link, one per “link another bank”), confirm clears that notification, and exclude removes the bank account. Fixtures gain helpers for mirrored external accounts and confirmation state; generated accounts use **one** external connection each (regenerated `bankAccounts.gen.ts`).
> 
> **Product fix:** In `LinkAccountsLinkStep`, the linking spinner is wrapped **outside** `ConditionalList` so refetches no longer remount the overlay and restart the spinner mid-link.
> 
> The **Default** story clears the store on load and remounts after completion so the wizard can be exercised repeatedly in Storybook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce37c9c4fb65e19e30c56fef118a16709e4d1b94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->