### PR TITLE
Add storybook for onboarding call card and safer type fallbacks

### DIFF
--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -70,7 +70,7 @@ const EmptyState = ({
         {stringOverrides?.description || t('callBookings:label.book_call_with_bookkeeper', 'Schedule an onboarding call with your bookkeeper')}
       </Span>
       <Button variant='solid' onClick={handleBookCall}>
-        {t('callBookings:action.book_call', 'Schedule Call')}
+        {t('callBookings:action.schedule_call', 'Schedule a call')}
       </Button>
     </VStack>
   )
@@ -85,11 +85,7 @@ const OnboardingCallCoverage = ({ coverage }: { coverage?: string }) => {
 
       <VStack pbe='md'>
         {coverage
-          ? (
-            <Span size='sm'>
-              {coverage}
-            </Span>
-          )
+          ? <Span size='sm'>{coverage}</Span>
           : (
             <>
               <Span

--- a/src/components/CallBooking/CallBooking.tsx
+++ b/src/components/CallBooking/CallBooking.tsx
@@ -64,10 +64,10 @@ const EmptyState = ({
   return (
     <VStack gap='md' align='center' pi='lg' pb='lg'>
       <Heading size='sm' align='center'>
-        {stringOverrides?.title ?? t('callBookings:prompt.ready_to_get_started', 'Ready to get started?')}
+        {stringOverrides?.title || t('callBookings:prompt.ready_to_get_started', 'Ready to get started?')}
       </Heading>
       <Span variant='subtle' align='center'>
-        {stringOverrides?.description ?? t('callBookings:label.book_call_with_bookkeeper', 'Schedule an onboarding call with your bookkeeper')}
+        {stringOverrides?.description || t('callBookings:label.book_call_with_bookkeeper', 'Schedule an onboarding call with your bookkeeper')}
       </Span>
       <Button variant='solid' onClick={handleBookCall}>
         {t('callBookings:action.book_call', 'Schedule Call')}
@@ -84,7 +84,7 @@ const OnboardingCallCoverage = ({ coverage }: { coverage?: string }) => {
       <Span className='Layer__CallBooking__Divider' />
 
       <VStack pbe='md'>
-        {coverage != null
+        {coverage
           ? (
             <Span size='sm'>
               {coverage}
@@ -152,10 +152,10 @@ export const CallBooking = ({
 
   const isOnboardingCall = callBooking.purpose === CallBookingPurpose.BOOKKEEPING_ONBOARDING
   const purpose = isOnboardingCall
-    ? (stringOverrides?.title ?? t('callBookings:label.onboarding_call', 'Onboarding call'))
+    ? (stringOverrides?.title || t('callBookings:label.onboarding_call', 'Onboarding call'))
     : t('callBookings:label.ad_hoc_call', 'Ad hoc call')
   const subtitle = isOnboardingCall
-    ? (stringOverrides?.description ?? t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team'))
+    ? (stringOverrides?.description || t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team'))
     : t('callBookings:label.meet_bookkeeping_team', 'Meet with our bookkeeping team')
   const callPlatform = callBooking.callType === CallBookingType.ZOOM ? 'Zoom' : 'Google Meet'
   const callLink = callBooking.callLink.toString()

--- a/src/schemas/bookkeepingConfiguration.ts
+++ b/src/schemas/bookkeepingConfiguration.ts
@@ -77,17 +77,17 @@ export const BookkeepingConfigurationSchema = Schema.Struct({
   ),
 
   onboardingCallCardTitleText: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.String)),
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
     Schema.fromKey('onboarding_call_card_title_text'),
   ),
 
   onboardingCallCardDescriptionText: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.String)),
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
     Schema.fromKey('onboarding_call_card_description_text'),
   ),
 
   onboardingCallCardCoverageText: pipe(
-    Schema.propertySignature(Schema.NullOr(Schema.String)),
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
     Schema.fromKey('onboarding_call_card_coverage_text'),
   ),
 })

--- a/src/views/BookkeepingOverview/BookkeepingOverview.stories.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.stories.tsx
@@ -1,10 +1,18 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
 
+import {
+  type CallBooking,
+  CallBookingPurpose,
+  CallBookingState,
+  CallBookingType,
+} from '@schemas/callBooking'
 import { BookkeepingStatus } from '@schemas/bookkeepingStatus'
 import { BookkeepingOverview } from '@views/BookkeepingOverview/BookkeepingOverview'
 
+import { get as getCallBookings } from '@msw/api/businesses/[business-id]/call-bookings/get'
+import { get as getBookkeepingConfiguration } from '@msw/api/businesses/[business-id]/bookkeeping/config/get'
 import { get as getBookkeepingStatus } from '@msw/api/businesses/[business-id]/bookkeeping/status/get'
-import { makeBookkeepingStatus } from '@fixtures/bookkeeping/mocks'
+import { makeBookkeepingConfiguration, makeBookkeepingStatus } from '@fixtures/bookkeeping/mocks'
 import {
   buildSummariesSlotProps,
   buildSummariesStringOverrides,
@@ -13,6 +21,35 @@ import {
   summariesStoryDefaultArgs,
 } from '@test-utils/summariesStoryControls'
 import { profitAndLossStoryHandlers, withOverviewStoryContext } from '@test-utils/withProfitAndLossStoryContext'
+
+const ONBOARDING_CALL_URL = 'https://calendly.com/layerfi/bookkeeping-onboarding'
+
+const scheduledOnboardingCall: CallBooking = {
+  id: '00000000-0000-4000-8000-000000000401',
+  businessId: '00000000-0000-4000-8000-000000000201',
+  externalId: 'calendly-event-1',
+  purpose: CallBookingPurpose.BOOKKEEPING_ONBOARDING,
+  state: CallBookingState.SCHEDULED,
+  callType: CallBookingType.GOOGLE_MEET,
+  eventStartAt: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+  eventEndAt: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000 + 30 * 60 * 1000),
+  callLink: new URL('https://meet.google.com/abc-defg-hij'),
+  bookkeeperName: 'Alex Bookkeeper',
+  bookkeeperEmail: 'alex@layerfi.com',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+const onboardingCallCardHandlers = (callBookings: readonly CallBooking[] = []) => [
+  getBookkeepingStatus.mock(makeBookkeepingStatus({
+    status: BookkeepingStatus.ACTIVE,
+    showEmbeddedOnboarding: true,
+    onboardingCallUrl: ONBOARDING_CALL_URL,
+  })),
+  getBookkeepingConfiguration.mock(makeBookkeepingConfiguration()),
+  getCallBookings.mock(callBookings),
+  ...profitAndLossStoryHandlers,
+]
 
 type BookkeepingOverviewStoryArgs = SummariesStoryArgs & {
   showTitle: boolean
@@ -62,3 +99,21 @@ export default meta
 type Story = StoryObj<BookkeepingOverviewStoryArgs>
 
 export const Default: Story = {}
+
+export const OnboardingCallCard: Story = {
+  name: 'Onboarding call card (empty)',
+  parameters: {
+    msw: {
+      handlers: onboardingCallCardHandlers(),
+    },
+  },
+}
+
+export const ScheduledOnboardingCallCard: Story = {
+  name: 'Onboarding call card (scheduled)',
+  parameters: {
+    msw: {
+      handlers: onboardingCallCardHandlers([scheduledOnboardingCall]),
+    },
+  },
+}

--- a/src/views/BookkeepingOverview/BookkeepingOverview.stories.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.stories.tsx
@@ -24,6 +24,12 @@ import { profitAndLossStoryHandlers, withOverviewStoryContext } from '@test-util
 
 const ONBOARDING_CALL_URL = 'https://calendly.com/layerfi/bookkeeping-onboarding'
 
+const onboardingCallCardConfiguration = makeBookkeepingConfiguration({
+  onboardingCallCardTitleText: 'Meet your new bookkeeper',
+  onboardingCallCardDescriptionText: 'Get set up on the new Jobber Bookkeeping experience, meet your bookkeeper, and review your books.',
+  onboardingCallCardCoverageText: 'On this call, we\'ll walk through the upgraded Jobber Bookkeeping experience, review your books, and answer any questions you have.',
+})
+
 const scheduledOnboardingCall: CallBooking = {
   id: '00000000-0000-4000-8000-000000000401',
   businessId: '00000000-0000-4000-8000-000000000201',
@@ -46,7 +52,7 @@ const onboardingCallCardHandlers = (callBookings: readonly CallBooking[] = []) =
     showEmbeddedOnboarding: true,
     onboardingCallUrl: ONBOARDING_CALL_URL,
   })),
-  getBookkeepingConfiguration.mock(makeBookkeepingConfiguration()),
+  getBookkeepingConfiguration.mock(onboardingCallCardConfiguration),
   getCallBookings.mock(callBookings),
   ...profitAndLossStoryHandlers,
 ]

--- a/src/views/BookkeepingOverview/BookkeepingOverview.stories.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.stories.tsx
@@ -1,17 +1,17 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
 
+import { BookkeepingStatus } from '@schemas/bookkeepingStatus'
 import {
   type CallBooking,
   CallBookingPurpose,
   CallBookingState,
   CallBookingType,
 } from '@schemas/callBooking'
-import { BookkeepingStatus } from '@schemas/bookkeepingStatus'
 import { BookkeepingOverview } from '@views/BookkeepingOverview/BookkeepingOverview'
 
-import { get as getCallBookings } from '@msw/api/businesses/[business-id]/call-bookings/get'
 import { get as getBookkeepingConfiguration } from '@msw/api/businesses/[business-id]/bookkeeping/config/get'
 import { get as getBookkeepingStatus } from '@msw/api/businesses/[business-id]/bookkeeping/status/get'
+import { get as getCallBookings } from '@msw/api/businesses/[business-id]/call-bookings/get'
 import { makeBookkeepingConfiguration, makeBookkeepingStatus } from '@fixtures/bookkeeping/mocks'
 import {
   buildSummariesSlotProps,

--- a/src/views/BookkeepingOverview/BookkeepingOverview.stories.tsx
+++ b/src/views/BookkeepingOverview/BookkeepingOverview.stories.tsx
@@ -24,12 +24,6 @@ import { profitAndLossStoryHandlers, withOverviewStoryContext } from '@test-util
 
 const ONBOARDING_CALL_URL = 'https://calendly.com/layerfi/bookkeeping-onboarding'
 
-const onboardingCallCardConfiguration = makeBookkeepingConfiguration({
-  onboardingCallCardTitleText: 'Meet your new bookkeeper',
-  onboardingCallCardDescriptionText: 'Get set up on the new Jobber Bookkeeping experience, meet your bookkeeper, and review your books.',
-  onboardingCallCardCoverageText: 'On this call, we\'ll walk through the upgraded Jobber Bookkeeping experience, review your books, and answer any questions you have.',
-})
-
 const scheduledOnboardingCall: CallBooking = {
   id: '00000000-0000-4000-8000-000000000401',
   businessId: '00000000-0000-4000-8000-000000000201',
@@ -52,7 +46,7 @@ const onboardingCallCardHandlers = (callBookings: readonly CallBooking[] = []) =
     showEmbeddedOnboarding: true,
     onboardingCallUrl: ONBOARDING_CALL_URL,
   })),
-  getBookkeepingConfiguration.mock(onboardingCallCardConfiguration),
+  getBookkeepingConfiguration.mock(makeBookkeepingConfiguration()),
   getCallBookings.mock(callBookings),
   ...profitAndLossStoryHandlers,
 ]


### PR DESCRIPTION
## Summary
- fall back to localized call card copy when override strings are empty, matching other `stringOverrides` usage
- allow onboarding call card copy fields to be absent from bookkeeping config responses via `NullishOr`
- mock configured copy in BookkeepingOverview onboarding call card stories

## Test plan
- [ ] Verify empty override strings fall back to default title, description, and coverage list
- [ ] Verify bookkeeping config decodes when onboarding call card copy fields are omitted
- [ ] Check BookkeepingOverview Storybook stories for empty and scheduled onboarding call cards

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and optional-field schema changes in the call booking UI with no auth, payment, or data-mutation logic.
> 
> **Overview**
> **CallBooking** now uses `||` instead of `??` for `stringOverrides` title, description, and scheduled onboarding labels so **empty strings** from config fall back to localized defaults (same idea as treating blank overrides as “not set”). Coverage rendering is tightened to treat any truthy `coverage` string as custom copy. The empty-state CTA copy switches to the `callBookings:action.schedule_call` key.
> 
> **Bookkeeping configuration** decoding widens the three onboarding call card text fields from `NullOr` to **`NullishOr`**, so API responses can omit those keys without failing validation.
> 
> **BookkeepingOverview Storybook** adds MSW-backed stories for the onboarding call card with no booking and with a scheduled onboarding call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b0dc873897256f133b54b7b84885c87f1b8759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->