### PR TITLE
feat: improve record transaction flow and deprecate description/receipt visibility props

### DIFF
--- a/src/components/BankTransactionFormFields/BankTransactionFormFields.tsx
+++ b/src/components/BankTransactionFormFields/BankTransactionFormFields.tsx
@@ -29,7 +29,6 @@ export function BankTransactionFormFields({
 }: BankTransactionFormFieldProps) {
   const showTags = useIsBankTransactionsFeatureEnabled(BankTransactionsFeature.Tags)
   const showCustomerVendor = useIsBankTransactionsFeatureEnabled(BankTransactionsFeature.CustomerVendor)
-  const showDescriptions = useIsBankTransactionsFeatureEnabled(BankTransactionsFeature.Descriptions)
 
   const isCategorizationEnabled = useBankTransactionsIsCategorizationEnabledContext()
 
@@ -73,10 +72,6 @@ export function BankTransactionFormFields({
     })
   }
 
-  if (!showTags && !showCustomerVendor && !showDescriptions) {
-    return null
-  }
-
   return (
     <VStack gap='md'>
       {showCustomerVendor && !hideCustomerVendor
@@ -90,12 +85,9 @@ export function BankTransactionFormFields({
             isReadOnly={!isCategorizationEnabled}
           />
         )}
-      {showDescriptions
-        && (
-          <VStack gap='sm'>
-            <BankTransactionMemo bankTransactionId={bankTransaction.id} memo={bankTransaction.memo} isMobile={isMobile} />
-          </VStack>
-        )}
+      <VStack gap='sm'>
+        <BankTransactionMemo bankTransactionId={bankTransaction.id} memo={bankTransaction.memo} isMobile={isMobile} />
+      </VStack>
     </VStack>
   )
 }

--- a/src/components/BankTransactions/BankTransactions.stories.tsx
+++ b/src/components/BankTransactions/BankTransactions.stories.tsx
@@ -163,8 +163,6 @@ const meta: Meta<BankTransactionsStoryArgs> = {
       pageSize,
       showCategorizationRules,
       showCustomerVendor,
-      showDescriptions,
-      showReceiptUploads,
       showStatusToggle,
       showTags,
       showTooltips,
@@ -181,8 +179,6 @@ const meta: Meta<BankTransactionsStoryArgs> = {
         pageSize={pageSize}
         showCategorizationRules={showCategorizationRules}
         showCustomerVendor={showCustomerVendor}
-        showDescriptions={showDescriptions}
-        showReceiptUploads={showReceiptUploads}
         showStatusToggle={showStatusToggle}
         showTags={showTags}
         showTooltips={showTooltips}

--- a/src/components/BankTransactions/BankTransactions.tsx
+++ b/src/components/BankTransactions/BankTransactions.tsx
@@ -70,7 +70,13 @@ export interface BankTransactionsProps {
 
   showCategorizationRules?: boolean
   showCustomerVendor?: boolean
+  /**
+   * @deprecated This prop is no longer honored; transaction descriptions are always enabled.
+   */
   showDescriptions?: boolean
+  /**
+   * @deprecated This prop is no longer honored; receipt uploads are always enabled.
+   */
   showReceiptUploads?: boolean
   showStatusToggle?: boolean
   showTags?: boolean
@@ -109,6 +115,8 @@ export const BankTransactions = ({
   renderInAppLink,
   filters,
   categorizeView: _categorizeView,
+  showDescriptions: _showDescriptions,
+  showReceiptUploads: _showReceiptUploads,
 
   asWidget,
   pageSize,

--- a/src/components/BankTransactions/RecordManualTransaction/RecordTransactionForm.tsx
+++ b/src/components/BankTransactions/RecordManualTransaction/RecordTransactionForm.tsx
@@ -5,8 +5,9 @@ import { useTranslation } from 'react-i18next'
 import type { BankTransaction } from '@internal-types/bankTransactions'
 import { isClassificationExclusion } from '@schemas/categorization'
 import { getDefaultSelectedCategoryForBankTransaction } from '@utils/bankTransactions/shared'
-import { positiveAmount, required } from '@utils/form/validators'
+import { dateNotBefore, dateNotInFuture, positiveAmount, required } from '@utils/form/validators'
 import { useTaxCodeOptions } from '@hooks/features/bankTransactions/useTaxCodeOptions'
+import { useBusinessActivationDate } from '@hooks/features/business/useBusinessActivationDate'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
 import { Form } from '@ui/Form/Form'
@@ -45,6 +46,7 @@ export function RecordTransactionForm({ form, variant, transaction }: RecordTran
   const { t } = useTranslation()
   const { formatCurrencyFromCents } = useIntlFormatter()
   const { taxCodeOptions, hasTaxCodeOptions, getSelectedTaxCodeOption } = useTaxCodeOptions(transaction)
+  const activationDate = useBusinessActivationDate()
   const { isMobile } = useSizeClass()
   const isInline = !isMobile
   const isExpense = variant === 'expense'
@@ -55,8 +57,18 @@ export function RecordTransactionForm({ form, variant, transaction }: RecordTran
   const isMultiSplit = category !== null && isSplitAsOption(category) && !category.isSingleSplit
 
   const accountLabel = isExpense
-    ? t('bankTransactions:recordTransaction.label.paid_to', 'Paid to')
+    ? t('bankTransactions:recordTransaction.label.paid_from', 'Paid from')
     : t('bankTransactions:recordTransaction.label.deposited_in', 'Deposited in')
+
+  const payeeLabel = isExpense
+    ? t('bankTransactions:recordTransaction.label.payee', 'Payee')
+    : t('bankTransactions:recordTransaction.label.payer', 'Payer')
+  const payeePlaceholder = isExpense
+    ? t('bankTransactions:recordTransaction.placeholder.payee', 'Who you paid')
+    : t('bankTransactions:recordTransaction.placeholder.payer', 'Who paid you')
+  const payeeRequiredMessage = isExpense
+    ? t('bankTransactions:recordTransaction.validation.payee_required', 'Payee is required')
+    : t('bankTransactions:recordTransaction.validation.payer_required', 'Payer is required')
 
   return (
     <Form
@@ -98,20 +110,25 @@ export function RecordTransactionForm({ form, variant, transaction }: RecordTran
             <>
               <form.AppField
                 name='description'
-                validators={{ onDynamic: ({ value }) => required(t('bankTransactions:recordTransaction.validation.description_required', 'Description is required'))(value) }}
+                validators={{ onDynamic: ({ value }) => required(payeeRequiredMessage)(value) }}
               >
                 {field => (
                   <field.FormTextField
-                    label={t('bankTransactions:recordTransaction.label.description', 'Description')}
+                    label={payeeLabel}
                     inline={isInline}
-                    placeholder={t('bankTransactions:recordTransaction.placeholder.description', 'Add a description...')}
+                    placeholder={payeePlaceholder}
                   />
                 )}
               </form.AppField>
 
               <form.AppField
                 name='date'
-                validators={{ onDynamic: ({ value }) => required(t('bankTransactions:recordTransaction.validation.date_required', 'Date is required'))(value) }}
+                validators={{
+                  onDynamic: ({ value }) =>
+                    required(t('bankTransactions:recordTransaction.validation.date_required', 'Date is required'))(value)
+                    ?? dateNotInFuture(t('bankTransactions:recordTransaction.validation.date_in_future', 'Date cannot be in the future'))(value)
+                    ?? dateNotBefore(activationDate, t('bankTransactions:recordTransaction.validation.date_before_activation', 'Date cannot be before the business activation date'))(value),
+                }}
               >
                 {field => (
                   <field.FormDateField label={t('bankTransactions:recordTransaction.label.date', 'Date')} inline={isInline} />
@@ -180,10 +197,10 @@ export function RecordTransactionForm({ form, variant, transaction }: RecordTran
 
               <form.AppField name='memo'>
                 {field => (
-                  <field.FormTextField
-                    label={t('bankTransactions:recordTransaction.label.memo', 'Memo')}
+                  <field.FormTextAreaField
+                    label={t('bankTransactions:recordTransaction.label.description', 'Description')}
                     inline={isInline}
-                    placeholder={t('bankTransactions:recordTransaction.placeholder.memo', 'Add a note about this transaction...')}
+                    placeholder={t('bankTransactions:recordTransaction.placeholder.description', 'Add a description...')}
                   />
                 )}
               </form.AppField>

--- a/src/components/BankTransactions/RecordManualTransaction/RecordTransactionForm.tsx
+++ b/src/components/BankTransactions/RecordManualTransaction/RecordTransactionForm.tsx
@@ -1,4 +1,5 @@
 import { type PropsWithChildren, type ReactNode } from 'react'
+import { type CalendarDate, getLocalTimeZone, today } from '@internationalized/date'
 import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 
@@ -6,6 +7,7 @@ import type { BankTransaction } from '@internal-types/bankTransactions'
 import { isClassificationExclusion } from '@schemas/categorization'
 import { getDefaultSelectedCategoryForBankTransaction } from '@utils/bankTransactions/shared'
 import { dateNotBefore, dateNotInFuture, positiveAmount, required } from '@utils/form/validators'
+import { convertDateToLocalCalendarDate } from '@utils/time/timeUtils'
 import { useTaxCodeOptions } from '@hooks/features/bankTransactions/useTaxCodeOptions'
 import { useBusinessActivationDate } from '@hooks/features/business/useBusinessActivationDate'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
@@ -131,7 +133,12 @@ export function RecordTransactionForm({ form, variant, transaction }: RecordTran
                 }}
               >
                 {field => (
-                  <field.FormDateField label={t('bankTransactions:recordTransaction.label.date', 'Date')} inline={isInline} />
+                  <field.FormDatePickerField<CalendarDate>
+                    label={t('bankTransactions:recordTransaction.label.date', 'Date')}
+                    inline={isInline}
+                    minDate={activationDate ? convertDateToLocalCalendarDate(activationDate) : undefined}
+                    maxDate={today(getLocalTimeZone())}
+                  />
                 )}
               </form.AppField>
 

--- a/src/components/BankTransactions/RecordManualTransaction/RecordTransactionModal.test.tsx
+++ b/src/components/BankTransactions/RecordManualTransaction/RecordTransactionModal.test.tsx
@@ -28,19 +28,19 @@ const RecordModalWrapper = ({ children }: { children: ReactNode }) => (
 const CUSTOM_ACCOUNT = makeCustomAccount({ accountName: 'Business Checking' })
 
 const EXPENSE_FORM_DATA = [
-  { kind: 'comboBox', field: 'Paid to', option: /Business Checking/ },
-  { kind: 'text', field: 'Description', value: '  Coffee shop  ' },
+  { kind: 'comboBox', field: 'Paid from', option: /Business Checking/ },
+  { kind: 'text', field: 'Payee', value: '  Coffee shop  ' },
   { kind: 'number', field: 'Amount', value: '125.50' },
   { kind: 'comboBox', field: 'Category', option: /^Cash$/ },
-  { kind: 'text', field: 'Memo', value: 'Team lunch' },
+  { kind: 'text', field: 'Description', value: 'Team lunch' },
 ] satisfies readonly FillFormSpec[]
 
 const INCOME_FORM_DATA = [
   { kind: 'comboBox', field: 'Deposited in', option: /Business Checking/ },
-  { kind: 'text', field: 'Description', value: 'Client payment' },
+  { kind: 'text', field: 'Payer', value: 'Client payment' },
   { kind: 'number', field: 'Amount', value: '80' },
   { kind: 'comboBox', field: 'Category', option: /^Cash$/ },
-  { kind: 'text', field: 'Memo', value: 'Cash sale' },
+  { kind: 'text', field: 'Description', value: 'Cash sale' },
 ] satisfies readonly FillFormSpec[]
 
 const renderModal = (variant: RecordTransactionVariant = 'expense') => {
@@ -179,7 +179,7 @@ describe('RecordTransactionModal', () => {
     await user.click(screen.getByRole('button', { name: /save/i }))
 
     expect(await screen.findByText('Account is required')).toBeInTheDocument()
-    expect(screen.getByText('Description is required')).toBeInTheDocument()
+    expect(screen.getByText('Payee is required')).toBeInTheDocument()
     expect(screen.getByText('Amount must be greater than zero')).toBeInTheDocument()
     expect(screen.getByText('Category is required')).toBeInTheDocument()
 

--- a/src/components/BankTransactions/RecordManualTransaction/RecordTransactionModal.tsx
+++ b/src/components/BankTransactions/RecordManualTransaction/RecordTransactionModal.tsx
@@ -3,8 +3,9 @@ import classNames from 'classnames'
 import { Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import type { BankTransaction } from '@internal-types/bankTransactions'
+import { type BankTransaction, DisplayState } from '@internal-types/bankTransactions'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
+import { useBankTransactionsFiltersContext } from '@contexts/BankTransactionsFiltersContext/BankTransactionsFiltersContext'
 import { Button } from '@ui/Button/Button'
 import { SubmitButton } from '@ui/Button/SubmitButton'
 import { Modal } from '@ui/Modal/Modal'
@@ -31,7 +32,16 @@ export function RecordTransactionModal({ variant, transaction, isOpen, onOpenCha
 
   const effectiveVariant = transaction ? getRecordTransactionVariant(transaction) : variant
 
-  const onSuccess = useCallback(() => onOpenChange(false), [onOpenChange])
+  const { setFilters } = useBankTransactionsFiltersContext()
+  const isCreating = transaction === undefined
+
+  const onSuccess = useCallback(() => {
+    // Land newly recorded transactions on the "Categorized" tab so the user can see the result.
+    if (isCreating) {
+      setFilters({ categorizationStatus: DisplayState.categorized })
+    }
+    onOpenChange(false)
+  }, [isCreating, setFilters, onOpenChange])
 
   const { form, isError } = useRecordTransactionForm({ variant: effectiveVariant, transaction, onSuccess })
 

--- a/src/components/BankTransactions/RecordManualTransaction/formUtils.ts
+++ b/src/components/BankTransactions/RecordManualTransaction/formUtils.ts
@@ -28,7 +28,7 @@ export function convertRecordTransactionFormToParams(
     transaction: {
       amount: convertNonRecursiveBigDecimalToCents(amount),
       direction: isExpense ? BankTransactionDirection.Debit : BankTransactionDirection.Credit,
-      date: toCalendarDate(date).toString(),
+      date: date.toString(),
       description: description.trim(),
       memo: memo.trim(),
       ...(category !== null && { categorization: { type: 'Category' as const, category, taxCode: isClassificationExclusion(category) ? null : taxCode } }),
@@ -49,7 +49,7 @@ export const getRecordTransactionFormValues = (
   },
   description: transaction.description ?? '',
   amount: convertCentsToNonRecursiveBigDecimal(transaction.amount),
-  date: fromDate(transaction.date, 'UTC'),
+  date: toCalendarDate(fromDate(transaction.date, 'UTC')),
   category: getDefaultSelectedCategoryForBankTransaction(transaction)?.classification ?? null,
   taxCode: getDefaultTaxCodeForBankTransaction(transaction),
   memo: transaction.memo ?? '',

--- a/src/components/BankTransactions/RecordManualTransaction/useRecordTransactionForm.ts
+++ b/src/components/BankTransactions/RecordManualTransaction/useRecordTransactionForm.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react'
 import { fromDate, getLocalTimeZone, type ZonedDateTime } from '@internationalized/date'
 import { revalidateLogic } from '@tanstack/react-form'
 import { startOfToday } from 'date-fns'
+import { useTranslation } from 'react-i18next'
 
 import type { BankTransaction } from '@internal-types/bankTransactions'
 import type { Classification } from '@schemas/categorization'
@@ -9,6 +10,7 @@ import type { NonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
 import { UpsertCustomAccountTransactionMode, useUpsertCustomAccountTransaction } from '@hooks/api/businesses/[business-id]/custom-accounts/[custom-account-id]/transactions/record/useRecordCustomAccountTransaction'
 import { useAppForm } from '@hooks/features/forms/useForm'
 import { useBankTransactionsCategorizationActions } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
+import { useLayerContext } from '@contexts/LayerContext/LayerContext'
 import { convertApiCategorizationToCategoryOrSplitAsOption } from '@components/BankTransactionCategoryComboBox/utils'
 import { convertRecordTransactionFormToParams, getRecordTransactionFormValues } from '@components/BankTransactions/RecordManualTransaction/formUtils'
 import type { AccountOption } from '@components/CustomAccountComboBox/AccountOption'
@@ -44,6 +46,8 @@ type UseRecordTransactionFormProps = {
 }
 
 export const useRecordTransactionForm = ({ variant, transaction, onSuccess }: UseRecordTransactionFormProps) => {
+  const { t } = useTranslation()
+  const { addToast } = useLayerContext()
   const createExternalId = useMemo(() => crypto.randomUUID(), [])
   const { trigger, isError } = useUpsertCustomAccountTransaction(
     transaction
@@ -70,6 +74,13 @@ export const useRecordTransactionForm = ({ variant, transaction, onSuccess }: Us
           setTransactionTaxCodeSelection(transaction.id, updated.taxCode ?? null)
         }
 
+        addToast({
+          content: transaction
+            ? t('bankTransactions:recordTransaction.toast.transaction_updated', 'Transaction updated')
+            : t('bankTransactions:recordTransaction.toast.transaction_recorded', 'Transaction recorded'),
+          type: 'success',
+        })
+
         onSuccess?.()
         formApi.reset()
       }
@@ -77,7 +88,7 @@ export const useRecordTransactionForm = ({ variant, transaction, onSuccess }: Us
         console.error(e)
       }
     },
-    [trigger, variant, transaction, createExternalId, setTransactionCategorization, setTransactionTaxCodeSelection, onSuccess],
+    [trigger, variant, transaction, createExternalId, setTransactionCategorization, setTransactionTaxCodeSelection, addToast, t, onSuccess],
   )
 
   const form = useAppForm<RecordTransactionFormValues>({

--- a/src/components/BankTransactions/RecordManualTransaction/useRecordTransactionForm.ts
+++ b/src/components/BankTransactions/RecordManualTransaction/useRecordTransactionForm.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react'
-import { fromDate, getLocalTimeZone, type ZonedDateTime } from '@internationalized/date'
+import { type CalendarDate, getLocalTimeZone, today } from '@internationalized/date'
 import { revalidateLogic } from '@tanstack/react-form'
-import { startOfToday } from 'date-fns'
 import { useTranslation } from 'react-i18next'
 
 import type { BankTransaction } from '@internal-types/bankTransactions'
@@ -21,7 +20,7 @@ export type RecordTransactionFormValues = {
   account: AccountOption | null
   description: string
   amount: NonRecursiveBigDecimal | null
-  date: ZonedDateTime | null
+  date: CalendarDate | null
   category: Classification | null
   taxCode: string | null
   memo: string
@@ -33,7 +32,7 @@ const getDefaultValues = (): RecordTransactionFormValues => ({
   account: null,
   description: '',
   amount: null,
-  date: fromDate(startOfToday(), getLocalTimeZone()),
+  date: today(getLocalTimeZone()),
   category: null,
   taxCode: null,
   memo: '',

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListBusinessForm.tsx
@@ -9,7 +9,6 @@ import { resolveCategoryTaxCode } from '@utils/bankTransactions/taxCode'
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
 import { useGetBankTransactionCategorizationWithDefault } from '@hooks/features/bankTransactions/useGetBankTransactionCategorizationWithDefault'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
-import { BankTransactionsFeature, useIsBankTransactionsFeatureEnabled } from '@providers/BankTransactionsFeatureVisibility/BankTransactionsFeatureVisibilityProvider'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { BankTransactionFormFields } from '@components/BankTransactionFormFields/BankTransactionFormFields'
@@ -28,7 +27,6 @@ export const BankTransactionsMobileListBusinessForm = ({
   showCategorization,
 }: BankTransactionsMobileListBusinessFormProps) => {
   const { t } = useTranslation()
-  const showReceiptUploads = useIsBankTransactionsFeatureEnabled(BankTransactionsFeature.ReceiptUploads)
   const receiptsRef = useRef<BankTransactionReceiptsHandle>(null)
 
   const {
@@ -93,25 +91,21 @@ export const BankTransactionsMobileListBusinessForm = ({
               : undefined,
           )}
         >
-          {showReceiptUploads && (
-            <BankTransactionReceipts
-              label={t('bankTransactions:label.receipts', 'Receipts')}
-              ref={receiptsRef}
-              floatingActions={false}
-              hideUploadButtons={true}
-            />
-          )}
+          <BankTransactionReceipts
+            label={t('bankTransactions:label.receipts', 'Receipts')}
+            ref={receiptsRef}
+            floatingActions={false}
+            hideUploadButtons={true}
+          />
         </div>
         <HStack gap='xs'>
-          {showReceiptUploads && (
-            <FileInput
-              onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
-              text={t('bankTransactions:action.upload_receipt', 'Upload receipt')}
-              icon
-              slots={{ Icon: <Paperclip size={20} /> }}
-              accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
-            />
-          )}
+          <FileInput
+            onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
+            text={t('bankTransactions:action.upload_receipt', 'Upload receipt')}
+            icon
+            slots={{ Icon: <Paperclip size={20} /> }}
+            accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
+          />
           {showCategorization && (
             <Button
               onClick={save}

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListMatchForm.tsx
@@ -13,7 +13,6 @@ import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
 import {
   useBankTransactionsCategorizationActions,
 } from '@providers/BankTransactionsCategorizationStore/BankTransactionsCategorizationStoreProvider'
-import { BankTransactionsFeature, useIsBankTransactionsFeatureEnabled } from '@providers/BankTransactionsFeatureVisibility/BankTransactionsFeatureVisibilityProvider'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
@@ -34,7 +33,6 @@ export const BankTransactionsMobileListMatchForm = ({
   showCategorization,
 }: BankTransactionsMobileListMatchFormProps) => {
   const { t } = useTranslation()
-  const showReceiptUploads = useIsBankTransactionsFeatureEnabled(BankTransactionsFeature.ReceiptUploads)
   const receiptsRef = useRef<BankTransactionReceiptsHandle>(null)
 
   const {
@@ -89,24 +87,20 @@ export const BankTransactionsMobileListMatchForm = ({
         hideTags
         isMobile
       />
-      {showReceiptUploads && (
-        <BankTransactionReceipts
-          ref={receiptsRef}
-          floatingActions={false}
-          hideUploadButtons={true}
-          label={t('bankTransactions:label.receipts', 'Receipts')}
-        />
-      )}
+      <BankTransactionReceipts
+        ref={receiptsRef}
+        floatingActions={false}
+        hideUploadButtons={true}
+        label={t('bankTransactions:label.receipts', 'Receipts')}
+      />
       <HStack gap='md'>
-        {showReceiptUploads && (
-          <FileInput
-            onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
-            text={t('bankTransactions:action.upload_receipt', 'Upload receipt')}
-            icon
-            slots={{ Icon: <Paperclip size={20} /> }}
-            accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
-          />
-        )}
+        <FileInput
+          onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
+          text={t('bankTransactions:action.upload_receipt', 'Upload receipt')}
+          icon
+          slots={{ Icon: <Paperclip size={20} /> }}
+          accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
+        />
         {showCategorization && (
           <Button
             fullWidth

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListPersonalForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListPersonalForm.tsx
@@ -8,7 +8,6 @@ import { CategorizationStatus } from '@schemas/bankTransactions/bankTransaction'
 import { hasReceipts, isCategorized, isMoneyIn } from '@utils/bankTransactions/shared'
 import { useCategorizeBankTransactionWithCacheUpdate } from '@hooks/features/bankTransactions/useCategorizeBankTransactionWithCacheUpdate'
 import { RECEIPT_ALLOWED_INPUT_FILE_TYPES } from '@hooks/legacy/useReceipts'
-import { BankTransactionsFeature, useIsBankTransactionsFeatureEnabled } from '@providers/BankTransactionsFeatureVisibility/BankTransactionsFeatureVisibilityProvider'
 import { Button } from '@ui/Button/Button'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { BankTransactionFormFields } from '@components/BankTransactionFormFields/BankTransactionFormFields'
@@ -60,7 +59,6 @@ export const BankTransactionsMobileListPersonalForm = ({
   showCategorization,
 }: BankTransactionsMobileListPersonalFormProps) => {
   const { t } = useTranslation()
-  const showReceiptUploads = useIsBankTransactionsFeatureEnabled(BankTransactionsFeature.ReceiptUploads)
   const receiptsRef = useRef<BankTransactionReceiptsHandle>(null)
 
   const {
@@ -115,25 +113,21 @@ export const BankTransactionsMobileListPersonalForm = ({
             : undefined,
         )}
       >
-        {showReceiptUploads && (
-          <BankTransactionReceipts
-            ref={receiptsRef}
-            floatingActions={false}
-            hideUploadButtons={true}
-            label={t('bankTransactions:label.receipts', 'Receipts')}
-          />
-        )}
+        <BankTransactionReceipts
+          ref={receiptsRef}
+          floatingActions={false}
+          hideUploadButtons={true}
+          label={t('bankTransactions:label.receipts', 'Receipts')}
+        />
       </div>
       <HStack gap='md'>
-        {showReceiptUploads && (
-          <FileInput
-            onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
-            text={t('bankTransactions:action.upload_receipt', 'Upload receipt')}
-            icon
-            slots={{ Icon: <Paperclip size={20} /> }}
-            accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
-          />
-        )}
+        <FileInput
+          onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
+          text={t('bankTransactions:action.upload_receipt', 'Upload receipt')}
+          icon
+          slots={{ Icon: <Paperclip size={20} /> }}
+          accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
+        />
         {showCategorization
           && (
             <Button

--- a/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
+++ b/src/components/BankTransactionsMobileList/BankTransactionsMobileListSplitForm.tsx
@@ -40,7 +40,6 @@ export const BankTransactionsMobileListSplitForm = ({
 }: BankTransactionsMobileListSplitFormProps) => {
   const { t } = useTranslation()
   const showTooltips = useIsBankTransactionsFeatureEnabled(BankTransactionsFeature.Tooltips)
-  const showReceiptUploads = useIsBankTransactionsFeatureEnabled(BankTransactionsFeature.ReceiptUploads)
   const { formatCurrencyFromCents } = useIntlFormatter()
   const receiptsRef = useRef<BankTransactionReceiptsHandle>(null)
   const totalInputId = useId()
@@ -191,25 +190,21 @@ export const BankTransactionsMobileListSplitForm = ({
             : undefined,
         )}
       >
-        {showReceiptUploads && (
-          <BankTransactionReceipts
-            ref={receiptsRef}
-            floatingActions={false}
-            hideUploadButtons={true}
-            label={t('bankTransactions:label.receipts', 'Receipts')}
-          />
-        )}
+        <BankTransactionReceipts
+          ref={receiptsRef}
+          floatingActions={false}
+          hideUploadButtons={true}
+          label={t('bankTransactions:label.receipts', 'Receipts')}
+        />
       </div>
       <HStack gap='md'>
-        {showReceiptUploads && (
-          <FileInput
-            onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
-            text={t('bankTransactions:action.upload_receipt', 'Upload receipt')}
-            icon
-            slots={{ Icon: <Paperclip size={20} /> }}
-            accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
-          />
-        )}
+        <FileInput
+          onUpload={files => receiptsRef.current?.uploadReceipt(files[0])}
+          text={t('bankTransactions:action.upload_receipt', 'Upload receipt')}
+          icon
+          slots={{ Icon: <Paperclip size={20} /> }}
+          accept={RECEIPT_ALLOWED_INPUT_FILE_TYPES}
+        />
         {showCategorization && (
           <Button
             fullWidth

--- a/src/components/BankTransactionsTable/BankTransactionDescriptionCell.tsx
+++ b/src/components/BankTransactionsTable/BankTransactionDescriptionCell.tsx
@@ -1,7 +1,6 @@
 import { File } from 'lucide-react'
 
 import { type BankTransaction } from '@internal-types/bankTransactions'
-import { BankTransactionsFeature, useIsBankTransactionsFeatureEnabled } from '@providers/BankTransactionsFeatureVisibility/BankTransactionsFeatureVisibilityProvider'
 import { HStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { EditCustomTransactionButton } from '@components/BankTransactions/RecordManualTransaction/EditCustomTransactionButton'
@@ -17,8 +16,7 @@ type BankTransactionDescriptionCellProps = {
 export const BankTransactionDescriptionCell = ({
   bankTransaction,
 }: BankTransactionDescriptionCellProps) => {
-  const showReceiptUploads = useIsBankTransactionsFeatureEnabled(BankTransactionsFeature.ReceiptUploads)
-  const hasReceipt = showReceiptUploads && bankTransaction.documentIds?.length > 0
+  const hasReceipt = bankTransaction.documentIds?.length > 0
   const isEditable = useIsEditableCustomTransaction(bankTransaction)
 
   return (

--- a/src/components/DateCalendar/DateCalendar.tsx
+++ b/src/components/DateCalendar/DateCalendar.tsx
@@ -1,4 +1,4 @@
-import { type ZonedDateTime } from '@internationalized/date'
+import { type DateValue } from '@internationalized/date'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 import type { View } from '@internal-types/general'
@@ -10,8 +10,8 @@ import { Heading } from '@ui/Typography/Heading'
 import './dateCalendar.scss'
 
 type DateCalendarProps = {
-  minDate?: ZonedDateTime | null
-  maxDate?: ZonedDateTime | null
+  minDate?: DateValue | null
+  maxDate?: DateValue | null
   variant?: View
 }
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
-import { type ZonedDateTime } from '@internationalized/date'
+import { type DateValue } from '@internationalized/date'
 import classNames from 'classnames'
+import { type DatePickerProps as ReactAriaDatePickerProps } from 'react-aria-components/DatePicker'
 import { Dialog } from 'react-aria-components/Dialog'
 
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
@@ -12,17 +13,17 @@ import { ResponsivePopover } from '@components/ResponsivePopover/ResponsivePopov
 
 import './datePicker.scss'
 
-type DatePickerProps = {
+type DatePickerProps<T extends DateValue> = {
   label: string
   isReadOnly?: boolean
   showLabel?: boolean
-  date: ZonedDateTime | null
-  minDate?: ZonedDateTime | null
-  maxDate?: ZonedDateTime | null
+  date: T | null
+  minDate?: DateValue | null
+  maxDate?: DateValue | null
   isInvalid?: boolean
   errorText?: string | null
   onBlur?: () => void
-  onChange: (date: ZonedDateTime | null) => void
+  onChange: (date: T | null) => void
   isDisabled?: boolean
   className?: string
   slotProps?: {
@@ -30,7 +31,7 @@ type DatePickerProps = {
   }
 }
 
-export const DatePicker = ({
+export const DatePicker = <T extends DateValue>({
   label,
   showLabel = false,
   date,
@@ -44,7 +45,7 @@ export const DatePicker = ({
   isReadOnly,
   className,
   slotProps,
-}: DatePickerProps) => {
+}: DatePickerProps<T>) => {
   const additionalAriaProps = !showLabel && { 'aria-label': label }
   const { value } = useSizeClass()
   const [isPopoverOpen, setPopoverOpen] = useState(false)
@@ -54,7 +55,8 @@ export const DatePicker = ({
       granularity='day'
       value={date}
       onBlur={onBlur}
-      onChange={onChange}
+      // MappedDateValue<T> resolves to T for every concrete DateValue, so this cast is safe.
+      onChange={onChange as ReactAriaDatePickerProps<T>['onChange']}
       isInvalid={isInvalid}
       {...additionalAriaProps}
       isOpen={isPopoverOpen}

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -93,7 +93,6 @@ export const ExpandedBankTransactionRow = ({
 
   const showTags = useIsBankTransactionsFeatureEnabled(BankTransactionsFeature.Tags)
   const showCustomerVendor = useIsBankTransactionsFeatureEnabled(BankTransactionsFeature.CustomerVendor)
-  const showReceiptUploads = useIsBankTransactionsFeatureEnabled(BankTransactionsFeature.ReceiptUploads)
 
   const [matchFormError, setMatchFormError] = useState<string | undefined>()
   const bodyRef = useRef<HTMLDivElement>(null)
@@ -369,14 +368,12 @@ export const ExpandedBankTransactionRow = ({
               />
             </VStack>
 
-            {showReceiptUploads && (
-              <BankTransactionReceiptsWithProvider
-                bankTransaction={bankTransaction}
-                isActive={true}
-                classNamePrefix='Layer__expanded-bank-transaction-row'
-                floatingActions={!asListItem}
-              />
-            )}
+            <BankTransactionReceiptsWithProvider
+              bankTransaction={bankTransaction}
+              isActive={true}
+              classNamePrefix='Layer__expanded-bank-transaction-row'
+              floatingActions={!asListItem}
+            />
           </div>
         </VStack>
       </div>

--- a/src/components/forms/FormDatePickerField.tsx
+++ b/src/components/forms/FormDatePickerField.tsx
@@ -1,5 +1,5 @@
 import { type PropsWithChildren, useCallback, useEffect, useState } from 'react'
-import type { ZonedDateTime } from '@internationalized/date'
+import type { DateValue } from '@internationalized/date'
 import classNames from 'classnames'
 
 import { useFieldContext } from '@hooks/features/forms/useForm'
@@ -9,13 +9,13 @@ import type { CommonFormFieldProps } from '@components/forms/types'
 import './formDatePickerField.scss'
 
 export type FormDatePickerFieldProps = CommonFormFieldProps & {
-  minDate?: ZonedDateTime | null
-  maxDate?: ZonedDateTime | null
+  minDate?: DateValue | null
+  maxDate?: DateValue | null
 }
 
 const FORM_DATE_PICKER_FIELD_CLASSNAME = 'Layer__FormDatePickerField'
 
-export function FormDatePickerField({
+export function FormDatePickerField<T extends DateValue>({
   label,
   className,
   inline = false,
@@ -25,18 +25,18 @@ export function FormDatePickerField({
   minDate,
   maxDate,
 }: PropsWithChildren<FormDatePickerFieldProps>) {
-  const field = useFieldContext<ZonedDateTime | null>()
+  const field = useFieldContext<T | null>()
 
   const { state, handleChange, handleBlur } = field
   const { meta, value } = state
   const { errors, isValid } = meta
-  const [localDate, setLocalDate] = useState<ZonedDateTime | null>(value)
+  const [localDate, setLocalDate] = useState<T | null>(value)
 
   useEffect(() => {
     setLocalDate(value)
   }, [value])
 
-  const onChange = useCallback((newValue: ZonedDateTime | null) => {
+  const onChange = useCallback((newValue: T | null) => {
     setLocalDate(newValue)
   }, [])
 

--- a/src/components/ui/Date/Date.tsx
+++ b/src/components/ui/Date/Date.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react'
-import type { DateValue, ZonedDateTime } from '@internationalized/date'
+import type { DateValue } from '@internationalized/date'
 import classNames from 'classnames'
 import {
   DateField as ReactAriaDateField,
@@ -89,12 +89,15 @@ export const DateSegment = forwardRef<HTMLDivElement, DateSegmentProps>(
   },
 )
 
-type DatePickerProps = Omit<ReactAriaDatePickerProps<ZonedDateTime>, 'className'> & {
+type DatePickerProps<T extends DateValue> = Omit<ReactAriaDatePickerProps<T>, 'className'> & {
   className?: string
 }
 
-export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
-  function DatePicker({ className, ...restProps }, ref) {
+export const DatePicker = forwardRef(
+  function DatePicker<T extends DateValue>(
+    { className, ...restProps }: DatePickerProps<T>,
+    ref: React.Ref<HTMLDivElement>,
+  ) {
     return (
       <ReactAriaDatePicker
         {...restProps}
@@ -103,4 +106,6 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       />
     )
   },
-)
+) as <T extends DateValue>(
+  props: DatePickerProps<T> & { ref?: React.Ref<HTMLDivElement> }
+) => React.ReactElement

--- a/src/components/ui/DropdownMenu/dropdownMenu.scss
+++ b/src/components/ui/DropdownMenu/dropdownMenu.scss
@@ -54,8 +54,8 @@
   }
 
   &[data-focus-visible] {
-    outline: 1px solid var(--color-base-100);
-    outline-offset: 1px;
+    outline: 1px auto -webkit-focus-ring-color;
+    outline-offset: 2px;
   }
 
   &[data-variant='compact'] {

--- a/src/components/ui/DropdownMenu/dropdownMenu.scss
+++ b/src/components/ui/DropdownMenu/dropdownMenu.scss
@@ -27,6 +27,7 @@
   padding: var(--spacing-sm);
   border-radius: var(--border-radius-xs);
   border: 1px solid var(--border-color);
+  outline: none;
   background: var(--color-base-0);
 
   &[data-variant='compact'] {
@@ -42,12 +43,19 @@
   border-radius: var(--border-radius-3xs);
   border: 1px solid var(--border-color);
 
+  outline: none;
+
   cursor: pointer;
   transition: background-color 0.1s ease-in-out;
 
   &:hover,
-  &:focus-visible {
+  &[data-focused] {
     background-color: var(--color-base-50);
+  }
+
+  &[data-focus-visible] {
+    outline: 1px solid var(--color-base-100);
+    outline-offset: 1px;
   }
 
   &[data-variant='compact'] {
@@ -64,6 +72,7 @@
 .Layer__UI__DropdownMenu__Menu {
   display: grid;
   gap: var(--spacing-3xs);
+  outline: none;
 
   &[data-variant='compact'] {
     gap: 0;

--- a/src/providers/BankTransactionsFeatureVisibility/BankTransactionsFeatureVisibilityProvider.tsx
+++ b/src/providers/BankTransactionsFeatureVisibility/BankTransactionsFeatureVisibilityProvider.tsx
@@ -3,8 +3,6 @@ import { createContext, type PropsWithChildren, useContext, useRef } from 'react
 export enum BankTransactionsFeature {
   CategorizationRules = 'showCategorizationRules',
   CustomerVendor = 'showCustomerVendor',
-  Descriptions = 'showDescriptions',
-  ReceiptUploads = 'showReceiptUploads',
   StatusToggle = 'showStatusToggle',
   Tags = 'showTags',
   Tooltips = 'showTooltips',
@@ -16,8 +14,6 @@ type BankTransactionsFeatureVisibility = Record<BankTransactionsFeature, boolean
 export const DEFAULT_FEATURE_VISIBILITY: BankTransactionsFeatureVisibility = {
   [BankTransactionsFeature.CategorizationRules]: false,
   [BankTransactionsFeature.CustomerVendor]: false,
-  [BankTransactionsFeature.Descriptions]: true,
-  [BankTransactionsFeature.ReceiptUploads]: true,
   [BankTransactionsFeature.StatusToggle]: true,
   [BankTransactionsFeature.Tags]: false,
   [BankTransactionsFeature.Tooltips]: false,

--- a/src/test-utils/bankTransactionsStoryControls.tsx
+++ b/src/test-utils/bankTransactionsStoryControls.tsx
@@ -8,8 +8,6 @@ import { type MobileComponentType } from '@components/BankTransactions/constants
 export type BankTransactionsStoryArgs = {
   showCategorizationRules: boolean
   showCustomerVendor: boolean
-  showDescriptions: boolean
-  showReceiptUploads: boolean
   showTags: boolean
   showTooltips: boolean
   showUploadOptions: boolean
@@ -19,8 +17,6 @@ export type BankTransactionsStoryArgs = {
 const FEATURE_TOGGLES = [
   'showCategorizationRules',
   'showCustomerVendor',
-  'showDescriptions',
-  'showReceiptUploads',
   'showTags',
   'showTooltips',
   'showUploadOptions',

--- a/src/utils/form/validators.ts
+++ b/src/utils/form/validators.ts
@@ -1,9 +1,23 @@
+import { type CalendarDate, fromDate, getLocalTimeZone, toCalendarDate, type ZonedDateTime } from '@internationalized/date'
 import { BigDecimal } from 'effect'
 
 import { fromNonRecursiveBigDecimal, type NonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
 
 export const required = (message: string) => (value: unknown) =>
   value === null || value === undefined || (typeof value === 'string' && value.trim() === '') ? message : undefined
+
+const toLocalCalendarDate = (date: Date) => toCalendarDate(fromDate(date, getLocalTimeZone()))
+
+const invalidDate = (isInvalid: (date: CalendarDate) => boolean) => (message: string) => (value: ZonedDateTime | null) =>
+  value !== null && isInvalid(toCalendarDate(value)) ? message : undefined
+
+export const dateNotBefore = (minDate: Date | undefined, message: string) =>
+  invalidDate(date => minDate !== undefined && date.compare(toLocalCalendarDate(minDate)) < 0)(message)
+
+export const dateNotAfter = (maxDate: Date | undefined, message: string) =>
+  invalidDate(date => maxDate !== undefined && date.compare(toLocalCalendarDate(maxDate)) > 0)(message)
+
+export const dateNotInFuture = (message: string) => dateNotAfter(new Date(), message)
 
 export const positiveAmount = (message: string) => (value: NonRecursiveBigDecimal | null) =>
   value !== null && BigDecimal.isPositive(fromNonRecursiveBigDecimal(value)) ? undefined : message

--- a/src/utils/form/validators.ts
+++ b/src/utils/form/validators.ts
@@ -1,4 +1,4 @@
-import { type CalendarDate, fromDate, getLocalTimeZone, toCalendarDate, type ZonedDateTime } from '@internationalized/date'
+import { type CalendarDate, type DateValue, fromDate, getLocalTimeZone, toCalendarDate } from '@internationalized/date'
 import { BigDecimal } from 'effect'
 
 import { fromNonRecursiveBigDecimal, type NonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
@@ -8,7 +8,7 @@ export const required = (message: string) => (value: unknown) =>
 
 const toLocalCalendarDate = (date: Date) => toCalendarDate(fromDate(date, getLocalTimeZone()))
 
-const invalidDate = (isInvalid: (date: CalendarDate) => boolean) => (message: string) => (value: ZonedDateTime | null) =>
+const invalidDate = (isInvalid: (date: CalendarDate) => boolean) => (message: string) => (value: DateValue | null) =>
   value !== null && isInvalid(toCalendarDate(value)) ? message : undefined
 
 export const dateNotBefore = (minDate: Date | undefined, message: string) =>

--- a/src/utils/form/validators.ts
+++ b/src/utils/form/validators.ts
@@ -1,21 +1,20 @@
-import { type CalendarDate, type DateValue, fromDate, getLocalTimeZone, toCalendarDate } from '@internationalized/date'
+import { type CalendarDate, type DateValue, toCalendarDate } from '@internationalized/date'
 import { BigDecimal } from 'effect'
 
 import { fromNonRecursiveBigDecimal, type NonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
+import { convertDateToLocalCalendarDate } from '@utils/time/timeUtils'
 
 export const required = (message: string) => (value: unknown) =>
   value === null || value === undefined || (typeof value === 'string' && value.trim() === '') ? message : undefined
-
-const toLocalCalendarDate = (date: Date) => toCalendarDate(fromDate(date, getLocalTimeZone()))
 
 const invalidDate = (isInvalid: (date: CalendarDate) => boolean) => (message: string) => (value: DateValue | null) =>
   value !== null && isInvalid(toCalendarDate(value)) ? message : undefined
 
 export const dateNotBefore = (minDate: Date | undefined, message: string) =>
-  invalidDate(date => minDate !== undefined && date.compare(toLocalCalendarDate(minDate)) < 0)(message)
+  invalidDate(date => minDate !== undefined && date.compare(convertDateToLocalCalendarDate(minDate)) < 0)(message)
 
 export const dateNotAfter = (maxDate: Date | undefined, message: string) =>
-  invalidDate(date => maxDate !== undefined && date.compare(toLocalCalendarDate(maxDate)) > 0)(message)
+  invalidDate(date => maxDate !== undefined && date.compare(convertDateToLocalCalendarDate(maxDate)) > 0)(message)
 
 export const dateNotInFuture = (message: string) => dateNotAfter(new Date(), message)
 

--- a/src/utils/time/timeUtils.ts
+++ b/src/utils/time/timeUtils.ts
@@ -1,4 +1,4 @@
-import { type CalendarDate, fromDate, getLocalTimeZone, ZonedDateTime } from '@internationalized/date'
+import { type CalendarDate, fromDate, getLocalTimeZone, toCalendarDate, ZonedDateTime } from '@internationalized/date'
 import { differenceInDays, formatISO } from 'date-fns'
 
 import type { DateFormatFn } from '@utils/i18n/date/formatters'
@@ -20,6 +20,8 @@ export function isZonedDateTime(val: unknown): val is ZonedDateTime {
 }
 
 export const convertDateToZonedDateTime = (date: Date) => fromDate(date, getLocalTimeZone())
+
+export const convertDateToLocalCalendarDate = (date: Date) => toCalendarDate(convertDateToZonedDateTime(date))
 
 export const formatCalendarDate = (date: CalendarDate, formatDate: DateFormatFn): string => {
   const localDate = new Date(date.year, date.month - 1, date.day)

--- a/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
+++ b/src/views/BankTransactionsWithLinkedAccounts/BankTransactionsWithLinkedAccounts.tsx
@@ -26,8 +26,14 @@ export interface BankTransactionsWithLinkedAccountsProps {
 
   showBreakConnection?: boolean
   showCustomerVendor?: boolean
+  /**
+   * @deprecated This prop is no longer honored; transaction descriptions are always enabled.
+   */
   showDescriptions?: boolean
   showLedgerBalance?: boolean
+  /**
+   * @deprecated This prop is no longer honored; receipt uploads are always enabled.
+   */
   showReceiptUploads?: boolean
   showTags?: boolean
   showTooltips?: boolean
@@ -58,9 +64,7 @@ const BankTransactionsWithLinkedAccountsContent = ({
 
   showBreakConnection = false,
   showCustomerVendor = false,
-  showDescriptions = true,
   showLedgerBalance = true,
-  showReceiptUploads = true,
   showTags = false,
   showTooltips = false,
   showUnlinkItem = false,
@@ -97,8 +101,6 @@ const BankTransactionsWithLinkedAccountsContent = ({
         asWidget
         filters={filters}
         showCustomerVendor={showCustomerVendor}
-        showDescriptions={showDescriptions}
-        showReceiptUploads={showReceiptUploads}
         showTags={showTags}
         showTooltips={showTooltips}
         showUploadOptions={showUploadOptions}


### PR DESCRIPTION
## Summary

### Record transaction modal
- Add date validation: the transaction date must not be in the future and must not be before the business activation date. Adds reusable curried validators (`dateNotBefore`, `dateNotAfter`, `dateNotInFuture`) to `utils/form/validators.ts` in the same style as `required`.
- Rename fields for consistency with the expanded bank transaction row: account label is now **Paid from** (expense), the description field is now **Payee** ("Who you paid") / **Payer** ("Who paid you"), and the memo field is now **Description** rendered as a textarea.
- After a successful save, show a success toast ("Transaction recorded" / "Transaction updated"). On create, land the user on the **Categorized** tab.

### Deprecate `showDescriptions` / `showReceiptUploads`
- Both props on `BankTransactions` and `BankTransactionsWithLinkedAccounts` are marked `@deprecated` and no longer honored — descriptions and receipt uploads are always enabled.
- Removed the corresponding features from `BankTransactionsFeatureVisibilityProvider` and hardcoded the always-on behavior at all consumers (expanded row, description cell, mobile list forms, form fields).
- Removed the toggles from Storybook controls.

### Dropdown menu focus fix
- `ui/DropdownMenu` was missing `outline: none` on its react-aria Dialog/Menu/MenuItem elements, so the browser's default blue focus ring appeared when opening menus (e.g. Record transaction). Now matches the `ui/Menu` focus conventions (`data-focused` background, subtle `data-focus-visible` outline).

## Verification
- `npx vitest run src/components/BankTransactions/RecordManualTransaction/RecordTransactionModal.test.tsx` — 9/9 pass
- `npx tsc --noEmit` and `npx eslint` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches manual transaction recording (field mapping, date bounds, post-create filter) and removes embedder control over memo/receipt visibility; API payload shape is unchanged but UX defaults shift for all consumers.
> 
> **Overview**
> **Record transaction** flow is reworked: labels align with the expanded row (**Paid from**, **Payee**/**Payer**, memo as **Description** textarea), dates use `CalendarDate` with picker min/max and validators (`dateNotInFuture`, `dateNotBefore` activation), success toasts fire on save, and **create** switches the list filter to **Categorized** before closing the modal.
> 
> **`showDescriptions` / `showReceiptUploads`** are deprecated and ignored on `BankTransactions` and linked-accounts views; those features are removed from `BankTransactionsFeatureVisibilityProvider` so memos (`BankTransactionMemo`) and receipt UI always render in table, expanded row, and mobile forms. Storybook toggles for those props are dropped.
> 
> Date picker stack is generalized to generic `DateValue` / `CalendarDate` (including `FormDatePickerField`). Dropdown menu focus styling is aligned with `ui/Menu` (`outline: none`, `data-focused` / `data-focus-visible`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae35e084c2332ddfb3bc851eba14b05fe9ecbb7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->