### PR TITLE
fix: resolve MSW service worker relative to Storybook base path

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -9,6 +9,7 @@ import { resetMockStores } from '../src/msw/utils/createMockStore'
 import { LayerTestProvider } from '../src/test-utils/LayerTestProvider'
 
 initialize({
+  serviceWorker: { url: `${import.meta.env.BASE_URL}mockServiceWorker.js` },
   onUnhandledRequest: (request, print) => {
     // Fail loudly on unmocked API calls; assets and Storybook's own requests pass through.
     if (new URL(request.url).hostname.endsWith('layerfi.com')) print.error()


### PR DESCRIPTION
## Scope

On the Pages deployment (`https://layer-fi.github.io/layer-react/`), MSW failed to register its service worker because it requests `/mockServiceWorker.js` at the domain root by default. Point it at `import.meta.env.BASE_URL` instead, which is `/` in local dev and `/layer-react/` in the Pages build (via `STORYBOOK_BASE_PATH`).

## Verification

Built with `STORYBOOK_BASE_PATH=/layer-react/` and confirmed the bundle references `/layer-react/mockServiceWorker.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Storybook/MSW configuration change with no impact on production app runtime or security-sensitive paths.
> 
> **Overview**
> Fixes MSW failing to register on the GitHub Pages Storybook deploy by configuring `initialize()` with `serviceWorker.url` set to `` `${import.meta.env.BASE_URL}mockServiceWorker.js` `` instead of the default root path `/mockServiceWorker.js`.
> 
> That matches Vite’s `base` from `STORYBOOK_BASE_PATH` (`/` locally, `/layer-react/` on Pages), so the worker is loaded under the same subpath as the built Storybook assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fecde7a9782226312f856bdd49cff5dc28fc4297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->