### PR TITLE
fix(bank-transactions): hide AI sparkle on split category selections

### DIFF
--- a/src/components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox.tsx
+++ b/src/components/BankTransactionCategoryComboBox/BankTransactionCategoryComboBox.tsx
@@ -82,6 +82,7 @@ type BankTransactionCategoryComboBoxBaseProps = {
   isDisabled?: boolean
   isLoading?: boolean
   inputId?: string
+  showAiSparkle?: boolean
 }
 
 type BankTransactionCategoryComboBoxWithMatchesProps = {
@@ -107,6 +108,7 @@ export const BankTransactionCategoryComboBox = ({
   isDisabled = false,
   isLoading = false,
   inputId,
+  showAiSparkle = true,
 }: BankTransactionCategoryComboBoxProps) => {
   const { t } = useTranslation()
   const { data: categories } = useCategories()
@@ -156,10 +158,10 @@ export const BankTransactionCategoryComboBox = ({
     return (
       <BankTransactionsUncategorizedSelectedValue
         selectedValue={selectedValue}
-        showAiSparkle={isSuggestedCategorySelected}
+        showAiSparkle={showAiSparkle && isSuggestedCategorySelected}
       />
     )
-  }, [isSuggestedCategorySelected, selectedValue])
+  }, [isSuggestedCategorySelected, selectedValue, showAiSparkle])
 
   const handleSelectedValueChange = useCallback((value: BankTransactionCategoryComboBoxOption | null) => {
     if (!includeSuggestedMatches) {

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -270,6 +270,7 @@ export const ExpandedBankTransactionRow = ({
                             }}
                             isDisabled={!isCategorizationEnabled}
                             includeSuggestedMatches={false}
+                            showAiSparkle={effectiveSplits.length === 1}
                           />
                           {hasTaxCodeOptions && (
                             <TaxCodeComboBox

--- a/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -270,7 +270,7 @@ export const ExpandedBankTransactionRow = ({
                             }}
                             isDisabled={!isCategorizationEnabled}
                             includeSuggestedMatches={false}
-                            showAiSparkle={effectiveSplits.length === 1}
+                            showAiSparkle={false}
                           />
                           {hasTaxCodeOptions && (
                             <TaxCodeComboBox


### PR DESCRIPTION
## Scope

The AI sparkle indicating a suggested category was rendering on every split row's category combobox. The suggestion applies to the transaction as a whole, so it never belongs in the split form.

- `BankTransactionCategoryComboBox` takes a `showAiSparkle` prop (defaults to `true`, so existing usages are unchanged).
- The split form in `ExpandedBankTransactionRow` passes `showAiSparkle={false}`.

## Verification

- `npx tsc --noEmit` clean.