### PR TITLE
Revert "hide rule creation"

### DIFF
--- a/src/components/CategorizationRules/CategorizationRulesMobileList/CategorizationRulesMobileList.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesMobileList/CategorizationRulesMobileList.tsx
@@ -18,7 +18,7 @@ import './categorizationRulesMobileList.scss'
 type CategorizationRuleMobileListItemProps = {
   rule: CategorizationRule
   options: NestedCategorization[]
-  onEditPress?: (rule: CategorizationRule) => void
+  onEditPress: (rule: CategorizationRule) => void
   onDeletePress: (rule: CategorizationRule) => void
 }
 
@@ -53,17 +53,15 @@ const CategorizationRuleMobileListItem = ({
         )}
       </VStack>
       <HStack gap='3xs' align='center'>
-        {onEditPress && (
-          <Button
-            inset
-            icon
-            onPress={() => onEditPress(rule)}
-            aria-label={t('categorizationRules:action.edit_rule', 'Edit Rule')}
-            variant='ghost'
-          >
-            <Pencil size={16} />
-          </Button>
-        )}
+        <Button
+          inset
+          icon
+          onPress={() => onEditPress(rule)}
+          aria-label={t('categorizationRules:action.edit_rule', 'Edit Rule')}
+          variant='ghost'
+        >
+          <Pencil size={16} />
+        </Button>
         <Button
           inset
           icon
@@ -84,7 +82,7 @@ export interface CategorizationRulesMobileListProps {
   isError: boolean
   paginationProps: TablePaginationProps
   options: NestedCategorization[]
-  onEditRule?: (rule: CategorizationRule) => void
+  onEditRule: (rule: CategorizationRule) => void
   onDeleteRule: (rule: CategorizationRule) => void
   slots: {
     EmptyState: React.FC

--- a/src/components/CategorizationRules/CategorizationRulesTable/CategorizationRulesTable.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesTable/CategorizationRulesTable.tsx
@@ -32,7 +32,7 @@ export interface CategorizationRulesTableProps {
   isError: boolean
   paginationProps: TablePaginationProps
   options: NestedCategorization[]
-  onEditRule?: (rule: CategorizationRule) => void
+  onEditRule: (rule: CategorizationRule) => void
   onDeleteRule: (rule: CategorizationRule) => void
   slots: {
     EmptyState: React.FC
@@ -85,22 +85,20 @@ export const CategorizationRulesTable = ({
       },
       isRowHeader: true,
     },
-    ...(onEditRule
-      ? [{
-        id: CategorizationRuleColumns.Edit,
-        cell: (row: Row<CategorizationRule>) => (
-          <Button
-            inset
-            icon
-            onPress={() => onEditRule(row.original)}
-            aria-label={t('categorizationRules:action.edit_rule', 'Edit Rule')}
-            variant='ghost'
-          >
-            <Pencil size={16} />
-          </Button>
-        ),
-      }]
-      : []),
+    {
+      id: CategorizationRuleColumns.Edit,
+      cell: (row: Row<CategorizationRule>) => (
+        <Button
+          inset
+          icon
+          onPress={() => onEditRule(row.original)}
+          aria-label={t('categorizationRules:action.edit_rule', 'Edit Rule')}
+          variant='ghost'
+        >
+          <Pencil size={16} />
+        </Button>
+      ),
+    },
     {
       id: CategorizationRuleColumns.Delete,
       cell: (row: Row<CategorizationRule>) => (

--- a/src/components/CategorizationRules/CategorizationRulesTable/categorizationRulesTable.scss
+++ b/src/components/CategorizationRules/CategorizationRulesTable/categorizationRulesTable.scss
@@ -10,6 +10,7 @@
       minmax(6rem, 14%)
       minmax(7rem, 20%)
       minmax(8rem, 30%)
+      auto
       auto;
   }
 

--- a/src/components/CategorizationRules/CategorizationRulesView/ResponsiveCategorizationRulesView.tsx
+++ b/src/components/CategorizationRules/CategorizationRulesView/ResponsiveCategorizationRulesView.tsx
@@ -53,11 +53,9 @@ const CategorizationRulesErrorState = () => {
   )
 }
 
-const ENABLE_CATEGORIZATION_RULE_EDITING = false
-
 type CategorizationRulesHeaderProps = {
   onGoBack?: () => void
-  onCreateRule?: () => void
+  onCreateRule: () => void
 }
 
 const CategorizationRulesHeader = ({ onGoBack, onCreateRule }: CategorizationRulesHeaderProps) => {
@@ -68,14 +66,12 @@ const CategorizationRulesHeader = ({ onGoBack, onCreateRule }: CategorizationRul
         {onGoBack && <BackButton onPress={onGoBack} />}
         <Heading size='sm'>{t('categorizationRules:label.categorization_rules', 'Categorization Rules')}</Heading>
       </HStack>
-      {onCreateRule && (
-        <HStack pie='md' align='center' gap='xs'>
-          <Button onPress={onCreateRule}>
-            {t('categorizationRules:action.create_rule', 'Create Rule')}
-            <Plus size={16} />
-          </Button>
-        </HStack>
-      )}
+      <HStack pie='md' align='center' gap='xs'>
+        <Button onPress={onCreateRule}>
+          {t('categorizationRules:action.create_rule', 'Create Rule')}
+          <Plus size={16} />
+        </Button>
+      </HStack>
     </HStack>
   )
 }
@@ -93,8 +89,6 @@ export const ResponsiveCategorizationRulesView = () => {
 
   const onCreateRule = useCallback(() => setFormState({ mode: 'create' }), [])
   const onEditRule = useCallback((rule: CategorizationRule) => setFormState({ mode: 'edit', rule }), [])
-  const createRuleHandler = ENABLE_CATEGORIZATION_RULE_EDITING ? onCreateRule : undefined
-  const editRuleHandler = ENABLE_CATEGORIZATION_RULE_EDITING ? onEditRule : undefined
   const onFormDrawerOpenChange = useCallback((isOpen: boolean) => {
     if (!isOpen) setFormState(null)
   }, [])
@@ -138,8 +132,8 @@ export const ResponsiveCategorizationRulesView = () => {
   const { toBankTransactionsTable } = useBankTransactionsNavigation()
 
   const DesktopHeader = useCallback(
-    () => <CategorizationRulesHeader onCreateRule={createRuleHandler} />,
-    [createRuleHandler],
+    () => <CategorizationRulesHeader onCreateRule={onCreateRule} />,
+    [onCreateRule],
   )
 
   const DesktopView = useMemo(() => (
@@ -154,7 +148,7 @@ export const ResponsiveCategorizationRulesView = () => {
         isError={isError}
         paginationProps={paginationProps}
         options={options}
-        onEditRule={editRuleHandler}
+        onEditRule={onEditRule}
         onDeleteRule={onDeleteRule}
         slots={{
           EmptyState: CategorizationRulesEmptyState,
@@ -162,18 +156,18 @@ export const ResponsiveCategorizationRulesView = () => {
         }}
       />
     </BaseDetailView>
-  ), [DesktopHeader, toBankTransactionsTable, categorizationRules, isLoading, isError, paginationProps, options, editRuleHandler, onDeleteRule])
+  ), [DesktopHeader, toBankTransactionsTable, categorizationRules, isLoading, isError, paginationProps, options, onEditRule, onDeleteRule])
 
   const MobileView = useMemo(() => (
     <VStack gap='md'>
-      <CategorizationRulesHeader onGoBack={toBankTransactionsTable} onCreateRule={createRuleHandler} />
+      <CategorizationRulesHeader onGoBack={toBankTransactionsTable} onCreateRule={onCreateRule} />
       <CategorizationRulesMobileList
         data={categorizationRules}
         isLoading={isLoading}
         isError={isError}
         paginationProps={paginationProps}
         options={options}
-        onEditRule={editRuleHandler}
+        onEditRule={onEditRule}
         onDeleteRule={onDeleteRule}
         slots={{
           EmptyState: CategorizationRulesEmptyState,
@@ -181,7 +175,7 @@ export const ResponsiveCategorizationRulesView = () => {
         }}
       />
     </VStack>
-  ), [toBankTransactionsTable, createRuleHandler, categorizationRules, isLoading, isError, paginationProps, options, editRuleHandler, onDeleteRule])
+  ), [toBankTransactionsTable, onCreateRule, categorizationRules, isLoading, isError, paginationProps, options, onEditRule, onDeleteRule])
 
   const selectedRuleCounterpartyLabel = (selectedRule && getCategorizationRuleCounterpartyLabel(selectedRule))
     ?? t('bankTransactions:label.selected_counterparty', 'this counterparty')


### PR DESCRIPTION
Reverts #1461, re-enabling categorization rule create/edit.

- Removes the `ENABLE_CATEGORIZATION_RULE_EDITING = false` flag and the conditional handlers in `ResponsiveCategorizationRulesView`
- Restores the Create Rule header button and the Edit column / mobile edit button (`onEditRule` / `onCreateRule` are required props again)
- Restores the 6th `auto` grid column in `categorizationRulesTable.scss` for the Edit cell, keeping the current `30% / 14% / 20% / 30%` widths from e05990b6

## Verification

- `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only re-exposure of existing form flows; no new API or auth logic in the diff.
> 
> **Overview**
> Re-enables categorization rule **create** and **edit** UI that had been gated off (revert of the “hide rule creation” change).
> 
> `ResponsiveCategorizationRulesView` drops `ENABLE_CATEGORIZATION_RULE_EDITING` and always wires `onCreateRule` / `onEditRule` into the header and list/table. **Create Rule** is always shown; `onCreateRule` is required on the header. Desktop table and mobile list always show edit actions, with `onEditRule` required instead of optional. `categorizationRulesTable.scss` adds a sixth `auto` grid column so the edit column lays out beside delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d0a7a32b7780f7da7e137bc1d3e7c5abe412484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->