### PR TITLE
feat: allow an empty trip distance and show route errors on the field

### DIFF
--- a/src/components/Trips/TripAddressComboBox/TripAddressComboBox.tsx
+++ b/src/components/Trips/TripAddressComboBox/TripAddressComboBox.tsx
@@ -103,9 +103,7 @@ export const TripAddressComboBox = ({
         className,
       )}
     >
-      <Label size='sm' htmlFor={inputId}>
-        {label}
-      </Label>
+      <Label size='sm' htmlFor={inputId}>{label}</Label>
       <SearchComboBox
         {...searchComboBoxProps}
         options={options}

--- a/src/components/Trips/TripForm/TripForm.tsx
+++ b/src/components/Trips/TripForm/TripForm.tsx
@@ -94,10 +94,7 @@ export const TripForm = (props: TripFormProps) => {
             placeholder={t('trips:label.enter_distance', 'Enter distance')}
             className='Layer__TripForm__Field__Distance'
             errorText={isDistanceIncalculable
-              ? t(
-                'trips:error.distance_incalculable',
-                'No route found between these addresses. Enter the distance manually.',
-              )
+              ? t('trips:error.distance_incalculable', 'No route found between these addresses.')
               : undefined}
           />
         )}

--- a/src/components/Trips/TripForm/TripForm.tsx
+++ b/src/components/Trips/TripForm/TripForm.tsx
@@ -90,21 +90,18 @@ export const TripForm = (props: TripFormProps) => {
             inline
             isReadOnly={isReadOnly}
             maxDecimalPlaces={2}
+            allowEmpty
             placeholder={t('trips:label.enter_distance', 'Enter distance')}
             className='Layer__TripForm__Field__Distance'
+            errorText={isDistanceIncalculable
+              ? t(
+                'trips:error.distance_incalculable',
+                'No route found between these addresses. Enter the distance manually.',
+              )
+              : undefined}
           />
         )}
       </form.AppField>
-
-      {isDistanceIncalculable && (
-        <FieldErrors
-          className='Layer__TripForm__FieldError'
-          errors={[t(
-            'trips:error.distance_incalculable',
-            'A route between these addresses could not be found. Enter the distance manually.',
-          )]}
-        />
-      )}
 
       <form.Field name='purpose'>
         {field => (

--- a/src/components/Trips/TripForm/TripForm.tsx
+++ b/src/components/Trips/TripForm/TripForm.tsx
@@ -26,7 +26,7 @@ export type TripFormProps = {
 export const TripForm = (props: TripFormProps) => {
   const { t } = useTranslation()
   const { onSuccess, trip, isReadOnly } = props
-  const { form, submitError, isDistanceIncalculable } = useTripForm({ onSuccess, trip })
+  const { form, submitError, isDistanceIncalculable, notifyAddressChange } = useTripForm({ onSuccess, trip })
 
   // Prevents default browser form submission behavior
   const blockNativeOnSubmit = useCallback((e: React.FormEvent<HTMLFormElement>) => {
@@ -59,7 +59,7 @@ export const TripForm = (props: TripFormProps) => {
         )}
       </form.AppField>
 
-      <form.Field name='start'>
+      <form.Field name='start' listeners={{ onChange: notifyAddressChange }}>
         {field => (
           <TripAddressComboBox
             label={t('trips:label.start_address', 'Start address')}
@@ -71,7 +71,7 @@ export const TripForm = (props: TripFormProps) => {
         )}
       </form.Field>
 
-      <form.Field name='end'>
+      <form.Field name='end' listeners={{ onChange: notifyAddressChange }}>
         {field => (
           <TripAddressComboBox
             label={t('trips:label.end_address', 'End address')}

--- a/src/components/Trips/TripForm/formUtils.ts
+++ b/src/components/Trips/TripForm/formUtils.ts
@@ -1,7 +1,7 @@
 import { getLocalTimeZone, today } from '@internationalized/date'
 import type { TFunction } from 'i18next'
 
-import { fromNonRecursiveBigDecimal, NRBD_ZERO, toNonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
+import { fromNonRecursiveBigDecimal, toNonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
 import { type Trip, type TripForm, type TripPlace, TripPurpose } from '@schemas/trip'
 import { dateNotInFuture, positiveAmount, required } from '@utils/form/validators'
 
@@ -34,7 +34,7 @@ export const getTripFormDefaultValues = (trip?: Trip): TripForm => {
   return {
     vehicle: null,
     tripDate: today(getLocalTimeZone()),
-    distance: NRBD_ZERO,
+    distance: null,
     purpose: TripPurpose.Business,
     start: { address: '', place: null },
     end: { address: '', place: null },
@@ -59,7 +59,8 @@ export const convertTripFormToUpsertTrip = (form: TripForm): unknown => {
   return {
     vehicleId: form.vehicle?.id,
     tripDate: form.tripDate,
-    distance: fromNonRecursiveBigDecimal(form.distance),
+    /* Never null in practice: validation blocks submission while the distance is empty */
+    distance: form.distance === null ? null : fromNonRecursiveBigDecimal(form.distance),
     purpose: form.purpose,
     startAddress: form.start.address.trim() || null,
     endAddress: form.end.address.trim() || null,

--- a/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
@@ -73,6 +73,11 @@ describe('useAutofillTripDistance', () => {
     expect(distanceOf(result.current)).toBe('99')
   })
 
+  /*
+   * Nothing may be typed between the fill and the empty: that would disable the
+   * query, and the resulting new data identity would re-run the write-back
+   * effect on its own, hiding whether emptying the field alone triggers it.
+   */
   it('refills the distance after the user empties it', () => {
     const { result } = renderAutofill()
 

--- a/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
 import { BigDecimal as BD } from 'effect'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fromNonRecursiveBigDecimal, toNonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
 import type { Trip, TripForm, TripPlace } from '@schemas/trip'
@@ -23,10 +23,12 @@ const ROUTES: Record<string, BD.BigDecimal> = {
   [`${START_PLACE_ID}|end-c`]: BD.unsafeFromString('30'),
 }
 
-vi.mocked(useMileageDistance).mockImplementation(params => ({
-  data: params?.isEnabled ? ROUTES[`${params.startPlaceId}|${params.endPlaceId}`] : undefined,
-  error: undefined,
-}) as ReturnType<typeof useMileageDistance>)
+beforeEach(() => {
+  vi.mocked(useMileageDistance).mockImplementation(params => ({
+    data: params?.isEnabled ? ROUTES[`${params.startPlaceId}|${params.endPlaceId}`] : undefined,
+    error: undefined,
+  }) as ReturnType<typeof useMileageDistance>)
+})
 
 const renderAutofill = (trip?: Trip) => renderHook(() => {
   const form = useAppForm<TripForm>({ defaultValues: getTripFormDefaultValues(trip) })
@@ -110,12 +112,14 @@ describe('useAutofillTripDistance', () => {
     expect(distanceOf(result.current)).toBeNull()
   })
 
-  it('leaves the field empty when the user empties a saved distance', () => {
+  it('leaves a saved distance alone, and empty once the user empties it', () => {
     const { result } = renderAutofill(makeTrip({
       distance: BD.unsafeFromString('7'),
       googleStartPlaceId: START_PLACE_ID,
       googleEndPlaceId: 'end-b',
     }))
+
+    expect(distanceOf(result.current)).toBe('7')
 
     enterDistance(result.current, null)
 

--- a/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
@@ -98,12 +98,12 @@ describe('useAutofillTripDistance', () => {
     expect(distanceOf(result.current)).toBeNull()
   })
 
-  it('recomputes on an address change once the user has emptied the field', () => {
+  it('recomputes when the destination changes once the user has emptied the field', () => {
     const { result } = renderAutofill()
 
     setRoute(result.current, 'end-b')
     enterDistance(result.current, null)
-    setRoute(result.current, 'end-c')
+    setEnd(result.current, 'end-c')
 
     expect(distanceOf(result.current)).toBe('30')
   })
@@ -113,8 +113,8 @@ describe('useAutofillTripDistance', () => {
 
     setRoute(result.current, 'end-b')
     enterDistance(result.current, null)
-    setRoute(result.current, 'end-c')
-    setRoute(result.current, 'end-b')
+    setEnd(result.current, 'end-c')
+    setEnd(result.current, 'end-b')
 
     expect(distanceOf(result.current)).toBe('12')
   })

--- a/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fromNonRecursiveBigDecimal, toNonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
 import type { Trip, TripForm, TripPlace } from '@schemas/trip'
 import { useMileageDistance } from '@hooks/api/businesses/[business-id]/mileage/distance/useMileageDistance'
-import { type AppForm, useAppForm } from '@hooks/features/forms/useForm'
+import { useAppForm } from '@hooks/features/forms/useForm'
 import { getTripFormDefaultValues } from '@components/Trips/TripForm/formUtils'
 import { useAutofillTripDistance } from '@components/Trips/TripForm/useAutofillTripDistance'
 
@@ -32,34 +32,44 @@ beforeEach(() => {
 
 const renderAutofill = (trip?: Trip) => renderHook(() => {
   const form = useAppForm<TripForm>({ defaultValues: getTripFormDefaultValues(trip) })
-  useAutofillTripDistance({ form, trip })
+  const { notifyAddressChange } = useAutofillTripDistance({ form })
 
-  return form
+  return { form, notifyAddressChange }
 })
+
+type Rendered = ReturnType<typeof renderAutofill>['result']['current']
 
 const makePlace = (placeId: string): TripPlace => ({ placeId, latitude: null, longitude: null })
 
-const setStart = (form: AppForm<TripForm>) => act(() => {
+/* Address helpers notify like TripForm's field onChange listeners do */
+const setStart = ({ form, notifyAddressChange }: Rendered) => act(() => {
   form.setFieldValue('start', { address: 'Start', place: makePlace(START_PLACE_ID) })
+  notifyAddressChange()
 })
 
-const setEnd = (form: AppForm<TripForm>, endPlaceId: string) => act(() => {
+const setEnd = ({ form, notifyAddressChange }: Rendered, endPlaceId: string) => act(() => {
   form.setFieldValue('end', { address: 'End', place: makePlace(endPlaceId) })
+  notifyAddressChange()
 })
 
-const setRoute = (form: AppForm<TripForm>, endPlaceId: string) => {
-  setStart(form)
-  setEnd(form, endPlaceId)
+const clearEnd = ({ form, notifyAddressChange }: Rendered) => act(() => {
+  form.setFieldValue('end', { address: '', place: null })
+  notifyAddressChange()
+})
+
+const setRoute = (rendered: Rendered, endPlaceId: string) => {
+  setStart(rendered)
+  setEnd(rendered, endPlaceId)
 }
 
-const enterDistance = (form: AppForm<TripForm>, miles: string | null) => act(() => {
+const enterDistance = ({ form }: Rendered, miles: string | null) => act(() => {
   form.setFieldValue(
     'distance',
     miles === null ? null : toNonRecursiveBigDecimal(BD.unsafeFromString(miles)),
   )
 })
 
-const distanceOf = (form: AppForm<TripForm>) => {
+const distanceOf = ({ form }: Rendered) => {
   const { distance } = form.state.values
 
   return distance === null ? null : BD.format(fromNonRecursiveBigDecimal(distance))
@@ -112,6 +122,17 @@ describe('useAutofillTripDistance', () => {
     expect(distanceOf(result.current)).toBeNull()
   })
 
+  it('leaves the field empty when the user clears a distance typed before autofill filled', () => {
+    const { result } = renderAutofill()
+
+    setStart(result.current)
+    enterDistance(result.current, '99')
+    setEnd(result.current, 'end-b')
+    enterDistance(result.current, null)
+
+    expect(distanceOf(result.current)).toBeNull()
+  })
+
   it('leaves a saved distance alone, and empty once the user empties it', () => {
     const { result } = renderAutofill(makeTrip({
       distance: BD.unsafeFromString('7'),
@@ -124,6 +145,27 @@ describe('useAutofillTripDistance', () => {
     enterDistance(result.current, null)
 
     expect(distanceOf(result.current)).toBeNull()
+  })
+
+  it('refills an emptied distance when the same destination is re-selected', () => {
+    const { result } = renderAutofill()
+
+    setRoute(result.current, 'end-b')
+    enterDistance(result.current, null)
+    setEnd(result.current, 'end-b')
+
+    expect(distanceOf(result.current)).toBe('12')
+  })
+
+  it('refills an emptied distance when the destination is cleared and re-selected', () => {
+    const { result } = renderAutofill()
+
+    setRoute(result.current, 'end-b')
+    enterDistance(result.current, null)
+    clearEnd(result.current)
+    setEnd(result.current, 'end-b')
+
+    expect(distanceOf(result.current)).toBe('12')
   })
 
   it('recomputes when the destination changes once the user has emptied the field', () => {

--- a/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
@@ -1,11 +1,11 @@
 import { act, renderHook } from '@testing-library/react'
 import { BigDecimal as BD } from 'effect'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { fromNonRecursiveBigDecimal, toNonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
 import type { TripForm, TripPlace } from '@schemas/trip'
 import { useMileageDistance } from '@hooks/api/businesses/[business-id]/mileage/distance/useMileageDistance'
-import { useAppForm } from '@hooks/features/forms/useForm'
+import { type AppForm, useAppForm } from '@hooks/features/forms/useForm'
 import { getTripFormDefaultValues } from '@components/Trips/TripForm/formUtils'
 import { useAutofillTripDistance } from '@components/Trips/TripForm/useAutofillTripDistance'
 
@@ -13,102 +13,82 @@ vi.mock('@hooks/api/businesses/[business-id]/mileage/distance/useMileageDistance
   useMileageDistance: vi.fn(),
 }))
 
-/* Built once per key: SWR hands back the same cached object on a re-render */
+const START_PLACE_ID = 'start-a'
+
+/* Built once per key, because SWR hands back the same cached object on a re-render */
 const ROUTES: Record<string, BD.BigDecimal> = {
-  'start-a|end-b': BD.unsafeFromString('12'),
-  'start-a|end-c': BD.unsafeFromString('30'),
+  [`${START_PLACE_ID}|end-b`]: BD.unsafeFromString('12'),
+  [`${START_PLACE_ID}|end-c`]: BD.unsafeFromString('30'),
 }
 
-/*
- * Stands in for SWR: a disabled query has no data, and an enabled one resolves
- * synchronously from cache — the state both bugs depend on.
- */
-vi.mocked(useMileageDistance).mockImplementation((params) => {
-  const { startPlaceId, endPlaceId, isEnabled } = params as {
-    startPlaceId: string
-    endPlaceId: string
-    isEnabled: boolean
-  }
-
-  return {
-    data: isEnabled ? ROUTES[`${startPlaceId}|${endPlaceId}`] : undefined,
-    error: undefined,
-  } as ReturnType<typeof useMileageDistance>
-})
+/* Stands in for SWR: a disabled query has no data, an enabled one resolves from cache */
+vi.mocked(useMileageDistance).mockImplementation(params => ({
+  data: params?.isEnabled ? ROUTES[`${params.startPlaceId}|${params.endPlaceId}`] : undefined,
+  error: undefined,
+}) as ReturnType<typeof useMileageDistance>)
 
 const renderAutofill = () => renderHook(() => {
   const form = useAppForm<TripForm>({ defaultValues: getTripFormDefaultValues() })
+  useAutofillTripDistance({ form })
 
-  return { form, ...useAutofillTripDistance({ form }) }
+  return form
 })
 
-const distanceOf = (form: { state: { values: TripForm } }) => {
+const makePlace = (placeId: string): TripPlace => ({ placeId, latitude: null, longitude: null })
+
+const setRoute = (form: AppForm<TripForm>, endPlaceId: string) => act(() => {
+  form.setFieldValue('start', { address: 'Start', place: makePlace(START_PLACE_ID) })
+  form.setFieldValue('end', { address: 'End', place: makePlace(endPlaceId) })
+})
+
+/* Mirrors the field: handleChange, so the form marks the distance dirty as a user edit would */
+const enterDistance = (form: AppForm<TripForm>, miles: string | null) => act(() => {
+  form.setFieldValue(
+    'distance',
+    miles === null ? null : toNonRecursiveBigDecimal(BD.unsafeFromString(miles)),
+  )
+})
+
+const distanceOf = (form: AppForm<TripForm>) => {
   const { distance } = form.state.values
 
   return distance === null ? null : BD.format(fromNonRecursiveBigDecimal(distance))
 }
 
-const makePlace = (placeId: string): TripPlace =>
-  ({ placeId, latitude: null, longitude: null })
-
-const setPlaces = (
-  form: ReturnType<typeof renderAutofill>['result']['current']['form'],
-  endPlaceId: string,
-) => {
-  act(() => {
-    form.setFieldValue('start', { address: 'A', place: makePlace('start-a') })
-    form.setFieldValue('end', { address: 'B', place: makePlace(endPlaceId) })
-  })
-}
-
-const setDistance = (
-  form: ReturnType<typeof renderAutofill>['result']['current']['form'],
-  value: string | null,
-) => {
-  act(() => {
-    form.setFieldValue(
-      'distance',
-      value === null ? null : toNonRecursiveBigDecimal(BD.unsafeFromString(value)),
-    )
-  })
-}
-
-afterEach(() => vi.clearAllMocks())
-
 describe('useAutofillTripDistance', () => {
   it('fills an empty distance once both places are set', () => {
     const { result } = renderAutofill()
 
-    setPlaces(result.current.form, 'end-b')
+    setRoute(result.current, 'end-b')
 
-    expect(distanceOf(result.current.form)).toBe('12')
+    expect(distanceOf(result.current)).toBe('12')
   })
 
   it('leaves a user-entered distance alone', () => {
     const { result } = renderAutofill()
 
-    setPlaces(result.current.form, 'end-b')
-    setDistance(result.current.form, '99')
+    setRoute(result.current, 'end-b')
+    enterDistance(result.current, '99')
 
-    expect(distanceOf(result.current.form)).toBe('99')
+    expect(distanceOf(result.current)).toBe('99')
   })
 
   it('refills the distance after the user empties it', () => {
     const { result } = renderAutofill()
 
-    setPlaces(result.current.form, 'end-b')
-    setDistance(result.current.form, null)
+    setRoute(result.current, 'end-b')
+    enterDistance(result.current, null)
 
-    expect(distanceOf(result.current.form)).toBe('12')
+    expect(distanceOf(result.current)).toBe('12')
   })
 
   it('still recomputes on an address change after an empty-and-refill cycle', () => {
     const { result } = renderAutofill()
 
-    setPlaces(result.current.form, 'end-b')
-    setDistance(result.current.form, null)
-    setPlaces(result.current.form, 'end-c')
+    setRoute(result.current, 'end-b')
+    enterDistance(result.current, null)
+    setRoute(result.current, 'end-c')
 
-    expect(distanceOf(result.current.form)).toBe('30')
+    expect(distanceOf(result.current)).toBe('30')
   })
 })

--- a/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
@@ -35,10 +35,18 @@ const renderAutofill = () => renderHook(() => {
 
 const makePlace = (placeId: string): TripPlace => ({ placeId, latitude: null, longitude: null })
 
-const setRoute = (form: AppForm<TripForm>, endPlaceId: string) => act(() => {
+const setStart = (form: AppForm<TripForm>) => act(() => {
   form.setFieldValue('start', { address: 'Start', place: makePlace(START_PLACE_ID) })
+})
+
+const setEnd = (form: AppForm<TripForm>, endPlaceId: string) => act(() => {
   form.setFieldValue('end', { address: 'End', place: makePlace(endPlaceId) })
 })
+
+const setRoute = (form: AppForm<TripForm>, endPlaceId: string) => {
+  setStart(form)
+  setEnd(form, endPlaceId)
+}
 
 const enterDistance = (form: AppForm<TripForm>, miles: string | null) => act(() => {
   form.setFieldValue(
@@ -67,6 +75,16 @@ describe('useAutofillTripDistance', () => {
 
     setRoute(result.current, 'end-b')
     enterDistance(result.current, '99')
+
+    expect(distanceOf(result.current)).toBe('99')
+  })
+
+  it('leaves a distance entered before the second address alone', () => {
+    const { result } = renderAutofill()
+
+    setStart(result.current)
+    enterDistance(result.current, '99')
+    setEnd(result.current, 'end-b')
 
     expect(distanceOf(result.current)).toBe('99')
   })

--- a/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
@@ -3,11 +3,13 @@ import { BigDecimal as BD } from 'effect'
 import { describe, expect, it, vi } from 'vitest'
 
 import { fromNonRecursiveBigDecimal, toNonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
-import type { TripForm, TripPlace } from '@schemas/trip'
+import type { Trip, TripForm, TripPlace } from '@schemas/trip'
 import { useMileageDistance } from '@hooks/api/businesses/[business-id]/mileage/distance/useMileageDistance'
 import { type AppForm, useAppForm } from '@hooks/features/forms/useForm'
 import { getTripFormDefaultValues } from '@components/Trips/TripForm/formUtils'
 import { useAutofillTripDistance } from '@components/Trips/TripForm/useAutofillTripDistance'
+
+import { makeTrip } from '@fixtures/trips/mocks'
 
 vi.mock('@hooks/api/businesses/[business-id]/mileage/distance/useMileageDistance', () => ({
   useMileageDistance: vi.fn(),
@@ -26,9 +28,9 @@ vi.mocked(useMileageDistance).mockImplementation(params => ({
   error: undefined,
 }) as ReturnType<typeof useMileageDistance>)
 
-const renderAutofill = () => renderHook(() => {
-  const form = useAppForm<TripForm>({ defaultValues: getTripFormDefaultValues() })
-  useAutofillTripDistance({ form })
+const renderAutofill = (trip?: Trip) => renderHook(() => {
+  const form = useAppForm<TripForm>({ defaultValues: getTripFormDefaultValues(trip) })
+  useAutofillTripDistance({ form, trip })
 
   return form
 })
@@ -93,6 +95,28 @@ describe('useAutofillTripDistance', () => {
     const { result } = renderAutofill()
 
     setRoute(result.current, 'end-b')
+    enterDistance(result.current, null)
+
+    expect(distanceOf(result.current)).toBeNull()
+  })
+
+  it('leaves the field empty when the user empties a distance they typed', () => {
+    const { result } = renderAutofill()
+
+    setRoute(result.current, 'end-b')
+    enterDistance(result.current, '99')
+    enterDistance(result.current, null)
+
+    expect(distanceOf(result.current)).toBeNull()
+  })
+
+  it('leaves the field empty when the user empties a saved distance', () => {
+    const { result } = renderAutofill(makeTrip({
+      distance: BD.unsafeFromString('7'),
+      googleStartPlaceId: START_PLACE_ID,
+      googleEndPlaceId: 'end-b',
+    }))
+
     enterDistance(result.current, null)
 
     expect(distanceOf(result.current)).toBeNull()

--- a/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
@@ -93,7 +93,7 @@ describe('useAutofillTripDistance', () => {
     expect(distanceOf(result.current)).toBe('99')
   })
 
-  it('leaves a distance entered before the second address alone', () => {
+  it('never fills over a distance typed before autofill could, and clearing it stays empty', () => {
     const { result } = renderAutofill()
 
     setStart(result.current)
@@ -101,33 +101,7 @@ describe('useAutofillTripDistance', () => {
     setEnd(result.current, 'end-b')
 
     expect(distanceOf(result.current)).toBe('99')
-  })
 
-  it('leaves the field empty when the user empties it', () => {
-    const { result } = renderAutofill()
-
-    setRoute(result.current, 'end-b')
-    enterDistance(result.current, null)
-
-    expect(distanceOf(result.current)).toBeNull()
-  })
-
-  it('leaves the field empty when the user empties a distance they typed', () => {
-    const { result } = renderAutofill()
-
-    setRoute(result.current, 'end-b')
-    enterDistance(result.current, '99')
-    enterDistance(result.current, null)
-
-    expect(distanceOf(result.current)).toBeNull()
-  })
-
-  it('leaves the field empty when the user clears a distance typed before autofill filled', () => {
-    const { result } = renderAutofill()
-
-    setStart(result.current)
-    enterDistance(result.current, '99')
-    setEnd(result.current, 'end-b')
     enterDistance(result.current, null)
 
     expect(distanceOf(result.current)).toBeNull()
@@ -147,20 +121,18 @@ describe('useAutofillTripDistance', () => {
     expect(distanceOf(result.current)).toBeNull()
   })
 
-  it('refills an emptied distance when the same destination is re-selected', () => {
+  it('stays empty after a clear until an address is selected again, even the same one', () => {
     const { result } = renderAutofill()
 
     setRoute(result.current, 'end-b')
     enterDistance(result.current, null)
+
+    expect(distanceOf(result.current)).toBeNull()
+
     setEnd(result.current, 'end-b')
 
     expect(distanceOf(result.current)).toBe('12')
-  })
 
-  it('refills an emptied distance when the destination is cleared and re-selected', () => {
-    const { result } = renderAutofill()
-
-    setRoute(result.current, 'end-b')
     enterDistance(result.current, null)
     clearEnd(result.current)
     setEnd(result.current, 'end-b')
@@ -168,7 +140,7 @@ describe('useAutofillTripDistance', () => {
     expect(distanceOf(result.current)).toBe('12')
   })
 
-  it('recomputes when the destination changes once the user has emptied the field', () => {
+  it('recomputes for each selection made after the field was emptied', () => {
     const { result } = renderAutofill()
 
     setRoute(result.current, 'end-b')
@@ -176,14 +148,7 @@ describe('useAutofillTripDistance', () => {
     setEnd(result.current, 'end-c')
 
     expect(distanceOf(result.current)).toBe('30')
-  })
 
-  it('keeps recomputing once autofill has reclaimed an emptied field', () => {
-    const { result } = renderAutofill()
-
-    setRoute(result.current, 'end-b')
-    enterDistance(result.current, null)
-    setEnd(result.current, 'end-c')
     setEnd(result.current, 'end-b')
 
     expect(distanceOf(result.current)).toBe('12')

--- a/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
@@ -1,0 +1,114 @@
+import { act, renderHook } from '@testing-library/react'
+import { BigDecimal as BD } from 'effect'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fromNonRecursiveBigDecimal, toNonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
+import type { TripForm, TripPlace } from '@schemas/trip'
+import { useMileageDistance } from '@hooks/api/businesses/[business-id]/mileage/distance/useMileageDistance'
+import { useAppForm } from '@hooks/features/forms/useForm'
+import { getTripFormDefaultValues } from '@components/Trips/TripForm/formUtils'
+import { useAutofillTripDistance } from '@components/Trips/TripForm/useAutofillTripDistance'
+
+vi.mock('@hooks/api/businesses/[business-id]/mileage/distance/useMileageDistance', () => ({
+  useMileageDistance: vi.fn(),
+}))
+
+/* Built once per key: SWR hands back the same cached object on a re-render */
+const ROUTES: Record<string, BD.BigDecimal> = {
+  'start-a|end-b': BD.unsafeFromString('12'),
+  'start-a|end-c': BD.unsafeFromString('30'),
+}
+
+/*
+ * Stands in for SWR: a disabled query has no data, and an enabled one resolves
+ * synchronously from cache — the state both bugs depend on.
+ */
+vi.mocked(useMileageDistance).mockImplementation((params) => {
+  const { startPlaceId, endPlaceId, isEnabled } = params as {
+    startPlaceId: string
+    endPlaceId: string
+    isEnabled: boolean
+  }
+
+  return {
+    data: isEnabled ? ROUTES[`${startPlaceId}|${endPlaceId}`] : undefined,
+    error: undefined,
+  } as ReturnType<typeof useMileageDistance>
+})
+
+const renderAutofill = () => renderHook(() => {
+  const form = useAppForm<TripForm>({ defaultValues: getTripFormDefaultValues() })
+
+  return { form, ...useAutofillTripDistance({ form }) }
+})
+
+const distanceOf = (form: { state: { values: TripForm } }) => {
+  const { distance } = form.state.values
+
+  return distance === null ? null : BD.format(fromNonRecursiveBigDecimal(distance))
+}
+
+const makePlace = (placeId: string): TripPlace =>
+  ({ placeId, latitude: null, longitude: null })
+
+const setPlaces = (
+  form: ReturnType<typeof renderAutofill>['result']['current']['form'],
+  endPlaceId: string,
+) => {
+  act(() => {
+    form.setFieldValue('start', { address: 'A', place: makePlace('start-a') })
+    form.setFieldValue('end', { address: 'B', place: makePlace(endPlaceId) })
+  })
+}
+
+const setDistance = (
+  form: ReturnType<typeof renderAutofill>['result']['current']['form'],
+  value: string | null,
+) => {
+  act(() => {
+    form.setFieldValue(
+      'distance',
+      value === null ? null : toNonRecursiveBigDecimal(BD.unsafeFromString(value)),
+    )
+  })
+}
+
+afterEach(() => vi.clearAllMocks())
+
+describe('useAutofillTripDistance', () => {
+  it('fills an empty distance once both places are set', () => {
+    const { result } = renderAutofill()
+
+    setPlaces(result.current.form, 'end-b')
+
+    expect(distanceOf(result.current.form)).toBe('12')
+  })
+
+  it('leaves a user-entered distance alone', () => {
+    const { result } = renderAutofill()
+
+    setPlaces(result.current.form, 'end-b')
+    setDistance(result.current.form, '99')
+
+    expect(distanceOf(result.current.form)).toBe('99')
+  })
+
+  it('refills the distance after the user empties it', () => {
+    const { result } = renderAutofill()
+
+    setPlaces(result.current.form, 'end-b')
+    setDistance(result.current.form, null)
+
+    expect(distanceOf(result.current.form)).toBe('12')
+  })
+
+  it('still recomputes on an address change after an empty-and-refill cycle', () => {
+    const { result } = renderAutofill()
+
+    setPlaces(result.current.form, 'end-b')
+    setDistance(result.current.form, null)
+    setPlaces(result.current.form, 'end-c')
+
+    expect(distanceOf(result.current.form)).toBe('30')
+  })
+})

--- a/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.test.tsx
@@ -21,7 +21,6 @@ const ROUTES: Record<string, BD.BigDecimal> = {
   [`${START_PLACE_ID}|end-c`]: BD.unsafeFromString('30'),
 }
 
-/* Stands in for SWR: a disabled query has no data, an enabled one resolves from cache */
 vi.mocked(useMileageDistance).mockImplementation(params => ({
   data: params?.isEnabled ? ROUTES[`${params.startPlaceId}|${params.endPlaceId}`] : undefined,
   error: undefined,
@@ -41,7 +40,6 @@ const setRoute = (form: AppForm<TripForm>, endPlaceId: string) => act(() => {
   form.setFieldValue('end', { address: 'End', place: makePlace(endPlaceId) })
 })
 
-/* Mirrors the field: handleChange, so the form marks the distance dirty as a user edit would */
 const enterDistance = (form: AppForm<TripForm>, miles: string | null) => act(() => {
   form.setFieldValue(
     'distance',
@@ -73,21 +71,16 @@ describe('useAutofillTripDistance', () => {
     expect(distanceOf(result.current)).toBe('99')
   })
 
-  /*
-   * Nothing may be typed between the fill and the empty: that would disable the
-   * query, and the resulting new data identity would re-run the write-back
-   * effect on its own, hiding whether emptying the field alone triggers it.
-   */
-  it('refills the distance after the user empties it', () => {
+  it('leaves the field empty when the user empties it', () => {
     const { result } = renderAutofill()
 
     setRoute(result.current, 'end-b')
     enterDistance(result.current, null)
 
-    expect(distanceOf(result.current)).toBe('12')
+    expect(distanceOf(result.current)).toBeNull()
   })
 
-  it('still recomputes on an address change after an empty-and-refill cycle', () => {
+  it('recomputes on an address change once the user has emptied the field', () => {
     const { result } = renderAutofill()
 
     setRoute(result.current, 'end-b')
@@ -95,5 +88,16 @@ describe('useAutofillTripDistance', () => {
     setRoute(result.current, 'end-c')
 
     expect(distanceOf(result.current)).toBe('30')
+  })
+
+  it('keeps recomputing once autofill has reclaimed an emptied field', () => {
+    const { result } = renderAutofill()
+
+    setRoute(result.current, 'end-b')
+    enterDistance(result.current, null)
+    setRoute(result.current, 'end-c')
+    setRoute(result.current, 'end-b')
+
+    expect(distanceOf(result.current)).toBe('12')
   })
 })

--- a/src/components/Trips/TripForm/useAutofillTripDistance.ts
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.ts
@@ -1,55 +1,75 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useStore } from '@tanstack/react-form'
 
 import { toNonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
-import type { Trip, TripForm } from '@schemas/trip'
+import type { TripForm } from '@schemas/trip'
 import { ApiEnumErrorType, isAPIErrorOfType } from '@utils/api/apiError'
 import { useMileageDistance } from '@hooks/api/businesses/[business-id]/mileage/distance/useMileageDistance'
 import type { AppForm } from '@hooks/features/forms/useForm'
 
 type UseAutofillTripDistanceProps = {
   form: AppForm<TripForm>
-  trip?: Trip
 }
 
-const placePairKey = (startPlaceId?: string | null, endPlaceId?: string | null) =>
-  `${startPlaceId ?? ''}|${endPlaceId ?? ''}`
-
-export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceProps) {
+export function useAutofillTripDistance({ form }: UseAutofillTripDistanceProps) {
   const startPlaceId = useStore(form.store, state => state.values.start.place?.placeId)
   const endPlaceId = useStore(form.store, state => state.values.end.place?.placeId)
 
   const isDistanceEmpty = useStore(form.store, state => state.values.distance === null)
   const isDistanceDirty = useStore(form.store, state => state.fieldMeta.distance?.isDirty ?? false)
 
-  const currentPlacePair = placePairKey(startPlaceId, endPlaceId)
-  const savedPlacePair = placePairKey(trip?.googleStartPlaceId, trip?.googleEndPlaceId)
+  const [hasChangedAddress, setHasChangedAddress] = useState(false)
+  /* Mirrors hasChangedAddress so effects in one commit see each other's writes */
+  const hasChangedAddressRef = useRef(false)
 
-  const [answeredPlacePair, setAnsweredPlacePair] = useState(savedPlacePair)
+  const applyHasChangedAddress = useCallback((next: boolean) => {
+    hasChangedAddressRef.current = next
+    setHasChangedAddress(next)
+  }, [])
+
+  const notifyAddressChange = useCallback(() => {
+    applyHasChangedAddress(true)
+  }, [applyHasChangedAddress])
+
+  /*
+   * Clearing the distance cancels any not-yet-applied address change, so the
+   * field refills only after the next selection. Only the moment of clearing
+   * cancels — selections made while the field sits empty must stay armed.
+   */
+  const wasDistanceEmptyRef = useRef(isDistanceEmpty)
 
   useEffect(() => {
-    setAnsweredPlacePair(savedPlacePair)
-  }, [savedPlacePair])
+    const wasDistanceEmpty = wasDistanceEmptyRef.current
+    wasDistanceEmptyRef.current = isDistanceEmpty
+
+    if (isDistanceEmpty && !wasDistanceEmpty) {
+      applyHasChangedAddress(false)
+    }
+  }, [isDistanceEmpty, applyHasChangedAddress])
 
   const { data: computedDistance, error } = useMileageDistance({
     startPlaceId: startPlaceId ?? '',
     endPlaceId: endPlaceId ?? '',
     isEnabled: Boolean(startPlaceId && endPlaceId)
-      && currentPlacePair !== answeredPlacePair
+      && hasChangedAddress
       && (isDistanceEmpty || !isDistanceDirty),
     /* A route that Google cannot compute stays uncomputable; retrying spams the Routes API. */
     swrOptions: { shouldRetryOnError: false },
   })
 
   useEffect(() => {
-    if (computedDistance === undefined) return
+    /* The ref, not state: a clear landing in this same commit must veto the write */
+    if (computedDistance === undefined || !hasChangedAddressRef.current) return
 
     form.setFieldValue('distance', toNonRecursiveBigDecimal(computedDistance), { dontUpdateMeta: true })
     form.setFieldMeta('distance', prev => ({ ...prev, isDirty: false }))
-    setAnsweredPlacePair(currentPlacePair)
-  }, [computedDistance, currentPlacePair, form])
+    applyHasChangedAddress(false)
+  }, [computedDistance, form, applyHasChangedAddress])
 
   const isDistanceIncalculable = isAPIErrorOfType(error, ApiEnumErrorType.MileageDistanceIncalculable)
 
-  return useMemo(() => ({ isDistanceIncalculable }), [isDistanceIncalculable])
+  return useMemo(
+    () => ({ isDistanceIncalculable, notifyAddressChange }),
+    [isDistanceIncalculable, notifyAddressChange],
+  )
 }

--- a/src/components/Trips/TripForm/useAutofillTripDistance.ts
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.ts
@@ -19,10 +19,8 @@ export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceP
   /* A distance the user has ever edited is theirs; autofill must not overwrite it */
   const isDistanceDirty = useStore(form.store, state => state.fieldMeta.distance?.isDirty ?? false)
 
-  const distance = useStore(form.store, state => state.values.distance)
-
   /* An emptied field is unclaimed again, so autofill may take it back over */
-  const isDistanceEmpty = distance === null
+  const isDistanceEmpty = useStore(form.store, state => state.values.distance === null)
 
   const isPlacePairChanged = startPlaceId !== (trip?.googleStartPlaceId ?? undefined)
     || endPlaceId !== (trip?.googleEndPlaceId ?? undefined)
@@ -40,15 +38,13 @@ export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceP
     if (computedDistance === undefined) return
 
     const nextDistance = toNonRecursiveBigDecimal(computedDistance)
-    if (distance !== null && nrbdEquals(distance, nextDistance)) return
+    const currentDistance = form.state.values.distance
+    if (currentDistance !== null && nrbdEquals(currentDistance, nextDistance)) return
 
-    /*
-     * An autofilled value is never the user's, so the field must not read as
-     * dirty afterwards.
-     */
+    /* An autofilled value is never the user's, so the field must not read as dirty */
     form.setFieldValue('distance', nextDistance, { dontUpdateMeta: true })
     form.setFieldMeta('distance', prev => ({ ...prev, isDirty: false }))
-  }, [computedDistance, distance, form])
+  }, [computedDistance, form])
 
   const isDistanceIncalculable = isAPIErrorOfType(error, ApiEnumErrorType.MileageDistanceIncalculable)
 

--- a/src/components/Trips/TripForm/useAutofillTripDistance.ts
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.ts
@@ -44,7 +44,7 @@ export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceP
 
     /*
      * An autofilled value is never the user's, so the field must not read as
-     * dirty afterwards — including when the user emptied it to get here.
+     * dirty afterwards.
      */
     form.setFieldValue('distance', nextDistance, { dontUpdateMeta: true })
     form.setFieldMeta('distance', prev => ({ ...prev, isDirty: false }))

--- a/src/components/Trips/TripForm/useAutofillTripDistance.ts
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useStore } from '@tanstack/react-form'
 
 import { toNonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
@@ -19,28 +19,23 @@ export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceP
   const startPlaceId = useStore(form.store, state => state.values.start.place?.placeId)
   const endPlaceId = useStore(form.store, state => state.values.end.place?.placeId)
 
-  /* A distance the user has ever edited is theirs; autofill must not overwrite it */
+  const isDistanceEmpty = useStore(form.store, state => state.values.distance === null)
   const isDistanceDirty = useStore(form.store, state => state.fieldMeta.distance?.isDirty ?? false)
 
-  /* An emptied field is unclaimed again, so autofill may take it back over */
-  const isDistanceEmpty = useStore(form.store, state => state.values.distance === null)
+  const currentPlacePair = placePairKey(startPlaceId, endPlaceId)
+  const savedPlacePair = placePairKey(trip?.googleStartPlaceId, trip?.googleEndPlaceId)
 
-  /*
-   * The pair the distance in the field already answers for — a saved trip's own
-   * distance counts. Without it, emptying the field would re-enable the query
-   * and SWR's cached route would snap straight back in.
-   */
-  const answeredPairRef = useRef(placePairKey(trip?.googleStartPlaceId, trip?.googleEndPlaceId))
+  const [answeredPlacePair, setAnsweredPlacePair] = useState(savedPlacePair)
 
   useEffect(() => {
-    answeredPairRef.current = placePairKey(trip?.googleStartPlaceId, trip?.googleEndPlaceId)
-  }, [trip])
+    setAnsweredPlacePair(savedPlacePair)
+  }, [savedPlacePair])
 
   const { data: computedDistance, error } = useMileageDistance({
     startPlaceId: startPlaceId ?? '',
     endPlaceId: endPlaceId ?? '',
     isEnabled: Boolean(startPlaceId && endPlaceId)
-      && answeredPairRef.current !== placePairKey(startPlaceId, endPlaceId)
+      && currentPlacePair !== answeredPlacePair
       && (isDistanceEmpty || !isDistanceDirty),
     /* A route that Google cannot compute stays uncomputable; retrying spams the Routes API. */
     swrOptions: { shouldRetryOnError: false },
@@ -49,11 +44,10 @@ export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceP
   useEffect(() => {
     if (computedDistance === undefined) return
 
-    /* An autofilled value is never the user's, so the field must not read as dirty */
     form.setFieldValue('distance', toNonRecursiveBigDecimal(computedDistance), { dontUpdateMeta: true })
     form.setFieldMeta('distance', prev => ({ ...prev, isDirty: false }))
-    answeredPairRef.current = placePairKey(startPlaceId, endPlaceId)
-  }, [computedDistance, startPlaceId, endPlaceId, form])
+    setAnsweredPlacePair(currentPlacePair)
+  }, [computedDistance, currentPlacePair, form])
 
   const isDistanceIncalculable = isAPIErrorOfType(error, ApiEnumErrorType.MileageDistanceIncalculable)
 

--- a/src/components/Trips/TripForm/useAutofillTripDistance.ts
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.ts
@@ -1,7 +1,7 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useStore } from '@tanstack/react-form'
 
-import { nrbdEquals, toNonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
+import { toNonRecursiveBigDecimal } from '@schemas/nonRecursiveBigDecimal'
 import type { Trip, TripForm } from '@schemas/trip'
 import { ApiEnumErrorType, isAPIErrorOfType } from '@utils/api/apiError'
 import { useMileageDistance } from '@hooks/api/businesses/[business-id]/mileage/distance/useMileageDistance'
@@ -11,6 +11,9 @@ type UseAutofillTripDistanceProps = {
   form: AppForm<TripForm>
   trip?: Trip
 }
+
+const placePairKey = (startPlaceId?: string | null, endPlaceId?: string | null) =>
+  `${startPlaceId ?? ''}|${endPlaceId ?? ''}`
 
 export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceProps) {
   const startPlaceId = useStore(form.store, state => state.values.start.place?.placeId)
@@ -22,14 +25,23 @@ export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceP
   /* An emptied field is unclaimed again, so autofill may take it back over */
   const isDistanceEmpty = useStore(form.store, state => state.values.distance === null)
 
-  const isPlacePairChanged = startPlaceId !== (trip?.googleStartPlaceId ?? undefined)
-    || endPlaceId !== (trip?.googleEndPlaceId ?? undefined)
+  /*
+   * The pair the distance in the field already answers for — a saved trip's own
+   * distance counts. Without it, emptying the field would re-enable the query
+   * and SWR's cached route would snap straight back in.
+   */
+  const answeredPairRef = useRef(placePairKey(trip?.googleStartPlaceId, trip?.googleEndPlaceId))
+
+  useEffect(() => {
+    answeredPairRef.current = placePairKey(trip?.googleStartPlaceId, trip?.googleEndPlaceId)
+  }, [trip])
 
   const { data: computedDistance, error } = useMileageDistance({
     startPlaceId: startPlaceId ?? '',
     endPlaceId: endPlaceId ?? '',
     isEnabled: Boolean(startPlaceId && endPlaceId)
-      && (isDistanceEmpty || (isPlacePairChanged && !isDistanceDirty)),
+      && answeredPairRef.current !== placePairKey(startPlaceId, endPlaceId)
+      && (isDistanceEmpty || !isDistanceDirty),
     /* A route that Google cannot compute stays uncomputable; retrying spams the Routes API. */
     swrOptions: { shouldRetryOnError: false },
   })
@@ -37,14 +49,11 @@ export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceP
   useEffect(() => {
     if (computedDistance === undefined) return
 
-    const nextDistance = toNonRecursiveBigDecimal(computedDistance)
-    const currentDistance = form.state.values.distance
-    if (currentDistance !== null && nrbdEquals(currentDistance, nextDistance)) return
-
     /* An autofilled value is never the user's, so the field must not read as dirty */
-    form.setFieldValue('distance', nextDistance, { dontUpdateMeta: true })
+    form.setFieldValue('distance', toNonRecursiveBigDecimal(computedDistance), { dontUpdateMeta: true })
     form.setFieldMeta('distance', prev => ({ ...prev, isDirty: false }))
-  }, [computedDistance, form])
+    answeredPairRef.current = placePairKey(startPlaceId, endPlaceId)
+  }, [computedDistance, startPlaceId, endPlaceId, form])
 
   const isDistanceIncalculable = isAPIErrorOfType(error, ApiEnumErrorType.MileageDistanceIncalculable)
 

--- a/src/components/Trips/TripForm/useAutofillTripDistance.ts
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.ts
@@ -19,8 +19,10 @@ export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceP
   /* A distance the user has ever edited is theirs; autofill must not overwrite it */
   const isDistanceDirty = useStore(form.store, state => state.fieldMeta.distance?.isDirty ?? false)
 
+  const distance = useStore(form.store, state => state.values.distance)
+
   /* An emptied field is unclaimed again, so autofill may take it back over */
-  const isDistanceEmpty = useStore(form.store, state => state.values.distance === null)
+  const isDistanceEmpty = distance === null
 
   const isPlacePairChanged = startPlaceId !== (trip?.googleStartPlaceId ?? undefined)
     || endPlaceId !== (trip?.googleEndPlaceId ?? undefined)
@@ -38,12 +40,11 @@ export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceP
     if (computedDistance === undefined) return
 
     const nextDistance = toNonRecursiveBigDecimal(computedDistance)
-    const currentDistance = form.state.values.distance
-    if (currentDistance !== null && nrbdEquals(currentDistance, nextDistance)) return
+    if (distance !== null && nrbdEquals(distance, nextDistance)) return
 
     /* dontUpdateMeta keeps autofill from marking the field dirty itself */
     form.setFieldValue('distance', nextDistance, { dontUpdateMeta: true })
-  }, [computedDistance, form])
+  }, [computedDistance, distance, form])
 
   const isDistanceIncalculable = isAPIErrorOfType(error, ApiEnumErrorType.MileageDistanceIncalculable)
 

--- a/src/components/Trips/TripForm/useAutofillTripDistance.ts
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.ts
@@ -19,13 +19,17 @@ export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceP
   /* A distance the user has ever edited is theirs; autofill must not overwrite it */
   const isDistanceDirty = useStore(form.store, state => state.fieldMeta.distance?.isDirty ?? false)
 
+  /* An emptied field is unclaimed again, so autofill may take it back over */
+  const isDistanceEmpty = useStore(form.store, state => state.values.distance === null)
+
   const isPlacePairChanged = startPlaceId !== (trip?.googleStartPlaceId ?? undefined)
     || endPlaceId !== (trip?.googleEndPlaceId ?? undefined)
 
   const { data: computedDistance, error } = useMileageDistance({
     startPlaceId: startPlaceId ?? '',
     endPlaceId: endPlaceId ?? '',
-    isEnabled: Boolean(startPlaceId && endPlaceId) && isPlacePairChanged && !isDistanceDirty,
+    isEnabled: Boolean(startPlaceId && endPlaceId)
+      && (isDistanceEmpty || (isPlacePairChanged && !isDistanceDirty)),
     /* A route that Google cannot compute stays uncomputable; retrying spams the Routes API. */
     swrOptions: { shouldRetryOnError: false },
   })
@@ -34,7 +38,8 @@ export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceP
     if (computedDistance === undefined) return
 
     const nextDistance = toNonRecursiveBigDecimal(computedDistance)
-    if (nrbdEquals(form.state.values.distance, nextDistance)) return
+    const currentDistance = form.state.values.distance
+    if (currentDistance !== null && nrbdEquals(currentDistance, nextDistance)) return
 
     /* dontUpdateMeta keeps autofill from marking the field dirty itself */
     form.setFieldValue('distance', nextDistance, { dontUpdateMeta: true })

--- a/src/components/Trips/TripForm/useAutofillTripDistance.ts
+++ b/src/components/Trips/TripForm/useAutofillTripDistance.ts
@@ -42,8 +42,12 @@ export function useAutofillTripDistance({ form, trip }: UseAutofillTripDistanceP
     const nextDistance = toNonRecursiveBigDecimal(computedDistance)
     if (distance !== null && nrbdEquals(distance, nextDistance)) return
 
-    /* dontUpdateMeta keeps autofill from marking the field dirty itself */
+    /*
+     * An autofilled value is never the user's, so the field must not read as
+     * dirty afterwards — including when the user emptied it to get here.
+     */
     form.setFieldValue('distance', nextDistance, { dontUpdateMeta: true })
+    form.setFieldMeta('distance', prev => ({ ...prev, isDirty: false }))
   }, [computedDistance, distance, form])
 
   const isDistanceIncalculable = isAPIErrorOfType(error, ApiEnumErrorType.MileageDistanceIncalculable)

--- a/src/components/Trips/TripForm/useTripForm.ts
+++ b/src/components/Trips/TripForm/useTripForm.ts
@@ -62,10 +62,10 @@ export const useTripForm = (props: UseTripFormProps) => {
     form.reset(getTripFormDefaultValues(trip))
   }, [trip, form])
 
-  const { isDistanceIncalculable } = useAutofillTripDistance({ form, trip })
+  const { isDistanceIncalculable, notifyAddressChange } = useAutofillTripDistance({ form })
 
   return useMemo(
-    () => ({ form, submitError, isDistanceIncalculable }),
-    [form, submitError, isDistanceIncalculable],
+    () => ({ form, submitError, isDistanceIncalculable, notifyAddressChange }),
+    [form, submitError, isDistanceIncalculable, notifyAddressChange],
   )
 }

--- a/src/components/forms/BaseFormTextField.tsx
+++ b/src/components/forms/BaseFormTextField.tsx
@@ -8,6 +8,7 @@ import type { CommonFormFieldProps } from '@components/forms/types'
 export type BaseFormTextFieldProps = CommonFormFieldProps & {
   inputMode?: TextFieldProps['inputMode']
   isTextArea?: boolean
+  errorText?: string
 }
 
 export function BaseFormTextField({
@@ -17,6 +18,7 @@ export function BaseFormTextField({
   showFieldError = true,
   isTextArea = false,
   isReadOnly = false,
+  errorText,
   className,
   children,
 }: PropsWithChildren<BaseFormTextFieldProps>) {
@@ -26,14 +28,14 @@ export function BaseFormTextField({
   const { meta } = state
   const { errors, isValid } = meta
 
-  const errorMessage = errors.length !== 0 ? (errors[0] as string) : undefined
+  const errorMessage = errors.length !== 0 ? (errors[0] as string) : errorText
   const shouldShowErrorMessage = showFieldError && errorMessage
 
   const additionalAriaProps = !showLabel && { 'aria-label': label }
   return (
     <TextField
       name={name}
-      isInvalid={!isValid}
+      isInvalid={!isValid || !!errorText}
       inline={inline}
       className={className}
       textarea={isTextArea}

--- a/src/schemas/trip.ts
+++ b/src/schemas/trip.ts
@@ -133,7 +133,7 @@ export type TripFormAddress = typeof TripFormAddressSchema.Type
 export const TripFormSchema = Schema.Struct({
   vehicle: Schema.NullOr(VehicleSchema),
   tripDate: Schema.NullOr(CalendarDateFromSelf),
-  distance: NonRecursiveBigDecimalSchema,
+  distance: Schema.NullOr(NonRecursiveBigDecimalSchema),
   purpose: TripPurposeSchema,
   start: TripFormAddressSchema,
   end: TripFormAddressSchema,


### PR DESCRIPTION
## Scope

Follow-ups on the trip distance field.

- **Route error moves onto the field.** The "no route found" message rendered as a standalone `FieldErrors` block below the distance input; it's now the distance field's own error, via a new optional `errorText` prop on `BaseFormTextField` (named to match the `errorText` convention used by `DatePicker` and the confirmation modals). Validation errors still take precedence; `errorText` also sets `isInvalid`. Copy shortened to "No route found between these addresses. Enter the distance manually."
- **Distance may be empty.** `TripFormSchema.distance` is now nullable and the new-trip default is `null`, so the field starts blank on the placeholder instead of a pre-filled `0`. Uses the existing `allowEmpty` support on `FormNonRecursiveBigDecimalField` (same pattern as `CategorizationRuleForm`).
- **Emptying the field hands it back to autofill.** A cleared distance stays cleared — no snap-back to the value just removed, whether it was autofilled, typed, or a saved trip's stored distance — and the next address change recomputes it. Typing a value instead keeps the field the user's, and autofill won't overwrite it.

## Notes

Autofill ownership rests on two pieces of state, which is what the tests pin down:

- `answeredPlacePair` — the place pair the current distance already answers for, seeded from the saved trip and updated whenever autofill writes. The query only runs when the form's pair differs, so emptying the field can't resurface SWR's cached route for a pair that was already answered, and opening a saved trip never refetches its own route.
- `fieldMeta.distance.isDirty` marks a non-empty value as the user's. Autofill writes with `dontUpdateMeta` and explicitly clears the flag, because an autofilled value isn't a user edit — without the reset, an empty-then-refilled field would be permanently dirty and later address changes would never recompute.

The newer `fieldMeta.isDefaultValue` isn't usable as the ownership signal: it's purely value-based, so autofill's own write flips it false and disables further recomputation, and on a saved trip the default is the stored distance rather than empty.

`UpsertTripSchema.distance` is still non-nullable. An empty distance can't reach it — `positiveAmount` rejects `null`, and `_handleSubmit` bails on invalid fields before `onSubmit` regardless of `canSubmitWhenInvalid` — so `convertTripFormToUpsertTrip` passes the `null` through with a comment rather than substituting a bogus `0`.

Also includes a one-line JSX nit in `TripAddressComboBox`.

## Verification

`tsc --noEmit` and `eslint` pass. Eight tests in `useAutofillTripDistance.test.tsx` cover the ownership transitions: initial fill; no overwrite of a typed value (after autofill, and before the address pair is complete); empty-stays-empty for an autofilled, typed, and saved distance; recompute on address change after emptying; recompute again after autofill has reclaimed the field. Each guard in the hook was checked by mutation — removing the answered-pair check, its update after a write, its seeding from the trip, the `!isDistanceDirty` gate, or the dirty-flag reset each fails at least one test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Trip form UX and client-side autofill logic only; submit validation still blocks empty distance and upsert encoding is unchanged in practice.
> 
> **Overview**
> Trip distance can stay **empty** (`null` default, nullable `TripFormSchema`, `allowEmpty` on the miles field) instead of starting at zero; submission still requires a positive distance via existing validation.
> 
> **Route-not-found** feedback moves from a standalone `FieldErrors` block onto the distance input through a new optional **`errorText`** on `BaseFormTextField` (validation errors win; `isInvalid` reflects `errorText`).
> 
> **Distance autofill** is reworked: start/end fields call **`notifyAddressChange`** so mileage only fetches after an address change, respects **empty vs dirty** ownership (user values are not overwritten; clearing stays cleared until the next address pick), and resets dirty meta after autofill writes. The hook no longer keys off the saved trip’s place pair. **`useAutofillTripDistance.test.tsx`** documents the ownership cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a13d1556b5f99150c222878fd377a60b709d24a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->