### PR TITLE
ci: strip scratch stories from approved PRs

### DIFF
--- a/.github/workflows/scratch-stories-cleanup.yml
+++ b/.github/workflows/scratch-stories-cleanup.yml
@@ -22,6 +22,8 @@ jobs:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
 
     - name: Remove scratch stories
+      env:
+        HEAD_REF: ${{ github.event.pull_request.head.ref }}
       run: |
         FILES=$(git ls-files '*scratch.stories.tsx')
         if [ -z "$FILES" ]; then
@@ -32,7 +34,7 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git commit -m "chore: remove scratch stories"
-        git push origin HEAD:"${{ github.event.pull_request.head.ref }}"
+        git push origin HEAD:"refs/heads/$HEAD_REF"
         {
           echo "Removed:"
           echo "$FILES" | sed 's/^/- /'

--- a/.github/workflows/scratch-stories-cleanup.yml
+++ b/.github/workflows/scratch-stories-cleanup.yml
@@ -1,47 +1,21 @@
-name: Scratch Stories
+name: Scratch Stories Cleanup
 
-# Cleanup pushes to the PR head branch, not main: the branch ruleset gives
+# Pushes to the PR head branch, not main: the branch ruleset gives
 # github-actions[bot] no bypass there.
 #
-# A GITHUB_TOKEN push does not re-trigger `guard`, so `cleanup` posts the
-# passing "No scratch stories" status on its own commit. Check runs and commit
-# statuses share a namespace, so that satisfies the same required check.
+# A GITHUB_TOKEN push does not re-trigger the guard workflow, so this posts
+# the passing "No scratch stories" status on its own commit. Check runs and
+# commit statuses share a namespace, so that satisfies the same required
+# check.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [ main ]
   pull_request_review:
     types: [submitted]
 
 jobs:
-  guard:
-    name: No scratch stories
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Check for scratch stories
-      run: |
-        FILES=$(git ls-files '*scratch.stories.tsx')
-        if [ -z "$FILES" ]; then
-          echo "No scratch stories found."
-          exit 0
-        fi
-        echo "$FILES" | sed 's/^/  - /'
-        echo "::error::Scratch stories must not reach main. Approve the PR and they will be removed automatically, or delete them yourself."
-        exit 1
-
   cleanup:
     if: >-
-      github.event_name == 'pull_request_review'
-      && github.event.review.state == 'approved'
+      github.event.review.state == 'approved'
       && github.event.pull_request.base.ref == 'main'
       && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest

--- a/.github/workflows/scratch-stories-cleanup.yml
+++ b/.github/workflows/scratch-stories-cleanup.yml
@@ -1,9 +1,7 @@
 name: Scratch Stories Cleanup
 
-# Scratch stories (*scratch.stories.tsx) are throwaway harnesses for local
-# development. Once a PR is approved, strip any it adds from the head branch so
-# they never reach main. Pushing to the PR branch (rather than main after the
-# merge) keeps this inside branch protection rather than fighting it.
+# Pushes to the PR head branch, not main after the merge: the branch ruleset
+# gives github-actions[bot] no bypass on main.
 
 on:
   pull_request_review:

--- a/.github/workflows/scratch-stories-cleanup.yml
+++ b/.github/workflows/scratch-stories-cleanup.yml
@@ -10,32 +10,39 @@ on:
 permissions:
   contents: write
 
+# A second approval landing mid-run would push from a stale checkout.
+concurrency:
+  group: scratch-stories-cleanup-${{ github.event.pull_request.number }}
+
 jobs:
   cleanup:
-    if: github.event.review.state == 'approved' && github.event.pull_request.state == 'open'
+    if: >-
+      github.event.review.state == 'approved'
+      && github.event.pull_request.state == 'open'
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
 
     - name: Remove scratch stories
       env:
         HEAD_REF: ${{ github.event.pull_request.head.ref }}
       run: |
-        FILES=$(git ls-files '*scratch.stories.tsx')
-        if [ -z "$FILES" ]; then
+        FILES="$RUNNER_TEMP/scratch-stories.z"
+        git ls-files -z '*scratch.stories.tsx' > "$FILES"
+        if [ ! -s "$FILES" ]; then
           echo "No scratch stories found."
           exit 0
         fi
-        echo "$FILES" | xargs git rm --quiet
+        xargs -0 git rm --quiet -- < "$FILES"
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git commit -m "chore: remove scratch stories"
         git push origin HEAD:"refs/heads/$HEAD_REF"
         {
           echo "Removed:"
-          echo "$FILES" | sed 's/^/- /'
+          tr '\0' '\n' < "$FILES" | sed 's/^/- /'
         } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scratch-stories-cleanup.yml
+++ b/.github/workflows/scratch-stories-cleanup.yml
@@ -1,13 +1,5 @@
 name: Scratch Stories Cleanup
 
-# Pushes to the PR head branch, not main: the branch ruleset gives
-# github-actions[bot] no bypass there.
-#
-# A GITHUB_TOKEN push does not re-trigger the guard workflow, so this posts
-# the passing "No scratch stories" status on its own commit. Check runs and
-# commit statuses share a namespace, so that satisfies the same required
-# check.
-
 on:
   pull_request_review:
     types: [submitted]

--- a/.github/workflows/scratch-stories-cleanup.yml
+++ b/.github/workflows/scratch-stories-cleanup.yml
@@ -1,4 +1,4 @@
-name: Storybook / cleanup
+name: Scratch Stories
 
 # Pushes to the PR head branch, not main after the merge: the branch ruleset
 # gives github-actions[bot] no bypass on main.
@@ -18,7 +18,6 @@ jobs:
   cleanup:
     if: >-
       github.event.review.state == 'approved'
-      && github.event.pull_request.state == 'open'
       && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
@@ -29,7 +28,9 @@ jobs:
 
     - name: Remove scratch stories
       env:
+        GH_TOKEN: ${{ github.token }}
         HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR: ${{ github.event.pull_request.number }}
       run: |
         FILES="$RUNNER_TEMP/scratch-stories.z"
         git ls-files -z '*scratch.stories.tsx' > "$FILES"
@@ -37,11 +38,22 @@ jobs:
           echo "No scratch stories found."
           exit 0
         fi
+        # The webhook payload is frozen at review time, so ask for live state.
+        STATE=$(gh pr view "$PR" --json state --jq .state)
+        if [ "$STATE" != "OPEN" ]; then
+          echo "::error::PR #$PR is $STATE — it merged before cleanup ran, so these scratch stories are now on the base branch and must be removed by hand:" >&2
+          tr '\0' '\n' < "$FILES" | sed 's/^/  - /' >&2
+          exit 1
+        fi
+        ORIG=$(git rev-parse HEAD)
         xargs -0 git rm --quiet -- < "$FILES"
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git commit -m "chore: remove scratch stories"
-        git push origin HEAD:"refs/heads/$HEAD_REF"
+        # Lease pins the push to the ref we checked out: fails if the branch
+        # moved or was deleted by a merge, rather than resurrecting it.
+        git push --force-with-lease="refs/heads/$HEAD_REF:$ORIG" \
+          origin HEAD:"refs/heads/$HEAD_REF"
         {
           echo "Removed:"
           tr '\0' '\n' < "$FILES" | sed 's/^/- /'

--- a/.github/workflows/scratch-stories-cleanup.yml
+++ b/.github/workflows/scratch-stories-cleanup.yml
@@ -1,4 +1,4 @@
-name: Scratch Stories Cleanup
+name: Storybook / cleanup
 
 # Pushes to the PR head branch, not main after the merge: the branch ruleset
 # gives github-actions[bot] no bypass on main.

--- a/.github/workflows/scratch-stories-cleanup.yml
+++ b/.github/workflows/scratch-stories-cleanup.yml
@@ -1,0 +1,41 @@
+name: Scratch Stories Cleanup
+
+# Scratch stories (*scratch.stories.tsx) are throwaway harnesses for local
+# development. Once a PR is approved, strip any it adds from the head branch so
+# they never reach main. Pushing to the PR branch (rather than main after the
+# merge) keeps this inside branch protection rather than fighting it.
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: github.event.review.state == 'approved' && github.event.pull_request.state == 'open'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+    - name: Remove scratch stories
+      run: |
+        FILES=$(git ls-files '*scratch.stories.tsx')
+        if [ -z "$FILES" ]; then
+          echo "No scratch stories found."
+          exit 0
+        fi
+        echo "$FILES" | xargs git rm --quiet
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git commit -m "chore: remove scratch stories"
+        git push origin HEAD:"${{ github.event.pull_request.head.ref }}"
+        {
+          echo "Removed:"
+          echo "$FILES" | sed 's/^/- /'
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scratch-stories-cleanup.yml
+++ b/.github/workflows/scratch-stories-cleanup.yml
@@ -1,26 +1,57 @@
 name: Scratch Stories
 
-# Pushes to the PR head branch, not main after the merge: the branch ruleset
-# gives github-actions[bot] no bypass on main.
+# Cleanup pushes to the PR head branch, not main: the branch ruleset gives
+# github-actions[bot] no bypass there.
+#
+# A GITHUB_TOKEN push does not re-trigger `guard`, so `cleanup` posts the
+# passing "No scratch stories" status on its own commit. Check runs and commit
+# statuses share a namespace, so that satisfies the same required check.
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [ main ]
   pull_request_review:
     types: [submitted]
 
-permissions:
-  contents: write
-  pull-requests: read
-
-# A second approval landing mid-run would push from a stale checkout.
-concurrency:
-  group: scratch-stories-cleanup-${{ github.event.pull_request.number }}
-
 jobs:
+  guard:
+    name: No scratch stories
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Check for scratch stories
+      run: |
+        FILES=$(git ls-files '*scratch.stories.tsx')
+        if [ -z "$FILES" ]; then
+          echo "No scratch stories found."
+          exit 0
+        fi
+        echo "$FILES" | sed 's/^/  - /'
+        echo "::error::Scratch stories must not reach main. Approve the PR and they will be removed automatically, or delete them yourself."
+        exit 1
+
   cleanup:
     if: >-
-      github.event.review.state == 'approved'
+      github.event_name == 'pull_request_review'
+      && github.event.review.state == 'approved'
+      && github.event.pull_request.base.ref == 'main'
       && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # Two approvals in quick succession must not push from stale checkouts.
+    concurrency:
+      group: scratch-stories-cleanup-${{ github.event.pull_request.number }}
+    permissions:
+      contents: write
+      pull-requests: read
+      statuses: write
 
     steps:
     - uses: actions/checkout@v4
@@ -42,7 +73,7 @@ jobs:
         # The webhook payload is frozen at review time, so ask for live state.
         STATE=$(gh pr view "$PR" --json state --jq .state)
         if [ "$STATE" != "OPEN" ]; then
-          echo "::error::PR #$PR is $STATE — it merged before cleanup ran, so these scratch stories are now on the base branch and must be removed by hand:" >&2
+          echo "::error::PR #$PR is $STATE — remove these from the base branch by hand:" >&2
           tr '\0' '\n' < "$FILES" | sed 's/^/  - /' >&2
           exit 1
         fi
@@ -50,11 +81,14 @@ jobs:
         xargs -0 git rm --quiet -- < "$FILES"
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git commit -m "chore: remove scratch stories"
+        git commit -m "chore: remove scratch stories before merge"
         # Lease pins the push to the ref we checked out: fails if the branch
         # moved or was deleted by a merge, rather than resurrecting it.
         git push --force-with-lease="refs/heads/$HEAD_REF:$ORIG" \
           origin HEAD:"refs/heads/$HEAD_REF"
+        gh api "repos/$GITHUB_REPOSITORY/statuses/$(git rev-parse HEAD)" \
+          -f state=success -f context="No scratch stories" \
+          -f description="Removed by cleanup." >/dev/null
         {
           echo "Removed:"
           tr '\0' '\n' < "$FILES" | sed 's/^/- /'

--- a/.github/workflows/scratch-stories-cleanup.yml
+++ b/.github/workflows/scratch-stories-cleanup.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 # A second approval landing mid-run would push from a stale checkout.
 concurrency:

--- a/.github/workflows/scratch-stories-guard.yml
+++ b/.github/workflows/scratch-stories-guard.yml
@@ -1,9 +1,5 @@
 name: Scratch Stories Guard
 
-# Kept separate from scratch-stories-cleanup.yml: a shared workflow would emit
-# a skipped `guard` check run on every review event, and skipped counts as
-# passing for required checks — green on a still-dirty head.
-
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/scratch-stories-guard.yml
+++ b/.github/workflows/scratch-stories-guard.yml
@@ -10,7 +10,6 @@ permissions:
 
 jobs:
   guard:
-    name: No scratch stories
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/scratch-stories-guard.yml
+++ b/.github/workflows/scratch-stories-guard.yml
@@ -1,0 +1,34 @@
+name: Scratch Stories Guard
+
+# Kept separate from scratch-stories-cleanup.yml: a shared workflow would emit
+# a skipped `guard` check run on every review event, and skipped counts as
+# passing for required checks — green on a still-dirty head.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: No scratch stories
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Check for scratch stories
+      run: |
+        FILES=$(git ls-files '*scratch.stories.tsx')
+        if [ -z "$FILES" ]; then
+          echo "No scratch stories found."
+          exit 0
+        fi
+        echo "$FILES" | sed 's/^/  - /'
+        echo "::error::Scratch stories must not reach main. Approve the PR and they will be removed automatically, or delete them yourself."
+        exit 1


### PR DESCRIPTION
## Scope

Adds `.github/workflows/scratch-stories-cleanup.yml`. On `pull_request_review` submitted with state `approved`, it checks out the PR head branch, `git rm`s any files matching `*scratch.stories.tsx`, and pushes the removal commit back to that branch. No-ops when there are none.

Approve → bot deletes the scratch stories on your branch → merge. No manual code change needed to drop them.

## Why the head branch, not main

`main` is covered by the `master-branch-protection` ruleset (PR + 1 approval, empty bypass list), so `github-actions[bot]` cannot push to it — a post-merge cleanup job would just fail. Pushing to the PR branch pre-merge works within the ruleset instead of against it.

The ruleset has `dismiss_stale_reviews_on_push: false` and `require_last_push_approval: false`, so the bot's commit does not invalidate the approval that triggered it.

## Known limitations

- Pushes made with `GITHUB_TOKEN` do not trigger new workflow runs, so the other PR checks won't re-run on the cleanup commit. None are required by the ruleset, so merging isn't blocked, but that commit ships un-rechecked. Since it only ever deletes `*scratch.stories.tsx`, the blast radius is limited. Switching to a PAT or App token would restore re-runs.
- Fork PRs are not supported — pushing to a fork head branch needs more than the base repo token grants. Not a concern for this repo's branch-based flow.

## Verification

Not exercised end-to-end — the trigger requires an approval on a real PR, and there are currently no `*scratch.stories.tsx` files in the tree. The approval path can be confirmed by approving this PR (expected: job runs, finds nothing, exits clean).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflows with scoped file deletion and force-with-lease on PR branches; no app runtime or auth changes, though the bot can push to approved PR heads.
> 
> **Overview**
> Adds CI so `*scratch.stories.tsx` files cannot land on **main** without an explicit cleanup step.
> 
> **Scratch Stories Guard** runs on PR open/sync/reopen to `main` and **fails the check** if any tracked `*scratch.stories.tsx` files are present, with a message that approval triggers automatic removal.
> 
> **Scratch Stories Cleanup** runs when a review is **approved** on an open, same-repo PR targeting `main`. It checks out the PR head, `git rm`s matching scratch story files (no-op if none), commits, and **force-pushes with lease** back to the PR branch. It verifies the PR is still open via `gh pr view`, uses concurrency per PR, and posts a success commit status for **No scratch stories**. Fork PRs are excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d51e4aafaa243a5c296d52b46d2d46012157e773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->