### PR TITLE
ci: scope down how often Chromatic runs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,14 +1,54 @@
 name: Chromatic
 
+# Only runs on PRs that touch files a snapshot could depend on. Within a run,
+# TurboSnap (onlyChanged) narrows further to the stories whose Vite dependency
+# graph the diff actually reaches, so a change under src/components/ui only
+# re-snapshots that component plus the feature stories rendering it.
+#
+# TurboSnap diffs against the newest ancestor build, so the push-on-main job
+# below keeps a baseline available for PRs branched off main.
+
 on:
   pull_request:
+    paths:
+      - src/**
+      - '!src/**/*.test.ts'
+      - '!src/**/*.test.tsx'
+      - '!src/**/*.test-d.ts'
+      - '!src/**/SKILL.md'
+      - .storybook/**
+      - vite.config.ts
+      - tsconfig.json
+      - package.json
+      - package-lock.json
+      - .github/workflows/chromatic.yml
+  push:
+    branches:
+      - main
+    paths:
+      - src/**
+      - '!src/**/*.test.ts'
+      - '!src/**/*.test.tsx'
+      - '!src/**/*.test-d.ts'
+      - '!src/**/SKILL.md'
+      - .storybook/**
+      - vite.config.ts
+      - tsconfig.json
+      - package.json
+      - package-lock.json
+      - .github/workflows/chromatic.yml
 
 permissions:
   contents: read
 
+concurrency:
+  group: chromatic-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v4
@@ -32,3 +72,4 @@ jobs:
         buildScriptName: storybook:build
         onlyChanged: true
         exitZeroOnChanges: true
+        autoAcceptChanges: ${{ github.event_name == 'push' }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,15 +1,23 @@
 name: Chromatic
 
-# Only runs on PRs that touch files a snapshot could depend on. Within a run,
-# TurboSnap (onlyChanged) narrows further to the stories whose Vite dependency
-# graph the diff actually reaches, so a change under src/components/ui only
-# re-snapshots that component plus the feature stories rendering it.
+# Snapshot budget is controlled at three levels:
+#   1. Trigger — path filters keep test-only, doc-only, and workflow-only PRs
+#      from starting a build at all, and drafts are skipped until review-ready.
+#   2. Concurrency — superseded commits on the same PR cancel the older build.
+#   3. TurboSnap (onlyChanged) — narrows to the stories whose Vite dependency
+#      graph the diff reaches, so a change under src/components/ui re-snapshots
+#      that component plus the feature stories rendering it.
 #
 # TurboSnap diffs against the newest ancestor build, so the push-on-main job
-# below keeps a baseline available for PRs branched off main.
+# keeps a baseline available for PRs branched off main.
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     paths:
       - src/**
       - '!src/**/*.test.ts'
@@ -55,6 +63,10 @@ jobs:
       with:
         # Chromatic's TurboSnap needs full git history to diff against baselines.
         fetch-depth: 0
+        # Check out the PR head instead of the ephemeral merge commit, which is
+        # absent from git history and degrades baseline/dependency analysis.
+        # Assumes same-repo PRs; a fork's head.ref would not resolve here.
+        ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v4
@@ -66,10 +78,20 @@ jobs:
       run: npm ci
 
     - name: Run Chromatic
+      id: chromatic
       uses: chromaui/action@v18
       with:
         projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
         buildScriptName: storybook:build
         onlyChanged: true
         exitZeroOnChanges: true
+        skip: ${{ github.event.pull_request.draft == true }}
         autoAcceptChanges: ${{ github.event_name == 'push' }}
+
+    - name: Link published Storybook
+      if: steps.chromatic.outputs.storybookUrl != ''
+      env:
+        STORYBOOK_URL: ${{ steps.chromatic.outputs.storybookUrl }}
+      run: |
+        echo "## Storybook preview" >> "$GITHUB_STEP_SUMMARY"
+        echo "$STORYBOOK_URL" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Scope

Reduces how often Chromatic runs and how many snapshots each run takes. Touches only `.github/workflows/chromatic.yml`.

Three layers of gating, cheapest first:

1. **Trigger path filters** — PRs that only touch tests, `SKILL.md` files, docs, or other workflows no longer start a build at all.
2. **Draft skipping** — adds `ready_for_review` to the trigger types and passes `skip` for drafts, so WIP branches don't consume snapshots.
3. **Concurrency** — superseded commits on the same PR cancel the older in-flight build instead of both running to completion.

Two supporting changes make the existing `onlyChanged: true` (TurboSnap) actually effective:

- **Check out the PR head rather than the merge commit.** TurboSnap analyses the checked-out commit, and GitHub's ephemeral merge commit isn't present in git history — it weakens both baseline selection and dependency tracing. This is the change most likely to cut snapshot counts on real PRs.
- **Add a `push` build on `main`** with `autoAcceptChanges`. TurboSnap diffs against the newest *ancestor* build; with no builds on `main`, PRs had no reliable baseline and degraded toward full-Storybook runs (69 stories). One extra run per merge buys cheap PR builds.

Note on story-level scoping: this deliberately does **not** hand-map paths to story globs (e.g. "only run `src/components/ui/**` stories when that directory changed"). TurboSnap traces the Vite dependency graph, so a change under `src/components/ui/Button` correctly re-snapshots Button's stories *and* every feature/view story that renders a Button. A manual mapping would miss exactly those downstream regressions.

## Verification

- `js-yaml` parses the workflow; trigger keys and both `paths` lists resolve as intended.
- Confirmed the `main` ruleset contains `deletion`, `code_scanning`, and `pull_request` rules but **no** `required_status_checks` — so a path-filtered skip cannot leave a required check pending. If Chromatic is ever made a required check, these path filters must be removed or paired with a skip-shim job.
- Verified all 297 `.scss` files reach the bundler (component-level imports plus `src/styles/index.scss` in `.storybook/preview.tsx`), so TurboSnap already traces them and no `externals` declaration is needed. Declaring them external would force a full rebuild on any style change.
- Verified `.storybook/public` holds only `mockServiceWorker.js` — no visual static assets needing `externals`.
- No dependabot/renovate config in the repo, so bot-branch ignores were unnecessary.

Action and Node versions are left at the repo-wide `@v4` / Node 22 pins rather than bumped in this one file.

## Follow-ups (not in this PR)

- `src/assets/locales/**` is currently *included* in the path filter, since en-US string changes can alter rendered snapshots. If stories rely solely on inline `t()` defaults, it can be excluded.
- The `ref: head.ref` checkout assumes same-repo PRs; a fork's head branch wouldn't resolve. Fine today, worth revisiting if external contributions start.
