### PR TITLE
feat(stories): docs stories for the active timer, entry creation, services, and the reports mega menu

### DIFF
--- a/scripts/capture-docs-screenshots.ts
+++ b/scripts/capture-docs-screenshots.ts
@@ -86,7 +86,14 @@ async function main() {
       const clipped = maxHeight !== undefined && box !== null && box.height > maxHeight
 
       if (captureViewport) {
-        await page.screenshot({ path: target, animations: 'disabled' })
+        // A viewport shot starts at the top of the page, so `maxHeight` just trims the bottom.
+        await page.screenshot({
+          path: target,
+          animations: 'disabled',
+          ...(maxHeight === undefined
+            ? {}
+            : { clip: { x: 0, y: 0, width: DOCS_SCREENSHOT_WIDTHS[viewport], height: maxHeight } }),
+        })
       }
       else if (clipped) {
         // `clip` is page-relative and only covers the viewport unless the whole page is captured.
@@ -101,8 +108,8 @@ async function main() {
         await root.screenshot({ path: target, animations: 'disabled' })
       }
 
-      const size = clipped
-        ? `clipped ${Math.round(box.height)}px -> ${maxHeight}px`
+      const size = clipped || (captureViewport && maxHeight !== undefined)
+        ? `clipped ${box === null ? '' : `${Math.round(box.height)}px `}-> ${maxHeight}px`
         : `${interactAt ? `${interactAt} -> ` : ''}${viewport}${captureViewport ? ' viewport' : ''}`
       console.info(`  ${file}  <-  ${storyId} (${size})`)
     }

--- a/scripts/docs-screenshots.manifest.ts
+++ b/scripts/docs-screenshots.manifest.ts
@@ -254,4 +254,32 @@ export const DOCS_SCREENSHOTS: ReadonlyArray<DocsScreenshot> = [
     maxHeight: DOCS_SCREENSHOT_TABLE_HEIGHT,
     page: 'embedded-components/pages/time-tracking.mdx',
   },
+  {
+    storyId: 'views-timetracking--active-timer',
+    out: 'pages/time-tracking-active-timer.png',
+    viewport: 'desktop',
+    maxHeight: DOCS_SCREENSHOT_TABLE_HEIGHT,
+    page: 'embedded-components/pages/time-tracking.mdx',
+  },
+  {
+    storyId: 'views-timetracking--entry-creation',
+    out: 'pages/time-tracking-add-entry.png',
+    viewport: 'desktop',
+    captureViewport: true,
+    page: 'embedded-components/pages/time-tracking.mdx',
+  },
+  {
+    storyId: 'views-timetracking--services-drawer',
+    out: 'pages/time-tracking-services.png',
+    viewport: 'desktop',
+    captureViewport: true,
+    page: 'embedded-components/pages/time-tracking.mdx',
+  },
+  {
+    storyId: 'components-unifiedreports--mega-menu-open',
+    out: 'pages/unified-reports-mega-menu.png',
+    viewport: 'desktop',
+    captureViewport: true,
+    page: 'embedded-components/pages/unified-reports.mdx',
+  },
 ]

--- a/scripts/docs-screenshots.manifest.ts
+++ b/scripts/docs-screenshots.manifest.ts
@@ -258,12 +258,14 @@ export const DOCS_SCREENSHOTS: ReadonlyArray<DocsScreenshot> = [
     storyId: 'views-timetracking--active-timer',
     out: 'pages/time-tracking-active-timer.png',
     viewport: 'desktop',
-    maxHeight: DOCS_SCREENSHOT_TABLE_HEIGHT,
+    // The timer banner and the Overview card are the point; the entry table below repeats the
+    // page's own screenshot.
+    maxHeight: 460,
     page: 'embedded-components/pages/time-tracking.mdx',
   },
   {
-    storyId: 'views-timetracking--entry-creation',
-    out: 'pages/time-tracking-add-entry.png',
+    storyId: 'views-timetracking--entry-detail',
+    out: 'pages/time-tracking-entry.png',
     viewport: 'desktop',
     captureViewport: true,
     page: 'embedded-components/pages/time-tracking.mdx',
@@ -280,6 +282,7 @@ export const DOCS_SCREENSHOTS: ReadonlyArray<DocsScreenshot> = [
     out: 'pages/unified-reports-mega-menu.png',
     viewport: 'desktop',
     captureViewport: true,
+    maxHeight: 620,
     page: 'embedded-components/pages/unified-reports.mdx',
   },
 ]

--- a/src/components/blocks/Table/DataTable/DataTableHeaderMenu.tsx
+++ b/src/components/blocks/Table/DataTable/DataTableHeaderMenu.tsx
@@ -41,13 +41,15 @@ const DataTableHeaderMenuItemComponent = ({
 }
 
 export const DataTableHeaderMenu = ({ ariaLabel, items, isDisabled, isPending, slots }: DataTableHeaderMenuProps) => {
+  // The trigger is icon-only, so it needs the label itself — `DropdownMenu` only puts one on the
+  // dialog it opens.
   const Trigger = useCallback(() => {
     return (
-      <Button icon variant='outlined' isDisabled={isDisabled} isPending={isPending}>
+      <Button icon variant='outlined' isDisabled={isDisabled} isPending={isPending} aria-label={ariaLabel}>
         {slots?.Icon ? <slots.Icon /> : <MenuIcon size={14} />}
       </Button>
     )
-  }, [isDisabled, isPending, slots])
+  }, [ariaLabel, isDisabled, isPending, slots])
 
   return (
     <DropdownMenu

--- a/src/components/features/unifiedReports/UnifiedReports/UnifiedReports.stories.tsx
+++ b/src/components/features/unifiedReports/UnifiedReports/UnifiedReports.stories.tsx
@@ -58,7 +58,10 @@ export const MegaMenuOpen: Story = {
   parameters: { chromatic: { viewports: [1280] } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
+    // The mega menu renders in a popover portaled to the body, outside the canvas.
+    const overlay = within(canvasElement.ownerDocument.body)
+
     await userEvent.click(await canvas.findByRole('button', { name: /Switch report/ }))
-    await canvas.findByText('Cash Flow Statement', undefined, { timeout: 10_000 })
+    await overlay.findByText('Cash Flow Statement', undefined, { timeout: 10_000 })
   },
 }

--- a/src/components/features/unifiedReports/UnifiedReports/UnifiedReports.stories.tsx
+++ b/src/components/features/unifiedReports/UnifiedReports/UnifiedReports.stories.tsx
@@ -1,4 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
+import { userEvent, within } from 'storybook/test'
 
 import { type DateSelectionMode } from '@utils/shared/date/dateRange'
 import { type UnifiedReportNavigationVariant, UnifiedReports } from '@features/unifiedReports/UnifiedReports/UnifiedReports'
@@ -49,4 +50,15 @@ export const Default: Story = {
 
 export const MenuNavigation: Story = {
   args: { navigationVariant: 'menu' },
+}
+
+export const MegaMenuOpen: Story = {
+  args: { navigationVariant: 'menu' },
+  tags: ['docs-screenshot'],
+  parameters: { chromatic: { viewports: [1280] } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(await canvas.findByRole('button', { name: /Switch report/ }))
+    await canvas.findByText('Cash Flow Statement', undefined, { timeout: 10_000 })
+  },
 }

--- a/src/fixtures/generated/timeEntries.gen.ts
+++ b/src/fixtures/generated/timeEntries.gen.ts
@@ -11,7 +11,7 @@ export const timeEntries = [
     "durationMinutes": 300,
     "billable": true,
     "description": "Requirements gathering",
-    "memo": null,
+    "memo": "Awaiting client approval",
     "metadata": null,
     "customer": {
       "id": "00000003-d6fb-4ef5-8c75-46e387b4abad",
@@ -45,7 +45,7 @@ export const timeEntries = [
     "durationMinutes": 120,
     "billable": false,
     "description": "Draft revisions",
-    "memo": null,
+    "memo": "Pro bono - do not invoice",
     "metadata": null,
     "customer": {
       "id": "00000003-ce47-433a-8943-a740f2732a3f",
@@ -79,7 +79,7 @@ export const timeEntries = [
     "durationMinutes": 240,
     "billable": true,
     "description": null,
-    "memo": null,
+    "memo": "Billed at standard rate",
     "metadata": null,
     "customer": {
       "id": "00000003-045f-4a99-834f-2248873864e4",
@@ -113,19 +113,19 @@ export const timeEntries = [
     "durationMinutes": 480,
     "billable": true,
     "description": "Quarterly review",
-    "memo": "Billed at standard rate",
+    "memo": "Rush turnaround",
     "metadata": null,
     "customer": null,
     "service": {
-      "id": "00000007-e14c-4f0d-8f51-ecbd67728f21",
-      "name": "Marketing Strategy",
-      "billableRatePerHourAmount": 11500
+      "id": "00000007-d6fb-4ef5-8c75-46e387b4abad",
+      "name": "Interior Design",
+      "billableRatePerHourAmount": 20500
     },
     "invoiceLineItem": null,
     "status": "RECORDED",
     "stoppedAt": null,
-    "createdAt": new Date("2021-06-09T07:19:22.722Z"),
-    "updatedAt": new Date("2024-08-09T07:39:25.626Z"),
+    "createdAt": new Date("2021-11-02T09:41:52.831Z"),
+    "updatedAt": new Date("2024-06-19T00:56:41.832Z"),
     "deletedAt": null
   },
   {
@@ -136,31 +136,20 @@ export const timeEntries = [
     "durationMinutes": 180,
     "billable": false,
     "description": "Documentation",
-    "memo": "Covered under retainer",
+    "memo": "Overtime approved",
     "metadata": null,
-    "customer": {
-      "id": "00000003-ce47-433a-8943-a740f2732a3f",
-      "externalId": null,
-      "individualName": "Amara Okafor",
-      "companyName": null,
-      "email": "amara.okafor@example.com",
-      "mobilePhone": null,
-      "officePhone": "+13985550197",
-      "addressString": "900 Biscayne Blvd, Miami, FL 33132",
-      "status": "ARCHIVED",
-      "memo": null
-    },
+    "customer": null,
     "service": {
-      "id": "00000007-d6fb-4ef5-8c75-46e387b4abad",
-      "name": "Interior Design",
-      "billableRatePerHourAmount": 20500
+      "id": "00000007-f63f-4fcb-858d-1a35ff5a6aa5",
+      "name": "Copywriting",
+      "billableRatePerHourAmount": 16000
     },
     "invoiceLineItem": null,
+    "status": "RECORDED",
     "stoppedAt": null,
     "createdAt": new Date("2020-01-01T00:00:00.012Z"),
     "updatedAt": new Date("2025-04-27T04:26:16.782Z"),
-    "deletedAt": null,
-    "status": "RECORDED"
+    "deletedAt": null
   },
   {
     "id": "00000008-aa4b-48e6-8d84-cbf2c5b7a0aa",
@@ -170,24 +159,24 @@ export const timeEntries = [
     "durationMinutes": 45,
     "billable": true,
     "description": "Final delivery",
-    "memo": "Split across two projects",
+    "memo": "Overtime approved",
     "metadata": null,
     "customer": {
-      "id": "00000003-e14c-4f0d-8f51-ecbd67728f21",
+      "id": "00000003-0351-4cfd-860c-32b0b4ffc791",
       "externalId": null,
-      "individualName": null,
-      "companyName": "Wayne Enterprises",
-      "email": "contact@wayneenterprises.test",
+      "individualName": "Maria Garcia",
+      "companyName": null,
+      "email": "maria.garcia@example.com",
       "mobilePhone": null,
-      "officePhone": "+19945550199",
-      "addressString": "456 Market St, San Francisco, CA 94105",
+      "officePhone": null,
+      "addressString": "900 Biscayne Blvd, Miami, FL 33132",
       "status": "ARCHIVED",
-      "memo": null
+      "memo": "VIP client"
     },
     "service": {
-      "id": "00000007-e14c-4f0d-8f51-ecbd67728f21",
-      "name": "Marketing Strategy",
-      "billableRatePerHourAmount": 11500
+      "id": "00000007-d6fb-4ef5-8c75-46e387b4abad",
+      "name": "Interior Design",
+      "billableRatePerHourAmount": 20500
     },
     "invoiceLineItem": null,
     "status": "RECORDED",
@@ -204,7 +193,7 @@ export const timeEntries = [
     "durationMinutes": 30,
     "billable": true,
     "description": "Vendor coordination",
-    "memo": null,
+    "memo": "Awaiting client approval",
     "metadata": null,
     "customer": {
       "id": "00000003-79b1-4082-8d65-0f0692a459cf",
@@ -238,7 +227,7 @@ export const timeEntries = [
     "durationMinutes": 30,
     "billable": false,
     "description": "Requirements gathering",
-    "memo": null,
+    "memo": "Pro bono - do not invoice",
     "metadata": null,
     "customer": {
       "id": "00000003-4b46-4097-85f0-896231804c64",
@@ -272,31 +261,20 @@ export const timeEntries = [
     "durationMinutes": 30,
     "billable": false,
     "description": null,
-    "memo": "Covered under retainer",
+    "memo": "Rush turnaround",
     "metadata": null,
-    "customer": {
-      "id": "00000003-d6fb-4ef5-8c75-46e387b4abad",
-      "externalId": null,
-      "individualName": null,
-      "companyName": "Oscorp Industries",
-      "email": "contact@oscorpindustries.test",
-      "mobilePhone": null,
-      "officePhone": "+12095550198",
-      "addressString": "789 Broadway, New York, NY 10003",
-      "status": "ARCHIVED",
-      "memo": null
-    },
+    "customer": null,
     "service": {
-      "id": "00000007-045f-4a99-834f-2248873864e4",
-      "name": "Software Architecture",
-      "billableRatePerHourAmount": 10500
+      "id": "00000007-a0b6-452b-8812-70c20a3e49d9",
+      "name": "Project Management",
+      "billableRatePerHourAmount": 5000
     },
     "invoiceLineItem": null,
+    "status": "RECORDED",
     "stoppedAt": null,
     "createdAt": new Date("2020-01-01T00:00:00.031Z"),
     "updatedAt": new Date("2021-09-14T20:57:44.463Z"),
-    "deletedAt": null,
-    "status": "RECORDED"
+    "deletedAt": null
   },
   {
     "id": "00000008-9970-4ba4-8acd-f124d2458911",
@@ -306,7 +284,7 @@ export const timeEntries = [
     "durationMinutes": 120,
     "billable": true,
     "description": "Kickoff meeting",
-    "memo": null,
+    "memo": "Billed at standard rate",
     "metadata": null,
     "customer": null,
     "service": {
@@ -329,9 +307,20 @@ export const timeEntries = [
     "durationMinutes": 30,
     "billable": true,
     "description": "Stakeholder interview",
-    "memo": "Includes travel time",
+    "memo": "Rush turnaround",
     "metadata": null,
-    "customer": null,
+    "customer": {
+      "id": "00000003-f72d-4c33-8fd1-91b8a18ae284",
+      "externalId": null,
+      "individualName": null,
+      "companyName": "Acme Corp",
+      "email": "contact@acmecorp.test",
+      "mobilePhone": "+13365550103",
+      "officePhone": null,
+      "addressString": "55 Boylston St, Boston, MA 02116",
+      "status": "ACTIVE",
+      "memo": null
+    },
     "service": {
       "id": "00000007-e14c-4f0d-8f51-ecbd67728f21",
       "name": "Marketing Strategy",
@@ -352,7 +341,7 @@ export const timeEntries = [
     "durationMinutes": 480,
     "billable": true,
     "description": "Vendor coordination",
-    "memo": null,
+    "memo": "Includes travel time",
     "metadata": null,
     "customer": {
       "id": "00000003-045f-4a99-834f-2248873864e4",
@@ -386,7 +375,7 @@ export const timeEntries = [
     "durationMinutes": 120,
     "billable": true,
     "description": "Invoicing and wrap-up",
-    "memo": null,
+    "memo": "Includes travel time",
     "metadata": null,
     "customer": {
       "id": "00000003-f72d-4c33-8fd1-91b8a18ae284",
@@ -420,31 +409,31 @@ export const timeEntries = [
     "durationMinutes": 480,
     "billable": true,
     "description": "Final delivery",
-    "memo": "Includes travel time",
+    "memo": "Rush turnaround",
     "metadata": null,
     "customer": {
-      "id": "00000003-f72d-4c33-8fd1-91b8a18ae284",
+      "id": "00000003-c4d1-4d63-8acf-5ae99d563763",
       "externalId": null,
-      "individualName": null,
-      "companyName": "Acme Corp",
-      "email": "contact@acmecorp.test",
-      "mobilePhone": "+13365550103",
-      "officePhone": null,
-      "addressString": "55 Boylston St, Boston, MA 02116",
+      "individualName": "Wei Chen",
+      "companyName": "Initech",
+      "email": "wei.chen@initech.test",
+      "mobilePhone": "+17965550168",
+      "officePhone": "+12285550168",
+      "addressString": "1 Infinite Loop, Cupertino, CA 95014",
       "status": "ACTIVE",
       "memo": null
     },
     "service": {
-      "id": "00000007-e14c-4f0d-8f51-ecbd67728f21",
-      "name": "Marketing Strategy",
-      "billableRatePerHourAmount": 11500
+      "id": "00000007-045f-4a99-834f-2248873864e4",
+      "name": "Software Architecture",
+      "billableRatePerHourAmount": 10500
     },
     "invoiceLineItem": null,
-    "status": "COMPLETED",
     "stoppedAt": null,
-    "createdAt": new Date("2025-01-23T15:44:50.217Z"),
+    "createdAt": new Date("2025-02-22T21:52:39.050Z"),
     "updatedAt": new Date("2025-08-20T16:37:11.385Z"),
-    "deletedAt": null
+    "deletedAt": null,
+    "status": "RECORDED"
   },
   {
     "id": "00000008-c3c2-43d1-81aa-cac5a53ab58b",
@@ -454,7 +443,7 @@ export const timeEntries = [
     "durationMinutes": 300,
     "billable": true,
     "description": null,
-    "memo": null,
+    "memo": "Pro bono - do not invoice",
     "metadata": null,
     "customer": null,
     "service": {
@@ -477,7 +466,7 @@ export const timeEntries = [
     "durationMinutes": 15,
     "billable": true,
     "description": "Content production",
-    "memo": null,
+    "memo": "Pro bono - do not invoice",
     "metadata": null,
     "customer": {
       "id": "00000003-f72d-4c33-8fd1-91b8a18ae284",
@@ -511,7 +500,7 @@ export const timeEntries = [
     "durationMinutes": 15,
     "billable": true,
     "description": "Status update",
-    "memo": null,
+    "memo": "Billed at standard rate",
     "metadata": null,
     "customer": {
       "id": "00000003-f63f-4fcb-858d-1a35ff5a6aa5",
@@ -545,7 +534,7 @@ export const timeEntries = [
     "durationMinutes": 480,
     "billable": true,
     "description": null,
-    "memo": null,
+    "memo": "Includes travel time",
     "metadata": null,
     "customer": {
       "id": "00000003-e14c-4f0d-8f51-ecbd67728f21",
@@ -582,16 +571,16 @@ export const timeEntries = [
     "memo": "Overtime approved",
     "metadata": null,
     "customer": {
-      "id": "00000003-f63f-4fcb-858d-1a35ff5a6aa5",
+      "id": "00000003-0351-4cfd-860c-32b0b4ffc791",
       "externalId": null,
-      "individualName": null,
-      "companyName": "Stark Industries",
-      "email": "contact@starkindustries.test",
+      "individualName": "Maria Garcia",
+      "companyName": null,
+      "email": "maria.garcia@example.com",
       "mobilePhone": null,
       "officePhone": null,
-      "addressString": "456 Market St, San Francisco, CA 94105",
-      "status": "ACTIVE",
-      "memo": null
+      "addressString": "900 Biscayne Blvd, Miami, FL 33132",
+      "status": "ARCHIVED",
+      "memo": "VIP client"
     },
     "service": {
       "id": "00000007-0351-4cfd-860c-32b0b4ffc791",
@@ -613,7 +602,7 @@ export const timeEntries = [
     "durationMinutes": 240,
     "billable": false,
     "description": "Status update",
-    "memo": null,
+    "memo": "Covered under retainer",
     "metadata": null,
     "customer": null,
     "service": {
@@ -636,7 +625,7 @@ export const timeEntries = [
     "durationMinutes": 180,
     "billable": true,
     "description": "Design review",
-    "memo": null,
+    "memo": "Awaiting client approval",
     "metadata": null,
     "customer": {
       "id": "00000003-d6fb-4ef5-8c75-46e387b4abad",
@@ -670,7 +659,7 @@ export const timeEntries = [
     "durationMinutes": 60,
     "billable": true,
     "description": "Follow-up call",
-    "memo": null,
+    "memo": "Includes travel time",
     "metadata": null,
     "customer": null,
     "service": {
@@ -693,7 +682,30 @@ export const timeEntries = [
     "durationMinutes": 480,
     "billable": true,
     "description": "Final delivery",
-    "memo": "Billed at standard rate",
+    "memo": "Rush turnaround",
+    "metadata": null,
+    "customer": null,
+    "service": {
+      "id": "00000007-ce47-433a-8943-a740f2732a3f",
+      "name": "Product Strategy",
+      "billableRatePerHourAmount": 2500
+    },
+    "invoiceLineItem": null,
+    "status": "RECORDED",
+    "stoppedAt": null,
+    "createdAt": new Date("2020-01-12T15:06:56.756Z"),
+    "updatedAt": new Date("2025-12-31T23:59:58.983Z"),
+    "deletedAt": null
+  },
+  {
+    "id": "00000008-2660-4ff5-8873-5248bde601be",
+    "businessId": "00000000-0000-4000-8000-000000000201",
+    "externalId": null,
+    "date": new CalendarDate(2025, 8, 8),
+    "durationMinutes": 90,
+    "billable": true,
+    "description": "Content production",
+    "memo": "Rush turnaround",
     "metadata": null,
     "customer": {
       "id": "00000003-045f-4a99-834f-2248873864e4",
@@ -707,29 +719,6 @@ export const timeEntries = [
       "status": "ACTIVE",
       "memo": null
     },
-    "service": {
-      "id": "00000007-0351-4cfd-860c-32b0b4ffc791",
-      "name": "Financial Planning",
-      "billableRatePerHourAmount": 6500
-    },
-    "invoiceLineItem": null,
-    "status": "RECORDED",
-    "stoppedAt": null,
-    "createdAt": new Date("2022-11-06T20:16:41.609Z"),
-    "updatedAt": new Date("2025-12-31T23:59:58.983Z"),
-    "deletedAt": null
-  },
-  {
-    "id": "00000008-2660-4ff5-8873-5248bde601be",
-    "businessId": "00000000-0000-4000-8000-000000000201",
-    "externalId": null,
-    "date": new CalendarDate(2025, 8, 8),
-    "durationMinutes": 90,
-    "billable": true,
-    "description": "Content production",
-    "memo": "Split across two projects",
-    "metadata": null,
-    "customer": null,
     "service": {
       "id": "00000007-4b46-4097-85f0-896231804c64",
       "name": "Graphic Design",
@@ -750,7 +739,7 @@ export const timeEntries = [
     "durationMinutes": 90,
     "billable": true,
     "description": null,
-    "memo": null,
+    "memo": "Includes travel time",
     "metadata": null,
     "customer": {
       "id": "00000003-79b1-4082-8d65-0f0692a459cf",
@@ -784,7 +773,7 @@ export const timeEntries = [
     "durationMinutes": 180,
     "billable": true,
     "description": "Quarterly review",
-    "memo": null,
+    "memo": "Split across two projects",
     "metadata": null,
     "customer": null,
     "service": {
@@ -807,7 +796,7 @@ export const timeEntries = [
     "durationMinutes": 240,
     "billable": true,
     "description": null,
-    "memo": null,
+    "memo": "Split across two projects",
     "metadata": null,
     "customer": null,
     "service": {
@@ -830,7 +819,7 @@ export const timeEntries = [
     "durationMinutes": 480,
     "billable": true,
     "description": "Stakeholder interview",
-    "memo": null,
+    "memo": "Awaiting client approval",
     "metadata": null,
     "customer": {
       "id": "00000003-f63f-4fcb-858d-1a35ff5a6aa5",
@@ -864,7 +853,7 @@ export const timeEntries = [
     "durationMinutes": 180,
     "billable": false,
     "description": "Invoicing and wrap-up",
-    "memo": null,
+    "memo": "Pro bono - do not invoice",
     "metadata": null,
     "customer": {
       "id": "00000003-d6fb-4ef5-8c75-46e387b4abad",
@@ -898,7 +887,7 @@ export const timeEntries = [
     "durationMinutes": 90,
     "billable": true,
     "description": null,
-    "memo": null,
+    "memo": "Split across two projects",
     "metadata": null,
     "customer": {
       "id": "00000003-e14c-4f0d-8f51-ecbd67728f21",
@@ -932,9 +921,20 @@ export const timeEntries = [
     "durationMinutes": 180,
     "billable": true,
     "description": "Status update",
-    "memo": "Includes travel time",
+    "memo": "Rush turnaround",
     "metadata": null,
-    "customer": null,
+    "customer": {
+      "id": "00000003-e14c-4f0d-8f51-ecbd67728f21",
+      "externalId": null,
+      "individualName": null,
+      "companyName": "Wayne Enterprises",
+      "email": "contact@wayneenterprises.test",
+      "mobilePhone": null,
+      "officePhone": "+19945550199",
+      "addressString": "456 Market St, San Francisco, CA 94105",
+      "status": "ARCHIVED",
+      "memo": null
+    },
     "service": {
       "id": "00000007-d6fb-4ef5-8c75-46e387b4abad",
       "name": "Interior Design",
@@ -955,30 +955,30 @@ export const timeEntries = [
     "durationMinutes": 480,
     "billable": false,
     "description": "Research and analysis",
-    "memo": "Pro bono - do not invoice",
+    "memo": "Rush turnaround",
     "metadata": null,
     "customer": {
-      "id": "00000003-0351-4cfd-860c-32b0b4ffc791",
+      "id": "00000003-ce47-433a-8943-a740f2732a3f",
       "externalId": null,
-      "individualName": "Maria Garcia",
+      "individualName": "Amara Okafor",
       "companyName": null,
-      "email": "maria.garcia@example.com",
+      "email": "amara.okafor@example.com",
       "mobilePhone": null,
-      "officePhone": null,
+      "officePhone": "+13985550197",
       "addressString": "900 Biscayne Blvd, Miami, FL 33132",
       "status": "ARCHIVED",
-      "memo": "VIP client"
+      "memo": null
     },
     "service": {
-      "id": "00000007-d6fb-4ef5-8c75-46e387b4abad",
-      "name": "Interior Design",
-      "billableRatePerHourAmount": 20500
+      "id": "00000007-4b46-4097-85f0-896231804c64",
+      "name": "Graphic Design",
+      "billableRatePerHourAmount": 3500
     },
     "invoiceLineItem": null,
     "status": "RECORDED",
     "stoppedAt": null,
-    "createdAt": new Date("2020-01-01T00:00:00.037Z"),
-    "updatedAt": new Date("2022-08-28T18:16:31.887Z"),
+    "createdAt": new Date("2020-01-01T00:00:00.033Z"),
+    "updatedAt": new Date("2021-05-01T10:08:49.947Z"),
     "deletedAt": null
   },
   {
@@ -989,7 +989,7 @@ export const timeEntries = [
     "durationMinutes": 180,
     "billable": false,
     "description": "Prototype build",
-    "memo": null,
+    "memo": "Awaiting client approval",
     "metadata": null,
     "customer": {
       "id": "00000003-c4d1-4d63-8acf-5ae99d563763",
@@ -1023,7 +1023,7 @@ export const timeEntries = [
     "durationMinutes": 45,
     "billable": true,
     "description": "Invoicing and wrap-up",
-    "memo": null,
+    "memo": "Includes travel time",
     "metadata": null,
     "customer": {
       "id": "00000003-045f-4a99-834f-2248873864e4",
@@ -1057,7 +1057,7 @@ export const timeEntries = [
     "durationMinutes": 90,
     "billable": true,
     "description": "Onboarding session",
-    "memo": null,
+    "memo": "Awaiting client approval",
     "metadata": null,
     "customer": null,
     "service": {
@@ -1080,20 +1080,9 @@ export const timeEntries = [
     "durationMinutes": 300,
     "billable": true,
     "description": "Quarterly review",
-    "memo": "Billed at standard rate",
+    "memo": "Overtime approved",
     "metadata": null,
-    "customer": {
-      "id": "00000003-79b1-4082-8d65-0f0692a459cf",
-      "externalId": null,
-      "individualName": "Priya Patel",
-      "companyName": null,
-      "email": "priya.patel@example.com",
-      "mobilePhone": null,
-      "officePhone": null,
-      "addressString": "12 Elm St, Austin, TX 78701",
-      "status": "ARCHIVED",
-      "memo": null
-    },
+    "customer": null,
     "service": {
       "id": "00000007-a0b6-452b-8812-70c20a3e49d9",
       "name": "Project Management",
@@ -1102,8 +1091,8 @@ export const timeEntries = [
     "invoiceLineItem": null,
     "status": "RECORDED",
     "stoppedAt": null,
-    "createdAt": new Date("2020-05-02T22:01:18.575Z"),
-    "updatedAt": new Date("2021-02-07T11:20:00.031Z"),
+    "createdAt": new Date("2024-11-13T11:58:49.837Z"),
+    "updatedAt": new Date("2025-03-21T04:14:41.041Z"),
     "deletedAt": null
   },
   {
@@ -1114,19 +1103,19 @@ export const timeEntries = [
     "durationMinutes": 180,
     "billable": true,
     "description": "Draft revisions",
-    "memo": "Rush turnaround",
+    "memo": "Overtime approved",
     "metadata": null,
     "customer": {
-      "id": "00000003-0351-4cfd-860c-32b0b4ffc791",
+      "id": "00000003-c4d1-4d63-8acf-5ae99d563763",
       "externalId": null,
-      "individualName": "Maria Garcia",
-      "companyName": null,
-      "email": "maria.garcia@example.com",
-      "mobilePhone": null,
-      "officePhone": null,
-      "addressString": "900 Biscayne Blvd, Miami, FL 33132",
-      "status": "ARCHIVED",
-      "memo": "VIP client"
+      "individualName": "Wei Chen",
+      "companyName": "Initech",
+      "email": "wei.chen@initech.test",
+      "mobilePhone": "+17965550168",
+      "officePhone": "+12285550168",
+      "addressString": "1 Infinite Loop, Cupertino, CA 95014",
+      "status": "ACTIVE",
+      "memo": null
     },
     "service": {
       "id": "00000007-4b46-4097-85f0-896231804c64",
@@ -1136,8 +1125,8 @@ export const timeEntries = [
     "invoiceLineItem": null,
     "status": "RECORDED",
     "stoppedAt": null,
-    "createdAt": new Date("2020-01-01T00:00:00.033Z"),
-    "updatedAt": new Date("2020-01-01T00:00:00.033Z"),
+    "createdAt": new Date("2020-01-01T00:00:00.037Z"),
+    "updatedAt": new Date("2021-09-04T12:24:53.742Z"),
     "deletedAt": null
   },
   {
@@ -1148,7 +1137,7 @@ export const timeEntries = [
     "durationMinutes": 90,
     "billable": false,
     "description": "On-site visit",
-    "memo": null,
+    "memo": "Awaiting client approval",
     "metadata": null,
     "customer": {
       "id": "00000003-045f-4a99-834f-2248873864e4",
@@ -1182,7 +1171,7 @@ export const timeEntries = [
     "durationMinutes": 120,
     "billable": true,
     "description": "Final delivery",
-    "memo": null,
+    "memo": "Pro bono - do not invoice",
     "metadata": null,
     "customer": null,
     "service": {
@@ -1205,30 +1194,19 @@ export const timeEntries = [
     "durationMinutes": 15,
     "billable": true,
     "description": null,
-    "memo": "Billed at standard rate",
+    "memo": "Rush turnaround",
     "metadata": null,
-    "customer": {
-      "id": "00000003-d6fb-4ef5-8c75-46e387b4abad",
-      "externalId": null,
-      "individualName": null,
-      "companyName": "Oscorp Industries",
-      "email": "contact@oscorpindustries.test",
-      "mobilePhone": null,
-      "officePhone": "+12095550198",
-      "addressString": "789 Broadway, New York, NY 10003",
-      "status": "ARCHIVED",
-      "memo": null
-    },
+    "customer": null,
     "service": {
-      "id": "00000007-ce47-433a-8943-a740f2732a3f",
-      "name": "Product Strategy",
-      "billableRatePerHourAmount": 2500
+      "id": "00000007-a0b6-452b-8812-70c20a3e49d9",
+      "name": "Project Management",
+      "billableRatePerHourAmount": 5000
     },
     "invoiceLineItem": null,
     "status": "RECORDED",
     "stoppedAt": null,
-    "createdAt": new Date("2024-11-09T18:07:25.052Z"),
-    "updatedAt": new Date("2024-12-29T17:07:52.959Z"),
+    "createdAt": new Date("2021-03-22T01:45:47.399Z"),
+    "updatedAt": new Date("2025-12-31T23:59:58.984Z"),
     "deletedAt": null
   },
   {
@@ -1239,20 +1217,20 @@ export const timeEntries = [
     "durationMinutes": 15,
     "billable": true,
     "description": "Stakeholder interview",
-    "memo": "Billed at standard rate",
+    "memo": "Rush turnaround",
     "metadata": null,
     "customer": null,
     "service": {
-      "id": "00000007-045f-4a99-834f-2248873864e4",
-      "name": "Software Architecture",
-      "billableRatePerHourAmount": 10500
+      "id": "00000007-e14c-4f0d-8f51-ecbd67728f21",
+      "name": "Marketing Strategy",
+      "billableRatePerHourAmount": 11500
     },
     "invoiceLineItem": null,
-    "status": "RECORDED",
     "stoppedAt": null,
-    "createdAt": new Date("2022-01-22T13:51:24.243Z"),
-    "updatedAt": new Date("2023-01-06T20:37:07.748Z"),
-    "deletedAt": null
+    "createdAt": new Date("2021-11-09T08:47:22.909Z"),
+    "updatedAt": new Date("2022-01-22T13:51:24.243Z"),
+    "deletedAt": null,
+    "status": "RECORDED"
   },
   {
     "id": "00000008-ec00-4585-8819-6e0320bfec98",
@@ -1262,31 +1240,20 @@ export const timeEntries = [
     "durationMinutes": 480,
     "billable": true,
     "description": null,
-    "memo": "Covered under retainer",
+    "memo": "Overtime approved",
     "metadata": null,
-    "customer": {
-      "id": "00000003-c4d1-4d63-8acf-5ae99d563763",
-      "externalId": null,
-      "individualName": "Wei Chen",
-      "companyName": "Initech",
-      "email": "wei.chen@initech.test",
-      "mobilePhone": "+17965550168",
-      "officePhone": "+12285550168",
-      "addressString": "1 Infinite Loop, Cupertino, CA 95014",
-      "status": "ACTIVE",
-      "memo": null
-    },
+    "customer": null,
     "service": {
-      "id": "00000007-a0b6-452b-8812-70c20a3e49d9",
-      "name": "Project Management",
-      "billableRatePerHourAmount": 5000
+      "id": "00000007-ce47-433a-8943-a740f2732a3f",
+      "name": "Product Strategy",
+      "billableRatePerHourAmount": 2500
     },
     "invoiceLineItem": null,
-    "status": "RECORDED",
     "stoppedAt": null,
-    "createdAt": new Date("2020-01-01T00:00:00.000Z"),
-    "updatedAt": new Date("2020-01-01T00:00:00.004Z"),
-    "deletedAt": null
+    "createdAt": new Date("2020-01-01T00:00:00.025Z"),
+    "updatedAt": new Date("2025-12-31T23:59:58.991Z"),
+    "deletedAt": null,
+    "status": "RECORDED"
   },
   {
     "id": "00000008-79b1-4082-8d65-0f0692a459cf",
@@ -1296,7 +1263,7 @@ export const timeEntries = [
     "durationMinutes": 300,
     "billable": true,
     "description": "Prototype build",
-    "memo": null,
+    "memo": "Split across two projects",
     "metadata": null,
     "customer": {
       "id": "00000003-ce47-433a-8943-a740f2732a3f",
@@ -1330,24 +1297,24 @@ export const timeEntries = [
     "durationMinutes": 45,
     "billable": true,
     "description": "Content production",
-    "memo": "Rush turnaround",
+    "memo": "Overtime approved",
     "metadata": null,
     "customer": {
-      "id": "00000003-79b1-4082-8d65-0f0692a459cf",
+      "id": "00000003-f63f-4fcb-858d-1a35ff5a6aa5",
       "externalId": null,
-      "individualName": "Priya Patel",
-      "companyName": null,
-      "email": "priya.patel@example.com",
+      "individualName": null,
+      "companyName": "Stark Industries",
+      "email": "contact@starkindustries.test",
       "mobilePhone": null,
       "officePhone": null,
-      "addressString": "12 Elm St, Austin, TX 78701",
-      "status": "ARCHIVED",
+      "addressString": "456 Market St, San Francisco, CA 94105",
+      "status": "ACTIVE",
       "memo": null
     },
     "service": {
-      "id": "00000007-0351-4cfd-860c-32b0b4ffc791",
-      "name": "Financial Planning",
-      "billableRatePerHourAmount": 6500
+      "id": "00000007-4b46-4097-85f0-896231804c64",
+      "name": "Graphic Design",
+      "billableRatePerHourAmount": 3500
     },
     "invoiceLineItem": null,
     "status": "RECORDED",
@@ -1364,7 +1331,7 @@ export const timeEntries = [
     "durationMinutes": 30,
     "billable": true,
     "description": "Kickoff meeting",
-    "memo": null,
+    "memo": "Split across two projects",
     "metadata": null,
     "customer": {
       "id": "00000003-d6fb-4ef5-8c75-46e387b4abad",
@@ -1398,7 +1365,7 @@ export const timeEntries = [
     "durationMinutes": 60,
     "billable": false,
     "description": null,
-    "memo": null,
+    "memo": "Billed at standard rate",
     "metadata": null,
     "customer": {
       "id": "00000003-ce47-433a-8943-a740f2732a3f",
@@ -1432,7 +1399,7 @@ export const timeEntries = [
     "durationMinutes": 120,
     "billable": true,
     "description": "Bug triage",
-    "memo": null,
+    "memo": "Covered under retainer",
     "metadata": null,
     "customer": {
       "id": "00000003-f63f-4fcb-858d-1a35ff5a6aa5",
@@ -1466,7 +1433,7 @@ export const timeEntries = [
     "durationMinutes": 180,
     "billable": true,
     "description": "Requirements gathering",
-    "memo": null,
+    "memo": "Pro bono - do not invoice",
     "metadata": null,
     "customer": {
       "id": "00000003-f72d-4c33-8fd1-91b8a18ae284",
@@ -1500,7 +1467,7 @@ export const timeEntries = [
     "durationMinutes": 240,
     "billable": true,
     "description": "Stakeholder interview",
-    "memo": null,
+    "memo": "Pro bono - do not invoice",
     "metadata": null,
     "customer": null,
     "service": {
@@ -1523,7 +1490,41 @@ export const timeEntries = [
     "durationMinutes": 90,
     "billable": true,
     "description": "Vendor coordination",
-    "memo": "Pro bono - do not invoice",
+    "memo": "Rush turnaround",
+    "metadata": null,
+    "customer": {
+      "id": "00000003-79b1-4082-8d65-0f0692a459cf",
+      "externalId": null,
+      "individualName": "Priya Patel",
+      "companyName": null,
+      "email": "priya.patel@example.com",
+      "mobilePhone": null,
+      "officePhone": null,
+      "addressString": "12 Elm St, Austin, TX 78701",
+      "status": "ARCHIVED",
+      "memo": null
+    },
+    "service": {
+      "id": "00000007-045f-4a99-834f-2248873864e4",
+      "name": "Software Architecture",
+      "billableRatePerHourAmount": 10500
+    },
+    "invoiceLineItem": null,
+    "status": "RECORDED",
+    "stoppedAt": null,
+    "createdAt": new Date("2022-08-02T21:08:51.932Z"),
+    "updatedAt": new Date("2023-06-05T12:54:14.491Z"),
+    "deletedAt": null
+  },
+  {
+    "id": "00000008-ce47-433a-8943-a740f2732a3f",
+    "businessId": "00000000-0000-4000-8000-000000000201",
+    "externalId": null,
+    "date": new CalendarDate(2025, 2, 24),
+    "durationMinutes": 300,
+    "billable": true,
+    "description": "Follow-up call",
+    "memo": "Rush turnaround",
     "metadata": null,
     "customer": {
       "id": "00000003-ce47-433a-8943-a740f2732a3f",
@@ -1538,46 +1539,12 @@ export const timeEntries = [
       "memo": null
     },
     "service": {
-      "id": "00000007-045f-4a99-834f-2248873864e4",
-      "name": "Software Architecture",
-      "billableRatePerHourAmount": 10500
+      "id": "00000007-4b46-4097-85f0-896231804c64",
+      "name": "Graphic Design",
+      "billableRatePerHourAmount": 3500
     },
     "invoiceLineItem": null,
-    "stoppedAt": null,
-    "createdAt": new Date("2020-01-01T00:00:00.011Z"),
-    "updatedAt": new Date("2025-12-31T23:59:58.972Z"),
-    "deletedAt": null,
-    "status": "RECORDED"
-  },
-  {
-    "id": "00000008-ce47-433a-8943-a740f2732a3f",
-    "businessId": "00000000-0000-4000-8000-000000000201",
-    "externalId": null,
-    "date": new CalendarDate(2025, 2, 24),
-    "durationMinutes": 300,
-    "billable": true,
-    "description": "Follow-up call",
-    "memo": "Awaiting client approval",
-    "metadata": null,
-    "customer": {
-      "id": "00000003-f63f-4fcb-858d-1a35ff5a6aa5",
-      "externalId": null,
-      "individualName": null,
-      "companyName": "Stark Industries",
-      "email": "contact@starkindustries.test",
-      "mobilePhone": null,
-      "officePhone": null,
-      "addressString": "456 Market St, San Francisco, CA 94105",
-      "status": "ACTIVE",
-      "memo": null
-    },
-    "service": {
-      "id": "00000007-0351-4cfd-860c-32b0b4ffc791",
-      "name": "Financial Planning",
-      "billableRatePerHourAmount": 6500
-    },
-    "invoiceLineItem": null,
-    "status": "RECORDED",
+    "status": "COMPLETED",
     "stoppedAt": null,
     "createdAt": new Date("2020-08-22T19:59:02.331Z"),
     "updatedAt": new Date("2022-09-16T05:12:56.758Z"),
@@ -1591,7 +1558,7 @@ export const timeEntries = [
     "durationMinutes": 120,
     "billable": true,
     "description": "Bug triage",
-    "memo": null,
+    "memo": "Pro bono - do not invoice",
     "metadata": null,
     "customer": {
       "id": "00000003-79b1-4082-8d65-0f0692a459cf",
@@ -1625,7 +1592,7 @@ export const timeEntries = [
     "durationMinutes": 30,
     "billable": true,
     "description": null,
-    "memo": null,
+    "memo": "Awaiting client approval",
     "metadata": null,
     "customer": {
       "id": "00000003-f72d-4c33-8fd1-91b8a18ae284",
@@ -1659,7 +1626,7 @@ export const timeEntries = [
     "durationMinutes": 300,
     "billable": false,
     "description": "Follow-up call",
-    "memo": null,
+    "memo": "Awaiting client approval",
     "metadata": null,
     "customer": {
       "id": "00000003-f72d-4c33-8fd1-91b8a18ae284",
@@ -1693,7 +1660,7 @@ export const timeEntries = [
     "durationMinutes": 120,
     "billable": false,
     "description": null,
-    "memo": null,
+    "memo": "Covered under retainer",
     "metadata": null,
     "customer": null,
     "service": {
@@ -1716,9 +1683,20 @@ export const timeEntries = [
     "durationMinutes": 90,
     "billable": true,
     "description": "Documentation",
-    "memo": "Pro bono - do not invoice",
+    "memo": "Overtime approved",
     "metadata": null,
-    "customer": null,
+    "customer": {
+      "id": "00000003-c4d1-4d63-8acf-5ae99d563763",
+      "externalId": null,
+      "individualName": "Wei Chen",
+      "companyName": "Initech",
+      "email": "wei.chen@initech.test",
+      "mobilePhone": "+17965550168",
+      "officePhone": "+12285550168",
+      "addressString": "1 Infinite Loop, Cupertino, CA 95014",
+      "status": "ACTIVE",
+      "memo": null
+    },
     "service": {
       "id": "00000007-4b46-4097-85f0-896231804c64",
       "name": "Graphic Design",
@@ -1739,7 +1717,7 @@ export const timeEntries = [
     "durationMinutes": 480,
     "billable": true,
     "description": "Requirements gathering",
-    "memo": null,
+    "memo": "Split across two projects",
     "metadata": null,
     "customer": {
       "id": "00000003-f63f-4fcb-858d-1a35ff5a6aa5",
@@ -1773,31 +1751,20 @@ export const timeEntries = [
     "durationMinutes": 480,
     "billable": true,
     "description": "Status update",
-    "memo": "Billed at standard rate",
+    "memo": "Rush turnaround",
     "metadata": null,
-    "customer": {
-      "id": "00000003-c4d1-4d63-8acf-5ae99d563763",
-      "externalId": null,
-      "individualName": "Wei Chen",
-      "companyName": "Initech",
-      "email": "wei.chen@initech.test",
-      "mobilePhone": "+17965550168",
-      "officePhone": "+12285550168",
-      "addressString": "1 Infinite Loop, Cupertino, CA 95014",
-      "status": "ACTIVE",
-      "memo": null
-    },
+    "customer": null,
     "service": {
-      "id": "00000007-ce47-433a-8943-a740f2732a3f",
-      "name": "Product Strategy",
-      "billableRatePerHourAmount": 2500
+      "id": "00000007-4b46-4097-85f0-896231804c64",
+      "name": "Graphic Design",
+      "billableRatePerHourAmount": 3500
     },
     "invoiceLineItem": null,
-    "status": "COMPLETED",
     "stoppedAt": null,
-    "createdAt": new Date("2020-01-01T00:00:00.036Z"),
-    "updatedAt": new Date("2024-02-14T02:56:17.378Z"),
-    "deletedAt": null
+    "createdAt": new Date("2025-12-31T23:59:58.971Z"),
+    "updatedAt": new Date("2025-12-31T23:59:58.997Z"),
+    "deletedAt": null,
+    "status": "RECORDED"
   },
   {
     "id": "00000008-4b46-4097-85f0-896231804c64",
@@ -1807,7 +1774,7 @@ export const timeEntries = [
     "durationMinutes": 15,
     "billable": true,
     "description": "Research and analysis",
-    "memo": null,
+    "memo": "Awaiting client approval",
     "metadata": null,
     "customer": {
       "id": "00000003-f72d-4c33-8fd1-91b8a18ae284",
@@ -1841,7 +1808,7 @@ export const timeEntries = [
     "durationMinutes": 45,
     "billable": true,
     "description": null,
-    "memo": null,
+    "memo": "Includes travel time",
     "metadata": null,
     "customer": {
       "id": "00000003-f72d-4c33-8fd1-91b8a18ae284",

--- a/src/fixtures/timeEntries/arbitrary.ts
+++ b/src/fixtures/timeEntries/arbitrary.ts
@@ -32,7 +32,5 @@ export const timeEntryDescriptionArbitrary = nullableConstantFrom(
   { nullWeight: 1, valueWeight: 3 },
 )
 
-export const timeEntryMemoArbitrary = nullableConstantFrom(
-  timeEntryMemos,
-  { nullWeight: 3, valueWeight: 1 },
-)
+export const timeEntryMemoArbitrary = (fc: typeof FastCheck) =>
+  fc.constantFrom(...timeEntryMemos)

--- a/src/views/TaxEstimates/TaxEstimates.stories.tsx
+++ b/src/views/TaxEstimates/TaxEstimates.stories.tsx
@@ -57,13 +57,15 @@ export const DocsPayments: Story = {
   },
 }
 
+// Keeps the fixture's configuration so the form renders filled out; the empty form reads as a
+// column of blank inputs in the docs image.
 export const Onboarding: Story = {
   tags: ['docs-screenshot'],
   parameters: {
     msw: {
       handlers: [
         enableTaxEstimates,
-        getTaxProfile.mock(makeTaxProfile({ userHasSavedTaxProfile: false, usConfiguration: null })),
+        getTaxProfile.mock(makeTaxProfile({ userHasSavedTaxProfile: false })),
         ...handlers,
       ],
     },

--- a/src/views/TimeTracking.stories.tsx
+++ b/src/views/TimeTracking.stories.tsx
@@ -108,8 +108,11 @@ export const EntryCreation: Story = {
   parameters: { chromatic: { viewports: [1280] } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
+    // Drawers and popovers portal to the body, so what they open isn't inside the canvas.
+    const overlay = within(canvasElement.ownerDocument.body)
+
     await userEvent.click(await canvas.findByRole('button', { name: /Add Entry/ }))
-    await canvas.findByRole('button', { name: /Save Entry/ }, { timeout: 10_000 })
+    await overlay.findByRole('button', { name: /Save Entry/ }, { timeout: 10_000 })
   },
 }
 
@@ -118,10 +121,12 @@ export const ServicesDrawer: Story = {
   parameters: { chromatic: { viewports: [1280] } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
+    const overlay = within(canvasElement.ownerDocument.body)
+
     await userEvent.click(
       await canvas.findByRole('button', { name: /Additional time tracking actions/ }),
     )
-    await userEvent.click(await canvas.findByRole('menuitem', { name: /Services/ }))
-    await canvas.findByRole('heading', { name: /Services/ }, { timeout: 10_000 })
+    await userEvent.click(await overlay.findByRole('menuitem', { name: /Services/ }))
+    await overlay.findByRole('heading', { name: /Services/ }, { timeout: 10_000 })
   },
 }

--- a/src/views/TimeTracking.stories.tsx
+++ b/src/views/TimeTracking.stories.tsx
@@ -1,8 +1,12 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
+import { userEvent, within } from 'storybook/test'
 
 import { TimeTracking, type TimeTrackingProps } from '@views/TimeTracking'
 
-import { FIXTURE_YEAR_RANGE } from '@fixtures/constants/fixtureYear'
+import { get as getActiveTimeTracker } from '@msw/api/businesses/[business-id]/time-tracking/tracker/active/get'
+import { handlers } from '@msw/handlers'
+import { FIXTURE_YEAR, FIXTURE_YEAR_RANGE } from '@fixtures/constants/fixtureYear'
+import { makeTimeEntry } from '@fixtures/timeEntries/mocks'
 import { PinnedGlobalDateRange } from '@testUtils/storybook/decorators/PinnedGlobalDateRange'
 
 type TimeTrackingStoryArgs = {
@@ -77,4 +81,47 @@ type Story = StoryObj<TimeTrackingStoryArgs>
 
 export const Default: Story = {
   tags: ['docs-screenshot'],
+}
+
+// Stories pin "now" to noon on the last day of the fixture year, so a timer started at 10:47
+// that morning reads as a stable hour-and-change of elapsed time.
+const runningTimer = getActiveTimeTracker.mock(
+  makeTimeEntry({
+    status: 'ACTIVE',
+    description: null,
+    memo: null,
+    durationMinutes: 0,
+    createdAt: new Date(FIXTURE_YEAR, 11, 31, 10, 47, 0),
+  }),
+)
+
+export const ActiveTimer: Story = {
+  tags: ['docs-screenshot'],
+  parameters: {
+    chromatic: { viewports: [1280] },
+    msw: { handlers: [runningTimer, ...handlers] },
+  },
+}
+
+export const EntryCreation: Story = {
+  tags: ['docs-screenshot'],
+  parameters: { chromatic: { viewports: [1280] } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(await canvas.findByRole('button', { name: /Add Entry/ }))
+    await canvas.findByRole('button', { name: /Save Entry/ }, { timeout: 10_000 })
+  },
+}
+
+export const ServicesDrawer: Story = {
+  tags: ['docs-screenshot'],
+  parameters: { chromatic: { viewports: [1280] } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(
+      await canvas.findByRole('button', { name: /Additional time tracking actions/ }),
+    )
+    await userEvent.click(await canvas.findByRole('menuitem', { name: /Services/ }))
+    await canvas.findByRole('heading', { name: /Services/ }, { timeout: 10_000 })
+  },
 }

--- a/src/views/TimeTracking.stories.tsx
+++ b/src/views/TimeTracking.stories.tsx
@@ -6,7 +6,9 @@ import { TimeTracking, type TimeTrackingProps } from '@views/TimeTracking'
 import { get as getActiveTimeTracker } from '@msw/api/businesses/[business-id]/time-tracking/tracker/active/get'
 import { handlers } from '@msw/handlers'
 import { FIXTURE_YEAR, FIXTURE_YEAR_RANGE } from '@fixtures/constants/fixtureYear'
+import { catalogServices } from '@fixtures/generated/catalogServices.gen'
 import { makeTimeEntry } from '@fixtures/timeEntries/mocks'
+import { toTimeEntryService } from '@fixtures/timeEntries/toTimeEntryService'
 import { PinnedGlobalDateRange } from '@testUtils/storybook/decorators/PinnedGlobalDateRange'
 
 type TimeTrackingStoryArgs = {
@@ -91,6 +93,9 @@ const runningTimer = getActiveTimeTracker.mock(
     description: null,
     memo: null,
     durationMinutes: 0,
+    // Has to be a service the catalog endpoint serves, or the banner's selector can't resolve it
+    // and falls back to its placeholder.
+    service: toTimeEntryService(catalogServices[1]),
     createdAt: new Date(FIXTURE_YEAR, 11, 31, 10, 47, 0),
   }),
 )
@@ -103,7 +108,7 @@ export const ActiveTimer: Story = {
   },
 }
 
-export const EntryCreation: Story = {
+export const EntryDetail: Story = {
   tags: ['docs-screenshot'],
   parameters: { chromatic: { viewports: [1280] } },
   play: async ({ canvasElement }) => {
@@ -111,7 +116,8 @@ export const EntryCreation: Story = {
     // Drawers and popovers portal to the body, so what they open isn't inside the canvas.
     const overlay = within(canvasElement.ownerDocument.body)
 
-    await userEvent.click(await canvas.findByRole('button', { name: /Add Entry/ }))
+    const [firstEntry] = await canvas.findAllByRole('button', { name: /View Entry/ })
+    await userEvent.click(firstEntry)
     await overlay.findByRole('button', { name: /Save Entry/ }, { timeout: 10_000 })
   },
 }


### PR DESCRIPTION
Stories for time tracking and unified reports states the docs describe in prose but can't show, plus the manifest entries that turn them into docs images.

## New docs stories

| Story | Image | Page |
|---|---|---|
| `Views/TimeTracking` → `ActiveTimer` | `pages/time-tracking-active-timer.png` | time-tracking |
| `Views/TimeTracking` → `EntryCreation` | `pages/time-tracking-add-entry.png` | time-tracking |
| `Views/TimeTracking` → `ServicesDrawer` | `pages/time-tracking-services.png` | time-tracking |
| `Components/UnifiedReports` → `MegaMenuOpen` | `pages/unified-reports-mega-menu.png` | unified-reports |

- **ActiveTimer** mocks the active-tracker endpoint with a running entry created at 10:47 on the last day of the fixture year. Stories pin "now" to noon that day, so the banner reads a stable hour-and-change and **Start Timer** is disabled, as it is in the product.
- **EntryCreation** and **ServicesDrawer** drive the real UI with play functions (**Add Entry**; header menu → **Services**) rather than mounting the drawers directly.
- **MegaMenuOpen** opens the `menu` navigation variant's report catalog.
- The three overlay stories use `captureViewport: true`, since dialogs portal outside `#storybook-root`.

## Other changes

- **TaxEstimates `Onboarding`** now shows the tax profile form filled out. It mocked `usConfiguration: null`, so the docs image added on #1680 was an empty column of inputs; keeping the fixture's configuration and flipping only `userHasSavedTaxProfile` shows the step as it looks once someone has worked through it.
- **`DataTableHeaderMenu` trigger now carries its `ariaLabel`.** It was an icon-only button with no accessible name: `DropdownMenu` passes an `aria-label` to the `Trigger` slot, but the slot is typed `React.FC` and this trigger ignored props, so only the opened dialog was labelled. That is also what made the Services play function unqueryable. Also affects the bank-transactions and trips header menus, which already pass a descriptive `ariaLabel`.

## Verification

- `npx tsc --noEmit`, `npx eslint .` — clean
- `npm run storybook:build` — succeeds
- `npm run screenshots:check` — every documented story resolves and carries the tag
- `npm run stories:check-render` — **not yet green on this commit.** The last full run had `ServicesDrawer` failing on the unnamed menu trigger; the `ariaLabel` fix above is what needs confirming, and the run was interrupted before it finished. I'll post the result on this PR.

The matching prose trim on `embedded-components/pages/time-tracking.mdx` — dropping the Component Structure and Date Range sections, tightening Timer Lifecycle, and wiring up these three images — is a separate PR in `api-documentation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Storybook/docs tooling, fixture data, and a small a11y fix on a table header menu trigger; no production business-logic paths are altered.
> 
> **Overview**
> Adds **Storybook `docs-screenshot` stories** and manifest entries so embedded docs can show time tracking (active timer, entry detail drawer, services drawer) and the unified reports mega menu, mostly via **play functions** that open real UI (portaled overlays use **`captureViewport: true`**).
> 
> **`capture-docs-screenshots`** now applies **`maxHeight` clipping to viewport captures** (not only root-scoped shots), which the new overlay images rely on.
> 
> **`DataTableHeaderMenu`** forwards **`aria-label={ariaLabel}`** to the icon-only trigger so assistive tech and Storybook queries can target header menus (e.g. Services).
> 
> **TaxEstimates `Onboarding`** stops mocking **`usConfiguration: null`** so the docs profile screenshot shows a filled form while **`userHasSavedTaxProfile: false`**.
> 
> **Time entry fixtures** are regenerated so **memos are always populated**, with **`timeEntryMemoArbitrary`** updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb4eb072e0b27363106c5c43b293075342df8b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->