### PR TITLE
fix: show Year label on unified report year picker

### DIFF
--- a/src/components/GlobalYearPicker/GlobalYearPicker.tsx
+++ b/src/components/GlobalYearPicker/GlobalYearPicker.tsx
@@ -6,7 +6,11 @@ import { useBusinessDatePickerBounds } from '@hooks/utils/dates/useBusinessDateP
 import { useGlobalDateRange, useGlobalDateRangeActions } from '@providers/DateStoreProvider/GlobalDateStoreProvider'
 import { YearPicker } from '@components/YearPicker/YearPicker'
 
-export const GlobalYearPicker = () => {
+type GlobalYearPickerProps = {
+  showLabel?: boolean
+}
+
+export const GlobalYearPicker = ({ showLabel = false }: GlobalYearPickerProps) => {
   const { minDate, maxDate } = useBusinessDatePickerBounds()
   const { setYear } = useGlobalDateRangeActions()
   const { startDate } = useGlobalDateRange({ dateSelectionMode: 'year' })
@@ -22,6 +26,7 @@ export const GlobalYearPicker = () => {
 
   return (
     <YearPicker
+      showLabel={showLabel}
       year={selectedYear}
       onChange={onChange}
       minDate={minDateZdt}

--- a/src/components/UnifiedReports/UnifiedReportControls.tsx
+++ b/src/components/UnifiedReports/UnifiedReportControls.tsx
@@ -80,7 +80,7 @@ export const UnifiedReportControls = () => {
         <UnifiedReportDateSelection isCompact={isCompact} />
         {(hasYear || hasGroupBy || hasReportingBasis || tagControl) && (
           <div className='Layer__UnifiedReports__AdditionalControls'>
-            {hasYear && <GlobalYearPicker />}
+            {hasYear && <GlobalYearPicker showLabel />}
             {hasGroupBy && <DateGroupByComboBox value={groupBy} onValueChange={setGroupBy} />}
             {tagControl && <UnifiedReportTagControl tagControl={tagControl} />}
             {hasReportingBasis && (

--- a/src/components/YearPicker/YearPicker.tsx
+++ b/src/components/YearPicker/YearPicker.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useId, useMemo } from 'react'
 import { type ZonedDateTime } from '@internationalized/date'
 import { useTranslation } from 'react-i18next'
 
 import { DateFormat } from '@utils/i18n/date/patterns'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { ComboBox } from '@ui/ComboBox/ComboBox'
+import { VStack } from '@ui/Stack/Stack'
+import { Label } from '@ui/Typography/Text'
 
 import './yearPicker.scss'
 
@@ -15,6 +17,7 @@ type YearOption = {
 
 type YearPickerProps = {
   label?: string
+  showLabel?: boolean
   year: number
   onChange: (year: number) => void
   minDate?: ZonedDateTime | null
@@ -24,6 +27,7 @@ type YearPickerProps = {
 
 export const YearPicker = ({
   label,
+  showLabel = false,
   year,
   onChange,
   minDate = null,
@@ -32,6 +36,7 @@ export const YearPicker = ({
 }: YearPickerProps) => {
   const { t } = useTranslation()
   const { formatDate } = useIntlFormatter()
+  const inputId = useId()
   const coercedLabel = label ?? t('date:label.year', 'Year')
   const minYear = minDate?.year ?? null
   const maxYear = maxDate?.year ?? null
@@ -63,16 +68,22 @@ export const YearPicker = ({
     }
   }, [onChange])
 
+  const additionalAriaProps = !showLabel && { 'aria-label': coercedLabel }
+
   return (
-    <ComboBox
-      selectedValue={selectedYearOption}
-      onSelectedValueChange={handleChange}
-      options={yearOptions}
-      isSearchable={false}
-      isClearable={false}
-      isDisabled={isDisabled}
-      aria-label={coercedLabel}
-      className='Layer__YearPicker'
-    />
+    <VStack>
+      {showLabel && <Label pbe='3xs' size='sm' htmlFor={inputId}>{coercedLabel}</Label>}
+      <ComboBox
+        selectedValue={selectedYearOption}
+        onSelectedValueChange={handleChange}
+        options={yearOptions}
+        isSearchable={false}
+        isClearable={false}
+        isDisabled={isDisabled}
+        inputId={inputId}
+        className='Layer__YearPicker'
+        {...additionalAriaProps}
+      />
+    </VStack>
   )
 }


### PR DESCRIPTION
<img width="923" height="145" alt="image" src="https://github.com/user-attachments/assets/c04cfb1b-498b-4a98-a128-fe3e8a32db60" />
No label for the year picker! Secondarily causes misaligned inputs, but I do believe that's downstream of the missing label.