### PR TITLE
DRAFT: LAY-2342 Journal Date Filter [6/n] [refactor] Support All Time date preset (Phase 2 — Reorder providers)

### DIFF
--- a/src/providers/BusinessProvider/BusinessProvider.tsx
+++ b/src/providers/BusinessProvider/BusinessProvider.tsx
@@ -5,14 +5,17 @@ import {
   type ColorsPaletteOption,
   type LayerContextAction,
   LayerContextActionName as Action,
+  type LayerContextDateRange,
   type LayerContextValues,
   type LayerThemeConfig,
 } from '@internal-types/layerContext'
 import { errorHandler, type LayerError } from '@utils/api/errorHandler'
 import { buildColorsPalette } from '@utils/colors'
+import { DatePreset, rangeForPreset } from '@utils/date/dateRangePresets'
 import { useAccountingConfiguration } from '@hooks/api/businesses/[business-id]/accounting-config/useAccountingConfiguration'
 import { useBusiness } from '@hooks/api/businesses/[business-id]/useBusiness'
-import { useGlobalDateRange, useGlobalDateRangeActions } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
+import { LayerContextDateRangeBridge } from '@providers/BusinessProvider/LayerContextDateRangeBridge'
+import { GlobalDateStoreProvider } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
 import { type LayerEvent } from '@providers/LayerProvider/layerEvents'
 import { type LayerProviderProps } from '@providers/LayerProvider/LayerProvider'
 import { BankAccountsProvider } from '@contexts/BankAccountsContext/BankAccountsContext'
@@ -100,13 +103,14 @@ export const BusinessProvider = ({
     eventCallbacks: {},
   })
 
-  const globalDateRange = useGlobalDateRange({ dateSelectionMode: 'full' })
-  const { setDateRange } = useGlobalDateRangeActions()
-
-  const dateRange = useMemo(() => ({
-    range: globalDateRange,
-    setRange: setDateRange,
-  }), [globalDateRange, setDateRange])
+  // Placeholder only. The real, store-backed `dateRange` is injected by
+  // `LayerContextDateRangeBridge`, which is mounted below the date store (see the
+  // return below). Nothing renders between this provider and the bridge, so this
+  // value is never observed by a consumer.
+  const dateRange = useMemo<LayerContextDateRange['dateRange']>(() => ({
+    range: rangeForPreset(DatePreset.ThisMonth),
+    setRange: range => range,
+  }), [])
 
   const { data: businessData } = useBusiness({ businessId })
 
@@ -226,10 +230,21 @@ export const BusinessProvider = ({
         dateRange,
       }}
     >
-      <BankAccountsProvider>
-        {children}
-      </BankAccountsProvider>
-      <ToastsContainer />
+      {/*
+        The date store is mounted here, below the business context, so its
+        resolver can read the business activation date directly (enabling the
+        context-dependent AllTime preset even for the global store). The bridge,
+        below the store, re-injects the store-backed `dateRange` onto the context
+        so `useLayerContext().dateRange` keeps working for embedding apps.
+      */}
+      <GlobalDateStoreProvider>
+        <LayerContextDateRangeBridge>
+          <BankAccountsProvider>
+            {children}
+          </BankAccountsProvider>
+          <ToastsContainer />
+        </LayerContextDateRangeBridge>
+      </GlobalDateStoreProvider>
     </LayerContext.Provider>
   )
 }

--- a/src/providers/BusinessProvider/LayerContextDateRangeBridge.test.tsx
+++ b/src/providers/BusinessProvider/LayerContextDateRangeBridge.test.tsx
@@ -1,0 +1,44 @@
+import { type PropsWithChildren } from 'react'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { LayerContextDateRangeBridge } from '@providers/BusinessProvider/LayerContextDateRangeBridge'
+import { GlobalDateStoreProvider } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
+import { LayerContext, useLayerContext } from '@contexts/LayerContext/LayerContext'
+
+import { setupFakeSystemTime } from '@test-utils/fakeSystemTime'
+import { CURRENT_MONTH_TO_DATE, FIVE_MONTHS_BEFORE_NOW, NOW, THREE_MONTHS_BEFORE_NOW } from '@test-utils/fixedDates'
+
+setupFakeSystemTime(NOW)
+
+// Mirrors the post-reorder tree: business context above the store, the bridge
+// below it re-injecting `dateRange` onto the context.
+function Wrapper({ children }: PropsWithChildren) {
+  return (
+    <LayerContext.Provider value={{} as never}>
+      <GlobalDateStoreProvider>
+        <LayerContextDateRangeBridge>
+          {children}
+        </LayerContextDateRangeBridge>
+      </GlobalDateStoreProvider>
+    </LayerContext.Provider>
+  )
+}
+
+describe('LayerContextDateRangeBridge', () => {
+  it('exposes the store-backed date range through useLayerContext (public API)', () => {
+    const { result } = renderHook(() => useLayerContext().dateRange, { wrapper: Wrapper })
+
+    expect(result.current.range).toEqual(CURRENT_MONTH_TO_DATE)
+  })
+
+  it('drives the store through the context setRange', () => {
+    const { result } = renderHook(() => useLayerContext().dateRange, { wrapper: Wrapper })
+
+    act(() => {
+      result.current.setRange({ startDate: FIVE_MONTHS_BEFORE_NOW, endDate: THREE_MONTHS_BEFORE_NOW })
+    })
+
+    expect(result.current.range.startDate).toEqual(FIVE_MONTHS_BEFORE_NOW)
+  })
+})

--- a/src/providers/BusinessProvider/LayerContextDateRangeBridge.tsx
+++ b/src/providers/BusinessProvider/LayerContextDateRangeBridge.tsx
@@ -1,0 +1,41 @@
+import { type PropsWithChildren, useContext, useMemo } from 'react'
+
+import { useGlobalDateRange, useGlobalDateRangeActions } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
+import { LayerContext } from '@contexts/LayerContext/LayerContext'
+
+/**
+ * Re-injects the global date range onto `LayerContext` from *below* the date
+ * store.
+ *
+ * After the provider reorder (`BusinessProvider` now wraps
+ * `GlobalDateStoreProvider`), the base `LayerContext` value is provided above the
+ * store and therefore cannot read it. The store's resolver reads the business
+ * from that base context; this bridge — mounted below the store — reads the store
+ * and re-provides the context with a live `dateRange`, keeping the public
+ * `useLayerContext().dateRange` API working for embedding applications.
+ *
+ * There is no circular dependency: business flows down from the base context into
+ * the store's resolver, and the resolved range flows back onto the context only
+ * here, below the store.
+ */
+export function LayerContextDateRangeBridge({ children }: PropsWithChildren) {
+  const base = useContext(LayerContext)
+
+  const range = useGlobalDateRange({ dateSelectionMode: 'full' })
+  const { setDateRange } = useGlobalDateRangeActions()
+
+  if (!base) {
+    throw new Error('LayerContextDateRangeBridge must be rendered within LayerContext.Provider')
+  }
+
+  const value = useMemo(
+    () => ({ ...base, dateRange: { range, setRange: setDateRange } }),
+    [base, range, setDateRange],
+  )
+
+  return (
+    <LayerContext.Provider value={value}>
+      {children}
+    </LayerContext.Provider>
+  )
+}

--- a/src/providers/LayerProvider/LayerProvider.tsx
+++ b/src/providers/LayerProvider/LayerProvider.tsx
@@ -8,7 +8,6 @@ import { DEFAULT_SWR_CONFIG } from '@utils/swr/defaultSWRConfig'
 import { localeKeyMiddleware } from '@utils/swr/localeKeyMiddleware'
 import { AuthInputProvider } from '@providers/AuthInputProvider'
 import { BusinessProvider } from '@providers/BusinessProvider/BusinessProvider'
-import { GlobalDateStoreProvider } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
 import type { Environment, EnvironmentConfigOverride } from '@providers/Environment/environmentConfigs'
 import { EnvironmentInputProvider } from '@providers/Environment/EnvironmentInputProvider'
 import { LayerI18nProvider } from '@providers/I18nProvider/LayerI18nProvider'
@@ -77,9 +76,7 @@ export const LayerProvider = ({
             appSecret={appSecret}
             businessAccessToken={businessAccessToken}
           >
-            <GlobalDateStoreProvider>
-              <BusinessProvider {...restProps} />
-            </GlobalDateStoreProvider>
+            <BusinessProvider {...restProps} />
           </AuthInputProvider>
         </EnvironmentInputProvider>
       </LayerI18nProvider>


### PR DESCRIPTION
# Description

Flip the provider order so BusinessProvider (which provides LayerContext) is the ancestor of GlobalDateStoreProvider. The date store's resolver can now read the business activation date structurally, enabling the AllTime preset even for the global store without special placement.

Because BusinessProvider now sits above the store it can no longer read it to populate LayerContext.dateRange (a public API — useLayerContext is exported). A new LayerContextDateRangeBridge, mounted below the store, re-injects the store-backed dateRange onto the context, so useLayerContext().dateRange keeps working for embedding applications. No circular dependency: business flows down into the resolver, the resolved range flows back onto the context only below the store.

The global default stays ThisMonth (synchronous, non-blocking). Setting the global default to AllTime is now possible but would show an app-wide loading state until the business loads — hence kept opt-in.

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core provider composition and the exported embedding API for global date range; behavior should stay equivalent for consumers under the bridge, but ordering mistakes could break date filters app-wide.
> 
> **Overview**
> **Reorders the React provider tree** so `BusinessProvider` (and `LayerContext`) wraps `GlobalDateStoreProvider` instead of the opposite. `GlobalDateStoreProvider` is removed from `LayerProvider` and nested inside `BusinessProvider`, so the date store can read business (e.g. activation date) from context when resolving presets such as **All Time** for the global store.
> 
> Because `LayerContext` is now above the store, `BusinessProvider` no longer wires `dateRange` from the store directly; it supplies a **This Month placeholder** on the outer context. A new **`LayerContextDateRangeBridge`** sits under the store, merges the store-backed `range` / `setRange` back onto `LayerContext`, and preserves the public **`useLayerContext().dateRange`** API for embedders without a circular dependency.
> 
> Tests cover that the bridge exposes the store range and that `setRange` updates the global store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 254bcecc2b86c9ca87a4178d4de4827ff73adadf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->