### PR TITLE
fix: keep the storybook date mock instanceof-compatible so date query params serialize

### DIFF
--- a/.storybook/mocks/systemDate.ts
+++ b/.storybook/mocks/systemDate.ts
@@ -5,19 +5,18 @@ const RealDate = Date
 // Clock ticks normally, but "now" is shifted to the last day of the fixture year.
 const offset = new RealDate(FIXTURE_YEAR, 11, 31, 12, 0, 0).getTime() - RealDate.now()
 
-class MockedDate extends RealDate {
-  constructor(...args: unknown[]) {
-    if (args.length === 0) {
-      super(RealDate.now() + offset)
-    }
-    else {
-      super(...args as ConstructorParameters<DateConstructor>)
-    }
-  }
+// A Proxy rather than a subclass, so instances stay real Dates: with a subclass,
+// `value instanceof Date` is false for dates built before this module ran (e.g. the
+// fixture range constants), and query-param serialization silently falls back to
+// `String(date)` instead of an ISO date.
+globalThis.Date = new Proxy(RealDate, {
+  construct: (target, args: ConstructorParameters<DateConstructor>) =>
+    args.length === 0 ? new target(RealDate.now() + offset) : new target(...args),
+  apply: () => new RealDate(RealDate.now() + offset).toString(),
+  get: (target, property, receiver) => {
+    if (property === 'now') return () => RealDate.now() + offset
 
-  static now() {
-    return RealDate.now() + offset
-  }
-}
-
-globalThis.Date = MockedDate as DateConstructor
+    const value: unknown = Reflect.get(target, property, receiver)
+    return value
+  },
+})


### PR DESCRIPTION
## Scope

The Time Tracking story rendered error states — "Failed to load time tracking summary" and "We couldn't load your time entries" — because date query params were serialized as `Date.prototype.toString()` output instead of ISO dates:

```
GET .../time-entries?start_date=Wed+Jan+01+2025+00%3A00%3A00+GMT-0800+(Pacific+Standard+Time)&end_date=2025-12-31
```

The mock endpoint's `matchesOnOrAfter` filter rejected that with `Invalid ISO 8601 date string`, msw turned the thrown error into a 500, and the view fell into its error states.

Root cause is in `.storybook/mocks/systemDate.ts`, not in the time tracking fixtures. It replaced `globalThis.Date` with a **subclass**, so any Date constructed before that module ran fails `value instanceof Date` (where `Date` is now the subclass) — and `toDefinedSearchParameters` uses exactly that check to decide between ISO formatting and `String(value)`. `FIXTURE_YEAR_RANGE` is always such a value, since `systemDate.ts` itself imports `fixtureYear.ts`. `end_date` escaped the bug only because the date store re-derives it through date-fns (`endOfDay`), producing a post-swap Date.

The mock is now a `Proxy` over the real `Date` rather than a subclass, so instances stay real Dates and `instanceof` holds in both directions, while `new Date()`, `Date.now()`, and `Date()` still return the shifted fixture-year clock.

This affected every story that passes the fixture range constants into API params — Time Tracking was just where it surfaced, because that mock endpoint validates its date params strictly.

## Verification

- Drove the story in Chromium against `storybook dev`: no 500s, no unhandled msw exceptions, stats and all three pages of entries render. The date preset also now correctly reads "This Year" rather than "Last Year".
- Re-probed 7 other date-driven view stories (Invoices, General Ledger, Mileage Tracking, Tax Estimates, Accounting/Solopreneur overviews, Bank Transactions with linked accounts) — no console or HTTP errors.
- `tsc --noEmit`, eslint, and the `DateStore` / `toDefinedSearchParameters` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storybook-only test harness change with no production runtime impact; behavior is intentionally aligned with real Date instanceof semantics.
> 
> **Overview**
> Replaces the Storybook **fixture-year clock** in `.storybook/mocks/systemDate.ts` from a `Date` **subclass** to a **`Proxy` around the real `Date`**, so `new Date()`, `Date.now()`, and `Date()` still use the shifted “now” while constructed values remain native `Date` instances.
> 
> That fixes **`instanceof Date`** for dates created before the mock loads (e.g. fixture range constants): `toDefinedSearchParameters` was falling back to **`String(date)`** instead of ISO, which broke MSW handlers that expect ISO 8601 and surfaced as failed loads in stories such as Time Tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e443df6d405263010807a4267ece386833611c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->