### PR TITLE
feat: tolerate unknown ledger entry and agent enum values

### DIFF
--- a/src/schemas/generalLedger/ledgerEntry.ts
+++ b/src/schemas/generalLedger/ledgerEntry.ts
@@ -3,6 +3,7 @@ import { pipe, Schema } from 'effect'
 import { CustomerSchema } from '@schemas/customer'
 import { LedgerEntryDirectionSchema, SingleChartAccountSchema } from '@schemas/generalLedger/ledgerAccount'
 import { TransactionTagSchema } from '@schemas/tag'
+import { createOpenEnumSchema } from '@schemas/utils'
 import { VendorSchema } from '@schemas/vendor'
 
 export enum ClassifierAgent {
@@ -13,7 +14,7 @@ export enum ClassifierAgent {
   QuickbooksSync = 'QUICKBOOKS_SYNC',
   CheckPayrollSync = 'CHECK_PAYROLL_SYNC',
 }
-const ClassifierAgentSchema = Schema.Enums(ClassifierAgent)
+const ClassifierAgentSchema = createOpenEnumSchema(ClassifierAgent)
 
 export enum EntryType {
   Expense = 'EXPENSE',
@@ -40,7 +41,7 @@ export enum EntryType {
   CustomerCredit = 'CUSTOMER_CREDIT',
   ClosingActionRecognizeExternalRevenue = 'CLOSING_ACTION_RECOGNIZE_EXTERNAL_REVENUE',
 }
-const EntryTypeSchema = Schema.Enums(EntryType)
+const EntryTypeSchema = createOpenEnumSchema(EntryType)
 
 export const LedgerEntryLineItemSchema = Schema.Struct({
   id: Schema.String,

--- a/src/schemas/utils.test.ts
+++ b/src/schemas/utils.test.ts
@@ -1,7 +1,11 @@
 import { Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
 
-import { createOpenEnumSchema, createTransformedEnumSchema } from '@schemas/utils'
+import {
+  createOpenEnumSchema,
+  createTransformedEnumSchema,
+  UnwrappedDataResponseSchema,
+} from '@schemas/utils'
 
 enum TestEnum {
   Known = 'KNOWN',
@@ -50,5 +54,28 @@ describe('createTransformedEnumSchema', () => {
 
   it('encodes back to the raw value', () => {
     expect(Schema.encodeSync(schema)(TestEnum.Known)).toBe('KNOWN')
+  })
+})
+
+describe('UnwrappedDataResponseSchema', () => {
+  const schema = UnwrappedDataResponseSchema(Schema.Struct({ id: Schema.NumberFromString }))
+  const decode = Schema.decodeUnknownSync(schema)
+
+  it('unwraps the data envelope and decodes the inner schema', () => {
+    expect(decode({ data: { id: '1' } })).toEqual({ id: 1 })
+  })
+
+  it('ignores extra keys alongside data', () => {
+    expect(decode({ data: { id: '1' }, meta: { page: 1 } })).toEqual({ id: 1 })
+  })
+
+  it('rejects a missing envelope or an invalid payload', () => {
+    expect(() => decode({ id: '1' })).toThrow()
+    expect(() => decode({ data: { id: 'not-a-number' } })).toThrow()
+    expect(() => decode(null)).toThrow()
+  })
+
+  it('re-wraps in a data envelope on encode', () => {
+    expect(Schema.encodeSync(schema)({ id: 1 })).toEqual({ data: { id: '1' } })
   })
 })

--- a/src/schemas/utils.test.ts
+++ b/src/schemas/utils.test.ts
@@ -1,0 +1,25 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { createOpenEnumSchema } from '@schemas/utils'
+
+enum TestEnum {
+  Known = 'KNOWN',
+}
+
+const decode = Schema.decodeUnknownSync(createOpenEnumSchema(TestEnum))
+
+describe('createOpenEnumSchema', () => {
+  it('decodes known enum members', () => {
+    expect(decode('KNOWN')).toBe(TestEnum.Known)
+  })
+
+  it('decodes strings outside of the enum', () => {
+    expect(decode('SOME_FUTURE_VALUE')).toBe('SOME_FUTURE_VALUE')
+  })
+
+  it('rejects non-string values', () => {
+    expect(() => decode(1)).toThrow()
+    expect(() => decode(null)).toThrow()
+  })
+})

--- a/src/schemas/utils.test.ts
+++ b/src/schemas/utils.test.ts
@@ -1,15 +1,16 @@
 import { Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
 
-import { createOpenEnumSchema } from '@schemas/utils'
+import { createOpenEnumSchema, createTransformedEnumSchema } from '@schemas/utils'
 
 enum TestEnum {
   Known = 'KNOWN',
+  Fallback = 'FALLBACK',
 }
 
-const decode = Schema.decodeUnknownSync(createOpenEnumSchema(TestEnum))
-
 describe('createOpenEnumSchema', () => {
+  const decode = Schema.decodeUnknownSync(createOpenEnumSchema(TestEnum))
+
   it('decodes known enum members', () => {
     expect(decode('KNOWN')).toBe(TestEnum.Known)
   })
@@ -21,5 +22,33 @@ describe('createOpenEnumSchema', () => {
   it('rejects non-string values', () => {
     expect(() => decode(1)).toThrow()
     expect(() => decode(null)).toThrow()
+  })
+})
+
+describe('createTransformedEnumSchema', () => {
+  const schema = createTransformedEnumSchema(
+    Schema.Enums(TestEnum),
+    TestEnum,
+    TestEnum.Fallback,
+  )
+  const decode = Schema.decodeUnknownSync(schema)
+
+  it('decodes known enum members', () => {
+    expect(decode('KNOWN')).toBe(TestEnum.Known)
+  })
+
+  it('falls back to the default for strings outside of the enum', () => {
+    expect(decode('SOME_FUTURE_VALUE')).toBe(TestEnum.Fallback)
+  })
+
+  it('rejects empty and non-string values', () => {
+    expect(() => decode('')).toThrow()
+    expect(() => decode('  ')).toThrow()
+    expect(() => decode(1)).toThrow()
+    expect(() => decode(null)).toThrow()
+  })
+
+  it('encodes back to the raw value', () => {
+    expect(Schema.encodeSync(schema)(TestEnum.Known)).toBe('KNOWN')
   })
 })

--- a/src/schemas/utils.ts
+++ b/src/schemas/utils.ts
@@ -13,13 +13,15 @@ export const UnwrappedDataResponseSchema = <A, I, R>(
     },
   )
 
-// Helper function to create enum schemas that accept values the backend may add
-// before this client knows about them, preserving the raw value for display.
-export const createOpenEnumSchema = <T extends Record<string, string>>(enumObject: T) =>
-  Schema.Union(
-    Schema.Enums(enumObject),
-    Schema.String as Schema.Schema<string & NonNullable<unknown>, string>,
-  )
+// `string & {}` accepts any string without collapsing the union, preserving autocomplete
+// for the known enum members.
+type AnyString = string & {}
+type OpenEnum<T extends string> = T | AnyString
+
+// Accepts values the backend may add before this client knows about them, preserving
+// the raw value for display.
+export const createOpenEnumSchema = <T extends Record<string, string>>(_enumObject: T) =>
+  Schema.String as Schema.Schema<OpenEnum<T[keyof T]>>
 
 // Helper function to create transformed enum schemas with safe defaults.
 export const createTransformedEnumSchema = <T extends Record<string, string>>(

--- a/src/schemas/utils.ts
+++ b/src/schemas/utils.ts
@@ -13,6 +13,14 @@ export const UnwrappedDataResponseSchema = <A, I, R>(
     },
   )
 
+// Helper function to create enum schemas that accept values the backend may add
+// before this client knows about them, preserving the raw value for display.
+export const createOpenEnumSchema = <T extends Record<string, string>>(enumObject: T) =>
+  Schema.Union(
+    Schema.Enums(enumObject),
+    Schema.String as Schema.Schema<string & NonNullable<unknown>, string>,
+  )
+
 // Helper function to create transformed enum schemas with safe defaults.
 export const createTransformedEnumSchema = <T extends Record<string, string>>(
   enumSchema: Schema.Schema<T[keyof T], T[keyof T]>,


### PR DESCRIPTION
## Summary
- Add `createOpenEnumSchema` so Effect schemas can accept unknown string values while keeping known enum members for autocomplete
- Wire `entry_type` and `agent` through it so future backend values no longer fail the entire journal entry decode
- Extend decode tests to assert unknown entry types and agents pass through as raw strings

Stacked on #1644.

## Test plan
- [ ] Confirm an entry with a known closing-action `entry_type` still decodes and renders
- [ ] Confirm an unknown `entry_type` / `agent` no longer surfaces as a journal-entry panel error (entry still loads; type humanizes from the raw string)
- [ ] `npx vitest run src/schemas/generalLedger/ledgerEntry.test.ts`
- [ ] After #1644 merges, retarget this PR to `main` if GitHub does not do so automatically

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow schema-layer change for forward compatibility; known values still decode the same and only non-strings are rejected.
> 
> **Overview**
> Introduces **`createOpenEnumSchema`** so Effect decoders accept any string for enum-like API fields while keeping known members in the type union for autocomplete. Unknown values pass through as raw strings instead of failing decode.
> 
> **`ClassifierAgent`** and **`EntryType`** on ledger entries now use this helper (replacing strict `Schema.Enums`), so new backend `entry_type` / `agent` values no longer break loading the whole journal entry.
> 
> Adds **`src/schemas/utils.test.ts`** covering open enums, transformed enums with fallbacks, and **`UnwrappedDataResponseSchema`** unwrap/encode behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd6186c67eeec60acd98e780f6cdcce90c136d3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->