### PR TITLE
chore: shoot the tax profile onboarding form for the docs

### DIFF
--- a/scripts/docs-screenshots.manifest.ts
+++ b/scripts/docs-screenshots.manifest.ts
@@ -222,6 +222,12 @@ export const DOCS_SCREENSHOTS: ReadonlyArray<DocsScreenshot> = [
     page: 'embedded-components/pages/solopreneur-overview.mdx',
   },
   {
+    storyId: 'views-taxestimates--onboarding',
+    out: 'pages/tax-estimates-profile.png',
+    viewport: 'desktop',
+    page: 'embedded-components/pages/tax-estimates.mdx',
+  },
+  {
     storyId: 'views-taxestimates--docs-payments',
     out: 'pages/tax-estimates-payments.png',
     viewport: 'desktop',

--- a/src/views/TaxEstimates/TaxEstimates.stories.tsx
+++ b/src/views/TaxEstimates/TaxEstimates.stories.tsx
@@ -58,6 +58,7 @@ export const DocsPayments: Story = {
 }
 
 export const Onboarding: Story = {
+  tags: ['docs-screenshot'],
   parameters: {
     msw: {
       handlers: [


### PR DESCRIPTION
Follow-on to #1677.

`tax-estimates.mdx` documents the tax profile onboarding form for first-time users but has no image of it. `views-taxestimates--onboarding` already renders exactly that state — it mocks `userHasSavedTaxProfile: false` — so this tags the existing story and adds a manifest entry rather than writing a new one.

| Story | Image |
| --- | --- |
| `views-taxestimates--onboarding` | `pages/tax-estimates-profile.png` |

No height cap; the form is 1078px and fits without clipping.

## Verification

- `npm run screenshots:check` — 32 entries, all resolve and carry the tag
- Captured and reviewed
- tsc clean

## Note

Shooting the form turned up a docs bug, fixed on the api-documentation side rather than here: `tax-estimates.mdx` currently claims the profile collects dependents, standard-vs-itemized deductions, non-business income, and additional estimated payments. The form actually collects federal filing status, W-2 / tip / overtime income, custom withholding, US state and state filing status, and the two deduction toggles (simplified home office, standard mileage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only Storybook tagging and manifest wiring; no runtime product or API behavior changes.
> 
> **Overview**
> Adds automated documentation imagery for the **first-time tax profile onboarding** state on `tax-estimates.mdx` by wiring the existing `Onboarding` Storybook story into the docs screenshot pipeline.
> 
> The `Onboarding` story is tagged with `docs-screenshot`, and `scripts/docs-screenshots.manifest.ts` gains an entry for `views-taxestimates--onboarding` → `pages/tax-estimates-profile.png` (desktop, no `maxHeight` cap). No new story or UI logic—only inclusion in the manifest/check flow used by `screenshots:check` and capture scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 966698f51b55709064c023a0d626ac38e47f135c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->