### PR TITLE
chore: promote MileageTracking and MileageSummaryCard to stable exports

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,7 +39,7 @@ export { GlobalDateRangeSelection } from './components/DateSelection/GlobalDateR
 export { GlobalMonthPicker } from './components/GlobalMonthPicker/GlobalMonthPicker'
 
 /* --------------------- Cards -------------------------- */
-export { MileageSummaryCard as unstable_MileageSummaryCard } from './components/MileageSummaryCard/MileageSummaryCard'
+export { MileageSummaryCard } from './components/MileageSummaryCard/MileageSummaryCard'
 
 /*
 ======================= Composite Views =======================
@@ -50,7 +50,7 @@ export { AccountingOverview } from './views/AccountingOverview/AccountingOvervie
 export { BankTransactionsWithLinkedAccounts } from './views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts'
 export { BookkeepingOverview } from './views/BookkeepingOverview/BookkeepingOverview'
 export { GeneralLedgerView } from './views/GeneralLedger/GeneralLedger'
-export { unstable_MileageTracking } from './views/MileageTracking'
+export { MileageTracking } from './views/MileageTracking'
 export { Reports } from './views/Reports/Reports'
 export { SolopreneurOverview } from './views/SolopreneurOverview/SolopreneurOverview'
 export { TaxEstimates } from './views/TaxEstimates/TaxEstimates'

--- a/src/views/MileageTracking.stories.tsx
+++ b/src/views/MileageTracking.stories.tsx
@@ -1,13 +1,13 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
 
-import { unstable_MileageTracking } from '@views/MileageTracking'
+import { MileageTracking } from '@views/MileageTracking'
 
 import { FIXTURE_YEAR_RANGE } from '@fixtures/constants/fixtureYear'
 import { PinnedGlobalDateRange } from '@test-utils/PinnedGlobalDateRange'
 
-const meta: Meta<typeof unstable_MileageTracking> = {
+const meta: Meta<typeof MileageTracking> = {
   title: 'Views/MileageTracking',
-  component: unstable_MileageTracking,
+  component: MileageTracking,
   args: {
     showTitle: true,
   },
@@ -28,6 +28,6 @@ const meta: Meta<typeof unstable_MileageTracking> = {
 
 export default meta
 
-type Story = StoryObj<typeof unstable_MileageTracking>
+type Story = StoryObj<typeof MileageTracking>
 
 export const Default: Story = {}

--- a/src/views/MileageTracking.tsx
+++ b/src/views/MileageTracking.tsx
@@ -8,7 +8,7 @@ import { MileageTrackingStats } from '@components/MileageTrackingStats/MileageTr
 import { Trips } from '@components/Trips/Trips'
 import { View } from '@components/View/View'
 
-export const unstable_MileageTracking = ({ showTitle = true }: { showTitle?: boolean }) => {
+export const MileageTracking = ({ showTitle = true }: { showTitle?: boolean }) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const { t } = useTranslation()
 


### PR DESCRIPTION
## Scope
Removes the `unstable_` prefix from the mileage tracking public API, marking it as stable.

- `unstable_MileageTracking` → `MileageTracking` (view + stories)
- `unstable_MileageSummaryCard` → `MileageSummaryCard` (index export)

## Verification
- `npx tsc --noEmit` passes with no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking rename of public package exports; downstream apps must update import names even though runtime behavior is unchanged.
> 
> **Overview**
> **Promotes mileage APIs from experimental to stable** by dropping the `unstable_` prefix on public exports.
> 
> `MileageTracking` is renamed in the view module and re-exported from `index.tsx`; Storybook stories import and reference the stable name. `MileageSummaryCard` is exported from `index.tsx` without the `unstable_` alias.
> 
> This is a **breaking change** for consumers still importing `unstable_MileageTracking` or `unstable_MileageSummaryCard`; behavior of the components is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5fa614578218e954d73ebe6fcffd26506afcf3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->