### PR TITLE
infra: add Storybook Pages deployment workflow

### DIFF
--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -3,13 +3,18 @@ name: Storybook Pages
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: Branch, tag, or SHA to build
+        required: true
+        type: string
+        default: main
       target:
-        description: Storybook target
+        description: Pages destination
         required: true
         type: choice
         options:
-        - dev
         - main
+        - dev
 
 permissions:
   contents: read
@@ -32,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.target }}
+        ref: ${{ inputs.ref }}
         persist-credentials: false
 
     - name: Setup Node.js

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -14,9 +14,6 @@ on:
 permissions:
   contents: read
 
-env:
-  STORYBOOK_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
-
 concurrency:
   group: storybook-pages
   cancel-in-progress: false
@@ -30,8 +27,7 @@ jobs:
       contents: read
 
     outputs:
-      destination_dir: ${{ steps.pages-target.outputs.destination_dir }}
-      storybook_url: ${{ steps.pages-target.outputs.storybook_url }}
+      destination_dir: ${{ steps.target.outputs.destination_dir }}
 
     steps:
     - uses: actions/checkout@v4
@@ -49,32 +45,19 @@ jobs:
       run: npm ci
 
     - name: Resolve Pages target
-      id: pages-target
+      id: target
       env:
         TARGET: ${{ inputs.target }}
-        REPO_NAME: ${{ github.event.repository.name }}
+        REPO: ${{ github.event.repository.name }}
       run: |
-        case "$TARGET" in
-          main)
-            echo "destination_dir=" >> "$GITHUB_OUTPUT"
-            echo "storybook_base_path=/$REPO_NAME/" >> "$GITHUB_OUTPUT"
-            echo "storybook_url=$STORYBOOK_URL/" >> "$GITHUB_OUTPUT"
-            ;;
-          dev)
-            echo "destination_dir=dev" >> "$GITHUB_OUTPUT"
-            echo "storybook_base_path=/$REPO_NAME/dev/" >> "$GITHUB_OUTPUT"
-            echo "storybook_url=$STORYBOOK_URL/dev/" >> "$GITHUB_OUTPUT"
-            ;;
-          *)
-            echo "Unsupported target: $TARGET"
-            exit 1
-            ;;
-        esac
+        SUBDIR=$([ "$TARGET" = main ] || echo "$TARGET")
+        echo "destination_dir=$SUBDIR" >> "$GITHUB_OUTPUT"
+        echo "base_path=/$REPO/${SUBDIR:+$SUBDIR/}" >> "$GITHUB_OUTPUT"
 
     - name: Build Storybook
       run: npm run storybook:build
       env:
-        STORYBOOK_BASE_PATH: ${{ steps.pages-target.outputs.storybook_base_path }}
+        STORYBOOK_BASE_PATH: ${{ steps.target.outputs.base_path }}
 
     - name: Upload Storybook artifact
       uses: actions/upload-artifact@v4
@@ -108,5 +91,7 @@ jobs:
 
     - name: Pages URL
       env:
-        STORYBOOK_DEPLOY_URL: ${{ needs.build.outputs.storybook_url }}
-      run: echo "$STORYBOOK_DEPLOY_URL"
+        OWNER: ${{ github.repository_owner }}
+        REPO: ${{ github.event.repository.name }}
+        SUBDIR: ${{ needs.build.outputs.destination_dir }}
+      run: echo "https://$OWNER.github.io/$REPO/${SUBDIR:+$SUBDIR/}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     permissions:
       contents: read
@@ -36,6 +37,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.target }}
+        persist-credentials: false
 
     - name: Setup Node.js
       uses: actions/setup-node@v4
@@ -48,20 +50,23 @@ jobs:
 
     - name: Resolve Pages target
       id: pages-target
+      env:
+        TARGET: ${{ inputs.target }}
+        REPO_NAME: ${{ github.event.repository.name }}
       run: |
-        case "${{ inputs.target }}" in
+        case "$TARGET" in
           main)
             echo "destination_dir=" >> "$GITHUB_OUTPUT"
-            echo "storybook_base_path=/${{ github.event.repository.name }}/" >> "$GITHUB_OUTPUT"
+            echo "storybook_base_path=/$REPO_NAME/" >> "$GITHUB_OUTPUT"
             echo "storybook_url=$STORYBOOK_URL/" >> "$GITHUB_OUTPUT"
             ;;
           dev)
             echo "destination_dir=dev" >> "$GITHUB_OUTPUT"
-            echo "storybook_base_path=/${{ github.event.repository.name }}/dev/" >> "$GITHUB_OUTPUT"
+            echo "storybook_base_path=/$REPO_NAME/dev/" >> "$GITHUB_OUTPUT"
             echo "storybook_url=$STORYBOOK_URL/dev/" >> "$GITHUB_OUTPUT"
             ;;
           *)
-            echo "Unsupported target: ${{ inputs.target }}"
+            echo "Unsupported target: $TARGET"
             exit 1
             ;;
         esac
@@ -76,10 +81,12 @@ jobs:
       with:
         name: storybook-static
         path: storybook-static
+        retention-days: 1
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     permissions:
       contents: write
@@ -92,7 +99,7 @@ jobs:
         path: storybook-static
 
     - name: Publish Storybook
-      uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b
+      uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b # v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: storybook-static
@@ -100,4 +107,6 @@ jobs:
         keep_files: true
 
     - name: Pages URL
-      run: echo "${{ needs.build.outputs.storybook_url }}"
+      env:
+        STORYBOOK_DEPLOY_URL: ${{ needs.build.outputs.storybook_url }}
+      run: echo "$STORYBOOK_DEPLOY_URL"

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -1,0 +1,103 @@
+name: Storybook Pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Storybook target
+        required: true
+        type: choice
+        options:
+        - dev
+        - main
+
+permissions:
+  contents: read
+
+env:
+  STORYBOOK_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+
+concurrency:
+  group: storybook-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    outputs:
+      destination_dir: ${{ steps.pages-target.outputs.destination_dir }}
+      storybook_url: ${{ steps.pages-target.outputs.storybook_url }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.target }}
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Resolve Pages target
+      id: pages-target
+      run: |
+        case "${{ inputs.target }}" in
+          main)
+            echo "destination_dir=" >> "$GITHUB_OUTPUT"
+            echo "storybook_base_path=/${{ github.event.repository.name }}/" >> "$GITHUB_OUTPUT"
+            echo "storybook_url=$STORYBOOK_URL/" >> "$GITHUB_OUTPUT"
+            ;;
+          dev)
+            echo "destination_dir=dev" >> "$GITHUB_OUTPUT"
+            echo "storybook_base_path=/${{ github.event.repository.name }}/dev/" >> "$GITHUB_OUTPUT"
+            echo "storybook_url=$STORYBOOK_URL/dev/" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "Unsupported target: ${{ inputs.target }}"
+            exit 1
+            ;;
+        esac
+
+    - name: Build Storybook
+      run: npm run storybook:build
+      env:
+        STORYBOOK_BASE_PATH: ${{ steps.pages-target.outputs.storybook_base_path }}
+
+    - name: Upload Storybook artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: storybook-static
+        path: storybook-static
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+    - name: Download Storybook artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: storybook-static
+        path: storybook-static
+
+    - name: Publish Storybook
+      uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: storybook-static
+        destination_dir: ${{ needs.build.outputs.destination_dir }}
+        keep_files: true
+
+    - name: Pages URL
+      run: echo "${{ needs.build.outputs.storybook_url }}"

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -8,13 +8,6 @@ on:
         required: true
         type: string
         default: main
-      target:
-        description: Pages destination
-        required: true
-        type: choice
-        options:
-        - main
-        - dev
 
 permissions:
   contents: read
@@ -27,12 +20,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
-    permissions:
-      contents: read
-
-    outputs:
-      destination_dir: ${{ steps.target.outputs.destination_dir }}
 
     steps:
     - uses: actions/checkout@v4
@@ -49,27 +36,15 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    - name: Resolve Pages target
-      id: target
-      env:
-        TARGET: ${{ inputs.target }}
-        REPO: ${{ github.event.repository.name }}
-      run: |
-        SUBDIR=$([ "$TARGET" = main ] || echo "$TARGET")
-        echo "destination_dir=$SUBDIR" >> "$GITHUB_OUTPUT"
-        echo "base_path=/$REPO/${SUBDIR:+$SUBDIR/}" >> "$GITHUB_OUTPUT"
-
     - name: Build Storybook
       run: npm run storybook:build
       env:
-        STORYBOOK_BASE_PATH: ${{ steps.target.outputs.base_path }}
+        STORYBOOK_BASE_PATH: /${{ github.event.repository.name }}/
 
-    - name: Upload Storybook artifact
-      uses: actions/upload-artifact@v4
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@v3
       with:
-        name: storybook-static
         path: storybook-static
-        retention-days: 1
 
   deploy:
     needs: build
@@ -77,26 +52,14 @@ jobs:
     timeout-minutes: 10
 
     permissions:
-      contents: write
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-    - name: Download Storybook artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: storybook-static
-        path: storybook-static
-
-    - name: Publish Storybook
-      uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b # v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: storybook-static
-        destination_dir: ${{ needs.build.outputs.destination_dir }}
-        keep_files: true
-
-    - name: Pages URL
-      env:
-        OWNER: ${{ github.repository_owner }}
-        REPO: ${{ github.event.repository.name }}
-        SUBDIR: ${{ needs.build.outputs.destination_dir }}
-      run: echo "https://$OWNER.github.io/$REPO/${SUBDIR:+$SUBDIR/}" >> "$GITHUB_STEP_SUMMARY"
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,7 +1,7 @@
 name: Storybook
 
 on:
-  push:
+  pull_request:
 
 permissions:
   contents: read

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -19,6 +19,7 @@ const config: StorybookConfig = {
   staticDirs: ['./public'],
   viteFinal: viteConfig => ({
     ...viteConfig,
+    base: process.env.STORYBOOK_BASE_PATH ?? viteConfig.base,
     resolve: {
       ...viteConfig.resolve,
       tsconfigPaths: true,


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Storybook static hosting configuration only; no application runtime, auth, or data paths.
> 
> **Overview**
> Adds a **manual** `storybook-pages` workflow that builds Storybook for a chosen ref, sets `STORYBOOK_BASE_PATH` to `/<repo-name>/` for GitHub Pages hosting, and deploys `storybook-static` via the Pages artifact + `deploy-pages` jobs (with concurrency pinned so in-progress deploys are not cancelled).
> 
> Updates `.storybook/main.ts` so Vite’s `base` follows `STORYBOOK_BASE_PATH` when set, keeping asset URLs correct under a subpath.
> 
> Changes the existing **Storybook** CI trigger from **push** to **pull_request** so Storybook still builds in PRs without duplicating push-based builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecfed6d80cd2ec3d6bbc8cb31da5e99bf3b6d282. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->