### PR TITLE
ci: auto-approve uploaded translations

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -72,6 +72,7 @@ jobs:
       uses: crowdin/github-action@v2
       with:
         command: upload translations
+        command_args: --auto-approve-imported
       env:
         CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
         CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -42,6 +42,7 @@ jobs:
       uses: crowdin/github-action@v2
       with:
         command: upload translations
+        command_args: --auto-approve-imported
       env:
         CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
         CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `--auto-approve-imported` to both `crowdin upload translations` invocations (`crowdin-upload.yml` and the sync workflow's push-translations step). Uploaded repo values are marked approved in Crowdin, so they win over translations approved in the Crowdin UI — git is the unconditional authority once a change merges.

## Verification

- `actionlint` on both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Crowdin CLI flag change; no runtime app code, with the main effect being Crowdin approval state favoring git after merges.
> 
> **Overview**
> Both Crowdin **upload translations** steps now pass **`--auto-approve-imported`** via `command_args`: the push-time step in **`crowdin-sync.yml`** (when non–en-US locale files change on `main`) and the dedicated step in **`crowdin-upload.yml`**.
> 
> Imported strings from the repo are marked **approved** in Crowdin on upload, so merged git translations take precedence over strings that were only approved in the Crowdin UI during later sync/download.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f557f8f7411bf2e864102059ae4e8c6269dfc55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->