### PR TITLE
chore: shoot the tax profile onboarding form for the docs

### DIFF
--- a/scripts/docs-screenshots.manifest.ts
+++ b/scripts/docs-screenshots.manifest.ts
@@ -222,6 +222,12 @@ export const DOCS_SCREENSHOTS: ReadonlyArray<DocsScreenshot> = [
     page: 'embedded-components/pages/solopreneur-overview.mdx',
   },
   {
+    storyId: 'views-taxestimates--onboarding',
+    out: 'pages/tax-estimates-profile.png',
+    viewport: 'desktop',
+    page: 'embedded-components/pages/tax-estimates.mdx',
+  },
+  {
     storyId: 'views-taxestimates--docs-payments',
     out: 'pages/tax-estimates-payments.png',
     viewport: 'desktop',

--- a/src/views/TaxEstimates/TaxEstimates.stories.tsx
+++ b/src/views/TaxEstimates/TaxEstimates.stories.tsx
@@ -58,6 +58,7 @@ export const DocsPayments: Story = {
 }
 
 export const Onboarding: Story = {
+  tags: ['docs-screenshot'],
   parameters: {
     msw: {
       handlers: [


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of the PR and what it addresses. -->

## Changes
<!-- [Optional] List the main changes made in this PR. -->

## Blockers
<!-- [Optional] List any blockers or issues that need to be resolved before merging this PR. -->

## How this has been tested?
<!-- Describe how this PR has been tested. You can provide commands to run, videos, screenshots, etc. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs screenshot manifest and Storybook tag only; no production UI or API behavior changes.
> 
> **Overview**
> Adds automated docs imagery for the **tax profile onboarding** state on the Tax Estimates embedded page.
> 
> The existing `Onboarding` Storybook story is tagged with `docs-screenshot`, and `scripts/docs-screenshots.manifest.ts` maps `views-taxestimates--onboarding` to `pages/tax-estimates-profile.png` for `embedded-components/pages/tax-estimates.mdx`. The story already mocks an unsaved tax profile (`userHasSavedTaxProfile: false`, `usConfiguration: null`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 966698f51b55709064c023a0d626ac38e47f135c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->