### PR TITLE
feat: add Tasks story with reconnect-accounts mock and style polish

### DIFF
--- a/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
+++ b/src/components/LinkAccounts/LinkAccountsLinkStep.tsx
@@ -46,7 +46,7 @@ export function LinkAccountsLinkStep({ showDoneLinkingButton = true }: LinkAccou
         <ConditionalList
           list={effectiveAccounts}
           Empty={(
-            <VStack gap='xl' pbe='md' align='start'>
+            <VStack gap='xl' align='start'>
               <P status='disabled'>
                 {t('linkedAccounts:label.connect_bank_accounts_and_credit_cards', 'Connect your bank accounts and credit cards to automatically import your business transactions.')}
               </P>

--- a/src/components/LinkedAccountThumb/linkedAccountThumb.scss
+++ b/src/components/LinkedAccountThumb/linkedAccountThumb.scss
@@ -46,7 +46,7 @@
   background: var(--color-base-0);
 
   &.--show-ledger-balance {
-    height: 154px;
+    height: 162px;
   }
 
   .Layer__linked-accounts__grid:not(.--locked) [data-selection-mode='multiple'] & {

--- a/src/components/LinkedAccounts/LinkedAccounts.stories.tsx
+++ b/src/components/LinkedAccounts/LinkedAccounts.stories.tsx
@@ -10,11 +10,8 @@ type LinkedAccountsStoryArgs = {
   title: string
 } & Pick<LinkedAccountsProps, 'stringOverrides'>
 
-/*
- * Trim the seeded store to two accounts instead of overriding the GET handler:
- * the add-account (plaid link exchange) and confirm/exclude mocks mutate the
- * store, so the GET must stay store-driven for those flows to work.
- */
+// Trim the store rather than overriding the GET handler: the add-account and
+// confirm/exclude mocks mutate the store, so the GET must stay store-driven.
 const keepTwoAccounts = () => {
   bankAccounts.slice(2).forEach(({ id }) => bankAccountStore.deleteById(id))
 }

--- a/src/components/LinkedAccounts/LinkedAccounts.stories.tsx
+++ b/src/components/LinkedAccounts/LinkedAccounts.stories.tsx
@@ -1,14 +1,53 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
 
-import { LinkedAccounts } from '@components/LinkedAccounts/LinkedAccounts'
+import { LinkedAccounts, type LinkedAccountsProps } from '@components/LinkedAccounts/LinkedAccounts'
 
-const meta = {
+import { bankAccountStore } from '@msw/api/businesses/[business-id]/bank-accounts/store'
+import { bankAccounts } from '@fixtures/generated/bankAccounts.gen'
+
+type LinkedAccountsStoryArgs = {
+  showLedgerBalance: boolean
+  title: string
+} & Pick<LinkedAccountsProps, 'stringOverrides'>
+
+/*
+ * Trim the seeded store to two accounts instead of overriding the GET handler:
+ * the add-account (plaid link exchange) and confirm/exclude mocks mutate the
+ * store, so the GET must stay store-driven for those flows to work.
+ */
+const keepTwoAccounts = () => {
+  bankAccounts.slice(2).forEach(({ id }) => bankAccountStore.deleteById(id))
+}
+
+const meta: Meta<LinkedAccountsStoryArgs> = {
   title: 'Components/LinkedAccounts',
   component: LinkedAccounts,
+  loaders: [keepTwoAccounts],
+  parameters: {
+    controls: { include: ['showLedgerBalance', 'stringOverrides.title'] },
+  },
+  args: {
+    showLedgerBalance: false,
+    title: '',
+  },
   argTypes: {
-    asWidget: { table: { disable: true } },
-    elevated: { table: { disable: true } },
-    plaidHostedLinkConfig: { table: { disable: true } },
+    stringOverrides: { table: { disable: true } },
+    showLedgerBalance: {
+      control: 'boolean',
+      description: 'Show each account’s ledger balance row',
+    },
+    title: {
+      name: 'stringOverrides.title',
+      control: 'text',
+      description:
+        'The real prop is `stringOverrides?: { title?: string }`. Type a value to set '
+        + '`stringOverrides.title`, or leave it blank to omit the override and use the default.',
+      table: {
+        category: 'String overrides',
+        type: { summary: '{ title?: string }' },
+        defaultValue: { summary: 'Linked Accounts' },
+      },
+    },
   },
   decorators: [
     Story => (
@@ -25,10 +64,16 @@ const meta = {
       </div>
     ),
   ],
-} satisfies Meta<typeof LinkedAccounts>
+  render: ({ showLedgerBalance, title }) => (
+    <LinkedAccounts
+      showLedgerBalance={showLedgerBalance}
+      stringOverrides={title ? { title } : undefined}
+    />
+  ),
+}
 
 export default meta
 
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<LinkedAccountsStoryArgs>
 
 export const Default: Story = {}

--- a/src/components/LinkedAccounts/linkedAccountsContent.scss
+++ b/src/components/LinkedAccounts/linkedAccountsContent.scss
@@ -4,6 +4,7 @@
   gap: var(--spacing-md);
   align-items: stretch;
   padding: var(--spacing-lg);
+  padding-top: 0;
 
   @media screen and (width <= 650px) {
     flex-wrap: nowrap;
@@ -26,10 +27,6 @@
     display: flex;
     outline: none;
   }
-}
-
-.Layer__linked-accounts__header + .Layer__linked-accounts__list {
-  padding-top: 0;
 }
 
 .Layer__linked-accounts__new-account {

--- a/src/components/Tasks/Tasks.stories.tsx
+++ b/src/components/Tasks/Tasks.stories.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef } from 'react'
+import { type Meta, type StoryObj } from '@storybook/react-vite'
+
+import { useBankAccountsGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bank-accounts/useListBankAccounts'
+import { Tasks } from '@components/Tasks/Tasks'
+
+import { get as getBankAccounts } from '@msw/api/businesses/[business-id]/bank-accounts/get'
+import { handlers } from '@msw/handlers'
+import { FIXTURE_YEAR_RANGE } from '@fixtures/constants/fixtureYear'
+import { bankAccounts } from '@fixtures/generated/bankAccounts.gen'
+import { PinnedGlobalDateRange } from '@test-utils/PinnedGlobalDateRange'
+
+type TasksStoryArgs = {
+  mobile: boolean
+  header: string
+  showReconnectAction: boolean
+  onClickReconnectAccounts?: () => void
+}
+
+/*
+ * The reconnect notification only renders when the bank-accounts response has
+ * accounts with `isDisconnected && notifyWhenDisconnected`, and MSW handlers
+ * are registered once per story load — they can't read args. The handler is
+ * given this mutable array, whose second entry is swapped when the callback
+ * toggle changes; the mock encodes it per request, so a refetch picks it up.
+ */
+const mockAccounts = [...bankAccounts]
+
+const setSecondAccountDisconnected = (disconnected: boolean) => {
+  mockAccounts[1] = disconnected
+    ? { ...bankAccounts[1], isDisconnected: true, notifyWhenDisconnected: true }
+    : bankAccounts[1]
+}
+
+const SyncDisconnectedAccountMock = ({ disconnected }: { disconnected: boolean }) => {
+  const { invalidate } = useBankAccountsGlobalCacheActions()
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    setSecondAccountDisconnected(disconnected)
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    void invalidate()
+  }, [disconnected, invalidate])
+
+  return null
+}
+
+const meta: Meta<TasksStoryArgs> = {
+  title: 'Components/Tasks',
+  component: Tasks,
+  parameters: {
+    msw: { handlers: [getBankAccounts.mock(mockAccounts), ...handlers] },
+    controls: { include: ['mobile', 'stringOverrides.header', 'onClickReconnectAccounts'] },
+  },
+  args: {
+    mobile: false,
+    header: '',
+    showReconnectAction: false,
+  },
+  argTypes: {
+    onClickReconnectAccounts: { table: { disable: true } },
+    mobile: {
+      control: 'boolean',
+      description:
+        'Forces the compact mobile layout for the task list only. Independent of the responsive '
+        + 'behavior: the year tabs and month selector adapt to the actual viewport width, not this prop.',
+    },
+    header: {
+      name: 'stringOverrides.header',
+      control: 'text',
+      description:
+        'The real prop is `stringOverrides?: { header?: string }`. Type a value to set '
+        + '`stringOverrides.header`, or leave it blank to omit the override and use the default.',
+      table: {
+        category: 'String overrides',
+        type: { summary: '{ header?: string }' },
+      },
+    },
+    showReconnectAction: {
+      name: 'onClickReconnectAccounts',
+      control: 'boolean',
+      description:
+        'The real prop is the `onClickReconnectAccounts: () => void` callback. Toggle this on to '
+        + 'provide it (an alert here) and to mark a mocked bank account as disconnected so the '
+        + 'notification banner renders; toggle off to omit both.',
+      table: {
+        category: 'Callbacks',
+        type: { summary: '() => void' },
+      },
+    },
+  },
+  decorators: [
+    Story => (
+      <PinnedGlobalDateRange dateRange={FIXTURE_YEAR_RANGE}>
+        <div style={{ display: 'grid', paddingBlock: '2rem', paddingInline: '3rem' }}>
+          <div style={{ display: 'grid', minInlineSize: '20rem', maxInlineSize: '48rem' }}>
+            <Story />
+          </div>
+        </div>
+      </PinnedGlobalDateRange>
+    ),
+  ],
+  render: ({ mobile, header, showReconnectAction }) => (
+    <>
+      <SyncDisconnectedAccountMock disconnected={showReconnectAction} />
+      <Tasks
+        mobile={mobile}
+        stringOverrides={header ? { header } : undefined}
+        onClickReconnectAccounts={showReconnectAction ? () => window.alert('Reconnect accounts clicked') : undefined}
+      />
+    </>
+  ),
+}
+
+export default meta
+
+type Story = StoryObj<TasksStoryArgs>
+
+export const Default: Story = {}

--- a/src/components/Tasks/Tasks.stories.tsx
+++ b/src/components/Tasks/Tasks.stories.tsx
@@ -17,13 +17,8 @@ type TasksStoryArgs = {
   onClickReconnectAccounts?: () => void
 }
 
-/*
- * The reconnect notification only renders when the bank-accounts response has
- * accounts with `isDisconnected && notifyWhenDisconnected`, and MSW handlers
- * are registered once per story load — they can't read args. The handler is
- * given this mutable array, whose second entry is swapped when the callback
- * toggle changes; the mock encodes it per request, so a refetch picks it up.
- */
+// MSW handlers register once per story load and can't read args, so the callback
+// toggle mutates this array and refetches to control the disconnected banner.
 const mockAccounts = [...bankAccounts]
 
 const setSecondAccountDisconnected = (disconnected: boolean) => {

--- a/src/components/Tasks/taskMonthTile.scss
+++ b/src/components/Tasks/taskMonthTile.scss
@@ -23,7 +23,7 @@
     box-shadow: 0 0 0 1px var(--color-base-500), 0 0 0 3px var(--color-base-300);
   }
 
-  .Layer__P {
+  & > .Layer__P {
     min-width: 24px;
   }
 }

--- a/src/components/Tasks/tasks.scss
+++ b/src/components/Tasks/tasks.scss
@@ -5,7 +5,7 @@
   max-height: calc(100vh - 2 * var(--spacing-lg));
 }
 
-// Inset the scrollbar 4px from the container's right edge (6px visible + 4px inset).
+// Inset the 6px scrollbar 4px from the right, top, and bottom container edges.
 .Layer__component.Layer__tasks {
   &::-webkit-scrollbar {
     width: 10px;
@@ -13,14 +13,12 @@
 
   &::-webkit-scrollbar-track,
   &::-webkit-scrollbar-thumb {
-    // The transparent right border eats into the right corners' radius, squaring
-    // them off; widen the right-side radii by the border width to compensate.
+    // The transparent border consumes the right corners' radius, so widen them to compensate.
     border-radius: 4px 8px 8px 4px / 4px;
     border-right: 4px solid transparent;
     background-clip: padding-box;
   }
 
-  // Invisible 4px scrollbar buttons inset the track and thumb travel from the top and bottom edges.
   &::-webkit-scrollbar-button {
     height: 4px;
     background: transparent;

--- a/src/components/Tasks/tasks.scss
+++ b/src/components/Tasks/tasks.scss
@@ -5,6 +5,28 @@
   max-height: calc(100vh - 2 * var(--spacing-lg));
 }
 
+// Inset the scrollbar 4px from the container's right edge (6px visible + 4px inset).
+.Layer__component.Layer__tasks {
+  &::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  &::-webkit-scrollbar-track,
+  &::-webkit-scrollbar-thumb {
+    // The transparent right border eats into the right corners' radius, squaring
+    // them off; widen the right-side radii by the border width to compensate.
+    border-radius: 4px 8px 8px 4px / 4px;
+    border-right: 4px solid transparent;
+    background-clip: padding-box;
+  }
+
+  // Invisible 4px scrollbar buttons inset the track and thumb travel from the top and bottom edges.
+  &::-webkit-scrollbar-button {
+    height: 4px;
+    background: transparent;
+  }
+}
+
 .Layer__tasks__content {
   min-height: 0;
   opacity: 1;

--- a/src/fixtures/bankAccounts/constants.ts
+++ b/src/fixtures/bankAccounts/constants.ts
@@ -1,9 +1,9 @@
 import { type AccountInstitution } from '@schemas/common/accountInstitution'
 
 export const accountNameKinds = [
-  'Business Checking',
-  'Business Savings',
-  'Business Credit Card',
+  'Checking',
+  'Savings',
+  'Credit Card',
 ] as const
 
 export const institutions: AccountInstitution[] = [

--- a/src/fixtures/bankAccounts/generator.ts
+++ b/src/fixtures/bankAccounts/generator.ts
@@ -3,10 +3,10 @@ import { schema } from '@fixtures/bankAccounts/schema'
 import { createGenerator } from '@fixtures/utils/createGenerator'
 
 const generate = createGenerator(schema, {
-  uniqueBy: [account => account.id],
+  uniqueBy: [account => account.id, account => account.accountName],
 })
 
-export const generator = () => generate({ numRuns: 5 })
+export const generator = () => generate({ numRuns: 5, seed: 3 })
 
 export const generateAccountsNeedingConfirmation = (count: number, seed: number) =>
   generate({ numRuns: count, seed }).map(markAccountNeedingConfirmation)

--- a/src/fixtures/generated/bankAccounts.gen.ts
+++ b/src/fixtures/generated/bankAccounts.gen.ts
@@ -3,22 +3,22 @@ import type { schema } from '@fixtures/bankAccounts/schema'
 
 export const bankAccounts = [
   {
-    "id": "00000001-e14c-4f0d-8f51-ecbd67728f21",
-    "accountName": "American Express Business Savings",
+    "id": "00000001-b730-442c-8d79-cb0f139d1307",
+    "accountName": "Chase Savings",
     "institution": {
-      "name": "American Express",
+      "name": "Chase",
       "logo": null
     },
     "notifyWhenDisconnected": false,
     "isDisconnected": false,
     "externalAccounts": [
       {
-        "id": "ffffffee-fff7-5fff-9c86-5097ffffffe3",
+        "id": "469aa9b2-35e4-509f-8c7d-061a6fa33d07",
         "externalAccountSource": "PLAID",
-        "externalAccountName": "American Express Business Savings",
-        "mask": "9995",
+        "externalAccountName": "Chase Savings",
+        "mask": "5717",
         "institution": {
-          "name": "American Express",
+          "name": "Chase",
           "logo": null
         },
         "notifications": [],
@@ -30,29 +30,29 @@ export const bankAccounts = [
       }
     ],
     "latestBalanceTimestamp": {
-      "balance": 2499900
+      "balance": 576200
     },
-    "currentLedgerBalance": 1084600,
-    "mask": "9995",
+    "currentLedgerBalance": 2498800,
+    "mask": "5717",
     "notifications": []
   },
   {
-    "id": "00000001-4b46-4097-85f0-896231804c64",
-    "accountName": "American Express Business Savings",
+    "id": "00000001-9a55-48cb-8f2a-738709fe0dd7",
+    "accountName": "Wells Fargo Checking",
     "institution": {
-      "name": "American Express",
+      "name": "Wells Fargo",
       "logo": null
     },
-    "notifyWhenDisconnected": false,
+    "notifyWhenDisconnected": true,
     "isDisconnected": false,
     "externalAccounts": [
       {
-        "id": "cdc54d3e-606e-4046-bfff-ffe8ffffffe9",
+        "id": "00000007-0009-1000-8000-001b8d4052ea",
         "externalAccountSource": "PLAID",
-        "externalAccountName": "American Express Business Savings",
-        "mask": "9988",
+        "externalAccountName": "Wells Fargo Checking",
+        "mask": "0001",
         "institution": {
-          "name": "American Express",
+          "name": "Wells Fargo",
           "logo": null
         },
         "notifications": [],
@@ -64,27 +64,27 @@ export const bankAccounts = [
       }
     ],
     "latestBalanceTimestamp": {
-      "balance": 50000
+      "balance": 1989800
     },
-    "currentLedgerBalance": 50600,
-    "mask": "9988",
+    "currentLedgerBalance": 51100,
+    "mask": "0001",
     "notifications": []
   },
   {
-    "id": "00000001-045f-4a99-834f-2248873864e4",
-    "accountName": "Capital One Business Credit Card",
+    "id": "00000001-4f9f-44c5-855f-1e87fbf9d696",
+    "accountName": "Capital One Checking",
     "institution": {
       "name": "Capital One",
       "logo": null
     },
-    "notifyWhenDisconnected": false,
+    "notifyWhenDisconnected": true,
     "isDisconnected": false,
     "externalAccounts": [
       {
-        "id": "00000003-001c-1000-bfff-ffe8fffffff4",
+        "id": "540a9839-0008-1000-bfef-0227ffffffef",
         "externalAccountSource": "PLAID",
-        "externalAccountName": "Capital One Business Credit Card",
-        "mask": "0008",
+        "externalAccountName": "Capital One Checking",
+        "mask": "0012",
         "institution": {
           "name": "Capital One",
           "logo": null
@@ -98,15 +98,15 @@ export const bankAccounts = [
       }
     ],
     "latestBalanceTimestamp": {
-      "balance": 78100
+      "balance": 2499400
     },
-    "currentLedgerBalance": 2499900,
-    "mask": "0008",
+    "currentLedgerBalance": 50900,
+    "mask": "0012",
     "notifications": []
   },
   {
-    "id": "00000001-a0b6-452b-8812-70c20a3e49d9",
-    "accountName": "Capital One Business Credit Card",
+    "id": "00000001-52bc-4e5b-8621-b3f696bff863",
+    "accountName": "Capital One Savings",
     "institution": {
       "name": "Capital One",
       "logo": null
@@ -115,9 +115,9 @@ export const bankAccounts = [
     "isDisconnected": false,
     "externalAccounts": [
       {
-        "id": "00000016-001e-1000-bfff-fff500000009",
+        "id": "00000017-0011-1000-8000-0009fffffffb",
         "externalAccountSource": "PLAID",
-        "externalAccountName": "Capital One Business Credit Card",
+        "externalAccountName": "Capital One Savings",
         "mask": "0006",
         "institution": {
           "name": "Capital One",
@@ -132,29 +132,29 @@ export const bankAccounts = [
       }
     ],
     "latestBalanceTimestamp": {
-      "balance": 51100
+      "balance": 1816000
     },
-    "currentLedgerBalance": 2416500,
+    "currentLedgerBalance": 50200,
     "mask": "0006",
     "notifications": []
   },
   {
-    "id": "00000001-d6fb-4ef5-8c75-46e387b4abad",
-    "accountName": "Chase Business Checking",
+    "id": "00000001-2211-45d8-8af4-5d23ec83708f",
+    "accountName": "Bank of America Savings",
     "institution": {
-      "name": "Chase",
+      "name": "Bank of America",
       "logo": null
     },
-    "notifyWhenDisconnected": false,
+    "notifyWhenDisconnected": true,
     "isDisconnected": false,
     "externalAccounts": [
       {
-        "id": "0000001f-fff1-5fff-bfff-fff6b4f4186a",
+        "id": "c5296f7f-fff2-5fff-8000-001cffffffe3",
         "externalAccountSource": "PLAID",
-        "externalAccountName": "Chase Business Checking",
-        "mask": "0010",
+        "externalAccountName": "Bank of America Savings",
+        "mask": "1846",
         "institution": {
-          "name": "Chase",
+          "name": "Bank of America",
           "logo": null
         },
         "notifications": [],
@@ -166,10 +166,10 @@ export const bankAccounts = [
       }
     ],
     "latestBalanceTimestamp": {
-      "balance": 2499300
+      "balance": 2500000
     },
-    "currentLedgerBalance": 600000,
-    "mask": "0010",
+    "currentLedgerBalance": 51400,
+    "mask": "1846",
     "notifications": []
   }
 ] as (typeof schema.Type)[]


### PR DESCRIPTION
## Summary
- Add a Storybook story for `Tasks` with controls for `mobile`, `stringOverrides.header`, and `onClickReconnectAccounts` (grouped under Callbacks; the raw docgen prop is hidden). Toggling the callback also marks a mocked bank account as disconnected — the MSW handler reads a mutable accounts array and the story invalidates the SWR bank-accounts cache — so the reconnect notification banner only renders when the callback is provided.
- Fix the LinkedAccounts story after the bank-account fixture regeneration (seed change removed the American Express account the story looked up): seed the mock store down to two accounts via a loader instead of statically overriding the GET handler, keeping the add-account (plaid link exchange) and confirm/exclude flows working.
- Style polish: remove top padding on the linked accounts list, remove stray padding under the "Connect my bank" button, inset the Tasks scrollbar 4px from the container's right/top/bottom edges (WebKit), and refresh bank-account fixture names/seed.

## Verification
- `tsc --noEmit`, `eslint`, and `stylelint` pass.
- Verified in Storybook: Tasks banner appears/disappears with the callback toggle; LinkedAccounts starts with two accounts and add/confirm/exclude flows work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storybook, SCSS, and mock fixture changes only; no production API or auth logic touched.
> 
> **Overview**
> Adds a **Storybook** story for `Tasks` with controls for mobile layout, header string overrides, and a reconnect-accounts callback. Toggling reconnect uses MSW + SWR cache invalidation to mark a mocked account disconnected so the reconnect banner only shows when the callback is wired.
> 
> **LinkedAccounts** stories are updated after bank-account fixture regeneration: a loader trims the MSW store to two accounts (instead of overriding GET) so add/confirm/exclude flows still work. Story controls now cover `showLedgerBalance` and title overrides.
> 
> **Styling**: linked accounts list always uses `padding-top: 0` (drops header-adjacent rule); removes bottom padding under the empty-state “Connect my bank” block; bumps ledger-balance thumb height to 162px; scopes task month tile `min-width` to direct child `P`; adds WebKit scrollbar inset on `Tasks`.
> 
> **Fixtures**: account name kinds drop the “Business ” prefix, generator uses fixed seed `3` and unique `accountName`, and `bankAccounts.gen.ts` is regenerated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fda91921daed9ae750e734272eb55221da8cb6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->