### PR TITLE
feat: added canada deployments and removed assumption for default env config

### DIFF
--- a/src/providers/Environment/EnvironmentInputProvider.tsx
+++ b/src/providers/Environment/EnvironmentInputProvider.tsx
@@ -37,14 +37,12 @@ export function useEnvironment() {
   } = useContext(AuthInputContext)
   const resolvedEnvironment = environmentOverride ?? environment
 
-  const defaultConfig = EnvironmentConfigs[resolvedEnvironment] ?? {}
-
   const {
     apiUrl: defaultApiUrl,
     authUrl: defaultAuthUrl,
     scope: defaultScope,
     usePlaidSandbox: defaultUsePlaidSandbox,
-  } = defaultConfig
+  } = EnvironmentConfigs[resolvedEnvironment]
 
   return {
     environment: resolvedEnvironment,

--- a/src/providers/Environment/EnvironmentInputProvider.tsx
+++ b/src/providers/Environment/EnvironmentInputProvider.tsx
@@ -37,12 +37,14 @@ export function useEnvironment() {
   } = useContext(AuthInputContext)
   const resolvedEnvironment = environmentOverride ?? environment
 
+  const defaultConfig = EnvironmentConfigs[resolvedEnvironment] ?? {}
+
   const {
     apiUrl: defaultApiUrl,
     authUrl: defaultAuthUrl,
     scope: defaultScope,
     usePlaidSandbox: defaultUsePlaidSandbox,
-  } = EnvironmentConfigs[resolvedEnvironment]
+  } = defaultConfig
 
   return {
     environment: resolvedEnvironment,

--- a/src/providers/Environment/environmentConfigs.ts
+++ b/src/providers/Environment/environmentConfigs.ts
@@ -1,4 +1,4 @@
-export type Environment = 'production' | 'sandbox' | 'staging' | 'internalStaging'
+export type Environment = 'production' | 'production-ca' | 'sandbox' | 'staging' | 'internalStaging'
 
 export type EnvironmentConfig = {
   environment: Environment
@@ -11,28 +11,35 @@ export type EnvironmentConfig = {
 export type EnvironmentConfigOverride = Omit<EnvironmentConfig, 'usePlaidSandbox'>
 
 export const EnvironmentConfigs = {
-  production: {
+  'production-ca': {
+    environment: 'production-ca',
+    apiUrl: 'https://api-ca.layerfi.com',
+    authUrl: 'https://auth.layerfi.com/oauth2/token',
+    scope: 'https://api-ca.layerfi.com/production',
+    usePlaidSandbox: false,
+  },
+  'production': {
     environment: 'production',
     apiUrl: 'https://api.layerfi.com',
     authUrl: 'https://auth.layerfi.com/oauth2/token',
     scope: 'https://api.layerfi.com/production',
     usePlaidSandbox: false,
   },
-  sandbox: {
+  'sandbox': {
     environment: 'sandbox',
     apiUrl: 'https://sandbox.layerfi.com',
     authUrl: 'https://auth.layerfi.com/oauth2/token',
     scope: 'https://sandbox.layerfi.com/sandbox',
     usePlaidSandbox: true,
   },
-  staging: {
+  'staging': {
     environment: 'staging',
     apiUrl: 'https://staging.layerfi.com',
     authUrl: 'https://auth.layerfi.com/oauth2/token',
     scope: 'https://sandbox.layerfi.com/sandbox',
     usePlaidSandbox: true,
   },
-  internalStaging: {
+  'internalStaging': {
     environment: 'internalStaging',
     apiUrl: 'https://staging.layerfi.com',
     authUrl: 'https://auth.layerfi.com/oauth2/token',


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change adding a new environment variant; callers must opt into `production-ca` via existing environment resolution.
> 
> **Overview**
> Introduces a **Canada production** deployment by extending the `Environment` union with `production-ca` and registering it in `EnvironmentConfigs` with `https://api-ca.layerfi.com`, shared auth URL, and scope `https://api-ca.layerfi.com/production` (live Plaid, same as US production).
> 
> `EnvironmentConfigs` entries are now keyed with quoted property names so `production-ca` is valid and the map still satisfies `Record<Environment, EnvironmentConfig>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b229854d3f5b094dbc702875b1dca3c5b6f3d521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->