### PR TITLE
Allow bookkeeping call card copy overrides

### DIFF
--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -154,7 +154,9 @@ export const CallBooking = ({
   const purpose = isOnboardingCall
     ? (stringOverrides?.title ?? t('callBookings:label.onboarding_call', 'Onboarding call'))
     : t('callBookings:label.ad_hoc_call', 'Ad hoc call')
-  const subtitle = stringOverrides?.description ?? t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team')
+  const subtitle = isOnboardingCall
+    ? (stringOverrides?.description ?? t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team'))
+    : t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team')
   const callPlatform = callBooking.callType === CallBookingType.ZOOM ? 'Zoom' : 'Google Meet'
   const callLink = callBooking.callLink.toString()
   const timeLabel = formatDate(callBooking.eventStartAt, DateFormat.MonthDayWithTimeReadable)

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -34,12 +34,25 @@ const ONBOARDING_CALL_COVERAGE_ITEMS = [
   },
 ] as const
 
+export interface CallBookingStringOverrides {
+  title?: string
+  description?: string
+  coverage?: string
+}
+
 export interface CallBookingProps {
   callBooking?: CallBookingData
   onBookCall?: () => void
+  stringOverrides?: CallBookingStringOverrides
 }
 
-const EmptyState = ({ onBookCall }: { onBookCall?: () => void }) => {
+const EmptyState = ({
+  onBookCall,
+  stringOverrides,
+}: {
+  onBookCall?: () => void
+  stringOverrides?: CallBookingStringOverrides
+}) => {
   const { t } = useTranslation()
   const emitLayerEvent = useEmitLayerEvent(LayerEventComponent.BookkeepingOverview)
 
@@ -51,10 +64,10 @@ const EmptyState = ({ onBookCall }: { onBookCall?: () => void }) => {
   return (
     <VStack gap='md' align='center' pi='lg' pb='lg'>
       <Heading size='sm' align='center'>
-        {t('callBookings:prompt.ready_to_get_started', 'Ready to get started?')}
+        {stringOverrides?.title ?? t('callBookings:prompt.ready_to_get_started', 'Ready to get started?')}
       </Heading>
       <Span variant='subtle' align='center'>
-        {t('callBookings:label.book_call_with_bookkeeper', 'Schedule an onboarding call with your bookkeeper')}
+        {stringOverrides?.description ?? t('callBookings:label.book_call_with_bookkeeper', 'Schedule an onboarding call with your bookkeeper')}
       </Span>
       <Button variant='solid' onClick={handleBookCall}>
         {t('callBookings:action.book_call', 'Schedule Call')}
@@ -63,7 +76,7 @@ const EmptyState = ({ onBookCall }: { onBookCall?: () => void }) => {
   )
 }
 
-const OnboardingCallCoverage = () => {
+const OnboardingCallCoverage = ({ coverage }: { coverage?: string }) => {
   const { t } = useTranslation()
 
   return (
@@ -71,43 +84,57 @@ const OnboardingCallCoverage = () => {
       <Span className='Layer__CallBooking__Divider' />
 
       <VStack pbe='md'>
-        <Span
-          size='2xs'
-          variant='subtle'
-          weight='bold'
-          pbe='sm'
-          className='Layer__CallBooking__CoverageHeading'
-        >
-          {t('callBookings:label.on_this_call_well', 'On this call, we\'ll')}
-        </Span>
-        <VStack role='list' gap='xs'>
-          {ONBOARDING_CALL_COVERAGE_ITEMS.map(({ key, i18nKey, defaultValue }) => (
-            <HStack
-              key={key}
-              className='Layer__CallBooking__CoverageItem'
-              align='start'
-              gap='sm'
-              role='listitem'
-            >
-              <HStack
-                className='Layer__CallBooking__CoverageBadge'
-                align='center'
-                justify='center'
-              >
-                <Check size={12} strokeWidth={2.5} />
-              </HStack>
+        {coverage != null
+          ? (
               <Span size='sm'>
-                {t(i18nKey, defaultValue)}
+                {coverage}
               </Span>
-            </HStack>
-          ))}
-        </VStack>
+            )
+          : (
+              <>
+                <Span
+                  size='2xs'
+                  variant='subtle'
+                  weight='bold'
+                  pbe='sm'
+                  className='Layer__CallBooking__CoverageHeading'
+                >
+                  {t('callBookings:label.on_this_call_well', 'On this call, we\'ll')}
+                </Span>
+                <VStack role='list' gap='xs'>
+                  {ONBOARDING_CALL_COVERAGE_ITEMS.map(({ key, i18nKey, defaultValue }) => (
+                    <HStack
+                      key={key}
+                      className='Layer__CallBooking__CoverageItem'
+                      align='start'
+                      gap='sm'
+                      role='listitem'
+                    >
+                      <HStack
+                        className='Layer__CallBooking__CoverageBadge'
+                        align='center'
+                        justify='center'
+                      >
+                        <Check size={12} strokeWidth={2.5} />
+                      </HStack>
+                      <Span size='sm'>
+                        {t(i18nKey, defaultValue)}
+                      </Span>
+                    </HStack>
+                  ))}
+                </VStack>
+              </>
+            )}
       </VStack>
     </>
   )
 }
 
-export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
+export const CallBooking = ({
+  callBooking,
+  onBookCall,
+  stringOverrides,
+}: CallBookingProps) => {
   const { t } = useTranslation()
   const { formatDate } = useIntlFormatter()
   const countdownLabel = useCallBookingCountdownLabel(callBooking?.eventStartAt)
@@ -115,16 +142,19 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
   if (callBooking == null) {
     return (
       <Container name='CallBooking'>
-        <EmptyState onBookCall={onBookCall} />
+        <EmptyState
+          onBookCall={onBookCall}
+          stringOverrides={stringOverrides}
+        />
       </Container>
     )
   }
 
   const isOnboardingCall = callBooking.purpose === CallBookingPurpose.BOOKKEEPING_ONBOARDING
   const purpose = isOnboardingCall
-    ? t('callBookings:label.onboarding_call', 'Onboarding call')
+    ? (stringOverrides?.title ?? t('callBookings:label.onboarding_call', 'Onboarding call'))
     : t('callBookings:label.ad_hoc_call', 'Ad hoc call')
-  const subtitle = t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team')
+  const subtitle = stringOverrides?.description ?? t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team')
   const callPlatform = callBooking.callType === CallBookingType.ZOOM ? 'Zoom' : 'Google Meet'
   const callLink = callBooking.callLink.toString()
   const timeLabel = formatDate(callBooking.eventStartAt, DateFormat.MonthDayWithTimeReadable)
@@ -174,7 +204,7 @@ export const CallBooking = ({ callBooking, onBookCall }: CallBookingProps) => {
           </Span>
         </HStack>
 
-        {isOnboardingCall && <OnboardingCallCoverage />}
+        {isOnboardingCall && <OnboardingCallCoverage coverage={stringOverrides?.coverage} />}
 
         <HStack align='center' gap='xs'>
           <HStack className='Layer__CallBooking__JoinAction'>

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -86,45 +86,45 @@ const OnboardingCallCoverage = ({ coverage }: { coverage?: string }) => {
       <VStack pbe='md'>
         {coverage != null
           ? (
-              <Span size='sm'>
-                {coverage}
-              </Span>
-            )
+            <Span size='sm'>
+              {coverage}
+            </Span>
+          )
           : (
-              <>
-                <Span
-                  size='2xs'
-                  variant='subtle'
-                  weight='bold'
-                  pbe='sm'
-                  className='Layer__CallBooking__CoverageHeading'
-                >
-                  {t('callBookings:label.on_this_call_well', 'On this call, we\'ll')}
-                </Span>
-                <VStack role='list' gap='xs'>
-                  {ONBOARDING_CALL_COVERAGE_ITEMS.map(({ key, i18nKey, defaultValue }) => (
+            <>
+              <Span
+                size='2xs'
+                variant='subtle'
+                weight='bold'
+                pbe='sm'
+                className='Layer__CallBooking__CoverageHeading'
+              >
+                {t('callBookings:label.on_this_call_well', 'On this call, we\'ll')}
+              </Span>
+              <VStack role='list' gap='xs'>
+                {ONBOARDING_CALL_COVERAGE_ITEMS.map(({ key, i18nKey, defaultValue }) => (
+                  <HStack
+                    key={key}
+                    className='Layer__CallBooking__CoverageItem'
+                    align='start'
+                    gap='sm'
+                    role='listitem'
+                  >
                     <HStack
-                      key={key}
-                      className='Layer__CallBooking__CoverageItem'
-                      align='start'
-                      gap='sm'
-                      role='listitem'
+                      className='Layer__CallBooking__CoverageBadge'
+                      align='center'
+                      justify='center'
                     >
-                      <HStack
-                        className='Layer__CallBooking__CoverageBadge'
-                        align='center'
-                        justify='center'
-                      >
-                        <Check size={12} strokeWidth={2.5} />
-                      </HStack>
-                      <Span size='sm'>
-                        {t(i18nKey, defaultValue)}
-                      </Span>
+                      <Check size={12} strokeWidth={2.5} />
                     </HStack>
-                  ))}
-                </VStack>
-              </>
-            )}
+                    <Span size='sm'>
+                      {t(i18nKey, defaultValue)}
+                    </Span>
+                  </HStack>
+                ))}
+              </VStack>
+            </>
+          )}
       </VStack>
     </>
   )

--- a/src/fixtures/bookkeeping/mocks.ts
+++ b/src/fixtures/bookkeeping/mocks.ts
@@ -33,6 +33,9 @@ const baseBookkeepingConfiguration: BookkeepingConfiguration = {
   notes: null,
   onboardingCallUrl: null,
   adhocCallUrl: null,
+  onboardingCallCardTitleText: null,
+  onboardingCallCardDescriptionText: null,
+  onboardingCallCardCoverageText: null,
 }
 
 export const { make: makeBookkeepingConfiguration } = createFixtureFactory(baseBookkeepingConfiguration)

--- a/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
+++ b/src/hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking.tsx
@@ -1,10 +1,12 @@
 import { useCallback } from 'react'
 
 import { type CallBooking, CallBookingPurpose, CallBookingType } from '@schemas/callBooking'
+import { useBookkeepingConfiguration } from '@hooks/api/businesses/[business-id]/bookkeeping/config/useBookkeepingConfiguration'
 import { useBookkeepingStatus, useBookkeepingStatusGlobalCacheActions } from '@hooks/api/businesses/[business-id]/bookkeeping/status/useBookkeepingStatus'
 import { useCallBookings } from '@hooks/api/businesses/[business-id]/call-bookings/useCallBookings'
 import { useCreateCallBooking } from '@hooks/api/businesses/[business-id]/call-bookings/useCreateCallBooking'
 import { type CalendlyPayload, useCalendly } from '@hooks/features/calendly/useCalendly'
+import { type CallBookingStringOverrides } from '@components/CallBooking/CallBooking'
 
 const getUuidFromCalendlyUri = (uri: string) => {
   try {
@@ -19,6 +21,7 @@ const getUuidFromCalendlyUri = (uri: string) => {
 
 export const useBookkeepingOnboardingCallBooking = () => {
   const { data: bookkeepingStatus } = useBookkeepingStatus()
+  const { data: bookkeepingConfiguration } = useBookkeepingConfiguration()
   const { forceReload: forceReloadBookkeepingStatus } = useBookkeepingStatusGlobalCacheActions()
   const { trigger: createCallBooking } = useCreateCallBooking()
   const { data: callBookings, isError, isLoading } = useCallBookings({ limit: 1 })
@@ -26,6 +29,12 @@ export const useBookkeepingOnboardingCallBooking = () => {
   const onboardingCallUrl = bookkeepingStatus?.showEmbeddedOnboarding
     ? bookkeepingStatus.onboardingCallUrl
     : undefined
+
+  const callBookingStringOverrides: CallBookingStringOverrides = {
+    title: bookkeepingConfiguration?.onboardingCallCardTitleText ?? undefined,
+    description: bookkeepingConfiguration?.onboardingCallCardDescriptionText ?? undefined,
+    coverage: bookkeepingConfiguration?.onboardingCallCardCoverageText ?? undefined,
+  }
 
   const recordCalendlyScheduled = useCallback(async (payload: CalendlyPayload) => {
     const externalId = getUuidFromCalendlyUri(payload.event.uri)
@@ -77,6 +86,7 @@ export const useBookkeepingOnboardingCallBooking = () => {
     callBooking: callBooking ?? undefined,
     showCallBookingCard: showScheduledCallBooking || showEmptyCallBooking,
     handleBookCall,
+    callBookingStringOverrides,
     isCalendlyVisible,
     calendlyLink,
     calendlyRef,

--- a/src/schemas/bookkeepingConfiguration.ts
+++ b/src/schemas/bookkeepingConfiguration.ts
@@ -75,6 +75,21 @@ export const BookkeepingConfigurationSchema = Schema.Struct({
     Schema.propertySignature(Schema.NullOr(Schema.String)),
     Schema.fromKey('adhoc_call_url'),
   ),
+
+  onboardingCallCardTitleText: pipe(
+    Schema.propertySignature(Schema.NullOr(Schema.String)),
+    Schema.fromKey('onboarding_call_card_title_text'),
+  ),
+
+  onboardingCallCardDescriptionText: pipe(
+    Schema.propertySignature(Schema.NullOr(Schema.String)),
+    Schema.fromKey('onboarding_call_card_description_text'),
+  ),
+
+  onboardingCallCardCoverageText: pipe(
+    Schema.propertySignature(Schema.NullOr(Schema.String)),
+    Schema.fromKey('onboarding_call_card_coverage_text'),
+  ),
 })
 
 export type BookkeepingConfiguration = typeof BookkeepingConfigurationSchema.Type

--- a/src/views/BookkeepingOverview/BookkeepingOverview.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.tsx
@@ -7,7 +7,7 @@ import { type CallBooking as CallBookingData } from '@schemas/callBooking'
 import { useBookkeepingOnboardingCallBooking } from '@hooks/features/bookkeeping/useBookkeepingOnboardingCallBooking'
 import { useSizeClass, useWindowSize } from '@hooks/utils/size/useWindowSize'
 import { VStack } from '@ui/Stack/Stack'
-import { CallBooking } from '@components/CallBooking/CallBooking'
+import { CallBooking, type CallBookingStringOverrides } from '@components/CallBooking/CallBooking'
 import { Container } from '@components/Container/Container'
 import { GlobalMonthPicker } from '@components/GlobalMonthPicker/GlobalMonthPicker'
 import { Header } from '@components/Header/Header'
@@ -33,6 +33,7 @@ type BookkeepingOverviewTasksContentProps = {
   showCallBookingCard: boolean
   tasksMobile: boolean
   tasksStringOverrides?: TasksStringOverrides
+  callBookingStringOverrides?: CallBookingStringOverrides
   onBookCall: () => void
   onClickReconnectAccounts?: () => void
 }
@@ -42,6 +43,7 @@ const BookkeepingOverviewTasksContent = ({
   showCallBookingCard,
   tasksMobile,
   tasksStringOverrides,
+  callBookingStringOverrides,
   onBookCall,
   onClickReconnectAccounts,
 }: BookkeepingOverviewTasksContentProps) => {
@@ -51,6 +53,7 @@ const BookkeepingOverviewTasksContent = ({
         <CallBooking
           callBooking={callBooking}
           onBookCall={onBookCall}
+          stringOverrides={callBookingStringOverrides}
         />
       )}
       <Tasks
@@ -116,6 +119,7 @@ export const BookkeepingOverview = ({
     callBooking,
     showCallBookingCard,
     handleBookCall,
+    callBookingStringOverrides,
     isCalendlyVisible,
     calendlyLink,
     calendlyRef,
@@ -147,6 +151,7 @@ export const BookkeepingOverview = ({
               showCallBookingCard={showCallBookingCard}
               tasksMobile={false}
               tasksStringOverrides={stringOverrides?.tasks}
+              callBookingStringOverrides={callBookingStringOverrides}
               onBookCall={handleBookCall}
               onClickReconnectAccounts={onClickReconnectAccounts}
             />
@@ -165,6 +170,7 @@ export const BookkeepingOverview = ({
                 showCallBookingCard={showCallBookingCard}
                 tasksMobile
                 tasksStringOverrides={stringOverrides?.tasks}
+                callBookingStringOverrides={callBookingStringOverrides}
                 onBookCall={handleBookCall}
                 onClickReconnectAccounts={onClickReconnectAccounts}
               />


### PR DESCRIPTION
## Summary
- add nullable onboarding call card copy fields to bookkeeping configuration
- pass grouped string overrides through the bookkeeping call booking flow
- replace default title, description, and coverage content when overrides are configured

## Test plan
- [ ] Verify the empty call card uses configured title and description
- [ ] Verify the scheduled onboarding card uses configured title, description, and plain-text coverage
- [ ] Verify null overrides retain the existing localized copy and bullet list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy overrides with null fallbacks to existing translations; no auth, payments, or data-model behavior changes beyond new optional config fields.
> 
> **Overview**
> **Bookkeeping onboarding call cards** can now show **per-business copy** from bookkeeping configuration instead of only the default i18n strings.
> 
> Three nullable API fields (`onboarding_call_card_title_text`, `description`, `coverage`) are added to the configuration schema and fixtures. `useBookkeepingOnboardingCallBooking` maps them into `CallBookingStringOverrides` and passes them through `BookkeepingOverview` into `CallBooking`.
> 
> `CallBooking` accepts optional `stringOverrides` for **title** and **description** on the empty “schedule call” state and on scheduled **onboarding** calls (ad hoc calls are unchanged). When **coverage** is set, the onboarding section shows that plain text; when it is unset, the existing localized bullet list still renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9360a4853df809903f588b8f254e632834eb3ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->