### PR TITLE
fix: prevent unexpected scroll in profit & loss summary card

### DIFF
--- a/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
+++ b/src/components/ProfitAndLossSummaryCard/profitAndLossSummaryCard.scss
@@ -1,3 +1,13 @@
 .Layer__ProfitAndLossSummaryCard {
   position: relative;
 }
+
+@media (width > 760px) {
+  .Layer__ProfitAndLossSummaryCard .Layer__ProfitAndLossChart {
+    block-size: 100%;
+  }
+
+  .Layer__ProfitAndLossSummaryCard .Layer__ProfitAndLossChart__Container {
+    min-block-size: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Fix unexpected scrollbar in the P&L summary card (solopreneur layout): the chart's 300px min-height overflowed the fixed-height card by a few pixels on desktop. Let the chart fill the content box instead.

## Demo
https://www.loom.com/share/efbe6576fe024843acd6671e035251ea