### PR TITLE
chore: dependency lanes + audit triage by consumer exposure (deps program 1/6)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,100 @@
+version: 2
+
+# Lanes are separated by consumer exposure, not by convenience. Security updates are opened by
+# Dependabot regardless of the groups/limits below and are never grouped with unrelated upgrades.
+# See docs/dependency-policy.md for the triage rules these lanes are built around.
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+      time: '13:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-development: 'chore(deps-dev)'
+
+    # First matching group wins, so these run most-specific first. Each group is scoped so that a
+    # red PR points at one ecosystem instead of an unattributable pile of upgrades.
+    groups:
+      storybook:
+        applies-to: version-updates
+        patterns:
+          - storybook
+          - '@storybook/*'
+          - msw-storybook-addon
+          - chromatic
+        update-types:
+          - minor
+          - patch
+      linting:
+        applies-to: version-updates
+        patterns:
+          - eslint
+          - eslint-*
+          - '@stylistic/*'
+          - stylelint
+          - stylelint-*
+          - typescript-eslint
+        update-types:
+          - minor
+          - patch
+      testing:
+        applies-to: version-updates
+        patterns:
+          - vitest
+          - '@vitest/*'
+          - '@testing-library/*'
+          - jsdom
+          - playwright
+          - msw
+        update-types:
+          - minor
+          - patch
+      dev-tooling:
+        applies-to: version-updates
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      # Runtime patches ship to consumers but are low-risk in aggregate. Runtime *minors* are
+      # deliberately left ungrouped so each one gets its own reviewable PR.
+      runtime-patch:
+        applies-to: version-updates
+        dependency-type: production
+        update-types:
+          - patch
+
+    ignore:
+      # Majors are scheduled, manually-reviewed work (monthly `npm outdated` review) rather than
+      # a PR that sits open and consumes the whole weekly limit. Security majors still come through.
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+      # Both are intentional aliases (`npm:@typescript/typescript6`, `npm:typescript@^7`) that
+      # Dependabot cannot reason about, and `overrides.react-intl.typescript` points at `$typescript`.
+      - dependency-name: typescript
+      - dependency-name: '@typescript/native'
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+      time: '13:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: 'chore(actions)'
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - '*'

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -122,20 +122,23 @@ jobs:
             const repo = { owner: context.repo.owner, repo: context.repo.repo };
 
             // A single-package PR names it in the title, a grouped PR lists each one in the body.
+            // Deduped, since a PR may well name the same package in both places.
             const packagesIn = (pr) => {
               const grouped = [...(pr.body ?? '').matchAll(/^Updates `([^`]+)` from/gm)].map(m => m[1]);
               const single = pr.title.match(/bump (@?[\w./-]+) from/i);
-              return single ? [...grouped, single[1]] : grouped;
+              return [...new Set(single ? [...grouped, single[1]] : grouped)];
             };
 
-            // Fix links are a convenience: a failed listing empties the column rather than taking
-            // the report down. pulls.list returns newest first, so the first match wins.
+            // A package can appear in more than one PR — security updates bypass grouping, so a
+            // grouped version bump and a standalone security bump can both be open. List all of
+            // them, newest first (pulls.list order). Links are a convenience: a failed listing
+            // empties the column rather than taking the report down.
             const fixPrs = new Map();
             try {
               const openPrs = await github.paginate(github.rest.pulls.list, { ...repo, state: 'open', per_page: 100 });
               for (const pr of openPrs.filter(pr => pr.user?.login === 'dependabot[bot]')) {
                 for (const name of packagesIn(pr)) {
-                  if (!fixPrs.has(name)) fixPrs.set(name, `[#${pr.number}](${pr.html_url})`);
+                  fixPrs.set(name, [...(fixPrs.get(name) ?? []), `[#${pr.number}](${pr.html_url})`]);
                 }
               }
             } catch (error) {
@@ -146,7 +149,7 @@ jobs:
               if (rows.length === 0) return '_None._\n';
               const header = '| package | severity | fix available | open PR | advisories |\n|---|---:|---|---|---|\n';
               const body = rows.slice(0, 50)
-                .map(v => `| ${v.name} | ${v.severity} | ${describeFix(v)} | ${fixPrs.get(v.name) ?? '—'} | ${describeVia(v)} |\n`)
+                .map(v => `| ${v.name} | ${v.severity} | ${describeFix(v)} | ${fixPrs.get(v.name)?.join(', ') ?? '—'} | ${describeVia(v)} |\n`)
                 .join('');
               const truncated = rows.length > 50
                 ? `\n_+${rows.length - 50} more (see the audit JSON)._\n`

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -192,7 +192,9 @@ jobs:
             };
 
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${repo.owner}/${repo.repo}/actions/runs/${context.runId}`;
-            const linked = runtime.flatMap(v => (fixPrs.get(v.name) ?? []).map(pr => `<${pr.url}|#${pr.number}>`));
+            // Every finding's PRs, not just the consumer-facing ones — a merge-ready dev PR is still
+            // work waiting. `vulns` is severity-ordered, so the links come out worst-first.
+            const linked = vulns.flatMap(v => (fixPrs.get(v.name) ?? []).map(pr => `<${pr.url}|#${pr.number}>`));
 
             core.setOutput('slack', [
               `[${repo.owner}/${repo.repo}] npm audit — ${vulns.length} findings`,

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -109,14 +109,14 @@ jobs:
               return [...new Set(seen)].join(', ');
             };
 
-            // A bare `fixAvailable: true` names no target version, so say where the bump lands:
-            // our own declared range for a direct dependency, someone else's for a transitive one.
+            // `true` means a patched version already satisfies the declared range, so the fix is a
+            // lockfile refresh. An object means a manifest change to that version. Anything else —
+            // false, null, absent — is no known fix, and must not read as one.
             const describeFix = (v) => {
-              if (v.fixAvailable === false) return 'no';
-              if (!v.fixAvailable?.version) return v.isDirect ? 'yes — bump ours' : 'yes — via parent';
-              return v.fixAvailable.isSemVerMajor
-                ? `${v.fixAvailable.name}@${v.fixAvailable.version} (major)`
-                : `${v.fixAvailable.name}@${v.fixAvailable.version}`;
+              if (v.fixAvailable === true) return 'yes — `npm audit fix`';
+              if (!v.fixAvailable?.version) return 'no';
+              const target = `${v.fixAvailable.name}@${v.fixAvailable.version}`;
+              return v.fixAvailable.isSemVerMajor ? `${target} (major)` : target;
             };
 
             const repo = { owner: context.repo.owner, repo: context.repo.repo };
@@ -200,4 +200,7 @@ jobs:
           fi
           PAYLOAD=$(jq -n --arg r "$RUNTIME" --arg t "$TOTAL" --arg repo "${{ github.repository }}" --arg url "$RUN_URL" \
             '{text: ("[" + $repo + "] npm audit: " + $r + " consumer-facing, " + $t + " total — <" + $url + "|run summary>")}')
-          curl -s -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "${{ secrets.SLACK_WEBHOOK }}"
+          # --fail-with-body: Slack answers a dead or revoked webhook with 4xx and a reason, which
+          # plain `curl -s` would swallow as exit 0 — a lost ping that looks like a delivered one.
+          curl -sS --fail-with-body -X POST -H 'Content-type: application/json' \
+            --data "$PAYLOAD" "${{ secrets.SLACK_WEBHOOK }}"

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -2,8 +2,12 @@ name: Daily npm audit
 
 on:
   schedule:
-    - cron: '0 16 * * *'   # daily at 08:00 UTC (adjust to your preferred time)
+    - cron: '0 16 * * *'   # daily at 16:00 UTC
   workflow_dispatch: {}   # manual run option
+
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   audit:
@@ -15,46 +19,105 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install
         run: npm ci
 
+      # Two audits: the full tree, and the production-only tree. Anything present in the
+      # production audit reaches consumers who install @layerfi/components; the difference is
+      # dev/CI-only exposure. npm audit covers neither set's peer dependencies.
       - name: Run npm audit
-        run: npm audit --json > audit.json || true
+        run: |
+          npm audit --json > audit-all.json || true
+          npm audit --omit=dev --json > audit-prod.json || true
+
+      - name: Upload audit JSON
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit
+          path: |
+            audit-all.json
+            audit-prod.json
 
       - name: Create/update daily vulnerability issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
+        env:
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
         with:
           script: |
             const fs = require('fs');
-            const audit = JSON.parse(fs.readFileSync('audit.json', 'utf8'));
-            if (!audit || !audit.vulnerabilities) {
+
+            const read = (file) => {
+              try {
+                return JSON.parse(fs.readFileSync(file, 'utf8'));
+              } catch {
+                return null;
+              }
+            };
+
+            const all = read('audit-all.json');
+            const prod = read('audit-prod.json');
+
+            if (!all || !all.vulnerabilities) {
               console.log('No vulnerability data available.');
               return;
             }
-            // Convert vulnerabilities into an array and pick ones above threshold
-            const vulns = Object.entries(audit.vulnerabilities)
+
+            const SEVERITIES = ['moderate', 'high', 'critical'];
+            const toList = audit => Object.entries(audit?.vulnerabilities ?? {})
               .map(([name, info]) => ({ name, ...info }))
-              // only keep moderate+ (customize severity threshold)
-              .filter(v => ['moderate', 'high', 'critical'].includes(v.severity));
+              .filter(v => SEVERITIES.includes(v.severity));
+
+            const runtimeNames = new Set(toList(prod).map(v => v.name));
+            const vulns = toList(all);
+            const runtime = vulns.filter(v => runtimeNames.has(v.name));
+            const dev = vulns.filter(v => !runtimeNames.has(v.name));
+
             if (vulns.length === 0) {
               console.log('No moderate+ vulnerabilities found.');
               return;
             }
 
-            // Build issue body
-            let body = `Automated daily npm audit report — found **${vulns.length}** vulnerabilities.\n\n`;
-            body += "| package | severity | via | title |\n";
-            body += "|---|---:|---|---|\n";
-            for (const v of vulns.slice(0, 50)) { // limit to 50 entries
-              const via = Array.isArray(v.via) ? v.via.map(x=> (typeof x === 'string' ? x : x.title || x.name)).join(", ") : v.via;
-              body += `| ${v.name} | ${v.severity} | ${via} | ${v.title || ''} |\n`;
-            }
-            body += `\n\nFull audit JSON attached to the issue.`;
+            const describeVia = (v) => Array.isArray(v.via)
+              ? v.via.map(x => (typeof x === 'string' ? x : x.title || x.name)).join(', ')
+              : v.via;
 
-            // Try to find an existing "Daily npm audit" issue to update
+            const table = (rows) => {
+              let out = '| package | severity | fix available | advisories |\n';
+              out += '|---|---:|---|---|\n';
+              for (const v of rows.slice(0, 50)) {
+                const fix = v.fixAvailable === false
+                  ? 'no'
+                  : (v.fixAvailable?.version ? `${v.fixAvailable.name}@${v.fixAvailable.version}` : 'yes');
+                out += `| ${v.name} | ${v.severity} | ${fix} | ${describeVia(v)} |\n`;
+              }
+              if (rows.length > 50) out += `\n_+${rows.length - 50} more (see the audit JSON)._\n`;
+              return out;
+            };
+
+            let body = `Automated daily npm audit report — **${runtime.length}** consumer-facing, `
+              + `**${dev.length}** dev/CI-only (moderate+).\n\n`;
+
+            body += `## Runtime (reaches consumers) — ${runtime.length}\n\n`;
+            body += runtime.length
+              ? table(runtime)
+              : '_None._\n';
+
+            body += `\n## Dev / CI only — ${dev.length}\n\n`;
+            body += dev.length
+              ? table(dev)
+              : '_None._\n';
+
+            body += '\n> Peer dependencies (`react`, `react-dom`) are not covered by `npm audit`.\n';
+            body += '> Triage rules and SLAs: `docs/dependency-policy.md`.\n';
+
+            if (process.env.ARTIFACT_URL) {
+              body += `\nFull audit JSON: ${process.env.ARTIFACT_URL}\n`;
+            }
+
             const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -81,6 +144,7 @@ jobs:
               });
               console.log(`Created issue #${newIssue.data.number}`);
             }
+
       - name: Send Slack notification
         if: ${{ success() }}
         run: |
@@ -88,13 +152,12 @@ jobs:
             echo "ERROR: SLACK_WEBHOOK secret not configured."
             exit 1
           fi
-          jq -r '.vulnerabilities | to_entries | length' audit.json > /tmp/count.txt || true
-          COUNT=$(cat /tmp/count.txt || echo 0)
-          if [ "$COUNT" -gt "0" ]; then
-            PAYLOAD=$(jq -n --arg c "$COUNT" --arg repo "${{ github.repository }}" '{text: ("[" + $repo + "] npm audit found " + $c + " vulnerabilities — see GitHub issues for details.")}')
+          RUNTIME=$(jq -r '[.vulnerabilities[] | select(.severity == "moderate" or .severity == "high" or .severity == "critical")] | length' audit-prod.json || echo 0)
+          TOTAL=$(jq -r '[.vulnerabilities[] | select(.severity == "moderate" or .severity == "high" or .severity == "critical")] | length' audit-all.json || echo 0)
+          if [ "$TOTAL" -gt "0" ]; then
+            PAYLOAD=$(jq -n --arg r "$RUNTIME" --arg t "$TOTAL" --arg repo "${{ github.repository }}" \
+              '{text: ("[" + $repo + "] npm audit: " + $r + " consumer-facing, " + $t + " total moderate+ vulnerabilities — see GitHub issues for details.")}')
             curl -s -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "${{ secrets.SLACK_WEBHOOK }}"
           else
             echo "No vulnerabilities to report to Slack."
           fi
-
-

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -3,7 +3,7 @@ name: Daily npm audit
 on:
   schedule:
     - cron: '0 16 * * *'   # daily at 16:00 UTC
-  workflow_dispatch: {}   # manual run option
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -25,16 +25,14 @@ jobs:
       - name: Install
         run: npm ci
 
-      # Two audits: the full tree, and the production-only tree. Anything present in the
-      # production audit reaches consumers who install @layerfi/components; the difference is
-      # dev/CI-only exposure. npm audit covers neither set's peer dependencies.
+      # The production-only tree is what consumers inherit; the difference is dev/CI-only.
+      # Peer dependencies appear in neither — npm audit does not cover them.
       - name: Run npm audit
         run: |
           npm audit --json > audit-all.json || true
           npm audit --omit=dev --json > audit-prod.json || true
 
-      # The artifact is a convenience; the report is the point. A failed upload must not take the
-      # issue and the Slack ping down with it — the script already treats ARTIFACT_URL as optional.
+      # The artifact is a convenience; a failed upload must not take the report down with it.
       - name: Upload audit JSON
         id: upload
         continue-on-error: true
@@ -64,7 +62,7 @@ jobs:
             const all = read('audit-all.json');
             const prod = read('audit-prod.json');
 
-            if (!all || !all.vulnerabilities) {
+            if (!all?.vulnerabilities) {
               console.log('No vulnerability data available.');
               return;
             }
@@ -76,94 +74,80 @@ jobs:
 
             const vulns = toList(all);
 
-            // Without the production audit there is no way to split the two sets. Defaulting to an
-            // empty runtime set would report "0 consumer-facing" and hide real exposure, so fail
-            // toward over-reporting: treat everything as potentially consumer-facing and mark the
-            // step failed so someone looks.
-            const prodAvailable = !!(prod && prod.vulnerabilities);
+            // Reporting an empty runtime set would read as "0 consumer-facing" and hide real
+            // exposure, so an unusable prod audit over-reports and fails the run instead.
+            const prodAvailable = !!prod?.vulnerabilities;
             if (!prodAvailable) {
               core.setFailed('audit-prod.json missing or unparseable — cannot split runtime from dev exposure.');
             }
-
-            const runtimeNames = new Set(toList(prod).map(v => v.name));
-            const runtime = prodAvailable ? vulns.filter(v => runtimeNames.has(v.name)) : vulns;
-            const dev = prodAvailable ? vulns.filter(v => !runtimeNames.has(v.name)) : [];
 
             if (vulns.length === 0) {
               console.log('No moderate+ vulnerabilities found.');
               return;
             }
 
-            const describeVia = (v) => Array.isArray(v.via)
+            const runtimeNames = new Set(toList(prod).map(v => v.name));
+            const runtime = prodAvailable ? vulns.filter(v => runtimeNames.has(v.name)) : vulns;
+            const dev = prodAvailable ? vulns.filter(v => !runtimeNames.has(v.name)) : [];
+
+            const describeVia = v => Array.isArray(v.via)
               ? v.via.map(x => (typeof x === 'string' ? x : x.title || x.name)).join(', ')
               : v.via;
 
+            const describeFix = v => v.fixAvailable === false
+              ? 'no'
+              : (v.fixAvailable?.version ? `${v.fixAvailable.name}@${v.fixAvailable.version}` : 'yes');
+
             const table = (rows) => {
-              let out = '| package | severity | fix available | advisories |\n';
-              out += '|---|---:|---|---|\n';
-              for (const v of rows.slice(0, 50)) {
-                const fix = v.fixAvailable === false
-                  ? 'no'
-                  : (v.fixAvailable?.version ? `${v.fixAvailable.name}@${v.fixAvailable.version}` : 'yes');
-                out += `| ${v.name} | ${v.severity} | ${fix} | ${describeVia(v)} |\n`;
-              }
-              if (rows.length > 50) out += `\n_+${rows.length - 50} more (see the audit JSON)._\n`;
-              return out;
+              if (rows.length === 0) return '_None._\n';
+              const header = '| package | severity | fix available | advisories |\n|---|---:|---|---|\n';
+              const body = rows.slice(0, 50)
+                .map(v => `| ${v.name} | ${v.severity} | ${describeFix(v)} | ${describeVia(v)} |\n`)
+                .join('');
+              const truncated = rows.length > 50
+                ? `\n_+${rows.length - 50} more (see the audit JSON)._\n`
+                : '';
+              return header + body + truncated;
             };
 
-            let body = prodAvailable
-              ? `Automated daily npm audit report — **${runtime.length}** consumer-facing, `
-                + `**${dev.length}** dev/CI-only (moderate+).\n\n`
-              : `> ⚠️ The production-only audit did not produce usable output, so runtime and dev\n`
-                + `> exposure could not be separated. All **${vulns.length}** moderate+ findings are\n`
-                + `> listed below as potentially consumer-facing. The workflow run is marked failed.\n\n`;
+            const body = [
+              prodAvailable
+                ? `Automated daily npm audit report — **${runtime.length}** consumer-facing, `
+                  + `**${dev.length}** dev/CI-only (moderate+).\n`
+                : '> ⚠️ The production-only audit did not produce usable output, so runtime and dev\n'
+                  + `> exposure could not be separated. All **${vulns.length}** moderate+ findings are\n`
+                  + '> listed below as potentially consumer-facing. The workflow run is marked failed.\n',
+              `## Runtime (reaches consumers) — ${runtime.length}\n`,
+              table(runtime),
+              `## Dev / CI only — ${dev.length}\n`,
+              table(dev),
+              '> Peer dependencies (`react`, `react-dom`) are not covered by `npm audit`.\n'
+                + '> Triage rules and SLAs: `docs/dependency-policy.md`.\n',
+              process.env.ARTIFACT_URL ? `Full audit JSON: ${process.env.ARTIFACT_URL}\n` : '',
+            ].filter(Boolean).join('\n');
 
-            body += `## Runtime (reaches consumers) — ${runtime.length}\n\n`;
-            body += runtime.length
-              ? table(runtime)
-              : '_None._\n';
-
-            body += `\n## Dev / CI only — ${dev.length}\n\n`;
-            body += dev.length
-              ? table(dev)
-              : '_None._\n';
-
-            body += '\n> Peer dependencies (`react`, `react-dom`) are not covered by `npm audit`.\n';
-            body += '> Triage rules and SLAs: `docs/dependency-policy.md`.\n';
-
-            if (process.env.ARTIFACT_URL) {
-              body += `\nFull audit JSON: ${process.env.ARTIFACT_URL}\n`;
-            }
-
-            const issues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+            const repo = { owner: context.repo.owner, repo: context.repo.repo };
+            const open = await github.rest.issues.listForRepo({
+              ...repo,
               labels: 'automated-vuln-report',
               state: 'open'
             });
 
-            if (issues.data && issues.data.length > 0) {
-              const issueNumber = issues.data[0].number;
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                body: body
-              });
+            if (open.data?.length > 0) {
+              const issueNumber = open.data[0].number;
+              await github.rest.issues.createComment({ ...repo, issue_number: issueNumber, body });
               console.log(`Appended comment to issue #${issueNumber}`);
             } else {
-              const newIssue = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: `Daily npm audit — ${new Date().toISOString().slice(0,10)}`,
-                body: body,
+              const created = await github.rest.issues.create({
+                ...repo,
+                title: `Daily npm audit — ${new Date().toISOString().slice(0, 10)}`,
+                body,
                 labels: ['automated-vuln-report']
               });
-              console.log(`Created issue #${newIssue.data.number}`);
+              console.log(`Created issue #${created.data.number}`);
             }
 
-      # `!cancelled()` rather than `success()`: a broken audit or a failed upload is exactly when
-      # the ping matters most, and skipping it would make a silent failure look like a clean day.
+      # A broken audit is when the ping matters most, so this runs on failure too.
       - name: Send Slack notification
         if: ${{ !cancelled() }}
         run: |
@@ -171,11 +155,11 @@ jobs:
             echo "ERROR: SLACK_WEBHOOK secret not configured."
             exit 1
           fi
-          count() { jq -r '[.vulnerabilities[] | select(.severity == "moderate" or .severity == "high" or .severity == "critical")] | length' "$1" 2>/dev/null; }
-          # `|| true` inside the substitution: the step runs under `bash -e`, where a failing jq in a
-          # bare assignment exits before the fallbacks below can apply.
-          RUNTIME=$(count audit-prod.json || true); RUNTIME=${RUNTIME:-unknown}
-          TOTAL=$(count audit-all.json || true); TOTAL=${TOTAL:-unknown}
+          # `|| echo unknown` is load-bearing: under `bash -e` a bare assignment from a failing jq
+          # exits the step, and an unreadable audit must still report rather than look like zero.
+          count() { jq -r '[.vulnerabilities[] | select(.severity == "moderate" or .severity == "high" or .severity == "critical")] | length' "$1" 2>/dev/null || echo unknown; }
+          RUNTIME=$(count audit-prod.json)
+          TOTAL=$(count audit-all.json)
           if [ "$TOTAL" != "0" ]; then
             PAYLOAD=$(jq -n --arg r "$RUNTIME" --arg t "$TOTAL" --arg repo "${{ github.repository }}" \
               '{text: ("[" + $repo + "] npm audit: " + $r + " consumer-facing, " + $t + " total moderate+ vulnerabilities — see GitHub issues for details.")}')

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -55,11 +55,7 @@ jobs:
             const fs = require('fs');
 
             const read = (file) => {
-              try {
-                return JSON.parse(fs.readFileSync(file, 'utf8'));
-              } catch {
-                return null;
-              }
+              try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return null; }
             };
 
             const all = read('audit-all.json');
@@ -82,16 +78,17 @@ jobs:
 
             const vulns = toList(all);
 
-            // Reporting an empty runtime set would read as "0 consumer-facing" and hide real
-            // exposure, so an unusable prod audit over-reports and fails the run instead.
+            // An empty runtime set would read as "0 consumer-facing" and hide real exposure, so an
+            // unusable prod audit over-reports and fails the run instead.
             const prodAvailable = !!prod?.vulnerabilities;
             if (!prodAvailable) {
               core.setFailed('audit-prod.json missing or unparseable — cannot split runtime from dev exposure.');
             }
 
-            const runtimeNames = new Set(toList(prod).map(v => v.name));
-            const runtime = prodAvailable ? vulns.filter(v => runtimeNames.has(v.name)) : vulns;
-            const dev = prodAvailable ? vulns.filter(v => !runtimeNames.has(v.name)) : [];
+            const inProd = new Set(toList(prod).map(v => v.name));
+            const [runtime, dev] = prodAvailable
+              ? [vulns.filter(v => inProd.has(v.name)), vulns.filter(v => !inProd.has(v.name))]
+              : [vulns, []];
 
             core.setOutput('total', String(vulns.length));
             core.setOutput('runtime', prodAvailable ? String(runtime.length) : 'unknown');
@@ -101,17 +98,21 @@ jobs:
               return;
             }
 
-            // npm emits one `via` entry per dependency path, so titles repeat; a bare string is a
-            // package that pulled the advisory in rather than an advisory title of its own.
+            // Both renderers walk this, so neither repeats the prod-available branch.
+            const groups = prodAvailable
+              ? [{ title: 'Consumer-facing', rows: runtime }, { title: 'Dev / CI only', rows: dev }]
+              : [{ title: '⚠️ Potentially consumer-facing — prod/dev split unknown', rows: vulns }];
+
+            // npm repeats a title per dependency path; a bare string is the package that pulled the
+            // advisory in, not a title.
             const describeVia = (v) => {
               if (!Array.isArray(v.via)) return v.via;
-              const seen = v.via.map(x => (typeof x === 'string' ? `via \`${x}\`` : x.title || x.name));
-              return [...new Set(seen)].join(', ');
+              const titles = v.via.map(x => (typeof x === 'string' ? `via \`${x}\`` : x.title || x.name));
+              return [...new Set(titles)].join(', ');
             };
 
-            // `true` means a patched version already satisfies the declared range, so the fix is a
-            // lockfile refresh. An object means a manifest change to that version. Anything else —
-            // false, null, absent — is no known fix, and must not read as one.
+            // `true` means a patched version already satisfies the declared range — a lockfile
+            // refresh. An object means a manifest change. Anything else is no known fix.
             const describeFix = (v) => {
               if (v.fixAvailable === true) return 'yes — `npm audit fix`';
               if (!v.fixAvailable?.version) return 'no';
@@ -120,19 +121,18 @@ jobs:
             };
 
             const repo = { owner: context.repo.owner, repo: context.repo.repo };
+            const slug = `${repo.owner}/${repo.repo}`;
 
-            // A single-package PR names it in the title, a grouped PR lists each one in the body.
-            // Deduped, since a PR may well name the same package in both places.
+            // Single-package PRs name it in the title, grouped PRs in the body. Deduped, since one
+            // PR can do both.
             const packagesIn = (pr) => {
               const grouped = [...(pr.body ?? '').matchAll(/^Updates `([^`]+)` from/gm)].map(m => m[1]);
               const single = pr.title.match(/bump (@?[\w./-]+) from/i);
               return [...new Set(single ? [...grouped, single[1]] : grouped)];
             };
 
-            // A package can appear in more than one PR — security updates bypass grouping, so a
-            // grouped version bump and a standalone security bump can both be open. List all of
-            // them, newest first (pulls.list order). Links are a convenience: a failed listing
-            // empties the column rather than taking the report down.
+            // A package can sit in several open PRs at once — security updates bypass grouping — so
+            // keep them all. Links are a convenience: a failed listing just empties the column.
             const fixPrs = new Map();
             try {
               const openPrs = await github.paginate(github.rest.pulls.list, { ...repo, state: 'open', per_page: 100 });
@@ -145,64 +145,51 @@ jobs:
               core.warning(`Could not list open PRs, omitting fix links: ${error.message}`);
             }
 
-            const prLinks = v => (fixPrs.get(v.name) ?? []).map(pr => `[#${pr.number}](${pr.url})`).join(', ');
+            const prs = v => (fixPrs.get(v.name) ?? []).map(pr => `[#${pr.number}](${pr.url})`).join(', ');
 
             const table = (rows) => {
               if (rows.length === 0) return '_None._\n';
-              const header = '| package | severity | fix available | open PR | advisories |\n|---|---:|---|---|---|\n';
+              const head = '| package | severity | fix available | open PR | advisories |\n|---|---:|---|---|---|\n';
               const body = rows.slice(0, 50)
-                .map(v => `| ${v.name} | ${v.severity} | ${describeFix(v)} | ${prLinks(v) || '—'} | ${describeVia(v)} |\n`)
+                .map(v => `| ${v.name} | ${v.severity} | ${describeFix(v)} | ${prs(v) || '—'} | ${describeVia(v)} |\n`)
                 .join('');
-              const truncated = rows.length > 50
-                ? `\n_+${rows.length - 50} more (see the audit JSON)._\n`
-                : '';
-              return header + body + truncated;
+              return head + body + (rows.length > 50 ? `\n_+${rows.length - 50} more (see the audit JSON)._\n` : '');
             };
 
-            const alerts = `https://github.com/${repo.owner}/${repo.repo}/security/dependabot`;
+            const alerts = `https://github.com/${slug}/security/dependabot`;
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${slug}/actions/runs/${context.runId}`;
 
-            const summary = [
+            await core.summary.addRaw([
               prodAvailable
                 ? `**${runtime.length}** consumer-facing, **${dev.length}** dev/CI-only, most severe first.\n`
-                : '> ⚠️ The production-only audit did not produce usable output, so runtime and dev\n'
-                  + `> exposure could not be separated. All **${vulns.length}** findings are\n`
-                  + '> listed below as potentially consumer-facing. The workflow run is marked failed.\n',
-              `## Runtime (reaches consumers) — ${runtime.length}\n`,
-              table(runtime),
-              `## Dev / CI only — ${dev.length}\n`,
-              table(dev),
+                : `> ⚠️ The production-only audit did not produce usable output, so all **${vulns.length}**\n`
+                  + '> findings are listed as potentially consumer-facing. The run is marked failed.\n',
+              ...groups.map(g => `## ${g.title} — ${g.rows.length}\n\n${table(g.rows)}`),
               '> Peer dependencies (`react`, `react-dom`) are not covered by `npm audit`.\n'
                 + `> Per-advisory state lives in [Dependabot alerts](${alerts}); triage rules and SLAs:\n`
                 + '> `docs/dependency-policy.md`.\n',
               process.env.ARTIFACT_URL ? `Full audit JSON: ${process.env.ARTIFACT_URL}\n` : '',
-            ].filter(Boolean).join('\n');
+            ].filter(Boolean).join('\n')).write();
 
-            await core.summary.addRaw(summary).write();
-
-            // Slack gets counts, not rows: it has no table primitive, and a fixed-width block would
-            // not reflow on mobile. One bolded header per environment, then a bullet per severity.
-            const SEVERITY_EMOJI = { critical: '🚨', high: '🔴', moderate: '🟠', low: '🟡' };
-
-            const section = (title, rows) => {
-              const bullets = [...SEVERITIES].reverse()
-                .map(severity => ({ severity, count: rows.filter(v => v.severity === severity).length }))
-                .filter(({ count }) => count > 0)
-                .map(({ severity, count }) => `• ${SEVERITY_EMOJI[severity]} ${count} ${severity}`);
-              return [`*${title} (${rows.length})*`, ...(bullets.length ? bullets : ['• none'])].join('\n');
+            // Slack has no table primitive and code blocks do not reflow on mobile, so it gets a
+            // header per environment and a bullet per severity.
+            const EMOJI = { critical: '🚨', high: '🔴', moderate: '🟠', low: '🟡' };
+            const bullets = (rows) => {
+              const lines = [...SEVERITIES].reverse()
+                .map(severity => [severity, rows.filter(v => v.severity === severity).length])
+                .filter(([, count]) => count > 0)
+                .map(([severity, count]) => `• ${EMOJI[severity]} ${count} ${severity}`);
+              return lines.length ? lines : ['• none'];
             };
 
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${repo.owner}/${repo.repo}/actions/runs/${context.runId}`;
-            // Every finding's PRs, not just the consumer-facing ones — a merge-ready dev PR is still
-            // work waiting. `vulns` is severity-ordered, so the links come out worst-first.
-            const linked = vulns.flatMap(v => (fixPrs.get(v.name) ?? []).map(pr => `<${pr.url}|#${pr.number}>`));
+            // Every finding's PRs, not just consumer-facing ones — a merge-ready dev PR is still work
+            // waiting. `vulns` is severity-ordered, so these come out worst-first.
+            const linked = new Set(vulns.flatMap(v => (fixPrs.get(v.name) ?? []).map(pr => `<${pr.url}|#${pr.number}>`)));
 
             core.setOutput('slack', [
-              `[${repo.owner}/${repo.repo}] npm audit — ${vulns.length} findings`,
-              prodAvailable
-                ? section('Consumer-facing', runtime)
-                : section(`⚠️ Potentially consumer-facing — prod audit unusable, split unknown`, vulns),
-              prodAvailable ? section('Dev / CI only', dev) : '',
-              linked.length ? `Open fix PRs: ${[...new Set(linked)].join(' ')}` : '',
+              `[${slug}] npm audit — ${vulns.length} findings`,
+              ...groups.map(g => [`*${g.title} (${g.rows.length})*`, ...bullets(g.rows)].join('\n')),
+              linked.size ? `Open fix PRs: ${[...linked].join(' ')}` : '',
               `Details: <${runUrl}|run summary> · <${alerts}|Dependabot alerts>`,
             ].filter(Boolean).join('\n\n'));
 

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -71,10 +71,13 @@ jobs:
               return;
             }
 
-            const SEVERITIES = ['moderate', 'high', 'critical'];
+            // Ascending, so indexOf doubles as the sort rank. `info` is excluded as noise.
+            const SEVERITIES = ['low', 'moderate', 'high', 'critical'];
             const toList = audit => Object.entries(audit?.vulnerabilities ?? {})
               .map(([name, info]) => ({ name, ...info }))
-              .filter(v => SEVERITIES.includes(v.severity));
+              .filter(v => SEVERITIES.includes(v.severity))
+              .sort((a, b) => SEVERITIES.indexOf(b.severity) - SEVERITIES.indexOf(a.severity)
+                || a.name.localeCompare(b.name));
 
             const vulns = toList(all);
 
@@ -93,17 +96,27 @@ jobs:
             core.setOutput('runtime', prodAvailable ? String(runtime.length) : 'unknown');
 
             if (vulns.length === 0) {
-              await core.summary.addRaw('No moderate+ vulnerabilities.\n').write();
+              await core.summary.addRaw('No vulnerabilities.\n').write();
               return;
             }
 
-            const describeVia = v => Array.isArray(v.via)
-              ? v.via.map(x => (typeof x === 'string' ? x : x.title || x.name)).join(', ')
-              : v.via;
+            // npm emits one `via` entry per dependency path, so titles repeat; a bare string is a
+            // package that pulled the advisory in rather than an advisory title of its own.
+            const describeVia = (v) => {
+              if (!Array.isArray(v.via)) return v.via;
+              const seen = v.via.map(x => (typeof x === 'string' ? `via \`${x}\`` : x.title || x.name));
+              return [...new Set(seen)].join(', ');
+            };
 
-            const describeFix = v => v.fixAvailable === false
-              ? 'no'
-              : (v.fixAvailable?.version ? `${v.fixAvailable.name}@${v.fixAvailable.version}` : 'yes');
+            // A bare `fixAvailable: true` names no target version, so say where the bump lands:
+            // our own declared range for a direct dependency, someone else's for a transitive one.
+            const describeFix = (v) => {
+              if (v.fixAvailable === false) return 'no';
+              if (!v.fixAvailable?.version) return v.isDirect ? 'yes — bump ours' : 'yes — via parent';
+              return v.fixAvailable.isSemVerMajor
+                ? `${v.fixAvailable.name}@${v.fixAvailable.version} (major)`
+                : `${v.fixAvailable.name}@${v.fixAvailable.version}`;
+            };
 
             const table = (rows) => {
               if (rows.length === 0) return '_None._\n';
@@ -121,9 +134,9 @@ jobs:
 
             const summary = [
               prodAvailable
-                ? `**${runtime.length}** consumer-facing, **${dev.length}** dev/CI-only (moderate+).\n`
+                ? `**${runtime.length}** consumer-facing, **${dev.length}** dev/CI-only, most severe first.\n`
                 : '> ⚠️ The production-only audit did not produce usable output, so runtime and dev\n'
-                  + `> exposure could not be separated. All **${vulns.length}** moderate+ findings are\n`
+                  + `> exposure could not be separated. All **${vulns.length}** findings are\n`
                   + '> listed below as potentially consumer-facing. The workflow run is marked failed.\n',
               `## Runtime (reaches consumers) — ${runtime.length}\n`,
               table(runtime),
@@ -159,5 +172,5 @@ jobs:
             exit 0
           fi
           PAYLOAD=$(jq -n --arg r "$RUNTIME" --arg t "$TOTAL" --arg repo "${{ github.repository }}" --arg url "$RUN_URL" \
-            '{text: ("[" + $repo + "] npm audit: " + $r + " consumer-facing, " + $t + " total moderate+ — <" + $url + "|run summary>")}')
+            '{text: ("[" + $repo + "] npm audit: " + $r + " consumer-facing, " + $t + " total — <" + $url + "|run summary>")}')
           curl -s -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "${{ secrets.SLACK_WEBHOOK }}"

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   audit:
@@ -43,7 +42,10 @@ jobs:
             audit-all.json
             audit-prod.json
 
-      - name: Create/update daily vulnerability issue
+      # Reports to the run summary rather than an issue: Dependabot alerts already track
+      # per-advisory state for this repo, so a second tracker would only duplicate it.
+      - name: Summarize audit
+        id: report
         uses: actions/github-script@v7
         env:
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
@@ -63,7 +65,9 @@ jobs:
             const prod = read('audit-prod.json');
 
             if (!all?.vulnerabilities) {
-              console.log('No vulnerability data available.');
+              core.setOutput('total', 'unknown');
+              core.setOutput('runtime', 'unknown');
+              core.setFailed('audit-all.json missing or unparseable.');
               return;
             }
 
@@ -81,14 +85,17 @@ jobs:
               core.setFailed('audit-prod.json missing or unparseable — cannot split runtime from dev exposure.');
             }
 
-            if (vulns.length === 0) {
-              console.log('No moderate+ vulnerabilities found.');
-              return;
-            }
-
             const runtimeNames = new Set(toList(prod).map(v => v.name));
             const runtime = prodAvailable ? vulns.filter(v => runtimeNames.has(v.name)) : vulns;
             const dev = prodAvailable ? vulns.filter(v => !runtimeNames.has(v.name)) : [];
+
+            core.setOutput('total', String(vulns.length));
+            core.setOutput('runtime', prodAvailable ? String(runtime.length) : 'unknown');
+
+            if (vulns.length === 0) {
+              await core.summary.addRaw('No moderate+ vulnerabilities.\n').write();
+              return;
+            }
 
             const describeVia = v => Array.isArray(v.via)
               ? v.via.map(x => (typeof x === 'string' ? x : x.title || x.name)).join(', ')
@@ -110,10 +117,11 @@ jobs:
               return header + body + truncated;
             };
 
-            const body = [
+            const alerts = `https://github.com/${context.repo.owner}/${context.repo.repo}/security/dependabot`;
+
+            const summary = [
               prodAvailable
-                ? `Automated daily npm audit report — **${runtime.length}** consumer-facing, `
-                  + `**${dev.length}** dev/CI-only (moderate+).\n`
+                ? `**${runtime.length}** consumer-facing, **${dev.length}** dev/CI-only (moderate+).\n`
                 : '> ⚠️ The production-only audit did not produce usable output, so runtime and dev\n'
                   + `> exposure could not be separated. All **${vulns.length}** moderate+ findings are\n`
                   + '> listed below as potentially consumer-facing. The workflow run is marked failed.\n',
@@ -122,48 +130,34 @@ jobs:
               `## Dev / CI only — ${dev.length}\n`,
               table(dev),
               '> Peer dependencies (`react`, `react-dom`) are not covered by `npm audit`.\n'
-                + '> Triage rules and SLAs: `docs/dependency-policy.md`.\n',
+                + `> Per-advisory state lives in [Dependabot alerts](${alerts}); triage rules and SLAs:\n`
+                + '> `docs/dependency-policy.md`.\n',
               process.env.ARTIFACT_URL ? `Full audit JSON: ${process.env.ARTIFACT_URL}\n` : '',
             ].filter(Boolean).join('\n');
 
-            const repo = { owner: context.repo.owner, repo: context.repo.repo };
-            const open = await github.rest.issues.listForRepo({
-              ...repo,
-              labels: 'automated-vuln-report',
-              state: 'open'
-            });
+            await core.summary.addRaw(summary).write();
 
-            if (open.data?.length > 0) {
-              const issueNumber = open.data[0].number;
-              await github.rest.issues.createComment({ ...repo, issue_number: issueNumber, body });
-              console.log(`Appended comment to issue #${issueNumber}`);
-            } else {
-              const created = await github.rest.issues.create({
-                ...repo,
-                title: `Daily npm audit — ${new Date().toISOString().slice(0, 10)}`,
-                body,
-                labels: ['automated-vuln-report']
-              });
-              console.log(`Created issue #${created.data.number}`);
-            }
-
-      # A broken audit is when the ping matters most, so this runs on failure too.
+      # A broken audit is when the ping matters most, so this runs on failure too. Counts come
+      # from the step above rather than a second jq pass, so both reports cannot disagree.
       - name: Send Slack notification
         if: ${{ !cancelled() }}
+        env:
+          RUNTIME: ${{ steps.report.outputs.runtime }}
+          TOTAL: ${{ steps.report.outputs.total }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           if [ -z "${{ secrets.SLACK_WEBHOOK }}" ]; then
             echo "ERROR: SLACK_WEBHOOK secret not configured."
             exit 1
           fi
-          # `|| echo unknown` is load-bearing: under `bash -e` a bare assignment from a failing jq
-          # exits the step, and an unreadable audit must still report rather than look like zero.
-          count() { jq -r '[.vulnerabilities[] | select(.severity == "moderate" or .severity == "high" or .severity == "critical")] | length' "$1" 2>/dev/null || echo unknown; }
-          RUNTIME=$(count audit-prod.json)
-          TOTAL=$(count audit-all.json)
-          if [ "$TOTAL" != "0" ]; then
-            PAYLOAD=$(jq -n --arg r "$RUNTIME" --arg t "$TOTAL" --arg repo "${{ github.repository }}" \
-              '{text: ("[" + $repo + "] npm audit: " + $r + " consumer-facing, " + $t + " total moderate+ vulnerabilities — see GitHub issues for details.")}')
-            curl -s -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "${{ secrets.SLACK_WEBHOOK }}"
-          else
+          # Unset when the summarize step died before setting outputs — still worth a ping, and
+          # `unknown` must not take the "nothing to report" branch the way 0 would.
+          RUNTIME=${RUNTIME:-unknown}
+          TOTAL=${TOTAL:-unknown}
+          if [ "$TOTAL" = "0" ]; then
             echo "No vulnerabilities to report to Slack."
+            exit 0
           fi
+          PAYLOAD=$(jq -n --arg r "$RUNTIME" --arg t "$TOTAL" --arg repo "${{ github.repository }}" --arg url "$RUN_URL" \
+            '{text: ("[" + $repo + "] npm audit: " + $r + " consumer-facing, " + $t + " total moderate+ — <" + $url + "|run summary>")}')
+          curl -s -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "${{ secrets.SLACK_WEBHOOK }}"

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -121,34 +121,32 @@ jobs:
 
             const repo = { owner: context.repo.owner, repo: context.repo.repo };
 
-            // Single-package PRs name it in the title; grouped PRs list each one in the body as
-            // "Updates `pkg` from". Fix links are a convenience, so a failed lookup just omits them.
+            // A single-package PR names it in the title, a grouped PR lists each one in the body.
+            const packagesIn = (pr) => {
+              const grouped = [...(pr.body ?? '').matchAll(/^Updates `([^`]+)` from/gm)].map(m => m[1]);
+              const single = pr.title.match(/bump (@?[\w./-]+) from/i);
+              return single ? [...grouped, single[1]] : grouped;
+            };
+
+            // Fix links are a convenience: a failed listing empties the column rather than taking
+            // the report down. pulls.list returns newest first, so the first match wins.
             const fixPrs = new Map();
             try {
-              const open = await github.paginate(github.rest.pulls.list, { ...repo, state: 'open', per_page: 100 });
-              for (const pr of open) {
-                if (pr.user?.login !== 'dependabot[bot]') continue;
-                const names = [...(pr.body ?? '').matchAll(/^Updates `([^`]+)` from/gm)].map(m => m[1]);
-                const titled = pr.title.match(/[Bb]ump (@?[\w./-]+) from/);
-                if (titled) names.push(titled[1]);
-                for (const name of names) {
-                  if (!fixPrs.has(name)) fixPrs.set(name, pr);
+              const openPrs = await github.paginate(github.rest.pulls.list, { ...repo, state: 'open', per_page: 100 });
+              for (const pr of openPrs.filter(pr => pr.user?.login === 'dependabot[bot]')) {
+                for (const name of packagesIn(pr)) {
+                  if (!fixPrs.has(name)) fixPrs.set(name, `[#${pr.number}](${pr.html_url})`);
                 }
               }
             } catch (error) {
               core.warning(`Could not list open PRs, omitting fix links: ${error.message}`);
             }
 
-            const describePr = (v) => {
-              const pr = fixPrs.get(v.name);
-              return pr ? `[#${pr.number}](${pr.html_url})` : '—';
-            };
-
             const table = (rows) => {
               if (rows.length === 0) return '_None._\n';
               const header = '| package | severity | fix available | open PR | advisories |\n|---|---:|---|---|---|\n';
               const body = rows.slice(0, 50)
-                .map(v => `| ${v.name} | ${v.severity} | ${describeFix(v)} | ${describePr(v)} | ${describeVia(v)} |\n`)
+                .map(v => `| ${v.name} | ${v.severity} | ${describeFix(v)} | ${fixPrs.get(v.name) ?? '—'} | ${describeVia(v)} |\n`)
                 .join('');
               const truncated = rows.length > 50
                 ? `\n_+${rows.length - 50} more (see the audit JSON)._\n`
@@ -156,7 +154,7 @@ jobs:
               return header + body + truncated;
             };
 
-            const alerts = `https://github.com/${context.repo.owner}/${context.repo.repo}/security/dependabot`;
+            const alerts = `https://github.com/${repo.owner}/${repo.repo}/security/dependabot`;
 
             const summary = [
               prodAvailable

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -138,18 +138,20 @@ jobs:
               const openPrs = await github.paginate(github.rest.pulls.list, { ...repo, state: 'open', per_page: 100 });
               for (const pr of openPrs.filter(pr => pr.user?.login === 'dependabot[bot]')) {
                 for (const name of packagesIn(pr)) {
-                  fixPrs.set(name, [...(fixPrs.get(name) ?? []), `[#${pr.number}](${pr.html_url})`]);
+                  fixPrs.set(name, [...(fixPrs.get(name) ?? []), { number: pr.number, url: pr.html_url }]);
                 }
               }
             } catch (error) {
               core.warning(`Could not list open PRs, omitting fix links: ${error.message}`);
             }
 
+            const prLinks = v => (fixPrs.get(v.name) ?? []).map(pr => `[#${pr.number}](${pr.url})`).join(', ');
+
             const table = (rows) => {
               if (rows.length === 0) return '_None._\n';
               const header = '| package | severity | fix available | open PR | advisories |\n|---|---:|---|---|---|\n';
               const body = rows.slice(0, 50)
-                .map(v => `| ${v.name} | ${v.severity} | ${describeFix(v)} | ${fixPrs.get(v.name)?.join(', ') ?? '—'} | ${describeVia(v)} |\n`)
+                .map(v => `| ${v.name} | ${v.severity} | ${describeFix(v)} | ${prLinks(v) || '—'} | ${describeVia(v)} |\n`)
                 .join('');
               const truncated = rows.length > 50
                 ? `\n_+${rows.length - 50} more (see the audit JSON)._\n`
@@ -177,16 +179,43 @@ jobs:
 
             await core.summary.addRaw(summary).write();
 
+            // Slack gets counts, not rows: it has no table primitive, and a fixed-width block would
+            // not reflow on mobile. One bolded header per environment, then a bullet per severity.
+            const SEVERITY_EMOJI = { critical: '🚨', high: '🔴', moderate: '🟠', low: '🟡' };
+
+            const section = (title, rows) => {
+              const bullets = [...SEVERITIES].reverse()
+                .map(severity => ({ severity, count: rows.filter(v => v.severity === severity).length }))
+                .filter(({ count }) => count > 0)
+                .map(({ severity, count }) => `• ${SEVERITY_EMOJI[severity]} ${count} ${severity}`);
+              return [`*${title} (${rows.length})*`, ...(bullets.length ? bullets : ['• none'])].join('\n');
+            };
+
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${repo.owner}/${repo.repo}/actions/runs/${context.runId}`;
+            const linked = runtime.flatMap(v => (fixPrs.get(v.name) ?? []).map(pr => `<${pr.url}|#${pr.number}>`));
+
+            core.setOutput('slack', [
+              `[${repo.owner}/${repo.repo}] npm audit — ${vulns.length} findings`,
+              prodAvailable
+                ? section('Consumer-facing', runtime)
+                : section(`⚠️ Potentially consumer-facing — prod audit unusable, split unknown`, vulns),
+              prodAvailable ? section('Dev / CI only', dev) : '',
+              linked.length ? `Open fix PRs: ${[...new Set(linked)].join(' ')}` : '',
+              `Details: <${runUrl}|run summary> · <${alerts}|Dependabot alerts>`,
+            ].filter(Boolean).join('\n\n'));
+
       # A broken audit is when the ping matters most, so this runs on failure too. Counts come
       # from the step above rather than a second jq pass, so both reports cannot disagree.
       - name: Send Slack notification
         if: ${{ !cancelled() }}
         env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TEXT: ${{ steps.report.outputs.slack }}
           RUNTIME: ${{ steps.report.outputs.runtime }}
           TOTAL: ${{ steps.report.outputs.total }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ -z "${{ secrets.SLACK_WEBHOOK }}" ]; then
+          if [ -z "$SLACK_WEBHOOK" ]; then
             echo "ERROR: SLACK_WEBHOOK secret not configured."
             exit 1
           fi
@@ -198,9 +227,11 @@ jobs:
             echo "No vulnerabilities to report to Slack."
             exit 0
           fi
-          PAYLOAD=$(jq -n --arg r "$RUNTIME" --arg t "$TOTAL" --arg repo "${{ github.repository }}" --arg url "$RUN_URL" \
-            '{text: ("[" + $repo + "] npm audit: " + $r + " consumer-facing, " + $t + " total — <" + $url + "|run summary>")}')
+          if [ -z "$SLACK_TEXT" ]; then
+            SLACK_TEXT="[$GITHUB_REPOSITORY] npm audit: $RUNTIME consumer-facing, $TOTAL total — <$RUN_URL|run summary>"
+          fi
+          PAYLOAD=$(jq -n --arg text "$SLACK_TEXT" '{text: $text}')
           # --fail-with-body: Slack answers a dead or revoked webhook with 4xx and a reason, which
           # plain `curl -s` would swallow as exit 0 — a lost ping that looks like a delivered one.
           curl -sS --fail-with-body -X POST -H 'Content-type: application/json' \
-            --data "$PAYLOAD" "${{ secrets.SLACK_WEBHOOK }}"
+            --data "$PAYLOAD" "$SLACK_WEBHOOK"

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read   # to link findings to the Dependabot PR that fixes them
 
 jobs:
   audit:
@@ -118,11 +119,36 @@ jobs:
                 : `${v.fixAvailable.name}@${v.fixAvailable.version}`;
             };
 
+            const repo = { owner: context.repo.owner, repo: context.repo.repo };
+
+            // Single-package PRs name it in the title; grouped PRs list each one in the body as
+            // "Updates `pkg` from". Fix links are a convenience, so a failed lookup just omits them.
+            const fixPrs = new Map();
+            try {
+              const open = await github.paginate(github.rest.pulls.list, { ...repo, state: 'open', per_page: 100 });
+              for (const pr of open) {
+                if (pr.user?.login !== 'dependabot[bot]') continue;
+                const names = [...(pr.body ?? '').matchAll(/^Updates `([^`]+)` from/gm)].map(m => m[1]);
+                const titled = pr.title.match(/[Bb]ump (@?[\w./-]+) from/);
+                if (titled) names.push(titled[1]);
+                for (const name of names) {
+                  if (!fixPrs.has(name)) fixPrs.set(name, pr);
+                }
+              }
+            } catch (error) {
+              core.warning(`Could not list open PRs, omitting fix links: ${error.message}`);
+            }
+
+            const describePr = (v) => {
+              const pr = fixPrs.get(v.name);
+              return pr ? `[#${pr.number}](${pr.html_url})` : '—';
+            };
+
             const table = (rows) => {
               if (rows.length === 0) return '_None._\n';
-              const header = '| package | severity | fix available | advisories |\n|---|---:|---|---|\n';
+              const header = '| package | severity | fix available | open PR | advisories |\n|---|---:|---|---|---|\n';
               const body = rows.slice(0, 50)
-                .map(v => `| ${v.name} | ${v.severity} | ${describeFix(v)} | ${describeVia(v)} |\n`)
+                .map(v => `| ${v.name} | ${v.severity} | ${describeFix(v)} | ${describePr(v)} | ${describeVia(v)} |\n`)
                 .join('');
               const truncated = rows.length > 50
                 ? `\n_+${rows.length - 50} more (see the audit JSON)._\n`

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -80,7 +80,7 @@ jobs:
             // empty runtime set would report "0 consumer-facing" and hide real exposure, so fail
             // toward over-reporting: treat everything as potentially consumer-facing and mark the
             // step failed so someone looks.
-            const prodAvailable = Boolean(prod && prod.vulnerabilities);
+            const prodAvailable = !!(prod && prod.vulnerabilities);
             if (!prodAvailable) {
               core.setFailed('audit-prod.json missing or unparseable — cannot split runtime from dev exposure.');
             }
@@ -172,8 +172,10 @@ jobs:
             exit 1
           fi
           count() { jq -r '[.vulnerabilities[] | select(.severity == "moderate" or .severity == "high" or .severity == "critical")] | length' "$1" 2>/dev/null; }
-          RUNTIME=$(count audit-prod.json); RUNTIME=${RUNTIME:-unknown}
-          TOTAL=$(count audit-all.json); TOTAL=${TOTAL:-0}
+          # `|| true` inside the substitution: the step runs under `bash -e`, where a failing jq in a
+          # bare assignment exits before the fallbacks below can apply.
+          RUNTIME=$(count audit-prod.json || true); RUNTIME=${RUNTIME:-unknown}
+          TOTAL=$(count audit-all.json || true); TOTAL=${TOTAL:-unknown}
           if [ "$TOTAL" != "0" ]; then
             PAYLOAD=$(jq -n --arg r "$RUNTIME" --arg t "$TOTAL" --arg repo "${{ github.repository }}" \
               '{text: ("[" + $repo + "] npm audit: " + $r + " consumer-facing, " + $t + " total moderate+ vulnerabilities — see GitHub issues for details.")}')

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -33,8 +33,11 @@ jobs:
           npm audit --json > audit-all.json || true
           npm audit --omit=dev --json > audit-prod.json || true
 
+      # The artifact is a convenience; the report is the point. A failed upload must not take the
+      # issue and the Slack ping down with it — the script already treats ARTIFACT_URL as optional.
       - name: Upload audit JSON
         id: upload
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: npm-audit
@@ -71,10 +74,20 @@ jobs:
               .map(([name, info]) => ({ name, ...info }))
               .filter(v => SEVERITIES.includes(v.severity));
 
-            const runtimeNames = new Set(toList(prod).map(v => v.name));
             const vulns = toList(all);
-            const runtime = vulns.filter(v => runtimeNames.has(v.name));
-            const dev = vulns.filter(v => !runtimeNames.has(v.name));
+
+            // Without the production audit there is no way to split the two sets. Defaulting to an
+            // empty runtime set would report "0 consumer-facing" and hide real exposure, so fail
+            // toward over-reporting: treat everything as potentially consumer-facing and mark the
+            // step failed so someone looks.
+            const prodAvailable = Boolean(prod && prod.vulnerabilities);
+            if (!prodAvailable) {
+              core.setFailed('audit-prod.json missing or unparseable — cannot split runtime from dev exposure.');
+            }
+
+            const runtimeNames = new Set(toList(prod).map(v => v.name));
+            const runtime = prodAvailable ? vulns.filter(v => runtimeNames.has(v.name)) : vulns;
+            const dev = prodAvailable ? vulns.filter(v => !runtimeNames.has(v.name)) : [];
 
             if (vulns.length === 0) {
               console.log('No moderate+ vulnerabilities found.');
@@ -98,8 +111,12 @@ jobs:
               return out;
             };
 
-            let body = `Automated daily npm audit report — **${runtime.length}** consumer-facing, `
-              + `**${dev.length}** dev/CI-only (moderate+).\n\n`;
+            let body = prodAvailable
+              ? `Automated daily npm audit report — **${runtime.length}** consumer-facing, `
+                + `**${dev.length}** dev/CI-only (moderate+).\n\n`
+              : `> ⚠️ The production-only audit did not produce usable output, so runtime and dev\n`
+                + `> exposure could not be separated. All **${vulns.length}** moderate+ findings are\n`
+                + `> listed below as potentially consumer-facing. The workflow run is marked failed.\n\n`;
 
             body += `## Runtime (reaches consumers) — ${runtime.length}\n\n`;
             body += runtime.length
@@ -145,16 +162,19 @@ jobs:
               console.log(`Created issue #${newIssue.data.number}`);
             }
 
+      # `!cancelled()` rather than `success()`: a broken audit or a failed upload is exactly when
+      # the ping matters most, and skipping it would make a silent failure look like a clean day.
       - name: Send Slack notification
-        if: ${{ success() }}
+        if: ${{ !cancelled() }}
         run: |
           if [ -z "${{ secrets.SLACK_WEBHOOK }}" ]; then
             echo "ERROR: SLACK_WEBHOOK secret not configured."
             exit 1
           fi
-          RUNTIME=$(jq -r '[.vulnerabilities[] | select(.severity == "moderate" or .severity == "high" or .severity == "critical")] | length' audit-prod.json || echo 0)
-          TOTAL=$(jq -r '[.vulnerabilities[] | select(.severity == "moderate" or .severity == "high" or .severity == "critical")] | length' audit-all.json || echo 0)
-          if [ "$TOTAL" -gt "0" ]; then
+          count() { jq -r '[.vulnerabilities[] | select(.severity == "moderate" or .severity == "high" or .severity == "critical")] | length' "$1" 2>/dev/null; }
+          RUNTIME=$(count audit-prod.json); RUNTIME=${RUNTIME:-unknown}
+          TOTAL=$(count audit-all.json); TOTAL=${TOTAL:-0}
+          if [ "$TOTAL" != "0" ]; then
             PAYLOAD=$(jq -n --arg r "$RUNTIME" --arg t "$TOTAL" --arg repo "${{ github.repository }}" \
               '{text: ("[" + $repo + "] npm audit: " + $r + " consumer-facing, " + $t + " total moderate+ vulnerabilities — see GitHub issues for details.")}')
             curl -s -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "${{ secrets.SLACK_WEBHOOK }}"


### PR DESCRIPTION
## Scope

Phase 1 of a six-PR dependency & supply-chain program. Establishes the automation and reporting that the later phases build on.

**New `.github/dependabot.yml`** — the repo has Dependabot *alerts* enabled (32 open on `main`) but no config, so no update PRs were ever opened. Lanes are separated by consumer exposure rather than convenience:

- `storybook`, `linting`, `testing`, then a catch-all `dev-tooling` group for dev-dependency minor+patch — a red PR points at one ecosystem instead of an unattributable pile
- `runtime-patch` groups production patches; runtime **minors are deliberately ungrouped** so each `react-aria-components` / `recharts` / `effect` bump is reviewed on its own
- majors are ignored in the weekly lane (they'd permanently occupy the 5-PR limit); they come from the monthly `npm outdated` review instead. Security updates bypass grouping and limits regardless.
- `typescript` and `@typescript/native` are ignored — both are intentional aliases (`npm:@typescript/typescript6`, `npm:typescript@^7`) that Dependabot can't reason about, and `overrides.react-intl.typescript` points at `$typescript`
- `github-actions` ecosystem added, which is a prerequisite for the SHA-pinning phase

**`.github/workflows/npm-audit.yml`** — the daily audit reported one undifferentiated count, which does not describe what consumers inherit. Now runs `npm audit` twice (full tree + `--omit=dev`) and reports **runtime vs dev/CI-only separately**, with a `fix available` column and a note that peer deps aren't covered by `npm audit` at all. Also: Node 18 → 22 (matched `.nvmrc` and every other workflow), explicit `permissions:` instead of the default write-all token, `github-script@v6` → `v7`, corrected the wrong cron comment, and the body's "Full audit JSON attached" claim is now true — it's uploaded as an artifact and linked.

## Verification

Ran both audits against the current lockfile and executed the workflow's `github-script` body locally against the real JSON (script extracted from the committed YAML, not a copy) to confirm the rendered issue:

**4 consumer-facing** moderate+ (`effect` high, `lodash-es` high, `uuid` moderate, `yaml` moderate — all with fixes available) vs **17 dev/CI-only**. The previous workflow would have reported a single "21".

Both YAML files parse. The audit workflow can be exercised on this branch with `workflow_dispatch`.

## Follow-ups in this program

2. packed-tarball consumer matrix (`npm pack` → install into Vite/Next-SSR/CJS fixtures) — the phase that changes what a green Dependabot PR proves
3. `publint` + `attw`, public-API snapshot, type tests
4. a11y gate + `size-limit` / `sideEffects`
5. `docs/dependency-policy.md` — the triage rules this PR's report is shaped around (referenced in the issue body ahead of landing)
6. SHA-pin actions, explicit `--provenance`, CODEOWNERS, rewrite the stale `PUBLISHING.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub automation (Dependabot and audit reporting); no application runtime or auth logic is modified.
> 
> **Overview**
> Introduces **Dependabot update automation** where the repo previously had alerts only: weekly npm and GitHub Actions lanes with ecosystem-scoped groups (Storybook, linting, testing, dev tooling, production patches), semver-major ignored for routine bumps, and explicit ignores for `typescript` / `@typescript/native`.
> 
> **Reworks the daily `npm-audit` workflow** from a single undifferentiated count and rotating GitHub issue into a **run summary** (plus Slack) that splits **consumer-facing** (`--omit=dev`) vs **dev/CI** findings, adds fix-availability and open Dependabot PR columns, uploads audit JSON artifacts, tightens token permissions, bumps Node to 22, and pings Slack on failures as well as findings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84f5d81cbae434525af3f265faed6d70982181b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->