### PR TITLE
chore: bring the remaining docs images under the screenshot pipeline

### DIFF
--- a/scripts/capture-docs-screenshots.ts
+++ b/scripts/capture-docs-screenshots.ts
@@ -37,7 +37,7 @@ async function main() {
   const browser = await chromium.launch()
   const failures: string[] = []
 
-  async function capture({ storyId, out: file, viewport, interactAt, maxHeight }: DocsScreenshot) {
+  async function capture({ storyId, out: file, viewport, interactAt, maxHeight, captureViewport }: DocsScreenshot) {
     const context = await browser.newContext({
       viewport: { width: DOCS_SCREENSHOT_WIDTHS[interactAt ?? viewport], height: 900 },
       deviceScaleFactor: 2,
@@ -85,7 +85,10 @@ async function main() {
       const box = maxHeight ? await root.boundingBox() : null
       const clipped = maxHeight !== undefined && box !== null && box.height > maxHeight
 
-      if (clipped) {
+      if (captureViewport) {
+        await page.screenshot({ path: target, animations: 'disabled' })
+      }
+      else if (clipped) {
         // `clip` is page-relative and only covers the viewport unless the whole page is captured.
         await page.screenshot({
           path: target,
@@ -98,7 +101,9 @@ async function main() {
         await root.screenshot({ path: target, animations: 'disabled' })
       }
 
-      const size = clipped ? `clipped ${Math.round(box.height)}px -> ${maxHeight}px` : `${interactAt ? `${interactAt} -> ` : ''}${viewport}`
+      const size = clipped
+        ? `clipped ${Math.round(box.height)}px -> ${maxHeight}px`
+        : `${interactAt ? `${interactAt} -> ` : ''}${viewport}${captureViewport ? ' viewport' : ''}`
       console.info(`  ${file}  <-  ${storyId} (${size})`)
     }
     finally {

--- a/scripts/docs-screenshots.manifest.ts
+++ b/scripts/docs-screenshots.manifest.ts
@@ -31,6 +31,11 @@ export type DocsScreenshot = {
   interactAt?: DocsScreenshotViewport
   /** Clips the capture to this many CSS pixels. Omit to capture the component's full height. */
   maxHeight?: number
+  /**
+   * Shoots the viewport instead of `#storybook-root`. Dialogs portal to `document.body`, so a
+   * root-scoped capture of a modal story is the page with the overlay missing.
+   */
+  captureViewport?: boolean
   /** The .mdx page that renders this image. Reported in the PR body; never edited. */
   page: string
 }
@@ -200,6 +205,32 @@ export const DOCS_SCREENSHOTS: ReadonlyArray<DocsScreenshot> = [
     out: 'pages/unified-reports-mobile.png',
     viewport: 'mobile',
     page: 'embedded-components/pages/unified-reports.mdx',
+  },
+  {
+    storyId: 'views-overview-solopreneur--default',
+    out: 'pages/solopreneur-overview.png',
+    viewport: 'desktop',
+    page: 'embedded-components/pages/solopreneur-overview.mdx',
+  },
+  {
+    storyId: 'views-taxestimates--docs-payments',
+    out: 'pages/tax-estimates-payments.png',
+    viewport: 'desktop',
+    page: 'embedded-components/pages/tax-estimates.mdx',
+  },
+  {
+    storyId: 'components-banktransactions--docs-rule-suggestion-prompt',
+    out: 'guides/categorization-rule-suggestion-prompt.png',
+    viewport: 'desktop',
+    captureViewport: true,
+    page: 'guides/transaction-categorization/rules-suggestion.mdx',
+  },
+  {
+    storyId: 'components-banktransactions--docs-rule-suggestion-preview',
+    out: 'guides/categorization-rule-suggestion-preview.png',
+    viewport: 'desktop',
+    captureViewport: true,
+    page: 'guides/transaction-categorization/rules-suggestion.mdx',
   },
   {
     storyId: 'views-timetracking--default',

--- a/scripts/docs-screenshots.manifest.ts
+++ b/scripts/docs-screenshots.manifest.ts
@@ -154,6 +154,7 @@ export const DOCS_SCREENSHOTS: ReadonlyArray<DocsScreenshot> = [
     storyId: 'views-mileagetracking--default',
     out: 'pages/mileage-tracking.png',
     viewport: 'desktop',
+    maxHeight: DOCS_SCREENSHOT_TABLE_HEIGHT,
     page: 'embedded-components/pages/mileage-tracking.mdx',
   },
   {
@@ -193,5 +194,18 @@ export const DOCS_SCREENSHOTS: ReadonlyArray<DocsScreenshot> = [
     out: 'pages/unified-reports.png',
     viewport: 'desktop',
     page: 'embedded-components/pages/unified-reports.mdx',
+  },
+  {
+    storyId: 'components-unifiedreports--default',
+    out: 'pages/unified-reports-mobile.png',
+    viewport: 'mobile',
+    page: 'embedded-components/pages/unified-reports.mdx',
+  },
+  {
+    storyId: 'views-timetracking--default',
+    out: 'pages/time-tracking.png',
+    viewport: 'desktop',
+    maxHeight: DOCS_SCREENSHOT_TABLE_HEIGHT,
+    page: 'embedded-components/pages/time-tracking.mdx',
   },
 ]

--- a/scripts/docs-screenshots.manifest.ts
+++ b/scripts/docs-screenshots.manifest.ts
@@ -207,6 +207,16 @@ export const DOCS_SCREENSHOTS: ReadonlyArray<DocsScreenshot> = [
     page: 'embedded-components/pages/unified-reports.mdx',
   },
   {
+    storyId: 'components-journal--docs-in-app-link',
+    out: 'components/journal-in-app-link.png',
+    // The link replaces the source badge in the entry drawer, which is a few pixels of a desktop
+    // page. Mobile stacks the drawer over the full width, so the top of the shot is the link.
+    viewport: 'mobile',
+    // Ends on the transaction source section boundary; the sections below it are not the point.
+    maxHeight: 292,
+    page: 'embedded-components/linking.mdx',
+  },
+  {
     storyId: 'views-overview-solopreneur--default',
     out: 'pages/solopreneur-overview.png',
     viewport: 'desktop',

--- a/scripts/docs-screenshots.manifest.ts
+++ b/scripts/docs-screenshots.manifest.ts
@@ -33,7 +33,7 @@ export type DocsScreenshot = {
   maxHeight?: number
   /**
    * Shoots the viewport instead of `#storybook-root`. Dialogs portal to `document.body`, so a
-   * root-scoped capture of a modal story is the page with the overlay missing.
+   * root-scoped capture of a modal story comes back with the overlay missing.
    */
   captureViewport?: boolean
   /** The .mdx page that renders this image. Reported in the PR body; never edited. */
@@ -209,10 +209,9 @@ export const DOCS_SCREENSHOTS: ReadonlyArray<DocsScreenshot> = [
   {
     storyId: 'components-journal--docs-in-app-link',
     out: 'components/journal-in-app-link.png',
-    // The link replaces the source badge in the entry drawer, which is a few pixels of a desktop
-    // page. Mobile stacks the drawer over the full width, so the top of the shot is the link.
+    // The link is a few pixels of a desktop page; mobile stacks the drawer over the full width.
     viewport: 'mobile',
-    // Ends on the transaction source section boundary; the sections below it are not the point.
+    // Lands on the transaction source section boundary.
     maxHeight: 292,
     page: 'embedded-components/linking.mdx',
   },

--- a/src/components/features/bankTransactions/BankTransactions/BankTransactions.stories.tsx
+++ b/src/components/features/bankTransactions/BankTransactions/BankTransactions.stories.tsx
@@ -1,13 +1,15 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
-import { userEvent, within } from 'storybook/test'
+import { screen, userEvent, within } from 'storybook/test'
 
 import { BookkeepingStatus } from '@schemas/bookkeeping/bookkeepingStatus'
 import { BankTransactions } from '@features/bankTransactions/BankTransactions/BankTransactions'
 import { type BankTransactionsStringOverrides } from '@features/bankTransactions/types'
 
+import { put as putCategorizeBankTransaction } from '@msw/api/businesses/[business-id]/bank-transactions/[bank-transaction-id]/categorize/put'
 import { get as getBookkeepingStatus } from '@msw/api/businesses/[business-id]/bookkeeping/status/get'
 import { handlers } from '@msw/handlers'
 import { makeBookkeepingStatus } from '@fixtures/bookkeeping/mocks'
+import { makeCategorizationRuleSuggestion } from '@fixtures/categorizationRules/mocks'
 import { bankTransactions } from '@fixtures/generated/bankTransactions.gen'
 import {
   type BankTransactionsStoryArgs as SharedBankTransactionsArgs,
@@ -236,5 +238,41 @@ export const DocsCategorization: Story = {
     const toggle = within(row).getByRole('button', { name: 'Toggle details' })
     await userEvent.click(toggle)
     await canvas.findByLabelText('Categorize or match transaction')
+  },
+}
+
+// The rule suggestion rides back on the categorize response, so confirming any row raises it.
+const suggestRuleAfterCategorizing = putCategorizeBankTransaction.mock({
+  ...bankTransactions[0],
+  updateCategorizationRulesSuggestion: makeCategorizationRuleSuggestion(),
+})
+
+async function confirmFirstCategorizableRow(canvasElement: HTMLElement): Promise<void> {
+  const canvas = within(canvasElement)
+  const rows = await findEntryRows(canvas)
+  const row = rows.find(candidate =>
+    CATEGORIZABLE_DESCRIPTIONS.some(description => candidate.textContent?.includes(description)),
+  )
+  if (!row) throw new Error('no categorizable transaction row is on the first page')
+
+  await userEvent.click(within(row).getByRole('button', { name: 'Confirm' }))
+  // The dialog portals out of the canvas, so query the whole document.
+  await screen.findByText('Always use this category?', undefined, { timeout: 10_000 })
+}
+
+export const DocsRuleSuggestionPrompt: Story = {
+  tags: ['!public-api', 'docs-screenshot'],
+  parameters: { msw: { handlers: [suggestRuleAfterCategorizing, ...handlers] } },
+  play: ({ canvasElement }) => confirmFirstCategorizableRow(canvasElement),
+}
+
+export const DocsRuleSuggestionPreview: Story = {
+  tags: ['!public-api', 'docs-screenshot'],
+  parameters: { msw: { handlers: [suggestRuleAfterCategorizing, ...handlers] } },
+  play: async ({ canvasElement }) => {
+    await confirmFirstCategorizableRow(canvasElement)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Yes, always categorize' }))
+    await screen.findByText(/transactions will be affected/)
   },
 }

--- a/src/components/features/bankTransactions/BankTransactions/BankTransactions.stories.tsx
+++ b/src/components/features/bankTransactions/BankTransactions/BankTransactions.stories.tsx
@@ -272,7 +272,7 @@ export const DocsRuleSuggestionPreview: Story = {
   play: async ({ canvasElement }) => {
     await confirmFirstCategorizableRow(canvasElement)
 
-    await userEvent.click(screen.getByRole('button', { name: 'Yes, always categorize' }))
+    await userEvent.click(await screen.findByRole('button', { name: 'Yes, always categorize' }))
     await screen.findByText(/transactions will be affected/)
   },
 }

--- a/src/components/features/generalLedger/Journal/Journal.stories.tsx
+++ b/src/components/features/generalLedger/Journal/Journal.stories.tsx
@@ -111,7 +111,7 @@ export const DocsInAppLink: Story = {
         <a
           href='https://layerfi.com'
           target='_blank'
-          rel='noreferrer'
+          rel='noopener noreferrer'
           style={{ color: '#007bff', textDecoration: 'none', fontWeight: 500 }}
         >
           {entityName}

--- a/src/components/features/generalLedger/Journal/Journal.stories.tsx
+++ b/src/components/features/generalLedger/Journal/Journal.stories.tsx
@@ -102,3 +102,33 @@ export const DrawerOpen: Story = {
     await canvas.findByText(/Journal Entry #/, undefined, { timeout: 10_000 })
   },
 }
+
+// Matches the anchor the in-app linking docs page renders in its `renderInAppLink` example,
+// rather than the Badge the interactive control uses.
+export const DocsInAppLink: Story = {
+  tags: ['!public-api', 'docs-screenshot'],
+  render: () => (
+    <Journal
+      renderInAppLink={({ entityName }) => (
+        <a
+          href='https://layerfi.com'
+          target='_blank'
+          rel='noreferrer'
+          style={{ color: '#007bff', textDecoration: 'none', fontWeight: 500 }}
+        >
+          {entityName}
+        </a>
+      )}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const rows = await findEntryRows(canvas)
+    // Only a sourced entry renders the link; an invoice payment matches the documented example.
+    const entry = rows.find(row => row.textContent?.includes('Invoice payment'))
+    if (!entry) throw new Error('no invoice payment entry is on the first page')
+
+    await userEvent.click(entry)
+    await canvas.findByText(/Journal Entry #/, undefined, { timeout: 10_000 })
+  },
+}

--- a/src/components/features/generalLedger/Journal/Journal.stories.tsx
+++ b/src/components/features/generalLedger/Journal/Journal.stories.tsx
@@ -103,8 +103,6 @@ export const DrawerOpen: Story = {
   },
 }
 
-// Matches the anchor the in-app linking docs page renders in its `renderInAppLink` example,
-// rather than the Badge the interactive control uses.
 export const DocsInAppLink: Story = {
   tags: ['!public-api', 'docs-screenshot'],
   render: () => (
@@ -124,7 +122,6 @@ export const DocsInAppLink: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const rows = await findEntryRows(canvas)
-    // Only a sourced entry renders the link; an invoice payment matches the documented example.
     const entry = rows.find(row => row.textContent?.includes('Invoice payment'))
     if (!entry) throw new Error('no invoice payment entry is on the first page')
 

--- a/src/fixtures/categorizationRules/mocks.ts
+++ b/src/fixtures/categorizationRules/mocks.ts
@@ -1,5 +1,7 @@
+import { BankTransactionDirection } from '@schemas/bankTransactions/base'
 import { type CategorizationRule } from '@schemas/categorization/categorizationRule'
 import { BankDirectionFilter } from '@schemas/categorization/categorizationRuleFilters'
+import { type UpdateCategorizationRulesSuggestion } from '@schemas/categorization/createCategorizationRule'
 import { makeStableName } from '@schemas/common/accountIdentifier'
 
 import { makeBusiness } from '@fixtures/business/mocks'
@@ -67,3 +69,55 @@ export const categorizationRules = {
     updatedAt: new Date(Date.UTC(FIXTURE_YEAR, 3, 8, 12)),
   }),
 }
+
+const AMAZON_COUNTERPARTY_ID = '00000000-0000-4000-8000-000000000411'
+
+const baseRuleSuggestion: UpdateCategorizationRulesSuggestion = {
+  type: 'Create_Categorization_Rule_For_Counterparty',
+  newRule: {
+    createdBySuggestionId: '00000000-0000-4000-8000-000000000501',
+    category: makeStableName('OFFICE_EXPENSES'),
+    counterpartyFilter: AMAZON_COUNTERPARTY_ID,
+    applyRetroactively: true,
+  },
+  counterparty: { id: AMAZON_COUNTERPARTY_ID, name: 'Amazon', mccs: [] },
+  suggestionPrompt:
+    'Would you like to create a rule to automatically categorize transactions from Amazon as '
+    + 'Office Expenses? You have categorized all 4 transactions from Amazon this way so far.',
+  transactionsThatWillBeAffected: [
+    {
+      id: '0000000f-0000-4000-8000-000000000601',
+      date: new Date(Date.UTC(FIXTURE_YEAR, 8, 2, 12)),
+      direction: BankTransactionDirection.Debit,
+      amount: 5580,
+      counterpartyName: 'Amazon',
+      description: 'AMAZON MKTPL*ZX81Q3',
+    },
+    {
+      id: '0000000f-0000-4000-8000-000000000602',
+      date: new Date(Date.UTC(FIXTURE_YEAR, 8, 17, 12)),
+      direction: BankTransactionDirection.Debit,
+      amount: 2640,
+      counterpartyName: 'Amazon',
+      description: 'AMAZON MKTPL*4KD02M',
+    },
+    {
+      id: '0000000f-0000-4000-8000-000000000603',
+      date: new Date(Date.UTC(FIXTURE_YEAR, 8, 26, 12)),
+      direction: BankTransactionDirection.Debit,
+      amount: 1680,
+      counterpartyName: 'Amazon',
+      description: 'AMAZON MKTPL*R71PQ9',
+    },
+    {
+      id: '0000000f-0000-4000-8000-000000000604',
+      date: new Date(Date.UTC(FIXTURE_YEAR, 9, 11, 12)),
+      direction: BankTransactionDirection.Debit,
+      amount: 3690,
+      counterpartyName: 'Amazon',
+      description: 'AMAZON MKTPL*88CV1T',
+    },
+  ],
+}
+
+export const { make: makeCategorizationRuleSuggestion } = createFixtureFactory(baseRuleSuggestion)

--- a/src/views/SolopreneurOverview/SolopreneurOverview.stories.tsx
+++ b/src/views/SolopreneurOverview/SolopreneurOverview.stories.tsx
@@ -59,4 +59,6 @@ export default meta
 
 type Story = StoryObj<SolopreneurOverviewStoryArgs>
 
-export const Default: Story = {}
+export const Default: Story = {
+  tags: ['docs-screenshot'],
+}

--- a/src/views/TaxEstimates/TaxEstimates.stories.tsx
+++ b/src/views/TaxEstimates/TaxEstimates.stories.tsx
@@ -1,4 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
+import { userEvent, within } from 'storybook/test'
 
 import { TaxEstimates } from '@views/TaxEstimates/TaxEstimates'
 
@@ -38,6 +39,21 @@ export const DocsDefault: Story = {
   tags: ['!public-api', 'docs-screenshot'],
   parameters: {
     msw: { handlers: [enableTaxEstimates, noUncategorizedTransactions, ...handlers] },
+  },
+}
+
+export const DocsPayments: Story = {
+  tags: ['!public-api', 'docs-screenshot'],
+  parameters: {
+    msw: { handlers: [enableTaxEstimates, noUncategorizedTransactions, ...handlers] },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const payments = await canvas.findByRole('radio', { name: 'Payments' })
+    await userEvent.click(payments)
+    await canvas.findByLabelText('Tax Payments')
+    // The click leaves a focus ring on the toggle, which reads as a selection state in the shot.
+    payments.blur()
   },
 }
 

--- a/src/views/TimeTracking.stories.tsx
+++ b/src/views/TimeTracking.stories.tsx
@@ -75,4 +75,6 @@ export default meta
 
 type Story = StoryObj<TimeTrackingStoryArgs>
 
-export const Default: Story = {}
+export const Default: Story = {
+  tags: ['docs-screenshot'],
+}


### PR DESCRIPTION
Brings the last hand-managed images in `Layer-Fi/api-documentation` under the screenshot pipeline, and tightens two captures that were running long.

## New manifest entries

| Story | Image | Notes |
| --- | --- | --- |
| `components-unifiedreports--default` | `pages/unified-reports-mobile.png` | Same story as the desktop shot, captured at mobile width |
| `views-timetracking--default` | `pages/time-tracking.png` | Clipped to the table height cap |
| `views-overview-solopreneur--default` | `pages/solopreneur-overview.png` | |
| `views-taxestimates--docs-payments` | `pages/tax-estimates-payments.png` | Play clicks the Payments toggle, then blurs it so the focus ring stays out of the shot |
| `components-banktransactions--docs-rule-suggestion-prompt` | `guides/categorization-rule-suggestion-prompt.png` | |
| `components-banktransactions--docs-rule-suggestion-preview` | `guides/categorization-rule-suggestion-preview.png` | |
| `components-journal--docs-in-app-link` | `components/journal-in-app-link.png` | Mobile, clipped to 292px |

Also clips `pages/mileage-tracking.png` to the table height cap — it was shooting 1777px.

## Manifest changes

`captureViewport` shoots the viewport instead of `#storybook-root`. The rule suggestion dialog portals to `document.body`, so a root-scoped capture of it is the transaction table with the modal missing.

`out` paths now also use a `guides/` folder alongside `components/` and `pages/`.

## Story notes

The two rule suggestion stories drive the real flow rather than rendering the dialog standalone: a new `makeCategorizationRuleSuggestion` fixture rides back on a mocked categorize response, the play confirms a row, and the modal opens over the transaction table — matching the images it replaces.

`DocsInAppLink` renders the blue anchor from the in-app linking docs page's own `renderInAppLink` example rather than the `Badge` the interactive control uses, and opens the drawer on an invoice-payment entry so the Source row is the documented link. Mobile framing means no cropping support was needed.

## Verification

- `npm run screenshots:check` — 31 entries, all resolve and carry the tag
- `npm run screenshots:capture` on every new and changed entry, each reviewed
- tsc and eslint clean

## Still hand-managed

- `embedded-components/components/{balance-sheet,cash-flow-statement,pnl-table}.mdx` and the P&L table image in `guides/reporting.mdx` — `BalanceSheet` and `StatementOfCashFlow` have no MSW handlers for their legacy report endpoints, so those need fixtures before they can be shot
- The BankTransactions match-link image in `embedded-components/linking.mdx` — lives in the suggested-match popover, a more involved interaction
- `pages/time-tracking.png` will be generated but nothing renders it yet; there is no `embedded-components/pages/time-tracking.mdx`

Docs side: Layer-Fi/api-documentation#364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Storybook stories, test fixtures, and the docs screenshot tooling with no production runtime impact.
> 
> **Overview**
> Extends the docs screenshot pipeline so more **api-documentation** images are generated from Storybook instead of hand-managed PNGs.
> 
> The capture script gains **`captureViewport`**, which screenshots the full viewport when modals portal outside `#storybook-root` (used for categorization rule-suggestion dialogs). **`docs-screenshots.manifest.ts`** adds entries for unified reports (mobile), time tracking, solopreneur overview, tax estimates payments, journal in-app linking, and rule-suggestion guide shots, and applies the existing table height cap to mileage tracking.
> 
> New or updated **`docs-screenshot`** stories drive real UI: Bank Transactions stories mock a categorize response with **`makeCategorizationRuleSuggestion`** and confirm a row to open the suggestion flow; Tax Estimates **`DocsPayments`** toggles Payments and blurs focus for a clean shot; Journal **`DocsInAppLink`** uses the documented blue anchor and opens the drawer on an invoice-payment row; Solopreneur Overview and Time Tracking defaults are tagged for capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d223fae173ec0be812e666d831940cdcfa37107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->