### PR TITLE
fix: remount mobile transactions list on tab change and close removed rows

### DIFF
--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileList.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileList.tsx
@@ -6,6 +6,7 @@ import { useUpsertBankTransactionsDefaultCategories } from '@hooks/features/bank
 import { useBulkSelectionActions } from '@providers/BulkSelectionStore/BulkSelectionStoreProvider'
 import { useMobileListBulkSelection } from '@providers/BulkSelectionStore/useMobileListBulkSelection'
 import { useBankTransactionsContext } from '@contexts/BankTransactionsContext/BankTransactionsContext'
+import { useBankTransactionsFiltersContext } from '@contexts/BankTransactionsFiltersContext/BankTransactionsFiltersContext'
 import { MobileList } from '@ui/MobileList/MobileList'
 import { useMobileListExpansion } from '@ui/MobileList/useMobileListExpansion'
 import { VStack } from '@ui/Stack/Stack'
@@ -86,9 +87,10 @@ const BankTransactionsMobileListContent = ({
   const onRemoveItem = useCallback(
     (bankTransaction: BankTransaction) => {
       removeAfterCategorize([bankTransaction.id])
+      close(bankTransaction.id)
       openNext(bankTransaction.id)
     },
-    [removeAfterCategorize, openNext],
+    [removeAfterCategorize, close, openNext],
   )
 
   const renderFooter = useCallback(
@@ -140,10 +142,18 @@ const BankTransactionsMobileListContent = ({
   )
 }
 
-export const BankTransactionsMobileList = () => (
-  <BankTransactionsPaginatedList>
-    {displayedTransactions => (
-      <BankTransactionsMobileListContent bankTransactions={displayedTransactions} />
-    )}
-  </BankTransactionsPaginatedList>
-)
+export const BankTransactionsMobileList = () => {
+  const { filters: { categorizationStatus } } = useBankTransactionsFiltersContext()
+
+  return (
+    <BankTransactionsPaginatedList>
+      {displayedTransactions => (
+        <BankTransactionsMobileListContent
+          // Remount on tab change so expansion and bulk-mode state reset per tab
+          key={categorizationStatus}
+          bankTransactions={displayedTransactions}
+        />
+      )}
+    </BankTransactionsPaginatedList>
+  )
+}


### PR DESCRIPTION
## Problem

Since v0.1.140 (#1535), transactions categorized in the mobile experience re-expand when viewing the Categorized tab.

The mobile list refactor lifted row expansion state into a `Set` of transaction IDs (`useMobileListExpansion`) held by `BankTransactionsMobileListContent`, which stays mounted across the To Review ↔ Categorized toggle — only the fetched data changes. Two leaks resulted:

1. Categorizing a transaction with hide-after-categorize never removed its ID from `expandedKeys` (`onRemoveItem` only called `removeAfterCategorize` + `openNext`), so the transaction rendered expanded when it reappeared in the Categorized tab.
2. Any rows manually expanded in one tab stayed in the set and rendered expanded in the other tab.

Pre-140, this couldn't happen: expansion state lived in each list item, and tab changes remounted the items, so state reset for free.

## Fix

- Key `BankTransactionsMobileListContent` on the display filter (`categorizationStatus`) so a tab change remounts it. This restores the pre-140 mechanism at the container level: expansion (and bulk-mode state, which had the same cross-tab leak) reset per tab, and the first row of the new tab auto-opens via the existing `open(firstId)` effect once its data arrives.
- `onRemoveItem` also closes the removed row's ID so it can't accumulate stale entries within a tab. It fires via `onExitComplete`, after the fade-out finishes, so there is no animation jank.

## Verification

- Typecheck and eslint pass; no existing tests cover these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped mobile UI state fix with no API, auth, or data-layer changes.
> 
> **Overview**
> Fixes mobile bank transactions where **expanded rows and bulk mode leaked** across To Review ↔ Categorized after the list expansion state was lifted to the parent.
> 
> **`BankTransactionsMobileList`** now reads `categorizationStatus` from filters and sets **`key={categorizationStatus}`** on `BankTransactionsMobileListContent`, so switching tabs remounts the list and clears expansion/bulk state (first row auto-opens again via existing logic).
> 
> When a row is removed after categorize, **`onRemoveItem`** also calls **`close`** on that transaction id so it is dropped from `expandedKeys` before it can show expanded on the Categorized tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a0b79d90081e3df42ded9e43042701daa06b96d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->