### PR TITLE
fix: let Journal component scale down on narrow screens (mobile)

### DIFF
--- a/src/components/Journal/journal.scss
+++ b/src/components/Journal/journal.scss
@@ -6,7 +6,7 @@
 }
 
 .Layer__journal .Layer__panel {
-  max-width: 100%;
+  max-inline-size: 100%;
 }
 
 .Layer__journal .Layer__panel__sidebar .Layer__panel__sidebar-content {
@@ -14,7 +14,7 @@
 }
 
 @container (max-width: 760px) {
-  .Layer__journal {
+  .Layer__component-container.Layer__journal {
     overflow: auto;
   }
 }

--- a/src/components/Journal/journal.scss
+++ b/src/components/Journal/journal.scss
@@ -2,8 +2,19 @@
   position: relative;
   display: flex;
   align-items: stretch;
+  overflow: hidden;
+}
+
+.Layer__journal .Layer__panel {
+  max-width: 100%;
 }
 
 .Layer__journal .Layer__panel__sidebar .Layer__panel__sidebar-content {
   width: 100%;
+}
+
+@container (max-width: 760px) {
+  .Layer__journal {
+    overflow: auto;
+  }
 }


### PR DESCRIPTION
## Description
Follow-up to #1628. That PR made the second (filter) header row horizontally scrollable on both Chart of Accounts and Journal. This PR fixes a remaining Journal-only issue: the whole Journal component — including its top header row — would not shrink below ~530px on narrow/mobile viewports, whereas Chart of Accounts scales down to ~260px.

**Root cause:** the Journal container is `display: flex` but, unlike Chart of Accounts, was missing the rules that cap the panel to the container width. As a result the table's intrinsic ~530px min-content width became a hard floor and the component refused to scale down.

## Changes
Ported the existing Chart of Accounts pattern into `journal.scss`:
- `.Layer__journal .Layer__panel { max-width: 100% }` — caps the panel to the container so it scales with the viewport.
- `overflow: hidden` on `.Layer__component-container.Layer__journal`, plus `@container (max-width: 760px) { overflow: auto }` — lets content scroll horizontally on mobile instead of forcing the layout wide.

No JS/behavior changes; this only mirrors the Chart of Accounts layout rules.

## How this has been tested?
- Verified in Storybook (Journal story) at narrow widths: the container, panel, and top header row now shrink to ~298px (and below) instead of being stuck at ~528px, matching Chart of Accounts. The filter row continues to scroll horizontally.
- `stylelint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped presentation-only SCSS with no logic, data, or auth impact.
> 
> **Overview**
> **Journal** now shrinks on narrow viewports instead of staying stuck at the table’s ~530px minimum width.
> 
> `journal.scss` adds **`max-inline-size: 100%`** on `.Layer__journal .Layer__panel` so the panel follows the container (same idea as Chart of Accounts). The journal root gets **`overflow: hidden`**, and at **`@container (max-width: 760px)`** it switches to **`overflow: auto`** so users can scroll horizontally on small screens rather than forcing the layout wide.
> 
> No JavaScript or behavior changes—layout/CSS only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d01d1891559ca35facf830844dcbf56e036606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->