### PR TITLE
feat: sparkles icon for suggested category in bank transactions combobox

### DIFF
--- a/src/components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox.tsx
+++ b/src/components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo } from 'react'
-import { SparklesIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { GroupBase } from 'react-select'
 
@@ -159,11 +158,7 @@ export const BankTransactionCategoryComboBox = ({
     return (
       <BankTransactionsUncategorizedSelectedValue
         selectedValue={selectedValue}
-        slots={{
-          Icon: isSuggestedCategorySelected
-            ? <SparklesIcon size={14} className='Layer__BankTransactionCategoryComboBox__SuggestedCategoryIcon' />
-            : undefined,
-        }}
+        showAiSparkle={isSuggestedCategorySelected}
       />
     )
   }, [isSuggestedCategorySelected, selectedValue])

--- a/src/components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox.tsx
+++ b/src/components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react'
+import { SparklesIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { GroupBase } from 'react-select'
 
@@ -149,9 +150,23 @@ export const BankTransactionCategoryComboBox = ({
         ? t('bankTransactions:action.categorize_or_match', 'Categorize or match...')
         : t('bankTransactions:action.select_category', 'Select category')
 
+  const isSuggestedCategorySelected = useMemo(() => {
+    if (!selectedValue || !suggestedGroup) return false
+    return suggestedGroup.options.some(option => option.value === selectedValue.value)
+  }, [selectedValue, suggestedGroup])
+
   const SingleValue = useCallback(() => {
-    return <BankTransactionsUncategorizedSelectedValue selectedValue={selectedValue} />
-  }, [selectedValue])
+    return (
+      <BankTransactionsUncategorizedSelectedValue
+        selectedValue={selectedValue}
+        slots={{
+          Icon: isSuggestedCategorySelected
+            ? <SparklesIcon size={14} className='Layer__BankTransactionCategoryComboBox__SuggestedCategoryIcon' />
+            : undefined,
+        }}
+      />
+    )
+  }, [isSuggestedCategorySelected, selectedValue])
 
   const handleSelectedValueChange = useCallback((value: BankTransactionCategoryComboBoxOption | null) => {
     if (!includeSuggestedMatches) {

--- a/src/components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox.tsx
+++ b/src/components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox.tsx
@@ -149,10 +149,8 @@ export const BankTransactionCategoryComboBox = ({
         ? t('bankTransactions:action.categorize_or_match', 'Categorize or match...')
         : t('bankTransactions:action.select_category', 'Select category')
 
-  const isSuggestedCategorySelected = useMemo(() => {
-    if (!selectedValue || !suggestedGroup) return false
-    return suggestedGroup.options.some(option => option.value === selectedValue.value)
-  }, [selectedValue, suggestedGroup])
+  const isSuggestedCategorySelected = selectedValue !== null
+    && (suggestedGroup?.options.some(option => option.value === selectedValue.value) ?? false)
 
   const SingleValue = useCallback(() => {
     return (

--- a/src/components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBox.scss
+++ b/src/components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBox.scss
@@ -2,10 +2,6 @@
   color: var(--color-base-900);
 }
 
-.Layer__BankTransactionCategoryComboBox__SuggestedCategoryIcon {
-  flex-shrink: 0;
-}
-
 .Layer__BankTransactionCategoryComboBox__CustomGroupHeading {
   /* style the parent .Layer__ComboBoxGroupHeading of this element */
   :is(.Layer__ComboBoxGroupHeading:has(&)) {

--- a/src/components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBox.scss
+++ b/src/components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBox.scss
@@ -2,6 +2,10 @@
   color: var(--color-base-900);
 }
 
+.Layer__BankTransactionCategoryComboBox__SuggestedCategoryIcon {
+  flex-shrink: 0;
+}
+
 .Layer__BankTransactionCategoryComboBox__CustomGroupHeading {
   /* style the parent .Layer__ComboBoxGroupHeading of this element */
   :is(.Layer__ComboBoxGroupHeading:has(&)) {

--- a/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection.tsx
+++ b/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelection.tsx
@@ -21,7 +21,7 @@ import {
   BankTransactionsMobileCategorySelectionItem,
   type BankTransactionsMobileCategorySelectionOptionValue,
 } from './BankTransactionsMobileCategorySelectionItem'
-import { buildCategoryOptions, buildInitialSessionCategoriesMap } from './utils'
+import { buildCategoryOptions, buildInitialSessionCategoriesMap, getSuggestedCategoryValues } from './utils'
 
 interface BankTransactionsMobileCategorySelectionProps {
   bankTransaction: BankTransaction
@@ -58,8 +58,9 @@ export const BankTransactionsMobileCategorySelection = ({
     () => buildCategoryOptions(
       sessionCategories,
       t('bankTransactions:action.show_all_categories', 'Show all categories'),
+      getSuggestedCategoryValues(bankTransaction),
     ),
-    [sessionCategories, t],
+    [bankTransaction, sessionCategories, t],
   )
 
   const handleCategoryGridSelect = useCallback((selectionKeys: Set<string | number> | 'all') => {

--- a/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelectionItem.tsx
+++ b/src/components/BankTransactionsMobileCategorySelection/BankTransactionsMobileCategorySelectionItem.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight } from 'lucide-react'
+import { ChevronRight, SparklesIcon } from 'lucide-react'
 import { GridListItem } from 'react-aria-components/GridList'
 
 import type { BankTransactionNonSuggestedMatchOption } from '@providers/BankTransactionsCategorizationStore/utils'
@@ -13,6 +13,7 @@ export type BankTransactionsMobileCategorySelectionOptionValue = BankTransaction
 export interface BankTransactionsMobileCategorySelectionItemOption {
   value: BankTransactionsMobileCategorySelectionOptionValue
   asLink?: boolean
+  isSuggested?: boolean
 }
 
 interface BankTransactionsMobileCategorySelectionItemProps {
@@ -40,7 +41,15 @@ export const BankTransactionsMobileCategorySelectionItem = ({
           />
         )}
 
-        <Span size='sm'>{label}</Span>
+        <HStack gap='xs' align='center'>
+          {option.isSuggested && (
+            <SparklesIcon
+              size={14}
+              className='Layer__BankTransactionsMobileCategorySelectionItem__sparkle-icon'
+            />
+          )}
+          <Span size='sm'>{label}</Span>
+        </HStack>
 
         {option.asLink && (
           <ChevronRight

--- a/src/components/BankTransactionsMobileCategorySelection/bankTransactionsMobileCategorySelectionItem.scss
+++ b/src/components/BankTransactionsMobileCategorySelection/bankTransactionsMobileCategorySelectionItem.scss
@@ -3,3 +3,7 @@
     background: var(--color-base-100);
   }
 }
+
+.Layer__BankTransactionsMobileCategorySelectionItem__sparkle-icon {
+  flex-shrink: 0;
+}

--- a/src/components/BankTransactionsMobileCategorySelection/utils.ts
+++ b/src/components/BankTransactionsMobileCategorySelection/utils.ts
@@ -15,6 +15,14 @@ const isSingleSelectedCategory = (selectedCategory: BankTransactionNonSuggestedM
   return true
 }
 
+const getSuggestedCategoryOptions = (bankTransaction: BankTransaction) => {
+  if (bankTransaction.categorizationFlow?.type !== InputStrategy.AskFromSuggestions) return []
+  return bankTransaction.categorizationFlow.suggestions.map(suggestion => new ApiCategorizationAsOption(suggestion))
+}
+
+export const getSuggestedCategoryValues = (bankTransaction: BankTransaction) =>
+  new Set(getSuggestedCategoryOptions(bankTransaction).map(option => option.value))
+
 export const buildInitialSessionCategoriesMap = (
   bankTransaction: BankTransaction,
   selectedCategory: BankTransactionNonSuggestedMatchOption | null,
@@ -28,12 +36,9 @@ export const buildInitialSessionCategoriesMap = (
     }
   }
 
-  if (bankTransaction?.categorizationFlow?.type === InputStrategy.AskFromSuggestions) {
-    bankTransaction.categorizationFlow.suggestions.forEach((suggestion) => {
-      const suggestionOption = new ApiCategorizationAsOption(suggestion)
-      categoriesMap.set(suggestionOption.value, suggestionOption)
-    })
-  }
+  getSuggestedCategoryOptions(bankTransaction).forEach((suggestionOption) => {
+    categoriesMap.set(suggestionOption.value, suggestionOption)
+  })
 
   if (selectedCategory && isSingleSelectedCategory(selectedCategory)) {
     categoriesMap.set(selectedCategory.value, selectedCategory)
@@ -45,9 +50,11 @@ export const buildInitialSessionCategoriesMap = (
 export const buildCategoryOptions = (
   sessionCategories: Map<string, BankTransactionNonSuggestedMatchOption>,
   showAllCategoriesLabel: string,
+  suggestedCategoryValues: ReadonlySet<string>,
 ): BankTransactionsMobileCategorySelectionItemOption[] => {
   const categoryOptionsList: BankTransactionsMobileCategorySelectionItemOption[] = Array.from(sessionCategories.values()).map(category => ({
     value: category,
+    isSuggested: suggestedCategoryValues.has(category.value),
   }))
 
   categoryOptionsList.push({

--- a/src/components/BankTransactionsSelectedValue/BankTransactionsBaseSelectedValue.tsx
+++ b/src/components/BankTransactionsSelectedValue/BankTransactionsBaseSelectedValue.tsx
@@ -58,7 +58,7 @@ export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSel
   return (
     <HStack gap='xs' align='center' className={className}>
       {showCategoryBadge && (
-        <Badge size={BadgeSize.SMALL} icon={<Layers2Icon size={11} />}>
+        <Badge size={BadgeSize.SMALL} icon={isCategorized ? <Layers2Icon size={11} /> : <SparklesIcon size={11} />}>
           {isCategorized ? t('common:label.category', 'Category') : t('bankTransactions:label.suggested_category', 'Suggested category')}
         </Badge>
       )}

--- a/src/components/BankTransactionsSelectedValue/BankTransactionsBaseSelectedValue.tsx
+++ b/src/components/BankTransactionsSelectedValue/BankTransactionsBaseSelectedValue.tsx
@@ -1,20 +1,19 @@
-import { Layers2Icon, Minimize2, Scissors } from 'lucide-react'
-import type { ReactNode } from 'react'
+import { Layers2Icon, Minimize2, Scissors, SparklesIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { HStack } from '@ui/Stack/Stack'
 import { Span } from '@ui/Typography/Text'
 import { Badge, BadgeSize } from '@components/Badge/Badge'
 
+import './bankTransactionsSelectedValue.scss'
+
 export type BankTransactionsBaseSelectedValueProps = {
   type: 'match' | 'transfer' | 'split' | 'category' | 'placeholder'
   label: string
   showCategoryBadge?: boolean
+  showAiSparkle?: boolean
   isCategorized?: boolean
   className?: string
-  slots?: {
-    Icon?: ReactNode
-  }
   slotProps?: {
     Label?: {
       size?: 'sm' | 'md'
@@ -24,12 +23,16 @@ export type BankTransactionsBaseSelectedValueProps = {
 
 export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSelectedValueProps) => {
   const { t } = useTranslation()
-  const { type, className, label, slots, slotProps, showCategoryBadge = false, isCategorized = false } = props
+  const { type, className, label, slotProps, showCategoryBadge = false, showAiSparkle = false, isCategorized = false } = props
+
+  const sparkle = showAiSparkle
+    ? <SparklesIcon size={14} className='Layer__BankTransactionsSelectedValue__AiSparkle' />
+    : null
 
   if (type === 'placeholder') {
     return (
       <HStack gap='xs' align='center' className={className}>
-        {slots?.Icon}
+        {sparkle}
         <Span ellipsis size={slotProps?.Label?.size ?? 'md'}>{label}</Span>
       </HStack>
     )
@@ -41,7 +44,7 @@ export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSel
         <Badge size={BadgeSize.SMALL} icon={<Minimize2 size={11} />}>
           {type === 'transfer' ? t('bankTransactions:label.transfer', 'Transfer') : t('bankTransactions:label.match', 'Match')}
         </Badge>
-        {slots?.Icon}
+        {sparkle}
         <Span ellipsis size={slotProps?.Label?.size ?? 'md'}>{label}</Span>
       </HStack>
     )
@@ -53,7 +56,7 @@ export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSel
         <Badge size={BadgeSize.SMALL} icon={<Scissors size={11} />}>
           {t('bankTransactions:action.split_label', 'Split')}
         </Badge>
-        {slots?.Icon}
+        {sparkle}
         <Span ellipsis size={slotProps?.Label?.size ?? 'md'}>{label}</Span>
       </HStack>
     )
@@ -66,7 +69,7 @@ export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSel
           {isCategorized ? t('common:label.category', 'Category') : t('bankTransactions:label.suggested_category', 'Suggested category')}
         </Badge>
       )}
-      {slots?.Icon}
+      {sparkle}
       <Span ellipsis size={slotProps?.Label?.size ?? 'md'}>{label}</Span>
     </HStack>
   )

--- a/src/components/BankTransactionsSelectedValue/BankTransactionsBaseSelectedValue.tsx
+++ b/src/components/BankTransactionsSelectedValue/BankTransactionsBaseSelectedValue.tsx
@@ -25,14 +25,9 @@ export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSel
   const { t } = useTranslation()
   const { type, className, label, slotProps, showCategoryBadge = false, showAiSparkle = false, isCategorized = false } = props
 
-  const sparkle = showAiSparkle
-    ? <SparklesIcon size={14} className='Layer__BankTransactionsSelectedValue__AiSparkle' />
-    : null
-
   if (type === 'placeholder') {
     return (
       <HStack gap='xs' align='center' className={className}>
-        {sparkle}
         <Span ellipsis size={slotProps?.Label?.size ?? 'md'}>{label}</Span>
       </HStack>
     )
@@ -44,7 +39,6 @@ export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSel
         <Badge size={BadgeSize.SMALL} icon={<Minimize2 size={11} />}>
           {type === 'transfer' ? t('bankTransactions:label.transfer', 'Transfer') : t('bankTransactions:label.match', 'Match')}
         </Badge>
-        {sparkle}
         <Span ellipsis size={slotProps?.Label?.size ?? 'md'}>{label}</Span>
       </HStack>
     )
@@ -56,7 +50,6 @@ export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSel
         <Badge size={BadgeSize.SMALL} icon={<Scissors size={11} />}>
           {t('bankTransactions:action.split_label', 'Split')}
         </Badge>
-        {sparkle}
         <Span ellipsis size={slotProps?.Label?.size ?? 'md'}>{label}</Span>
       </HStack>
     )
@@ -69,7 +62,7 @@ export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSel
           {isCategorized ? t('common:label.category', 'Category') : t('bankTransactions:label.suggested_category', 'Suggested category')}
         </Badge>
       )}
-      {sparkle}
+      {showAiSparkle && <SparklesIcon size={14} className='Layer__BankTransactionsSelectedValue__AiSparkle' />}
       <Span ellipsis size={slotProps?.Label?.size ?? 'md'}>{label}</Span>
     </HStack>
   )

--- a/src/components/BankTransactionsSelectedValue/BankTransactionsBaseSelectedValue.tsx
+++ b/src/components/BankTransactionsSelectedValue/BankTransactionsBaseSelectedValue.tsx
@@ -1,4 +1,5 @@
 import { Layers2Icon, Minimize2, Scissors } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { HStack } from '@ui/Stack/Stack'
@@ -11,6 +12,9 @@ export type BankTransactionsBaseSelectedValueProps = {
   showCategoryBadge?: boolean
   isCategorized?: boolean
   className?: string
+  slots?: {
+    Icon?: ReactNode
+  }
   slotProps?: {
     Label?: {
       size?: 'sm' | 'md'
@@ -20,11 +24,12 @@ export type BankTransactionsBaseSelectedValueProps = {
 
 export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSelectedValueProps) => {
   const { t } = useTranslation()
-  const { type, className, label, slotProps, showCategoryBadge = false, isCategorized = false } = props
+  const { type, className, label, slots, slotProps, showCategoryBadge = false, isCategorized = false } = props
 
   if (type === 'placeholder') {
     return (
       <HStack gap='xs' align='center' className={className}>
+        {slots?.Icon}
         <Span ellipsis size={slotProps?.Label?.size ?? 'md'}>{label}</Span>
       </HStack>
     )
@@ -36,6 +41,7 @@ export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSel
         <Badge size={BadgeSize.SMALL} icon={<Minimize2 size={11} />}>
           {type === 'transfer' ? t('bankTransactions:label.transfer', 'Transfer') : t('bankTransactions:label.match', 'Match')}
         </Badge>
+        {slots?.Icon}
         <Span ellipsis size={slotProps?.Label?.size ?? 'md'}>{label}</Span>
       </HStack>
     )
@@ -47,6 +53,7 @@ export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSel
         <Badge size={BadgeSize.SMALL} icon={<Scissors size={11} />}>
           {t('bankTransactions:action.split_label', 'Split')}
         </Badge>
+        {slots?.Icon}
         <Span ellipsis size={slotProps?.Label?.size ?? 'md'}>{label}</Span>
       </HStack>
     )
@@ -59,6 +66,7 @@ export const BankTransactionsBaseSelectedValue = (props: BankTransactionsBaseSel
           {isCategorized ? t('common:label.category', 'Category') : t('bankTransactions:label.suggested_category', 'Suggested category')}
         </Badge>
       )}
+      {slots?.Icon}
       <Span ellipsis size={slotProps?.Label?.size ?? 'md'}>{label}</Span>
     </HStack>
   )

--- a/src/components/BankTransactionsSelectedValue/BankTransactionsUncategorizedSelectedValue.tsx
+++ b/src/components/BankTransactionsSelectedValue/BankTransactionsUncategorizedSelectedValue.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 import { type BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { isSplitAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
@@ -7,6 +9,9 @@ type BankTransactionsUncategorizedSelectedValueProps = {
   selectedValue: BankTransactionCategoryComboBoxOption | null
   className?: string
   showCategoryBadge?: boolean
+  slots?: {
+    Icon?: ReactNode
+  }
   slotProps?: {
     Label?: {
       size?: 'sm' | 'md'
@@ -15,7 +20,7 @@ type BankTransactionsUncategorizedSelectedValueProps = {
 }
 
 export const BankTransactionsUncategorizedSelectedValue = (props: BankTransactionsUncategorizedSelectedValueProps) => {
-  const { selectedValue, className, slotProps, showCategoryBadge } = props
+  const { selectedValue, className, slots, slotProps, showCategoryBadge } = props
 
   if (!selectedValue) return null
 
@@ -23,6 +28,7 @@ export const BankTransactionsUncategorizedSelectedValue = (props: BankTransactio
   return (
     <BankTransactionsBaseSelectedValue
       {...baseSelectedValue}
+      slots={slots}
       slotProps={slotProps}
       className={className}
       showCategoryBadge={showCategoryBadge}

--- a/src/components/BankTransactionsSelectedValue/BankTransactionsUncategorizedSelectedValue.tsx
+++ b/src/components/BankTransactionsSelectedValue/BankTransactionsUncategorizedSelectedValue.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from 'react'
-
 import { type BankTransactionCategoryComboBoxOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { isSuggestedMatchAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
 import { isSplitAsOption } from '@components/BankTransactionCategoryComboBox/bankTransactionCategoryComboBoxOption'
@@ -9,9 +7,7 @@ type BankTransactionsUncategorizedSelectedValueProps = {
   selectedValue: BankTransactionCategoryComboBoxOption | null
   className?: string
   showCategoryBadge?: boolean
-  slots?: {
-    Icon?: ReactNode
-  }
+  showAiSparkle?: boolean
   slotProps?: {
     Label?: {
       size?: 'sm' | 'md'
@@ -20,7 +16,7 @@ type BankTransactionsUncategorizedSelectedValueProps = {
 }
 
 export const BankTransactionsUncategorizedSelectedValue = (props: BankTransactionsUncategorizedSelectedValueProps) => {
-  const { selectedValue, className, slots, slotProps, showCategoryBadge } = props
+  const { selectedValue, className, slotProps, showCategoryBadge, showAiSparkle } = props
 
   if (!selectedValue) return null
 
@@ -28,8 +24,8 @@ export const BankTransactionsUncategorizedSelectedValue = (props: BankTransactio
   return (
     <BankTransactionsBaseSelectedValue
       {...baseSelectedValue}
-      slots={slots}
       slotProps={slotProps}
+      showAiSparkle={showAiSparkle}
       className={className}
       showCategoryBadge={showCategoryBadge}
     />

--- a/src/components/BankTransactionsSelectedValue/bankTransactionsSelectedValue.scss
+++ b/src/components/BankTransactionsSelectedValue/bankTransactionsSelectedValue.scss
@@ -1,0 +1,3 @@
+.Layer__BankTransactionsSelectedValue__AiSparkle {
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Scope

Adds a lucide `SparklesIcon` to the bank transactions category combobox input when the currently selected value is one of the AI-suggested categories.

- `BankTransactionsBaseSelectedValue` gains a `showAiSparkle` prop (alongside the existing `showCategoryBadge`), rendering the icon immediately before the label in every variant. Size, color, and layout live in the component.
- `BankTransactionsUncategorizedSelectedValue` threads the prop through.
- `BankTransactionCategoryComboBox` derives `isSuggestedCategorySelected` by checking whether the selected option's value appears in the SUGGESTIONS group.
- Icon is `size={14}`, inherits `currentColor`, spaced by the existing `HStack gap='xs'`, with `flex-shrink: 0` so it never squeezes against ellipsized text.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on both touched directories
- `storybook build` succeeds; verified visually in Storybook dev

## Notes

A suggested multi-category split and a user-built split both serialize to `value: 'split'`, so a manual split identical to a suggested one would also show the sparkle. Left as-is rather than adding identity plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to bank transaction categorization UI with no auth, API, or data-handling impact.
> 
> **Overview**
> Adds **Sparkles** affordances so users can tell when a category comes from AI suggestions, on desktop combobox and mobile category grids.
> 
> The category combobox derives whether the current selection is in the **suggestions** group and passes **`showAiSparkle`** through `BankTransactionsUncategorizedSelectedValue` into `BankTransactionsBaseSelectedValue`, which renders a 14px sparkle before the label (with `flex-shrink: 0`). When **`showCategoryBadge`** is on, the suggested-category badge icon switches from layers to sparkle for uncategorized suggestions.
> 
> Mobile category selection refactors suggestion detection into **`getSuggestedCategoryOptions`** / **`getSuggestedCategoryValues`** (shared with session map building) and marks grid rows with **`isSuggested`**, showing the same sparkle beside the label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 111e2a7a08dfd799b90855f2566a524b71a5b9d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->