### PR TITLE
i18n: include fr-CA in key extraction

### DIFF
--- a/.github/workflows/i18n-english-keys.yml
+++ b/.github/workflows/i18n-english-keys.yml
@@ -2,9 +2,8 @@ name: i18n - Extract English Keys
 
 # Collect English source keys from code into a stable PR (run manually).
 #
-# extract en-US keys -> open/update one PR with src/assets/locales/en-US only.
-#
-# French is intentionally excluded from extraction; fr-CA is managed by Crowdin.
+# extract keys for all locales -> open/update one PR. fr-CA gets keys
+# scaffolded/removed here; its values are managed by Crowdin.
 
 on:
   workflow_dispatch:
@@ -47,7 +46,7 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        git add src/assets/locales/en-US
+        git add src/assets/locales
         BR=i18n/english-keys
         if git diff --cached --quiet; then
           echo "No English translation key changes."

--- a/.github/workflows/i18n-extract-keys.yml
+++ b/.github/workflows/i18n-extract-keys.yml
@@ -1,6 +1,6 @@
-name: i18n - Extract English Keys
+name: i18n - Extract Keys
 
-# Collect English source keys from code into a stable PR (run manually).
+# Collect translation keys from code into a stable PR (run manually).
 #
 # extract keys for all locales -> open/update one PR. fr-CA gets keys
 # scaffolded/removed here; its values are managed by Crowdin.
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: i18n-english-keys
+  group: i18n-extract-keys
   cancel-in-progress: false
 
 jobs:
@@ -39,36 +39,36 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-    - name: Extract English translation keys
+    - name: Extract translation keys
       run: npx i18next-cli extract --sync-primary
 
-    - name: Open English manifest PR
+    - name: Open translation keys PR
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
         git add src/assets/locales
-        BR=i18n/english-keys
+        BR=i18n/extract-keys
         if git diff --cached --quiet; then
-          echo "No English translation key changes."
-          echo "No English translation key changes." >> "$GITHUB_STEP_SUMMARY"
+          echo "No translation key changes."
+          echo "No translation key changes." >> "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
         git checkout -B "$BR"
-        git commit -m "i18n: extract English translation keys"
+        git commit -m "i18n: extract translation keys"
         git push -f origin "$BR"
         PR_NUMBER=$(gh pr list --head "$BR" --state open --json number --jq '.[0].number // empty')
         if [ -z "$PR_NUMBER" ]; then
           PR_URL=$(gh pr create --base main --head "$BR" \
-            --title "i18n: extract English keys" \
-            --body "Extracted English translation keys from source with i18next-cli extract for @layerfi/components.")
+            --title "i18n: extract translation keys" \
+            --body "Extracted translation keys from source with i18next-cli extract for @layerfi/components.")
         else
           gh pr edit "$PR_NUMBER" \
-            --title "i18n: extract English keys" \
-            --body "Extracted English translation keys from source with i18next-cli extract for @layerfi/components."
+            --title "i18n: extract translation keys" \
+            --body "Extracted translation keys from source with i18next-cli extract for @layerfi/components."
           PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
         fi
         if [ -z "$PR_URL" ]; then
-          echo "::error::Unable to resolve English keys PR URL."
+          echo "::error::Unable to resolve translation keys PR URL."
           exit 1
         fi
-        echo "[English keys PR]($PR_URL)" >> "$GITHUB_STEP_SUMMARY"
+        echo "[Translation keys PR]($PR_URL)" >> "$GITHUB_STEP_SUMMARY"

--- a/i18next.config.ts
+++ b/i18next.config.ts
@@ -5,7 +5,7 @@ import pluralPlugin from './scripts/i18next/pluralPlugin'
 import translationKeyPlugin from './scripts/i18next/translationKeyPlugin'
 
 export default defineConfig({
-  locales: ['en-US'],
+  locales: ['en-US', 'fr-CA'],
   plugins: [conditionalPlugin, pluralPlugin, translationKeyPlugin],
   extract: {
     input: 'src/**/*.{js,jsx,ts,tsx}',


### PR DESCRIPTION
## Summary

- Adds `fr-CA` back to `locales` in `i18next.config.ts` so `i18next-cli extract` also maintains the French manifests: removes keys whose `t()` calls are gone (orphan cleanup), and scaffolds missing keys/plural forms as `""` (safe at runtime via `returnEmptyString: false`; filled by the Crowdin sync).
- Extraction workflow now stages all locales and its comment reflects that French keys are managed here while values stay Crowdin-managed.

Verified locally on the translations branch: with fr-CA included, extraction removed the 13 orphaned fr-CA keys and added only `bookkeeping:label.completed_over_total_done_many` (a French-only CLDR plural form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and i18n manifest maintenance only; no runtime app logic or auth changes, with French copy still sourced from Crowdin sync.
> 
> **Overview**
> **`fr-CA` is included in `i18next-cli` extraction** so French locale manifests stay aligned with code: orphaned keys are removed and missing keys (including locale-specific plural forms) are scaffolded as empty strings, while **Crowdin continues to own translated values**.
> 
> The **manual extract-keys GitHub Action** is broadened from English-only to **all locales under `src/assets/locales`**, with renamed workflow/concurrency group, branch (`i18n/extract-keys`), and PR titles/messages documenting that `fr-CA` key structure is maintained here and values remain Crowdin-managed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea8f649426c8618e06e957f1fe3425fd037a9115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->