### PR TITLE
fix: hide P&L summary mini chart when tile total is negative

### DIFF
--- a/src/components/ProfitAndLossSummaries/internal/SummariesContent.tsx
+++ b/src/components/ProfitAndLossSummaries/internal/SummariesContent.tsx
@@ -105,7 +105,7 @@ export function SummariesContent({
               isExpense={isExpense}
               mode={mode}
               slots={{
-                Chart: renderChart(chartData),
+                Chart: amount < 0 ? null : renderChart(chartData),
                 Footer: config.renderFooter?.(breakdown, isLoading),
               }}
             />


### PR DESCRIPTION
## Scope

Hides the mini chart (donut) in a P&L / cashflow summary row when that tile's total value is negative.

- **P&L mode** — the revenue row hides its chart when revenue is negative; the expenses row hides its chart when expenses is negative.
- **Cashflow mode** — "money in" is the revenue tile (`income + uncategorizedInflows`) and "money out" is the expenses tile (`totalExpenses + uncategorizedOutflows`); a net-negative money-in/money-out hides that tile's chart via the same gate.
- **Net-positive but one segment negative** (cashflow) — the tile total is `>= 0`, so the chart still renders; `ProfitAndLossSummariesMiniChart` already clamps each negative segment to `0`, leaving the pie at 100% of the positive category. No change needed there.

Single-line gate in `SummariesContent.tsx`:

```jsx
Chart: amount < 0 ? null : renderChart(chartData),
```

## Verification

- `tsc --noEmit` clean for the affected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in presentation logic with no API, auth, or data changes; `ProfitAndLossSummariesSummary` already omits the chart area when `Chart` is null.
> 
> **Overview**
> **Hides the mini donut chart** on each P&L / cashflow summary tile when that tile’s displayed **total (`amount`) is negative**, by gating the `Chart` slot in `SummariesContent.tsx`: `amount < 0 ? null : renderChart(chartData)`.
> 
> This applies per row (revenue, expenses, and net) in both modes—e.g. negative revenue or net cashflow no longer renders a misleading breakdown chart. Tiles with **non‑negative totals** still show the chart; segment-level negative values in cashflow continue to be handled inside `ProfitAndLossSummariesMiniChart` (unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae7f70b1ce78069a8615dfb626816de135a580c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->