### PR TITLE
feat: add Storybook stories for `GlobalMonthPicker` and `GlobalDateSelection`

### DIFF
--- a/src/components/DateSelection/DateRangeSelection.tsx
+++ b/src/components/DateSelection/DateRangeSelection.tsx
@@ -21,7 +21,7 @@ export const DateRangeSelection = ({
 }: DateRangeSelectionProps) => {
   return (
     <div
-      className={classNames('Layer__DateRangeSelection', {
+      className={classNames('Layer__DateRangeSelection Layer__variables', {
         'Layer__DateRangeSelection--compact': isCompact,
       })}
     >

--- a/src/components/DateSelection/GlobalDateRangeSelection.stories.tsx
+++ b/src/components/DateSelection/GlobalDateRangeSelection.stories.tsx
@@ -5,14 +5,14 @@ import { GlobalDateRangeSelection, type GlobalDateRangeSelectionProps } from '@c
 import { get as getBusiness } from '@msw/api/businesses/[business-id]/get'
 import { handlers } from '@msw/handlers'
 import { makeBusiness } from '@fixtures/business/mocks'
-import { FIXTURE_YEAR_RANGE } from '@fixtures/constants/fixtureYear'
+import { FIXTURE_YEAR, FIXTURE_YEAR_RANGE } from '@fixtures/constants/fixtureYear'
 import { PinnedGlobalDateRange } from '@test-utils/PinnedGlobalDateRange'
 
 const meta: Meta<GlobalDateRangeSelectionProps> = {
   title: 'Date/GlobalDateRangeSelection',
   component: GlobalDateRangeSelection,
   parameters: {
-    msw: { handlers: [getBusiness.mock(makeBusiness({ activationAt: new Date(2024, 0, 1) })), ...handlers] },
+    msw: { handlers: [getBusiness.mock(makeBusiness({ activationAt: new Date(FIXTURE_YEAR - 1, 0, 1) })), ...handlers] },
     controls: { include: ['showLabels', 'isCompact'] },
   },
   decorators: [

--- a/src/components/DateSelection/GlobalDateRangeSelection.stories.tsx
+++ b/src/components/DateSelection/GlobalDateRangeSelection.stories.tsx
@@ -1,23 +1,12 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
 
-import { type DateRange } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
-import { GlobalDateRangeSelection } from '@components/DateSelection/GlobalDateRangeSelection'
+import { GlobalDateRangeSelection, type GlobalDateRangeSelectionProps } from '@components/DateSelection/GlobalDateRangeSelection'
 
 import { get as getBusiness } from '@msw/api/businesses/[business-id]/get'
 import { handlers } from '@msw/handlers'
 import { makeBusiness } from '@fixtures/business/mocks'
-import { FIXTURE_YEAR } from '@fixtures/constants/fixtureYear'
+import { FIXTURE_YEAR_RANGE } from '@fixtures/constants/fixtureYear'
 import { PinnedGlobalDateRange } from '@test-utils/PinnedGlobalDateRange'
-
-const PINNED_RANGE: DateRange = {
-  startDate: new Date(FIXTURE_YEAR, 8, 1),
-  endDate: new Date(FIXTURE_YEAR, 8, 30),
-}
-
-type GlobalDateRangeSelectionProps = {
-  showLabels?: boolean
-  isCompact?: boolean
-}
 
 const meta: Meta<GlobalDateRangeSelectionProps> = {
   title: 'Date/GlobalDateRangeSelection',
@@ -28,7 +17,7 @@ const meta: Meta<GlobalDateRangeSelectionProps> = {
   },
   decorators: [
     Story => (
-      <PinnedGlobalDateRange dateRange={PINNED_RANGE}>
+      <PinnedGlobalDateRange dateRange={FIXTURE_YEAR_RANGE}>
         <div style={{ padding: '2rem' }}>
           <Story />
         </div>

--- a/src/components/DateSelection/GlobalDateRangeSelection.stories.tsx
+++ b/src/components/DateSelection/GlobalDateRangeSelection.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
 
 import { type DateRange } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
-import { GlobalDateSelection } from '@components/DateSelection/GlobalDateSelection'
+import { GlobalDateRangeSelection } from '@components/DateSelection/GlobalDateRangeSelection'
 
 import { get as getBusiness } from '@msw/api/businesses/[business-id]/get'
 import { handlers } from '@msw/handlers'
@@ -14,14 +14,14 @@ const PINNED_RANGE: DateRange = {
   endDate: new Date(FIXTURE_YEAR, 8, 30),
 }
 
-type GlobalDateSelectionProps = {
+type GlobalDateRangeSelectionProps = {
   showLabels?: boolean
   isCompact?: boolean
 }
 
-const meta: Meta<GlobalDateSelectionProps> = {
-  title: 'Date/GlobalDateSelection',
-  component: GlobalDateSelection,
+const meta: Meta<GlobalDateRangeSelectionProps> = {
+  title: 'Date/GlobalDateRangeSelection',
+  component: GlobalDateRangeSelection,
   parameters: {
     msw: { handlers: [getBusiness.mock(makeBusiness({ activationAt: new Date(2024, 0, 1) })), ...handlers] },
     controls: { include: ['showLabels', 'isCompact'] },
@@ -42,7 +42,7 @@ const meta: Meta<GlobalDateSelectionProps> = {
   argTypes: {
     showLabels: {
       control: 'boolean',
-      description: 'Render labels above the range combobox and date picker',
+      description: 'Render labels above the range combobox and date pickers',
     },
     isCompact: {
       control: 'boolean',
@@ -53,6 +53,6 @@ const meta: Meta<GlobalDateSelectionProps> = {
 
 export default meta
 
-type Story = StoryObj<GlobalDateSelectionProps>
+type Story = StoryObj<GlobalDateRangeSelectionProps>
 
 export const Default: Story = {}

--- a/src/components/DateSelection/GlobalDateRangeSelection.tsx
+++ b/src/components/DateSelection/GlobalDateRangeSelection.tsx
@@ -1,7 +1,7 @@
 import { useGlobalDateRange, useGlobalDateRangeActions } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
 import { DateRangeSelection } from '@components/DateSelection/DateRangeSelection'
 
-type GlobalDateRangeSelectionProps = {
+export type GlobalDateRangeSelectionProps = {
   showLabels?: boolean
   isCompact?: boolean
 }

--- a/src/components/DateSelection/GlobalDateSelection.stories.tsx
+++ b/src/components/DateSelection/GlobalDateSelection.stories.tsx
@@ -1,0 +1,58 @@
+import { type Meta, type StoryObj } from '@storybook/react-vite'
+
+import { type DateRange } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
+import { GlobalDateSelection } from '@components/DateSelection/GlobalDateSelection'
+
+import { get as getBusiness } from '@msw/api/businesses/[business-id]/get'
+import { handlers } from '@msw/handlers'
+import { makeBusiness } from '@fixtures/business/mocks'
+import { FIXTURE_YEAR } from '@fixtures/constants/fixtureYear'
+import { PinnedGlobalDateRange } from '@test-utils/PinnedGlobalDateRange'
+
+const PINNED_RANGE: DateRange = {
+  startDate: new Date(FIXTURE_YEAR, 8, 1),
+  endDate: new Date(FIXTURE_YEAR, 8, 30),
+}
+
+type GlobalDateSelectionProps = {
+  showLabels?: boolean
+  isCompact?: boolean
+}
+
+const meta: Meta<GlobalDateSelectionProps> = {
+  title: 'Date/GlobalDateSelection',
+  component: GlobalDateSelection,
+  parameters: {
+    msw: { handlers: [getBusiness.mock(makeBusiness({ activationAt: new Date(2024, 0, 1) })), ...handlers] },
+    controls: { include: ['showLabels', 'isCompact'] },
+  },
+  decorators: [
+    Story => (
+      <PinnedGlobalDateRange dateRange={PINNED_RANGE}>
+        <div style={{ padding: '2rem' }}>
+          <Story />
+        </div>
+      </PinnedGlobalDateRange>
+    ),
+  ],
+  args: {
+    showLabels: false,
+    isCompact: false,
+  },
+  argTypes: {
+    showLabels: {
+      control: 'boolean',
+      description: 'Render labels above the range combobox and date picker',
+    },
+    isCompact: {
+      control: 'boolean',
+      description: 'Use the compact layout variant',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<GlobalDateSelectionProps>
+
+export const Default: Story = {}

--- a/src/components/DateSelection/GlobalDateSelection.tsx
+++ b/src/components/DateSelection/GlobalDateSelection.tsx
@@ -17,7 +17,7 @@ export const GlobalDateSelection = ({ showLabels = false, isCompact = false }: G
 
   return (
     <div
-      className={classNames('Layer__GlobalDateSelection', {
+      className={classNames('Layer__GlobalDateSelection Layer__variables', {
         'Layer__GlobalDateSelection--compact': isCompact,
       })}
     >

--- a/src/components/DateSelection/dateRangeSelection.scss
+++ b/src/components/DateSelection/dateRangeSelection.scss
@@ -2,6 +2,7 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(10rem, 1fr));
   gap: var(--spacing-xs);
+  max-inline-size: 37rem;
 
   &--compact {
     grid-template-columns: repeat(2, minmax(6.75rem, 1fr));

--- a/src/components/DateSelection/globalDateSelection.scss
+++ b/src/components/DateSelection/globalDateSelection.scss
@@ -2,6 +2,7 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(10rem, 1fr));
   gap: var(--spacing-xs);
+  max-inline-size: 25rem;
 
   &--compact {
     grid-template-columns: minmax(6.75rem, 1fr);

--- a/src/components/GlobalMonthPicker/GlobalMonthPicker.stories.tsx
+++ b/src/components/GlobalMonthPicker/GlobalMonthPicker.stories.tsx
@@ -1,23 +1,12 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
 
-import { type DateRange } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
-import { GlobalMonthPicker } from '@components/GlobalMonthPicker/GlobalMonthPicker'
+import { GlobalMonthPicker, type GlobalMonthPickerProps } from '@components/GlobalMonthPicker/GlobalMonthPicker'
 
 import { get as getBusiness } from '@msw/api/businesses/[business-id]/get'
 import { handlers } from '@msw/handlers'
 import { makeBusiness } from '@fixtures/business/mocks'
-import { FIXTURE_YEAR } from '@fixtures/constants/fixtureYear'
+import { FIXTURE_YEAR_RANGE } from '@fixtures/constants/fixtureYear'
 import { PinnedGlobalDateRange } from '@test-utils/PinnedGlobalDateRange'
-
-const PINNED_RANGE: DateRange = {
-  startDate: new Date(FIXTURE_YEAR, 8, 1),
-  endDate: new Date(FIXTURE_YEAR, 8, 30),
-}
-
-type GlobalMonthPickerProps = {
-  truncateMonth?: boolean
-  showLabel?: boolean
-}
 
 const meta: Meta<GlobalMonthPickerProps> = {
   title: 'Date/GlobalMonthPicker',
@@ -28,7 +17,7 @@ const meta: Meta<GlobalMonthPickerProps> = {
   },
   decorators: [
     Story => (
-      <PinnedGlobalDateRange dateRange={PINNED_RANGE}>
+      <PinnedGlobalDateRange dateRange={FIXTURE_YEAR_RANGE}>
         <div style={{ padding: '2rem', maxInlineSize: '20rem' }}>
           <Story />
         </div>

--- a/src/components/GlobalMonthPicker/GlobalMonthPicker.stories.tsx
+++ b/src/components/GlobalMonthPicker/GlobalMonthPicker.stories.tsx
@@ -1,0 +1,58 @@
+import { type Meta, type StoryObj } from '@storybook/react-vite'
+
+import { type DateRange } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
+import { GlobalMonthPicker } from '@components/GlobalMonthPicker/GlobalMonthPicker'
+
+import { get as getBusiness } from '@msw/api/businesses/[business-id]/get'
+import { handlers } from '@msw/handlers'
+import { makeBusiness } from '@fixtures/business/mocks'
+import { FIXTURE_YEAR } from '@fixtures/constants/fixtureYear'
+import { PinnedGlobalDateRange } from '@test-utils/PinnedGlobalDateRange'
+
+const PINNED_RANGE: DateRange = {
+  startDate: new Date(FIXTURE_YEAR, 8, 1),
+  endDate: new Date(FIXTURE_YEAR, 8, 30),
+}
+
+type GlobalMonthPickerProps = {
+  truncateMonth?: boolean
+  showLabel?: boolean
+}
+
+const meta: Meta<GlobalMonthPickerProps> = {
+  title: 'Date/GlobalMonthPicker',
+  component: GlobalMonthPicker,
+  parameters: {
+    msw: { handlers: [getBusiness.mock(makeBusiness({ activationAt: new Date(2024, 0, 1) })), ...handlers] },
+    controls: { include: ['showLabel', 'truncateMonth'] },
+  },
+  decorators: [
+    Story => (
+      <PinnedGlobalDateRange dateRange={PINNED_RANGE}>
+        <div style={{ padding: '2rem', maxInlineSize: '20rem' }}>
+          <Story />
+        </div>
+      </PinnedGlobalDateRange>
+    ),
+  ],
+  args: {
+    showLabel: false,
+    truncateMonth: false,
+  },
+  argTypes: {
+    showLabel: {
+      control: 'boolean',
+      description: 'Render the "Month" label above the picker',
+    },
+    truncateMonth: {
+      control: 'boolean',
+      description: 'Use the short month format (e.g. Sep) instead of the full name',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<GlobalMonthPickerProps>
+
+export const Default: Story = {}

--- a/src/components/GlobalMonthPicker/GlobalMonthPicker.stories.tsx
+++ b/src/components/GlobalMonthPicker/GlobalMonthPicker.stories.tsx
@@ -5,14 +5,14 @@ import { GlobalMonthPicker, type GlobalMonthPickerProps } from '@components/Glob
 import { get as getBusiness } from '@msw/api/businesses/[business-id]/get'
 import { handlers } from '@msw/handlers'
 import { makeBusiness } from '@fixtures/business/mocks'
-import { FIXTURE_YEAR_RANGE } from '@fixtures/constants/fixtureYear'
+import { FIXTURE_YEAR, FIXTURE_YEAR_RANGE } from '@fixtures/constants/fixtureYear'
 import { PinnedGlobalDateRange } from '@test-utils/PinnedGlobalDateRange'
 
 const meta: Meta<GlobalMonthPickerProps> = {
   title: 'Date/GlobalMonthPicker',
   component: GlobalMonthPicker,
   parameters: {
-    msw: { handlers: [getBusiness.mock(makeBusiness({ activationAt: new Date(2024, 0, 1) })), ...handlers] },
+    msw: { handlers: [getBusiness.mock(makeBusiness({ activationAt: new Date(FIXTURE_YEAR - 1, 0, 1) })), ...handlers] },
     controls: { include: ['showLabel', 'truncateMonth'] },
   },
   decorators: [

--- a/src/components/GlobalMonthPicker/GlobalMonthPicker.tsx
+++ b/src/components/GlobalMonthPicker/GlobalMonthPicker.tsx
@@ -7,7 +7,7 @@ import { useBusinessDatePickerBounds } from '@hooks/utils/dates/useBusinessDateP
 import { useGlobalDate, useGlobalDateRangeActions } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
 import { MonthPicker } from '@components/MonthPicker/MonthPicker'
 
-type GlobalMonthPickerProps = {
+export type GlobalMonthPickerProps = {
   truncateMonth?: boolean
   showLabel?: boolean
 }

--- a/src/components/MonthPicker/MonthPicker.tsx
+++ b/src/components/MonthPicker/MonthPicker.tsx
@@ -54,7 +54,7 @@ export const MonthPicker = ({
 
   const inputId = useId()
   return (
-    <VStack>
+    <VStack className='Layer__variables'>
       {showLabel && <Label pbe='3xs' size='sm' htmlFor={inputId}>{label}</Label>}
       <DialogTrigger isOpen={isPopoverOpen} onOpenChange={setPopoverOpen}>
         <InputGroup


### PR DESCRIPTION
…tion

Group both under a new Date section in the sidebar.

## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storybook and presentational CSS/className changes only; no date-store or API behavior changes.
> 
> **Overview**
> Adds Storybook coverage under **`Date/`** for **`GlobalDateRangeSelection`** and **`GlobalMonthPicker`**, with MSW business fixtures, **`PinnedGlobalDateRange`**, and controls for layout/label props. **`GlobalDateRangeSelectionProps`** and **`GlobalMonthPickerProps`** are **exported** so stories can type args.
> 
> To render correctly in isolation, **`Layer__variables`** is applied on **`DateRangeSelection`**, **`GlobalDateSelection`**, and **`MonthPicker`**. Layout caps **`max-inline-size: 37rem`** / **`25rem`** are added on the date-range and global date-selection grids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 990b4d49108645e4eba8c04d0d55666fb5f805bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->