### PR TITLE
docs: change the key when translated copy changes

### DIFF
--- a/src/assets/locales/SKILL.md
+++ b/src/assets/locales/SKILL.md
@@ -50,10 +50,9 @@ project causes spurious "omitted" warnings on download.
 without renaming the key risks the stale `fr-CA` translation surviving; a new key
 (`label.payment_due`) is unambiguously untranslated, so Crowdin translates it fresh.
 
-Grep for the old key and update **both the key and the default value together at every call
-site** — `t()` calls, `translationKey(...)` constants, and `tPlural`/`tConditional` case maps.
-A half-migrated key leaves two keys in the extracted JSON with conflicting English, and the
-call sites still on the old key keep rendering the old French.
+Grep for the old key and change **both the key and the default value at every call site** —
+`t()`, `translationKey(...)` constants, `tPlural`/`tConditional` case maps. Half-migrating
+leaves two keys with conflicting English, and the stragglers keep rendering the old French.
 
 ```diff
 -t('invoices:label.due_date', 'Due date')

--- a/src/assets/locales/SKILL.md
+++ b/src/assets/locales/SKILL.md
@@ -48,8 +48,17 @@ project causes spurious "omitted" warnings on download.
 
 **Change the key too.** Editing the default of `label.due_date` from "Due date" to "Payment due"
 without renaming the key risks the stale `fr-CA` translation surviving; a new key
-(`label.payment_due`) is unambiguously untranslated, so Crowdin translates it fresh. Rename the
-key in every call site along with the copy change.
+(`label.payment_due`) is unambiguously untranslated, so Crowdin translates it fresh.
+
+Grep for the old key and update **both the key and the default value together at every call
+site** — `t()` calls, `translationKey(...)` constants, and `tPlural`/`tConditional` case maps.
+A half-migrated key leaves two keys in the extracted JSON with conflicting English, and the
+call sites still on the old key keep rendering the old French.
+
+```diff
+-t('invoices:label.due_date', 'Due date')
++t('invoices:label.payment_due', 'Payment due')
+```
 
 ## Renaming or deleting a key
 

--- a/src/assets/locales/SKILL.md
+++ b/src/assets/locales/SKILL.md
@@ -46,9 +46,9 @@ project causes spurious "omitted" warnings on download.
 
 ## Changing the English text of an existing key
 
-**Change the key too.** Editing the default of `label.due_date` from "Due date" to "Payment due"
-without renaming the key risks the stale `fr-CA` translation surviving; a new key
-(`label.payment_due`) is unambiguously untranslated, so Crowdin translates it fresh.
+**Change the key too.** Editing the default of `invoices:label.due_date` from "Due date" to
+"Payment due" without renaming the key risks the stale `fr-CA` translation surviving; a new key
+(`invoices:label.payment_due`) is unambiguously untranslated, so Crowdin translates it fresh.
 
 Grep for the old key and change **both the key and the default value at every call site** —
 `t()`, `translationKey(...)` constants, `tPlural`/`tConditional` case maps. Half-migrating

--- a/src/assets/locales/SKILL.md
+++ b/src/assets/locales/SKILL.md
@@ -44,6 +44,13 @@ Things to know when the pipeline misbehaves: both Crowdin workflows share a
 runs need the `CROWDIN_AI_PROMPT_ID` variable; and a stale `main/` folder left in the Crowdin
 project causes spurious "omitted" warnings on download.
 
+## Changing the English text of an existing key
+
+**Change the key too.** Editing the default of `label.due_date` from "Due date" to "Payment due"
+without renaming the key risks the stale `fr-CA` translation surviving; a new key
+(`label.payment_due`) is unambiguously untranslated, so Crowdin translates it fresh. Rename the
+key in every call site along with the copy change.
+
 ## Renaming or deleting a key
 
 Change or remove it in the code; extraction reconciles the JSON on its next run. Don't delete


### PR DESCRIPTION
## Scope

Adds a section to the translations SKILL.md (`src/assets/locales/SKILL.md`): when you change the English text of an existing key, rename the key too, at every call site. A new key is unambiguously untranslated so Crowdin retranslates it, instead of a stale `fr-CA` value potentially surviving the copy change.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to i18n contributor guidance; no runtime or pipeline code is modified.
> 
> **Overview**
> Adds a **Changing the English text of an existing key** section to `src/assets/locales/SKILL.md`, placed before the existing rename/delete guidance.
> 
> It tells contributors to **rename the i18n key whenever the English default changes**, so Crowdin treats the string as new and retranslates instead of keeping a `fr-CA` value that still matches the old meaning. The doc also says to grep and update every call site (`t()`, `translationKey`, `tPlural`/`tConditional`) together, with a small diff example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32872e0646d49ed5d0c76a1d49146bf4473dc393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->