### PR TITLE
feat: support legacy description-filter categorization rules read-only

### DIFF
--- a/src/components/CategorizationRules/CategorizationRuleForm/CategorizationRuleForm.tsx
+++ b/src/components/CategorizationRules/CategorizationRuleForm/CategorizationRuleForm.tsx
@@ -11,7 +11,7 @@ import { Form } from '@ui/Form/Form'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { CategorySelect } from '@components/CategorizationRules/CategorizationRuleForm/CategorySelect'
 import { CounterpartySelect } from '@components/CategorizationRules/CategorizationRuleForm/CounterpartySelect'
-import { type CategorizationRuleFormState, type DirectionFormValue } from '@components/CategorizationRules/CategorizationRuleForm/formUtils'
+import { type CategorizationRuleFormState, type DirectionFormValue, getRuleTransactionDescription } from '@components/CategorizationRules/CategorizationRuleForm/formUtils'
 import { useCategorizationRuleForm } from '@components/CategorizationRules/CategorizationRuleForm/useCategorizationRuleForm'
 import { FieldErrors } from '@components/forms/FieldErrors'
 
@@ -26,6 +26,7 @@ export const CategorizationRuleForm = ({ formState, onSuccess }: CategorizationR
   const { t } = useTranslation()
   const { form, submitError } = useCategorizationRuleForm({ formState, onSuccess })
   const { formatCurrencyFromCents } = useIntlFormatter()
+  const transactionDescription = getRuleTransactionDescription(formState)
 
   const blockNativeOnSubmit = useCallback((e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -43,9 +44,11 @@ export const CategorizationRuleForm = ({ formState, onSuccess }: CategorizationR
       <form.Field
         name='counterparty'
         validators={{
-          onDynamic: ({ value }) => required(
-            t('categorizationRules:validation.counterparty_required', 'Counterparty is required.'),
-          )(value),
+          onDynamic: ({ value }) => transactionDescription
+            ? undefined
+            : required(
+              t('categorizationRules:validation.counterparty_required', 'Counterparty is required.'),
+            )(value),
         }}
       >
         {field => (
@@ -55,6 +58,7 @@ export const CategorizationRuleForm = ({ formState, onSuccess }: CategorizationR
               value={field.state.value}
               onValueChange={field.handleChange}
               placeholder={t('categorizationRules:placeholder.select_counterparty', 'Select counterparty')}
+              transactionDescription={transactionDescription}
               showLabel
             />
             <FieldErrors errors={field.state.meta.errors} />

--- a/src/components/CategorizationRules/CategorizationRuleForm/CounterpartyComboBox.tsx
+++ b/src/components/CategorizationRules/CategorizationRuleForm/CounterpartyComboBox.tsx
@@ -5,7 +5,7 @@ import type { BankTransactionCounterparty } from '@schemas/bankTransactions/base
 import { SearchComboBox, useSearchComboBox } from '@ui/ComboBox/SearchComboBox'
 import { VStack } from '@ui/Stack/Stack'
 import { Label, Span } from '@ui/Typography/Text'
-import { type CounterpartyComboBoxOption } from '@components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption'
+import { CounterpartyComboBoxOption, type CounterpartyOption } from '@components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption'
 import { useCounterpartyOptions } from '@components/CategorizationRules/CategorizationRuleForm/useCounterpartyOptions'
 
 type CounterpartyComboBoxProps = {
@@ -16,6 +16,7 @@ type CounterpartyComboBoxProps = {
   isReadOnly?: boolean
   isError?: boolean
   placeholder?: string
+  transactionDescription?: string | null
 }
 
 export const CounterpartyComboBox = ({
@@ -26,6 +27,7 @@ export const CounterpartyComboBox = ({
   isReadOnly,
   isError,
   placeholder,
+  transactionDescription,
 }: CounterpartyComboBoxProps) => {
   const { t } = useTranslation()
   const inputId = useId()
@@ -35,7 +37,7 @@ export const CounterpartyComboBox = ({
     selectedOption,
     isLoading,
     isError: isListError,
-  } = useCounterpartyOptions(value, searchQuery)
+  } = useCounterpartyOptions({ value, searchQuery, transactionDescription })
 
   const slots = useMemo(() => {
     let emptyMessageContent = t('categorizationRules:empty.no_matching_counterparties', 'No matching counterparties.')
@@ -65,8 +67,8 @@ export const CounterpartyComboBox = ({
   )
 
   const handleSelectedValueChange = useCallback(
-    (option: CounterpartyComboBoxOption | null) => {
-      onValueChange(option?.original ?? null)
+    (option: CounterpartyOption | null) => {
+      onValueChange(option instanceof CounterpartyComboBoxOption ? option.original : null)
     },
     [onValueChange],
   )
@@ -78,7 +80,7 @@ export const CounterpartyComboBox = ({
           {label}
         </Label>
       )}
-      <SearchComboBox
+      <SearchComboBox<CounterpartyOption>
         {...searchComboBoxProps}
         options={options}
         selectedValue={selectedOption}

--- a/src/components/CategorizationRules/CategorizationRuleForm/CounterpartyComboBox.tsx
+++ b/src/components/CategorizationRules/CategorizationRuleForm/CounterpartyComboBox.tsx
@@ -5,7 +5,11 @@ import type { BankTransactionCounterparty } from '@schemas/bankTransactions/base
 import { SearchComboBox, useSearchComboBox } from '@ui/ComboBox/SearchComboBox'
 import { VStack } from '@ui/Stack/Stack'
 import { Label, Span } from '@ui/Typography/Text'
-import { type CounterpartyOption, toCounterpartyValue } from '@components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption'
+import {
+  type CounterpartyOption,
+  isTransactionDescriptionOption,
+  toCounterpartyValue,
+} from '@components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption'
 import { useCounterpartyOptions } from '@components/CategorizationRules/CategorizationRuleForm/useCounterpartyOptions'
 
 type CounterpartyComboBoxProps = {
@@ -85,6 +89,7 @@ export const CounterpartyComboBox = ({
         options={options}
         selectedValue={selectedOption}
         onSelectedValueChange={handleSelectedValueChange}
+        isClearable={!isTransactionDescriptionOption(selectedOption)}
         inputId={inputId}
         isLoading={isLoading}
         isReadOnly={isReadOnly}

--- a/src/components/CategorizationRules/CategorizationRuleForm/CounterpartyComboBox.tsx
+++ b/src/components/CategorizationRules/CategorizationRuleForm/CounterpartyComboBox.tsx
@@ -5,7 +5,7 @@ import type { BankTransactionCounterparty } from '@schemas/bankTransactions/base
 import { SearchComboBox, useSearchComboBox } from '@ui/ComboBox/SearchComboBox'
 import { VStack } from '@ui/Stack/Stack'
 import { Label, Span } from '@ui/Typography/Text'
-import { CounterpartyComboBoxOption, type CounterpartyOption } from '@components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption'
+import { type CounterpartyOption, toCounterpartyValue } from '@components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption'
 import { useCounterpartyOptions } from '@components/CategorizationRules/CategorizationRuleForm/useCounterpartyOptions'
 
 type CounterpartyComboBoxProps = {
@@ -68,7 +68,7 @@ export const CounterpartyComboBox = ({
 
   const handleSelectedValueChange = useCallback(
     (option: CounterpartyOption | null) => {
-      onValueChange(option instanceof CounterpartyComboBoxOption ? option.original : null)
+      onValueChange(toCounterpartyValue(option))
     },
     [onValueChange],
   )

--- a/src/components/CategorizationRules/CategorizationRuleForm/CounterpartyMobileDrawer.tsx
+++ b/src/components/CategorizationRules/CategorizationRuleForm/CounterpartyMobileDrawer.tsx
@@ -10,7 +10,7 @@ import { Drawer } from '@ui/Modal/Modal'
 import { ModalHeading, ModalTitleWithClose } from '@ui/Modal/ModalSlots'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Label, Span } from '@ui/Typography/Text'
-import { type CounterpartyComboBoxOption } from '@components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption'
+import { CounterpartyComboBoxOption, type CounterpartyOption } from '@components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption'
 import { useCounterpartyOptions } from '@components/CategorizationRules/CategorizationRuleForm/useCounterpartyOptions'
 import { SearchField } from '@components/SearchField/SearchField'
 
@@ -21,6 +21,7 @@ type CounterpartyMobileDrawerProps = {
   showLabel?: boolean
   isReadOnly?: boolean
   placeholder?: string
+  transactionDescription?: string | null
 }
 
 export const CounterpartyMobileDrawer = ({
@@ -30,6 +31,7 @@ export const CounterpartyMobileDrawer = ({
   showLabel,
   isReadOnly,
   placeholder,
+  transactionDescription,
 }: CounterpartyMobileDrawerProps) => {
   const { t } = useTranslation()
   const inputId = useId()
@@ -40,7 +42,7 @@ export const CounterpartyMobileDrawer = ({
     selectedOption,
     isLoading,
     isError: isListError,
-  } = useCounterpartyOptions(value, searchQuery)
+  } = useCounterpartyOptions({ value, searchQuery, transactionDescription })
 
   const Header = useCallback(() => (
     <ModalTitleWithClose
@@ -95,12 +97,12 @@ export const CounterpartyMobileDrawer = ({
               onChange={handleInputChange}
               label={t('common:action.search_label', 'Search')}
             />
-            <MobileSelectionDrawerList<CounterpartyComboBoxOption>
+            <MobileSelectionDrawerList<CounterpartyOption>
               ariaLabel={label}
               options={options}
               selectedValue={selectedOption}
               onSelectedValueChange={(option) => {
-                onValueChange(option?.original ?? null)
+                onValueChange(option instanceof CounterpartyComboBoxOption ? option.original : null)
                 close()
               }}
               isLoading={isLoading}

--- a/src/components/CategorizationRules/CategorizationRuleForm/CounterpartyMobileDrawer.tsx
+++ b/src/components/CategorizationRules/CategorizationRuleForm/CounterpartyMobileDrawer.tsx
@@ -10,7 +10,7 @@ import { Drawer } from '@ui/Modal/Modal'
 import { ModalHeading, ModalTitleWithClose } from '@ui/Modal/ModalSlots'
 import { HStack, VStack } from '@ui/Stack/Stack'
 import { Label, Span } from '@ui/Typography/Text'
-import { CounterpartyComboBoxOption, type CounterpartyOption } from '@components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption'
+import { type CounterpartyOption, toCounterpartyValue } from '@components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption'
 import { useCounterpartyOptions } from '@components/CategorizationRules/CategorizationRuleForm/useCounterpartyOptions'
 import { SearchField } from '@components/SearchField/SearchField'
 
@@ -102,7 +102,7 @@ export const CounterpartyMobileDrawer = ({
               options={options}
               selectedValue={selectedOption}
               onSelectedValueChange={(option) => {
-                onValueChange(option instanceof CounterpartyComboBoxOption ? option.original : null)
+                onValueChange(toCounterpartyValue(option))
                 close()
               }}
               isLoading={isLoading}

--- a/src/components/CategorizationRules/CategorizationRuleForm/CounterpartySelect.tsx
+++ b/src/components/CategorizationRules/CategorizationRuleForm/CounterpartySelect.tsx
@@ -11,6 +11,7 @@ type CounterpartySelectProps = {
   isReadOnly?: boolean
   isError?: boolean
   placeholder?: string
+  transactionDescription?: string | null
 }
 
 export const CounterpartySelect = (props: CounterpartySelectProps) => {

--- a/src/components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption.ts
+++ b/src/components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption.ts
@@ -19,8 +19,6 @@ export class CounterpartyComboBoxOption extends BaseComboBoxOption<BankTransacti
   }
 }
 
-/* Legacy rules filter on a transaction description instead of a counterparty. Never listed as
- * an option - only ever the current selection - so it cannot be picked. */
 export class TransactionDescriptionComboBoxOption extends BaseComboBoxOption<string> {
   get original() {
     return this.internalValue
@@ -39,3 +37,6 @@ export type CounterpartyOption = CounterpartyComboBoxOption | TransactionDescrip
 
 export const toCounterpartyValue = (option: CounterpartyOption | null) =>
   option instanceof CounterpartyComboBoxOption ? option.original : null
+
+export const isTransactionDescriptionOption = (option: CounterpartyOption | null) =>
+  option instanceof TransactionDescriptionComboBoxOption

--- a/src/components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption.ts
+++ b/src/components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption.ts
@@ -19,8 +19,8 @@ export class CounterpartyComboBoxOption extends BaseComboBoxOption<BankTransacti
   }
 }
 
-/* Legacy rules filter on a transaction description rather than a counterparty. They stay
- * viewable, but the description can never be picked as a value for a new or updated rule. */
+/* Legacy rules filter on a transaction description instead of a counterparty. Never listed as
+ * an option - only ever the current selection - so it cannot be picked. */
 export class TransactionDescriptionComboBoxOption extends BaseComboBoxOption<string> {
   get original() {
     return this.internalValue
@@ -33,14 +33,9 @@ export class TransactionDescriptionComboBoxOption extends BaseComboBoxOption<str
   get value() {
     return `transaction-description:${this.internalValue}`
   }
-
-  get isDisabled() {
-    return true
-  }
-
-  get isHidden() {
-    return true
-  }
 }
 
 export type CounterpartyOption = CounterpartyComboBoxOption | TransactionDescriptionComboBoxOption
+
+export const toCounterpartyValue = (option: CounterpartyOption | null) =>
+  option instanceof CounterpartyComboBoxOption ? option.original : null

--- a/src/components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption.ts
+++ b/src/components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption.ts
@@ -18,3 +18,29 @@ export class CounterpartyComboBoxOption extends BaseComboBoxOption<BankTransacti
     return this.internalValue.id
   }
 }
+
+/* Legacy rules filter on a transaction description rather than a counterparty. They stay
+ * viewable, but the description can never be picked as a value for a new or updated rule. */
+export class TransactionDescriptionComboBoxOption extends BaseComboBoxOption<string> {
+  get original() {
+    return this.internalValue
+  }
+
+  get label() {
+    return this.internalValue
+  }
+
+  get value() {
+    return `transaction-description:${this.internalValue}`
+  }
+
+  get isDisabled() {
+    return true
+  }
+
+  get isHidden() {
+    return true
+  }
+}
+
+export type CounterpartyOption = CounterpartyComboBoxOption | TransactionDescriptionComboBoxOption

--- a/src/components/CategorizationRules/CategorizationRuleForm/formUtils.ts
+++ b/src/components/CategorizationRules/CategorizationRuleForm/formUtils.ts
@@ -80,8 +80,8 @@ export const convertFormToCreateBody = (values: CategorizationRuleFormValues) =>
   return Schema.encodeUnknownSync(CreateCategorizationRuleSchema)(parsed)
 }
 
-export const convertFormToPatchBody = (values: CategorizationRuleFormValues) => {
-  if (!values.counterparty) {
+export const convertFormToPatchBody = (values: CategorizationRuleFormValues, rule: CategorizationRule) => {
+  if (!values.counterparty && !rule.readableTransactionDescriptionFilter) {
     throw new Error('Counterparty is required to update a categorization rule')
   }
   if (!values.category || !isClassificationAccountIdentifier(values.category)) {
@@ -91,10 +91,14 @@ export const convertFormToPatchBody = (values: CategorizationRuleFormValues) => 
   const parsed = {
     category: values.category,
     bankDirectionFilter: values.bankDirectionFilter === '' ? null : values.bankDirectionFilter,
-    counterpartyFilter: values.counterparty.id,
+    /* Leaving the counterparty untouched preserves a legacy rule's description filter. */
+    ...(values.counterparty ? { counterpartyFilter: values.counterparty.id } : {}),
     amountMinFilter: formAmountToCents(values.amountMinFilter),
     amountMaxFilter: formAmountToCents(values.amountMaxFilter),
   }
 
   return Schema.encodeUnknownSync(PatchCategorizationRuleSchema)(parsed)
 }
+
+export const getRuleTransactionDescription = (state: CategorizationRuleFormState) =>
+  state.mode === 'edit' ? state.rule.readableTransactionDescriptionFilter ?? null : null

--- a/src/components/CategorizationRules/CategorizationRuleForm/formUtils.ts
+++ b/src/components/CategorizationRules/CategorizationRuleForm/formUtils.ts
@@ -80,8 +80,11 @@ export const convertFormToCreateBody = (values: CategorizationRuleFormValues) =>
   return Schema.encodeUnknownSync(CreateCategorizationRuleSchema)(parsed)
 }
 
-export const convertFormToPatchBody = (values: CategorizationRuleFormValues, rule: CategorizationRule) => {
-  if (!values.counterparty && !rule.readableTransactionDescriptionFilter) {
+export const convertFormToPatchBody = (
+  values: CategorizationRuleFormValues,
+  transactionDescription: string | null,
+) => {
+  if (!values.counterparty && !transactionDescription) {
     throw new Error('Counterparty is required to update a categorization rule')
   }
   if (!values.category || !isClassificationAccountIdentifier(values.category)) {
@@ -91,7 +94,7 @@ export const convertFormToPatchBody = (values: CategorizationRuleFormValues, rul
   const parsed = {
     category: values.category,
     bankDirectionFilter: values.bankDirectionFilter === '' ? null : values.bankDirectionFilter,
-    /* Leaving the counterparty untouched preserves a legacy rule's description filter. */
+    /* Omitting the counterparty preserves a legacy rule's description filter. */
     ...(values.counterparty ? { counterpartyFilter: values.counterparty.id } : {}),
     amountMinFilter: formAmountToCents(values.amountMinFilter),
     amountMaxFilter: formAmountToCents(values.amountMaxFilter),

--- a/src/components/CategorizationRules/CategorizationRuleForm/formUtils.ts
+++ b/src/components/CategorizationRules/CategorizationRuleForm/formUtils.ts
@@ -94,8 +94,9 @@ export const convertFormToPatchBody = (
   const parsed = {
     category: values.category,
     bankDirectionFilter: values.bankDirectionFilter === '' ? null : values.bankDirectionFilter,
-    /* Omitting the counterparty preserves a legacy rule's description filter. */
-    ...(values.counterparty ? { counterpartyFilter: values.counterparty.id } : {}),
+    ...(values.counterparty
+      ? { counterpartyFilter: values.counterparty.id, transactionDescriptionFilter: null }
+      : {}),
     amountMinFilter: formAmountToCents(values.amountMinFilter),
     amountMaxFilter: formAmountToCents(values.amountMaxFilter),
   }
@@ -104,4 +105,4 @@ export const convertFormToPatchBody = (
 }
 
 export const getRuleTransactionDescription = (state: CategorizationRuleFormState) =>
-  state.mode === 'edit' ? state.rule.readableTransactionDescriptionFilter ?? null : null
+  state.mode === 'edit' ? state.rule.readableTransactionDescriptionFilter?.trim() || null : null

--- a/src/components/CategorizationRules/CategorizationRuleForm/useCategorizationRuleForm.ts
+++ b/src/components/CategorizationRules/CategorizationRuleForm/useCategorizationRuleForm.ts
@@ -39,7 +39,7 @@ export const useCategorizationRuleForm = ({ formState, onSuccess }: UseCategoriz
   const onSubmit = useCallback(async ({ value }: { value: CategorizationRuleFormValues }) => {
     try {
       const result = formState.mode === 'edit'
-        ? await upsertCategorizationRule(convertFormToPatchBody(value))
+        ? await upsertCategorizationRule(convertFormToPatchBody(value, formState.rule))
         : await upsertCategorizationRule(convertFormToCreateBody(value))
 
       setSubmitError(undefined)

--- a/src/components/CategorizationRules/CategorizationRuleForm/useCategorizationRuleForm.ts
+++ b/src/components/CategorizationRules/CategorizationRuleForm/useCategorizationRuleForm.ts
@@ -12,6 +12,7 @@ import {
   convertFormToCreateBody,
   convertFormToPatchBody,
   getCategorizationRuleFormDefaultValues,
+  getRuleTransactionDescription,
 } from '@components/CategorizationRules/CategorizationRuleForm/formUtils'
 
 type UseCategorizationRuleFormProps = {
@@ -39,7 +40,7 @@ export const useCategorizationRuleForm = ({ formState, onSuccess }: UseCategoriz
   const onSubmit = useCallback(async ({ value }: { value: CategorizationRuleFormValues }) => {
     try {
       const result = formState.mode === 'edit'
-        ? await upsertCategorizationRule(convertFormToPatchBody(value, formState.rule))
+        ? await upsertCategorizationRule(convertFormToPatchBody(value, getRuleTransactionDescription(formState)))
         : await upsertCategorizationRule(convertFormToCreateBody(value))
 
       setSubmitError(undefined)

--- a/src/components/CategorizationRules/CategorizationRuleForm/useCounterpartyOptions.ts
+++ b/src/components/CategorizationRules/CategorizationRuleForm/useCounterpartyOptions.ts
@@ -2,9 +2,23 @@ import { useMemo } from 'react'
 
 import type { BankTransactionCounterparty } from '@schemas/bankTransactions/base'
 import { useListCounterparties } from '@hooks/api/businesses/[business-id]/counterparties/useListCounterparties'
-import { CounterpartyComboBoxOption } from '@components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption'
+import {
+  CounterpartyComboBoxOption,
+  type CounterpartyOption,
+  TransactionDescriptionComboBoxOption,
+} from '@components/CategorizationRules/CategorizationRuleForm/counterpartyComboBoxOption'
 
-export const useCounterpartyOptions = (value: BankTransactionCounterparty | null, searchQuery: string) => {
+type UseCounterpartyOptionsProps = {
+  value: BankTransactionCounterparty | null
+  searchQuery: string
+  transactionDescription?: string | null
+}
+
+export const useCounterpartyOptions = ({
+  value,
+  searchQuery,
+  transactionDescription,
+}: UseCounterpartyOptionsProps) => {
   const { flattenedData, isLoading, isError } = useListCounterparties({
     q: searchQuery || undefined,
     limit: 50,
@@ -21,10 +35,14 @@ export const useCounterpartyOptions = (value: BankTransactionCounterparty | null
     return [new CounterpartyComboBoxOption(value), ...fetchedOptions]
   }, [fetchedOptions, value])
 
-  const selectedOption = useMemo(() => {
-    if (!value) return null
+  const selectedOption = useMemo<CounterpartyOption | null>(() => {
+    if (!value) {
+      return transactionDescription
+        ? new TransactionDescriptionComboBoxOption(transactionDescription)
+        : null
+    }
     return options.find(option => option.value === value.id) ?? null
-  }, [options, value])
+  }, [options, value, transactionDescription])
 
   return useMemo(
     () => ({ options, selectedOption, isLoading, isError }),

--- a/src/msw/api/businesses/[business-id]/categorization-rules/get.ts
+++ b/src/msw/api/businesses/[business-id]/categorization-rules/get.ts
@@ -1,10 +1,9 @@
 import { Schema } from 'effect'
 
-import { type CategorizationRule, CategorizationRuleSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
-import { DIRECTION_CONFIG, getCategorizationRuleCounterpartyLabel } from '@components/CategorizationRules/utils'
+import { BankDirectionFilter, type CategorizationRule, CategorizationRuleSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 
 import { categorizationRuleStore } from '@msw/api/businesses/[business-id]/categorization-rules/store'
-import { ledgerAccountStore } from '@msw/api/businesses/[business-id]/ledger/accounts/store'
+import { findAccountByIdentifier } from '@msw/api/businesses/[business-id]/ledger/accounts/store'
 import { paginatedApiData } from '@msw/utils/apiResponse'
 import { createListFilter, matchesQuery } from '@msw/utils/createListFilter'
 import { createListSorter } from '@msw/utils/createListSorter'
@@ -15,29 +14,20 @@ const encodeCategorizationRule = Schema.encodeSync(CategorizationRuleSchema)
 const toResponse = (rules: readonly CategorizationRule[], request: Request) =>
   paginatedApiData(rules.map(rule => encodeCategorizationRule(rule)), request)
 
-const directionLabel = ({ bankDirectionFilter }: CategorizationRule) => {
-  if (bankDirectionFilter == null) return 'Any direction'
-
-  return DIRECTION_CONFIG.find(({ value }) => value === bankDirectionFilter)?.defaultValue
-}
-
-const categoryLabel = ({ category }: CategorizationRule) => {
-  if (category == null) return undefined
-
-  const account = ledgerAccountStore.all().find(({ accountId, stableName }) =>
-    category.type === 'AccountId' ? accountId === category.id : stableName === category.stableName,
-  )
-
-  return account?.name ?? (category.type === 'StableName' ? category.stableName : undefined)
+/* Untranslated - the mock layer has no access to i18n. */
+const DIRECTION_TEXT: Record<BankDirectionFilter, string> = {
+  [BankDirectionFilter.MONEY_IN]: 'Money In',
+  [BankDirectionFilter.MONEY_OUT]: 'Money Out',
 }
 
 const filterCategorizationRules = createListFilter<CategorizationRule>({
   include_archived: (rule, value) => value === 'true' || rule.archivedAt == null,
   q: matchesQuery(rule => [
     rule.name,
-    directionLabel(rule),
-    getCategorizationRuleCounterpartyLabel(rule),
-    categoryLabel(rule),
+    rule.bankDirectionFilter == null ? 'Any direction' : DIRECTION_TEXT[rule.bankDirectionFilter],
+    rule.counterpartyFilter?.name,
+    rule.readableTransactionDescriptionFilter,
+    rule.category == null ? undefined : findAccountByIdentifier(rule.category)?.name,
   ]),
 })
 

--- a/src/msw/api/businesses/[business-id]/categorization-rules/get.ts
+++ b/src/msw/api/businesses/[business-id]/categorization-rules/get.ts
@@ -1,10 +1,12 @@
 import { Schema } from 'effect'
 
 import { type CategorizationRule, CategorizationRuleSchema } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
+import { DIRECTION_CONFIG, getCategorizationRuleCounterpartyLabel } from '@components/CategorizationRules/utils'
 
 import { categorizationRuleStore } from '@msw/api/businesses/[business-id]/categorization-rules/store'
+import { ledgerAccountStore } from '@msw/api/businesses/[business-id]/ledger/accounts/store'
 import { paginatedApiData } from '@msw/utils/apiResponse'
-import { createListFilter } from '@msw/utils/createListFilter'
+import { createListFilter, matchesQuery } from '@msw/utils/createListFilter'
 import { createListSorter } from '@msw/utils/createListSorter'
 import { createMockEndpoint } from '@msw/utils/createMockEndpoint'
 
@@ -13,8 +15,30 @@ const encodeCategorizationRule = Schema.encodeSync(CategorizationRuleSchema)
 const toResponse = (rules: readonly CategorizationRule[], request: Request) =>
   paginatedApiData(rules.map(rule => encodeCategorizationRule(rule)), request)
 
+const directionLabel = ({ bankDirectionFilter }: CategorizationRule) => {
+  if (bankDirectionFilter == null) return 'Any direction'
+
+  return DIRECTION_CONFIG.find(({ value }) => value === bankDirectionFilter)?.defaultValue
+}
+
+const categoryLabel = ({ category }: CategorizationRule) => {
+  if (category == null) return undefined
+
+  const account = ledgerAccountStore.all().find(({ accountId, stableName }) =>
+    category.type === 'AccountId' ? accountId === category.id : stableName === category.stableName,
+  )
+
+  return account?.name ?? (category.type === 'StableName' ? category.stableName : undefined)
+}
+
 const filterCategorizationRules = createListFilter<CategorizationRule>({
   include_archived: (rule, value) => value === 'true' || rule.archivedAt == null,
+  q: matchesQuery(rule => [
+    rule.name,
+    directionLabel(rule),
+    getCategorizationRuleCounterpartyLabel(rule),
+    categoryLabel(rule),
+  ]),
 })
 
 const sortCategorizationRules = createListSorter<CategorizationRule>({

--- a/src/msw/api/businesses/[business-id]/categorization-rules/get.ts
+++ b/src/msw/api/businesses/[business-id]/categorization-rules/get.ts
@@ -14,7 +14,6 @@ const encodeCategorizationRule = Schema.encodeSync(CategorizationRuleSchema)
 const toResponse = (rules: readonly CategorizationRule[], request: Request) =>
   paginatedApiData(rules.map(rule => encodeCategorizationRule(rule)), request)
 
-/* Untranslated - the mock layer has no access to i18n. */
 const DIRECTION_TEXT: Record<BankDirectionFilter, string> = {
   [BankDirectionFilter.MONEY_IN]: 'Money In',
   [BankDirectionFilter.MONEY_OUT]: 'Money Out',

--- a/src/msw/api/businesses/[business-id]/categorization-rules/ruleFromUpsertRequest.ts
+++ b/src/msw/api/businesses/[business-id]/categorization-rules/ruleFromUpsertRequest.ts
@@ -9,12 +9,16 @@ import {
 } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 
 import { readRequestJson } from '@msw/utils/request'
+import { counterparties } from '@fixtures/generated/counterparties.gen'
 
 const decodeCreateBody = Schema.decodeUnknownSync(CreateCategorizationRuleSchema)
 const decodePatchBody = Schema.decodeUnknownSync(PatchCategorizationRuleSchema)
 
+const resolveCounterparty = (counterpartyId: string) =>
+  counterparties.find(({ id }) => id === counterpartyId) ?? { id: counterpartyId, name: null, mccs: [] }
+
 // The description filter is echoed as the readable filter, and the bare
-// counterparty id becomes a minimal counterparty the real API would resolve.
+// counterparty id is resolved against the counterparties fixture as the real API would.
 const applyRuleFields = (
   base: CategorizationRule,
   body: CreateCategorizationRule | PatchCategorizationRule,
@@ -34,7 +38,7 @@ const applyRuleFields = (
   ...(body.counterpartyFilter !== undefined && {
     counterpartyFilter: body.counterpartyFilter == null
       ? null
-      : { id: body.counterpartyFilter, name: null, mccs: [] },
+      : resolveCounterparty(body.counterpartyFilter),
   }),
   updatedAt: new Date(),
 })

--- a/src/msw/api/businesses/[business-id]/categorization-rules/ruleFromUpsertRequest.ts
+++ b/src/msw/api/businesses/[business-id]/categorization-rules/ruleFromUpsertRequest.ts
@@ -8,17 +8,16 @@ import {
   PatchCategorizationRuleSchema,
 } from '@schemas/bankTransactions/categorizationRules/categorizationRule'
 
+import { counterpartyStore } from '@msw/api/businesses/[business-id]/counterparties/store'
 import { readRequestJson } from '@msw/utils/request'
-import { counterparties } from '@fixtures/generated/counterparties.gen'
 
 const decodeCreateBody = Schema.decodeUnknownSync(CreateCategorizationRuleSchema)
 const decodePatchBody = Schema.decodeUnknownSync(PatchCategorizationRuleSchema)
 
 const resolveCounterparty = (counterpartyId: string) =>
-  counterparties.find(({ id }) => id === counterpartyId) ?? { id: counterpartyId, name: null, mccs: [] }
+  counterpartyStore.findById(counterpartyId) ?? { id: counterpartyId, name: null, mccs: [] }
 
-// The description filter is echoed as the readable filter, and the bare
-// counterparty id is resolved against the counterparties fixture as the real API would.
+// A posted description filter is echoed back as the rule's readable filter.
 const applyRuleFields = (
   base: CategorizationRule,
   body: CreateCategorizationRule | PatchCategorizationRule,

--- a/src/msw/api/businesses/[business-id]/categorization-rules/ruleFromUpsertRequest.ts
+++ b/src/msw/api/businesses/[business-id]/categorization-rules/ruleFromUpsertRequest.ts
@@ -17,7 +17,6 @@ const decodePatchBody = Schema.decodeUnknownSync(PatchCategorizationRuleSchema)
 const resolveCounterparty = (counterpartyId: string) =>
   counterpartyStore.findById(counterpartyId) ?? { id: counterpartyId, name: null, mccs: [] }
 
-// A posted description filter is echoed back as the rule's readable filter.
 const applyRuleFields = (
   base: CategorizationRule,
   body: CreateCategorizationRule | PatchCategorizationRule,

--- a/src/msw/api/businesses/[business-id]/counterparties/get.ts
+++ b/src/msw/api/businesses/[business-id]/counterparties/get.ts
@@ -2,11 +2,11 @@ import { Schema } from 'effect'
 
 import { type BankTransactionCounterparty, BankTransactionCounterpartySchema } from '@schemas/bankTransactions/base'
 
+import { counterpartyStore } from '@msw/api/businesses/[business-id]/counterparties/store'
 import { paginatedApiData } from '@msw/utils/apiResponse'
 import { createListFilter, matchesQuery } from '@msw/utils/createListFilter'
 import { createListSorter } from '@msw/utils/createListSorter'
 import { createMockEndpoint } from '@msw/utils/createMockEndpoint'
-import { counterparties as defaultCounterparties } from '@fixtures/generated/counterparties.gen'
 
 const encodeCounterparty = Schema.encodeSync(BankTransactionCounterpartySchema)
 
@@ -24,6 +24,6 @@ const toResponse = (counterparties: readonly BankTransactionCounterparty[], requ
 export const get = createMockEndpoint<readonly BankTransactionCounterparty[], ReturnType<typeof toResponse>>({
   method: 'get',
   path: '*/v1/businesses/:businessId/counterparties',
-  resolve: ({ override: counterparties = defaultCounterparties, request }) =>
+  resolve: ({ override: counterparties = counterpartyStore.all(), request }) =>
     toResponse(sortCounterparties(filterCounterparties(counterparties, request), request), request),
 })

--- a/src/msw/api/businesses/[business-id]/counterparties/store.ts
+++ b/src/msw/api/businesses/[business-id]/counterparties/store.ts
@@ -1,0 +1,4 @@
+import { createMockStore } from '@msw/utils/createMockStore'
+import { counterparties } from '@fixtures/generated/counterparties.gen'
+
+export const counterpartyStore = createMockStore(() => counterparties)

--- a/src/msw/api/businesses/[business-id]/ledger/accounts/store.ts
+++ b/src/msw/api/businesses/[business-id]/ledger/accounts/store.ts
@@ -1,5 +1,8 @@
+import type { AccountIdentifier } from '@schemas/accountIdentifier'
 import { type SingleChartAccountType } from '@schemas/generalLedger/ledgerAccount'
+import { accountIdentifierIsForCategory } from '@utils/categories'
 
+import { accountCategorizationFields } from '@msw/api/businesses/[business-id]/ledger/accounts/accountCategorizationFields'
 import { ledgerEntryStore } from '@msw/api/businesses/[business-id]/ledger/entries/store'
 import { createMockStore } from '@msw/utils/createMockStore'
 import { PARENT_BY_STABLE_NAME } from '@fixtures/chartOfAccounts/constants'
@@ -11,6 +14,12 @@ export const ledgerAccountStore = createMockStore(
 )
 
 export const accountParentStore = createMockStore<{ id: string, parentAccountId: string }>(() => [])
+
+export const findAccountByIdentifier = (identifier: AccountIdentifier) =>
+  ledgerAccountStore.all().find(account => accountIdentifierIsForCategory(identifier, {
+    type: 'AccountNested',
+    ...accountCategorizationFields(account),
+  }))
 
 export const resolveParentAccountId = (account: SingleChartAccountType): string | null => {
   const runtimeParent = accountParentStore.findById(account.accountId)


### PR DESCRIPTION
## Scope

Categorization rules created before counterparty filters existed have a `readable_transaction_description_filter` instead of a `counterparty_filter`. They were unrepresentable in the edit form: the counterparty select rendered empty and the required-field validator blocked saving.

These legacy rules are now supported read-only — viewable and editable, but never creatable.

- `TransactionDescriptionComboBoxOption` (disabled + hidden) renders the description as the counterparty select's value on desktop and mobile. It is deliberately **not** in the option list, so it can't be picked again.
- `useCounterpartyOptions` takes `{ value, searchQuery, transactionDescription }` and returns the description option as `selectedOption` only when there's no counterparty.
- Selection handlers narrow with `instanceof CounterpartyComboBoxOption`, so only real counterparties reach `onValueChange`.
- The "Counterparty is required" validator is skipped when the rule has a description filter, so other fields can be saved.
- `convertFormToPatchBody` omits `counterparty_filter` when no counterparty is selected and the rule has a description filter — the patch preserves the legacy filter. Picking a counterparty sends it and overwrites. Create is unchanged: still requires a counterparty.

Mock improvements so the flow is exercisable locally:

- The categorization-rules GET mock now filters `q`, matching rule name, direction text (`Money In` / `Money Out` / `Any direction`), the counterparty label (counterparty name falling back to the readable description, same as the table), and the resolved category display name.
- The upsert mock resolves a posted counterparty id against the counterparties fixture instead of returning `name: null`, so switching a legacy rule to a counterparty shows the real name.

## Verification

- `tsc --noEmit` and `eslint` clean.
- Manual, against mocks: the `softwareSubscriptions` (Adobe), `coffeeRuns` (Starbucks), `rideshare` (Uber), and `payrollRuns` (Gusto) fixtures are all legacy description-filter rules.
  - Editing one shows the description in the counterparty select; it does not appear in the dropdown or mobile drawer.
  - Changing only the category/direction/amount saves and leaves the description filter intact.
  - Selecting a counterparty replaces it and the table shows the counterparty's name.
- No automated tests existed for these modules; none added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PATCH semantics and form validation for categorization rules, but scope is limited to legacy description filters and create behavior is unchanged.
> 
> **Overview**
> **Legacy categorization rules** that only have a `readable_transaction_description_filter` (no counterparty) can now be edited without a broken empty counterparty field or a blocked save.
> 
> The edit form derives `transactionDescription` from the rule, passes it into the counterparty select (desktop combobox and mobile drawer), and **skips the required counterparty validator** when that description is present. A new `TransactionDescriptionComboBoxOption` shows the description as the selected value but stays out of the pickable list; selection handlers use `toCounterpartyValue` so only real counterparties update form state, and the combobox is **not clearable** for description-only selections.
> 
> **Patch payloads** accept either a counterparty or a legacy description: `convertFormToPatchBody` no longer requires a counterparty when a description exists, omits `counterparty_filter` in that case so the API keeps the legacy filter, and when the user picks a counterparty it sends `counterparty_filter` and clears `transaction_description_filter`. Create flow is unchanged (counterparty still required).
> 
> **MSW** gains `q` search on categorization rules (name, direction, counterparty/description, category name), a shared `counterpartyStore`, upsert resolving counterparty names from fixtures, and `findAccountByIdentifier` for category labels in search.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f3b691bd738e7a432787b041bddc71ce884f523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->