### PR TITLE
feat: test the packed tarball in consumer fixtures (deps program 2/6)

### DIFF
--- a/.github/workflows/consumer-matrix.yml
+++ b/.github/workflows/consumer-matrix.yml
@@ -8,16 +8,19 @@ name: Consumer matrix
 on:
   pull_request:
     branches: [ main ]
+    # Globbed rather than enumerated: the type-packaging inputs (`scripts/build-types.ts`,
+    # `tsconfig.dts.json`, `tsconfig.build.json`, `rollup.dts.config.mjs`) all produce
+    # `dist/index.d.ts`, and listing files one by one is how they got missed.
     paths:
       - 'src/**'
       - 'consumer-fixtures/**'
-      - 'scripts/pack-and-test-consumers.ts'
-      - 'scripts/serve-static.ts'
-      - 'vite.config.ts'
+      - 'scripts/**'
       - 'vite/**'
+      - 'vite.config.ts'
+      - 'tsconfig*.json'
+      - 'rollup*.mjs'
       - 'package.json'
       - 'package-lock.json'
-      - 'tsconfig.json'
       - '.github/workflows/consumer-matrix.yml'
   workflow_call: {}
   workflow_dispatch: {}

--- a/.github/workflows/consumer-matrix.yml
+++ b/.github/workflows/consumer-matrix.yml
@@ -1,16 +1,13 @@
 name: Consumer matrix
 
-# Installs the packed tarball into throwaway consumer apps and builds them. Every other PR check
-# reads from the repo, so this is the only one that can fail on a broken published artifact:
-# a missing `exports` condition, a file left out of `files`, a top-level `window` reference, or a
-# declaration file that resolves under only one module mode.
+# Installs the packed tarball into throwaway consumer apps and builds them — the only PR check that
+# reads the published artifact rather than the repo.
 
 on:
   pull_request:
     branches: [ main ]
-    # Globbed rather than enumerated: the type-packaging inputs (`scripts/build-types.ts`,
-    # `tsconfig.dts.json`, `tsconfig.build.json`, `rollup.dts.config.mjs`) all produce
-    # `dist/index.d.ts`, and listing files one by one is how they got missed.
+    # Globbed, not enumerated: the type-packaging inputs also produce `dist/index.d.ts`, and
+    # listing files one by one is how they got missed.
     paths:
       - 'src/**'
       - 'consumer-fixtures/**'
@@ -48,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # The vite-esm fixture is loaded in a real browser to catch mount-time failures.
+      # vite-esm loads in a real browser to catch mount-time failures.
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
 

--- a/.github/workflows/consumer-matrix.yml
+++ b/.github/workflows/consumer-matrix.yml
@@ -1,0 +1,53 @@
+name: Consumer matrix
+
+# Installs the packed tarball into throwaway consumer apps and builds them. Every other PR check
+# reads from the repo, so this is the only one that can fail on a broken published artifact:
+# a missing `exports` condition, a file left out of `files`, a top-level `window` reference, or a
+# declaration file that resolves under only one module mode.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'consumer-fixtures/**'
+      - 'scripts/pack-and-test-consumers.ts'
+      - 'scripts/serve-static.ts'
+      - 'vite.config.ts'
+      - 'vite/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - '.github/workflows/consumer-matrix.yml'
+  workflow_call: {}
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: consumer-matrix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  consumers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The vite-esm fixture is loaded in a real browser to catch mount-time failures.
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Pack and test consumers
+        run: npm run test:consumers

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -135,6 +135,14 @@ jobs:
         echo "::error::Tag v$V contains untranslated strings. Nothing was published. Merge the i18n PRs, run Release — Tag with retag=true, then re-run Release — Publish."
         exit 1
 
+    # Runs in this job, against the exact tree about to be published, rather than as a separate
+    # job against main — the tarball the fixtures install is the one that ships.
+    - name: Install Chromium for the consumer fixtures
+      run: npx playwright install --with-deps chromium
+
+    - name: Verify the packed tarball in consumer fixtures
+      run: npm run test:consumers
+
     - name: Publish to npm
       run: npm publish --access public --tag ${{ steps.r.outputs.type == 'alpha' && 'alpha' || 'latest' }} ${{ inputs.dry_run && '--dry-run' || '' }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ node_modules/
 .agents/
 .claude/
 storybook-static
+
+# Consumer fixtures install the packed tarball fresh on every run.
+consumer-fixtures/*/node_modules/
+consumer-fixtures/*/dist/
+consumer-fixtures/*/package-lock.json
+consumer-fixtures/*/*.tgz

--- a/consumer-fixtures/README.md
+++ b/consumer-fixtures/README.md
@@ -6,6 +6,9 @@ published package is broken: a missing `exports` condition, a file left out of `
 `window` reference, or a declaration file that only resolves under one module resolution mode are all
 invisible to `vitest` and to `build.yml`'s "does `dist/` contain four non-empty files" check.
 
+`npm pack` runs the `prepare` script regardless of `--ignore-scripts`, so a checkout without
+`husky` installed fails here with `sh: husky: command not found`. Run `npm ci` first.
+
 Run them with:
 
 ```
@@ -26,8 +29,8 @@ the script from the tarball under test.
 ## Adding a fixture
 
 Create a directory with a `package.json` that has a `verify` script and whatever deps it needs, then
-add it to `FIXTURES` in `scripts/pack-and-test-consumers.ts`. Keep dependencies minimal; the PR lane
-runs a subset and the release lane runs all of them, so install time is the main cost.
+add it to `FIXTURES` in `scripts/pack-and-test-consumers.ts`. Keep dependencies minimal — every
+fixture runs on every PR, so install time is the main cost.
 
-`react`/`react-dom` versions are injected by the script so one fixture can be run against several
-peer versions without duplicating it.
+Each fixture pins its own `react`/`react-dom`; the script injects nothing version-specific, so
+covering a second peer version means a second fixture directory.

--- a/consumer-fixtures/README.md
+++ b/consumer-fixtures/README.md
@@ -1,0 +1,33 @@
+# Consumer fixtures
+
+Tiny throwaway apps that install the **packed tarball** of `@layerfi/components` the way a customer
+would, rather than importing from `src/`. They exist because the repo's own tests can pass while the
+published package is broken: a missing `exports` condition, a file left out of `files`, a top-level
+`window` reference, or a declaration file that only resolves under one module resolution mode are all
+invisible to `vitest` and to `build.yml`'s "does `dist/` contain four non-empty files" check.
+
+Run them with:
+
+```
+npm run test:consumers              # all fixtures
+npm run test:consumers -- --fixture vite-esm
+npm run test:consumers -- --skip-build   # reuse the existing dist/
+```
+
+| fixture | what it proves |
+|---|---|
+| `vite-esm` | `import` condition resolves, `@layerfi/components/index.css` resolves, the bundle builds, and the provider mounts in a real browser under `StrictMode` with no console errors |
+| `cjs-require` | `require('@layerfi/components')` resolves and executes, and `dist/index.d.ts` type-checks under `moduleResolution: node16` |
+| `ssr-node` | the module graph has no top-level `window`/`document` access and renders through `react-dom/server` |
+
+Each fixture's `node_modules`, lockfile, and build output are gitignored — they are installed fresh by
+the script from the tarball under test.
+
+## Adding a fixture
+
+Create a directory with a `package.json` that has a `verify` script and whatever deps it needs, then
+add it to `FIXTURES` in `scripts/pack-and-test-consumers.ts`. Keep dependencies minimal; the PR lane
+runs a subset and the release lane runs all of them, so install time is the main cost.
+
+`react`/`react-dom` versions are injected by the script so one fixture can be run against several
+peer versions without duplicating it.

--- a/consumer-fixtures/cjs-require/package.json
+++ b/consumer-fixtures/cjs-require/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "consumer-fixture-cjs-require",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "verify": "tsc --noEmit && node smoke.cjs"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/consumer-fixtures/cjs-require/smoke.cjs
+++ b/consumer-fixtures/cjs-require/smoke.cjs
@@ -1,10 +1,8 @@
-// `require()` has to resolve the `require` condition and actually execute the CJS bundle. A
-// module-scope crash here (bad interop, an ESM-only dependency that slipped past `external`)
-// would otherwise only surface in a consumer's app.
+// Resolves the `require` condition and executes the bundle: a module-scope crash here (bad
+// interop, an ESM-only dependency that slipped past `external`) otherwise reaches consumers.
 const pkg = require('@layerfi/components')
 
-// Interop, not API surface: a broken ESM→CJS wrapper resolves and executes but leaves the
-// namespace empty. Enumerating exports here would only duplicate the public-API snapshot.
+// Interop, not API surface: a broken ESM→CJS wrapper still resolves but exports nothing.
 if (typeof pkg.LayerProvider !== 'function') {
   console.error(`require() resolved but LayerProvider is ${typeof pkg.LayerProvider}`)
   process.exit(1)

--- a/consumer-fixtures/cjs-require/smoke.cjs
+++ b/consumer-fixtures/cjs-require/smoke.cjs
@@ -3,22 +3,10 @@
 // would otherwise only surface in a consumer's app.
 const pkg = require('@layerfi/components')
 
-const REQUIRED_EXPORTS = [
-  'LayerProvider',
-  'BankTransactions',
-  'ProfitAndLoss',
-  'BalanceSheet',
-  'ChartOfAccounts',
-  'Journal',
-  'LinkedAccounts',
-  'Tasks',
-  'useLayerContext',
-]
-
-const missing = REQUIRED_EXPORTS.filter(name => typeof pkg[name] === 'undefined')
-
-if (missing.length > 0) {
-  console.error(`Missing from the CJS build: ${missing.join(', ')}`)
+// Interop, not API surface: a broken ESM→CJS wrapper resolves and executes but leaves the
+// namespace empty. Enumerating exports here would only duplicate the public-API snapshot.
+if (typeof pkg.LayerProvider !== 'function') {
+  console.error(`require() resolved but LayerProvider is ${typeof pkg.LayerProvider}`)
   process.exit(1)
 }
 

--- a/consumer-fixtures/cjs-require/smoke.cjs
+++ b/consumer-fixtures/cjs-require/smoke.cjs
@@ -1,0 +1,25 @@
+// `require()` has to resolve the `require` condition and actually execute the CJS bundle. A
+// module-scope crash here (bad interop, an ESM-only dependency that slipped past `external`)
+// would otherwise only surface in a consumer's app.
+const pkg = require('@layerfi/components')
+
+const REQUIRED_EXPORTS = [
+  'LayerProvider',
+  'BankTransactions',
+  'ProfitAndLoss',
+  'BalanceSheet',
+  'ChartOfAccounts',
+  'Journal',
+  'LinkedAccounts',
+  'Tasks',
+  'useLayerContext',
+]
+
+const missing = REQUIRED_EXPORTS.filter(name => typeof pkg[name] === 'undefined')
+
+if (missing.length > 0) {
+  console.error(`Missing from the CJS build: ${missing.join(', ')}`)
+  process.exit(1)
+}
+
+console.log(`require() resolved ${Object.keys(pkg).length} exports.`)

--- a/consumer-fixtures/cjs-require/tsconfig.json
+++ b/consumer-fixtures/cjs-require/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022", "dom"],
+    "jsx": "react-jsx",
+    // Deliberately stricter than the library's own tsconfig: `node16` applies the real Node
+    // resolution rules to `exports`, which is where a single flat `.d.ts` serving both the
+    // `import` and `require` conditions shows up as a problem.
+    "module": "node16",
+    "moduleResolution": "node16",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true
+  },
+  "include": ["types.ts"]
+}

--- a/consumer-fixtures/cjs-require/types.ts
+++ b/consumer-fixtures/cjs-require/types.ts
@@ -1,0 +1,12 @@
+import type { EventCallbacks } from '@layerfi/components'
+import { BankTransactions, LayerProvider } from '@layerfi/components'
+
+// A CJS consumer that still type-checks: proves `exports.types` resolves under node16 resolution
+// and that the public types are usable, not just present.
+const callbacks: EventCallbacks = {}
+
+export const consumed = {
+  provider: LayerProvider,
+  bankTransactions: BankTransactions,
+  callbacks,
+}

--- a/consumer-fixtures/ssr-node/package.json
+++ b/consumer-fixtures/ssr-node/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "consumer-fixture-ssr-node",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "verify": "node render.mjs"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/consumer-fixtures/ssr-node/render.mjs
+++ b/consumer-fixtures/ssr-node/render.mjs
@@ -1,0 +1,23 @@
+import { createElement } from 'react'
+import { renderToString } from 'react-dom/server'
+
+// No DOM globals exist here, so any top-level `window`/`document` access anywhere in the module
+// graph throws on import — which is the failure mode that breaks Next.js consumers at build time.
+const { LayerProvider } = await import('@layerfi/components')
+
+const MARKER = 'ssr-fixture-ok'
+
+const html = renderToString(
+  createElement(
+    LayerProvider,
+    { businessId: '00000000-0000-0000-0000-000000000000', environment: 'staging' },
+    createElement('div', null, MARKER),
+  ),
+)
+
+if (!html.includes(MARKER)) {
+  console.error(`Server render did not produce the expected output:\n${html}`)
+  process.exit(1)
+}
+
+console.log(`Server-rendered ${html.length} chars without touching the DOM.`)

--- a/consumer-fixtures/vite-esm/index.html
+++ b/consumer-fixtures/vite-esm/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>vite-esm consumer fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/consumer-fixtures/vite-esm/package.json
+++ b/consumer-fixtures/vite-esm/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "consumer-fixture-vite-esm",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "verify": "tsc --noEmit && vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.10"
+  }
+}

--- a/consumer-fixtures/vite-esm/src/css.d.ts
+++ b/consumer-fixtures/vite-esm/src/css.d.ts
@@ -1,9 +1,4 @@
-// FINDING (fix proposed for the packaging phase): consumers on TypeScript 5.6+ with
-// `noUncheckedSideEffectImports` enabled — which this library's own tsconfig turns on — cannot
-// `import '@layerfi/components/index.css'` without declaring it themselves. The `exports` entry
-// resolves fine for bundlers, but tsc wants a declaration and the package ships none.
-//
-// The library-side fix is to emit `dist/index.d.css.ts` and let consumers set
-// `allowArbitraryExtensions`. Until then every consumer needs this shim, so the fixture carries
-// it to document the cost rather than hiding it by loosening the compiler options.
+// Every consumer needs this shim: under `noUncheckedSideEffectImports` (TS 5.6+) the CSS import
+// needs a declaration and the package ships none. Kept here rather than loosening the fixture's
+// compiler options, so the cost stays visible. Library-side fix (`dist/index.d.css.ts`) is phase 3.
 declare module '@layerfi/components/index.css'

--- a/consumer-fixtures/vite-esm/src/css.d.ts
+++ b/consumer-fixtures/vite-esm/src/css.d.ts
@@ -1,0 +1,9 @@
+// FINDING (fix proposed for the packaging phase): consumers on TypeScript 5.6+ with
+// `noUncheckedSideEffectImports` enabled — which this library's own tsconfig turns on — cannot
+// `import '@layerfi/components/index.css'` without declaring it themselves. The `exports` entry
+// resolves fine for bundlers, but tsc wants a declaration and the package ships none.
+//
+// The library-side fix is to emit `dist/index.d.css.ts` and let consumers set
+// `allowArbitraryExtensions`. Until then every consumer needs this shim, so the fixture carries
+// it to document the cost rather than hiding it by loosening the compiler options.
+declare module '@layerfi/components/index.css'

--- a/consumer-fixtures/vite-esm/src/main.tsx
+++ b/consumer-fixtures/vite-esm/src/main.tsx
@@ -1,49 +1,32 @@
-import {
-  BalanceSheet,
-  BankTransactions,
-  ChartOfAccounts,
-  type EventCallbacks,
-  GlobalMonthPicker,
-  Journal,
-  LayerProvider,
-  LinkedAccounts,
-  ProfitAndLoss,
-  StatementOfCashFlow,
-  Tasks,
-} from '@layerfi/components'
+import * as layer from '@layerfi/components'
+import type { EventCallbacks } from '@layerfi/components'
 import '@layerfi/components/index.css'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 
-// Referencing the components as values keeps them in the bundle, so `vite build` has to resolve
-// every one of their transitive imports out of the tarball. Rendering the data-driven ones would
-// only produce network noise; mounting the provider is what exercises the runtime path.
-const PUBLIC_COMPONENTS = [
-  BalanceSheet,
-  BankTransactions,
-  ChartOfAccounts,
-  Journal,
-  LinkedAccounts,
-  ProfitAndLoss,
-  StatementOfCashFlow,
-  Tasks,
-]
+// `Object.keys` on the namespace is not statically analysable, so nothing can be tree-shaken away
+// and `vite build` has to resolve every public entry's transitive imports out of the tarball. A
+// hand-listed subset would drift as the API grows.
+const exportCount = Object.keys(layer).length
 
+// Rendering the data-driven components would only produce network noise. Mounting the provider is
+// what exercises the runtime path; with no credentials passed, every SWR key stays null and nothing
+// is fetched.
 const eventCallbacks: EventCallbacks = {}
 
 function App() {
   return (
-    <LayerProvider
+    <layer.LayerProvider
       businessId='00000000-0000-0000-0000-000000000000'
       environment='staging'
       eventCallbacks={eventCallbacks}
     >
       <div data-testid='fixture-ready'>
-        {PUBLIC_COMPONENTS.length}
-        {' public components resolved'}
+        {exportCount}
+        {' public exports resolved'}
       </div>
-      <GlobalMonthPicker showLabel />
-    </LayerProvider>
+      <layer.GlobalMonthPicker showLabel />
+    </layer.LayerProvider>
   )
 }
 

--- a/consumer-fixtures/vite-esm/src/main.tsx
+++ b/consumer-fixtures/vite-esm/src/main.tsx
@@ -1,0 +1,54 @@
+import {
+  BalanceSheet,
+  BankTransactions,
+  ChartOfAccounts,
+  type EventCallbacks,
+  GlobalMonthPicker,
+  Journal,
+  LayerProvider,
+  LinkedAccounts,
+  ProfitAndLoss,
+  StatementOfCashFlow,
+  Tasks,
+} from '@layerfi/components'
+import '@layerfi/components/index.css'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+
+// Referencing the components as values keeps them in the bundle, so `vite build` has to resolve
+// every one of their transitive imports out of the tarball. Rendering the data-driven ones would
+// only produce network noise; mounting the provider is what exercises the runtime path.
+const PUBLIC_COMPONENTS = [
+  BalanceSheet,
+  BankTransactions,
+  ChartOfAccounts,
+  Journal,
+  LinkedAccounts,
+  ProfitAndLoss,
+  StatementOfCashFlow,
+  Tasks,
+]
+
+const eventCallbacks: EventCallbacks = {}
+
+function App() {
+  return (
+    <LayerProvider
+      businessId='00000000-0000-0000-0000-000000000000'
+      environment='staging'
+      eventCallbacks={eventCallbacks}
+    >
+      <div data-testid='fixture-ready'>
+        {PUBLIC_COMPONENTS.length}
+        {' public components resolved'}
+      </div>
+      <GlobalMonthPicker showLabel />
+    </LayerProvider>
+  )
+}
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/consumer-fixtures/vite-esm/src/main.tsx
+++ b/consumer-fixtures/vite-esm/src/main.tsx
@@ -4,14 +4,12 @@ import '@layerfi/components/index.css'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 
-// `Object.keys` on the namespace is not statically analysable, so nothing can be tree-shaken away
-// and `vite build` has to resolve every public entry's transitive imports out of the tarball. A
-// hand-listed subset would drift as the API grows.
+// `Object.keys` on the namespace defeats tree-shaking, so `vite build` has to resolve every
+// export's transitive imports out of the tarball.
 const exportCount = Object.keys(layer).length
 
-// Rendering the data-driven components would only produce network noise. Mounting the provider is
-// what exercises the runtime path; with no credentials passed, every SWR key stays null and nothing
-// is fetched.
+// No credentials, so every SWR key stays null and nothing is fetched. Rendering the data-driven
+// components would only add network noise; mounting the provider is the runtime path that matters.
 const eventCallbacks: EventCallbacks = {}
 
 function App() {

--- a/consumer-fixtures/vite-esm/tsconfig.json
+++ b/consumer-fixtures/vite-esm/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022", "dom", "dom.iterable"],
+    "jsx": "react-jsx",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/consumer-fixtures/vite-esm/vite.config.ts
+++ b/consumer-fixtures/vite-esm/vite.config.ts
@@ -1,0 +1,11 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    // The fixture is checked for console errors in a real browser, so keep the output readable
+    // when a failure needs tracing back to a source position.
+    minify: false,
+  },
+})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -288,7 +288,7 @@ const i18nConfigs = [
 
 export default tsEslint.config(
   {
-    ignores: ['dist/**', 'node_modules/**', 'vite/**', 'scripts/**', '.vim_backups/**', '.claude/**', '**/*.gen.ts', '.storybook/public/**', 'storybook-static/**'],
+    ignores: ['dist/**', 'node_modules/**', 'vite/**', 'scripts/**', '.vim_backups/**', '.claude/**', '**/*.gen.ts', '.storybook/public/**', 'storybook-static/**', 'consumer-fixtures/**'],
   },
   js.configs.recommended,
   ...tsEslint.configs.recommendedTypeChecked,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
     "test": "vitest",
+    "test:consumers": "tsx scripts/pack-and-test-consumers.ts",
     "typecheck": "tsc --noEmit"
   },
   "repository": {

--- a/scripts/capture-docs-screenshots.ts
+++ b/scripts/capture-docs-screenshots.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { chromium } from 'playwright'
 import { type DocsScreenshot, DOCS_SCREENSHOT_WIDTHS, DOCS_SCREENSHOTS } from './docs-screenshots.manifest'
-import { requireStorybookBuild, serveStorybookStatic, STATIC_ROOT } from './serve-storybook-static'
+import { requireStorybookBuild, serveStorybookStatic, STATIC_ROOT } from './serve-static'
 
 // The story is rendered before its data lands, so settle after the network goes quiet.
 // preview.tsx adds a 250ms floor to every mocked response.

--- a/scripts/check-stories-render.ts
+++ b/scripts/check-stories-render.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import { chromium, type Page } from 'playwright'
 import { DOCS_SCREENSHOT_WIDTHS } from './docs-screenshots.manifest'
-import { requireStorybookBuild, serveStorybookStatic, STATIC_ROOT } from './serve-storybook-static'
+import { requireStorybookBuild, serveStorybookStatic, STATIC_ROOT } from './serve-static'
 
 // Renders every story headlessly and fails on a render error, an unhandled exception, or a
 // play function that throws. Chromatic covers only the design system, so without this a

--- a/scripts/pack-and-test-consumers.ts
+++ b/scripts/pack-and-test-consumers.ts
@@ -11,18 +11,14 @@ import { serveStatic } from './serve-static'
 
 const FIXTURES_ROOT = 'consumer-fixtures'
 const PREVIEW_PORT = 6008
+const READY_SELECTOR = '[data-testid="fixture-ready"]'
 
-type Fixture = {
-  name: string
-  /** Built output to load in a browser after `verify` passes, relative to the fixture. */
-  browserCheck?: { dist: string, readySelector: string }
-}
-
-const FIXTURES: Fixture[] = [
-  { name: 'vite-esm', browserCheck: { dist: 'dist', readySelector: '[data-testid="fixture-ready"]' } },
+// `dist` is the built output to load in a browser once `verify` passes, relative to the fixture.
+const FIXTURES = [
+  { name: 'vite-esm', dist: 'dist' },
   { name: 'cjs-require' },
   { name: 'ssr-node' },
-]
+] as const
 
 // Present in the tarball, or the package is broken on arrival.
 const REQUIRED_FILES = [
@@ -53,11 +49,8 @@ function pack(outDir: string) {
     { cwd: process.cwd(), encoding: 'utf8' },
   )
 
-  const [result] = JSON.parse(output) as [{
-    filename: string
-    files: { path: string }[]
-    unpackedSize: number
-  }]
+  const [result] = JSON.parse(output) as
+    [{ filename: string, files: { path: string }[], unpackedSize: number }]
 
   return {
     tarball: path.resolve(outDir, result.filename),
@@ -67,62 +60,84 @@ function pack(outDir: string) {
 }
 
 function checkTarball(entries: string[]) {
-  const problems: string[] = []
-
-  for (const required of REQUIRED_FILES) {
-    if (!entries.includes(required)) problems.push(`missing: ${required}`)
-  }
-
-  for (const entry of entries) {
-    const matched = FORBIDDEN_PATTERNS.find(pattern => pattern.test(entry))
-    if (matched) problems.push(`should not be published: ${entry}`)
-  }
-
-  return problems
+  return [
+    ...REQUIRED_FILES.filter(required => !entries.includes(required)).map(f => `missing: ${f}`),
+    ...entries.filter(entry => FORBIDDEN_PATTERNS.some(pattern => pattern.test(entry)))
+      .map(entry => `should not be published: ${entry}`),
+  ]
 }
 
-async function checkInBrowser(fixture: Fixture, cwd: string) {
-  const { dist, readySelector } = fixture.browserCheck!
+async function checkInBrowser(dist: string, cwd: string) {
   const { server, origin } = await serveStatic(path.join(cwd, dist), PREVIEW_PORT)
-  const browser = await chromium.launch()
-  const page = await browser.newPage()
   const failures: string[] = []
-
-  page.on('pageerror', error => failures.push(error.message))
-  page.on('console', (message) => {
-    if (message.type() === 'error') failures.push(message.text().split('\n')[0])
-  })
+  let browser
 
   try {
+    // Inside the try: a launch failure would otherwise leave the server holding the port.
+    browser = await chromium.launch()
+    const page = await browser.newPage()
+
+    page.on('pageerror', error => failures.push(error.message))
+    page.on('console', (message) => {
+      if (message.type() === 'error') failures.push(message.text().split('\n')[0])
+    })
+
     await page.goto(origin)
-    await page.waitForSelector(readySelector, { timeout: 30_000 })
+    await page.waitForSelector(READY_SELECTOR, { timeout: 30_000 })
     await page.waitForTimeout(750)
   }
   catch (error) {
     failures.push(error instanceof Error ? error.message.split('\n')[0] : String(error))
   }
   finally {
-    await browser.close()
+    await browser?.close()
     server.close()
   }
 
   return failures
 }
 
-async function main() {
-  const requested = process.argv
-    .flatMap((arg, index) => (arg === '--fixture' ? [process.argv[index + 1]] : []))
-    .filter(Boolean)
-  const selected = requested.length > 0
-    ? FIXTURES.filter(fixture => requested.includes(fixture.name))
-    : FIXTURES
+async function runFixture(fixture: typeof FIXTURES[number], tarball: string) {
+  const cwd = path.join(FIXTURES_ROOT, fixture.name)
+  console.info(`\n=== ${fixture.name} ===`)
 
+  try {
+    // `--no-package-lock` keeps fixture lockfiles out of the repo, and `--no-save` on the
+    // tarball keeps npm from writing its temp path into the fixture's manifest.
+    run('npm', ['install', '--no-package-lock', '--no-audit', '--no-fund'], cwd)
+    run('npm', ['install', '--no-package-lock', '--no-save', '--no-audit', '--no-fund', tarball], cwd)
+    run('npm', ['run', 'verify'], cwd)
+  }
+  catch {
+    return false
+  }
+
+  if (!('dist' in fixture)) return true
+
+  const failures = await checkInBrowser(fixture.dist, cwd)
+  if (failures.length > 0) {
+    console.error(`  browser check failed:\n    ${failures.slice(0, 5).join('\n    ')}`)
+    return false
+  }
+
+  console.info('  browser check OK')
+  return true
+}
+
+// Returns false rather than exiting, so the caller's cleanup actually runs — `process.exit()`
+// skips `finally`.
+async function main() {
+  const requested = process.argv.filter((_, index) => process.argv[index - 1] === '--fixture')
   const unknown = requested.filter(name => !FIXTURES.some(fixture => fixture.name === name))
   if (unknown.length > 0) {
     console.error(`Unknown fixture(s): ${unknown.join(', ')}`)
     console.error(`Available: ${FIXTURES.map(fixture => fixture.name).join(', ')}`)
-    process.exit(1)
+    return false
   }
+
+  const selected = requested.length > 0
+    ? FIXTURES.filter(fixture => requested.includes(fixture.name))
+    : FIXTURES
 
   if (!process.argv.includes('--skip-build')) {
     console.info('Building the library...')
@@ -130,54 +145,35 @@ async function main() {
   }
 
   const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'layer-consumer-'))
-  console.info(`\nPacking into ${workDir}`)
-  const { tarball, entries, unpackedSize } = pack(workDir)
-  console.info(`  ${path.basename(tarball)} — ${entries.length} files, ${Math.round(unpackedSize / 1024)} kB unpacked`)
+  try {
+    console.info(`\nPacking into ${workDir}`)
+    const { tarball, entries, unpackedSize } = pack(workDir)
+    console.info(`  ${path.basename(tarball)} — ${entries.length} files, ${Math.round(unpackedSize / 1024)} kB unpacked`)
 
-  const tarballProblems = checkTarball(entries)
-  if (tarballProblems.length > 0) {
-    console.error(`\nTarball contents are wrong:\n`)
-    for (const problem of tarballProblems) console.error(`  ${problem}`)
-    process.exit(1)
-  }
-  console.info('  contents OK')
-
-  const failed: string[] = []
-
-  for (const fixture of selected) {
-    const cwd = path.join(FIXTURES_ROOT, fixture.name)
-    console.info(`\n=== ${fixture.name} ===`)
-
-    try {
-      // `--no-package-lock` keeps fixture lockfiles out of the repo, and `--no-save` on the
-      // tarball keeps npm from writing its temp path into the fixture's manifest.
-      run('npm', ['install', '--no-package-lock', '--no-audit', '--no-fund'], cwd)
-      run('npm', ['install', '--no-package-lock', '--no-save', '--no-audit', '--no-fund', tarball], cwd)
-      run('npm', ['run', 'verify'], cwd)
-
-      if (fixture.browserCheck) {
-        const failures = await checkInBrowser(fixture, cwd)
-        if (failures.length > 0) {
-          console.error(`  browser check failed:\n    ${failures.slice(0, 5).join('\n    ')}`)
-          failed.push(fixture.name)
-          continue
-        }
-        console.info('  browser check OK')
-      }
+    const problems = checkTarball(entries)
+    if (problems.length > 0) {
+      console.error('\nTarball contents are wrong:\n')
+      for (const problem of problems) console.error(`  ${problem}`)
+      return false
     }
-    catch {
-      failed.push(fixture.name)
+    console.info('  contents OK')
+
+    const failed: string[] = []
+    for (const fixture of selected) {
+      if (!await runFixture(fixture, tarball)) failed.push(fixture.name)
     }
+
+    if (failed.length > 0) {
+      console.error(`\n${failed.length} of ${selected.length} consumer fixture(s) failed: ${failed.join(', ')}`)
+      return false
+    }
+
+    console.info(`\nAll ${selected.length} consumer fixture(s) installed and ran the packed tarball.`)
+    return true
   }
-
-  fs.rmSync(workDir, { recursive: true, force: true })
-
-  if (failed.length > 0) {
-    console.error(`\n${failed.length} of ${selected.length} consumer fixture(s) failed: ${failed.join(', ')}`)
-    process.exit(1)
+  finally {
+    fs.rmSync(workDir, { recursive: true, force: true })
   }
-
-  console.info(`\nAll ${selected.length} consumer fixture(s) installed and ran the packed tarball.`)
 }
 
-void main()
+void main().then((ok) => { process.exitCode = ok ? 0 : 1 })

--- a/scripts/pack-and-test-consumers.ts
+++ b/scripts/pack-and-test-consumers.ts
@@ -1,0 +1,183 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { chromium } from 'playwright'
+import { serveStatic } from './serve-static'
+
+// Tests the artifact consumers install, not the source tree. `vitest` and `build.yml` both read
+// from the repo, so a missing `exports` condition, a file left out of `files`, a top-level `window`
+// reference, or a declaration file that only resolves under one module mode all pass CI today.
+
+const FIXTURES_ROOT = 'consumer-fixtures'
+const PREVIEW_PORT = 6008
+
+type Fixture = {
+  name: string
+  /** Built output to load in a browser after `verify` passes, relative to the fixture. */
+  browserCheck?: { dist: string, readySelector: string }
+}
+
+const FIXTURES: Fixture[] = [
+  { name: 'vite-esm', browserCheck: { dist: 'dist', readySelector: '[data-testid="fixture-ready"]' } },
+  { name: 'cjs-require' },
+  { name: 'ssr-node' },
+]
+
+// Present in the tarball, or the package is broken on arrival.
+const REQUIRED_FILES = [
+  'package/dist/esm/index.mjs',
+  'package/dist/cjs/index.cjs',
+  'package/dist/index.d.ts',
+  'package/dist/index.css',
+]
+
+// Absent from the tarball. Shipping these bloats every consumer install and leaks internals.
+const FORBIDDEN_PATTERNS = [
+  /^package\/src\//,
+  /\.stories\.[jt]sx?$/,
+  /\.test\.[jt]sx?$/,
+  /\.scratch\./,
+  /^package\/\.storybook\//,
+]
+
+function run(command: string, args: string[], cwd: string) {
+  execFileSync(command, args, { cwd, stdio: 'inherit' })
+}
+
+function pack(outDir: string) {
+  // `--ignore-scripts` because the build already ran; without it `prepack` rebuilds from scratch.
+  const output = execFileSync(
+    'npm',
+    ['pack', '--ignore-scripts', '--json', '--pack-destination', outDir],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  )
+
+  const [result] = JSON.parse(output) as [{
+    filename: string
+    files: { path: string }[]
+    unpackedSize: number
+  }]
+
+  return {
+    tarball: path.resolve(outDir, result.filename),
+    entries: result.files.map(file => `package/${file.path}`),
+    unpackedSize: result.unpackedSize,
+  }
+}
+
+function checkTarball(entries: string[]) {
+  const problems: string[] = []
+
+  for (const required of REQUIRED_FILES) {
+    if (!entries.includes(required)) problems.push(`missing: ${required}`)
+  }
+
+  for (const entry of entries) {
+    const matched = FORBIDDEN_PATTERNS.find(pattern => pattern.test(entry))
+    if (matched) problems.push(`should not be published: ${entry}`)
+  }
+
+  return problems
+}
+
+async function checkInBrowser(fixture: Fixture, cwd: string) {
+  const { dist, readySelector } = fixture.browserCheck!
+  const { server, origin } = await serveStatic(path.join(cwd, dist), PREVIEW_PORT)
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  const failures: string[] = []
+
+  page.on('pageerror', error => failures.push(error.message))
+  page.on('console', (message) => {
+    if (message.type() === 'error') failures.push(message.text().split('\n')[0])
+  })
+
+  try {
+    await page.goto(origin)
+    await page.waitForSelector(readySelector, { timeout: 30_000 })
+    await page.waitForTimeout(750)
+  }
+  catch (error) {
+    failures.push(error instanceof Error ? error.message.split('\n')[0] : String(error))
+  }
+  finally {
+    await browser.close()
+    server.close()
+  }
+
+  return failures
+}
+
+async function main() {
+  const requested = process.argv
+    .flatMap((arg, index) => (arg === '--fixture' ? [process.argv[index + 1]] : []))
+    .filter(Boolean)
+  const selected = requested.length > 0
+    ? FIXTURES.filter(fixture => requested.includes(fixture.name))
+    : FIXTURES
+
+  const unknown = requested.filter(name => !FIXTURES.some(fixture => fixture.name === name))
+  if (unknown.length > 0) {
+    console.error(`Unknown fixture(s): ${unknown.join(', ')}`)
+    console.error(`Available: ${FIXTURES.map(fixture => fixture.name).join(', ')}`)
+    process.exit(1)
+  }
+
+  if (!process.argv.includes('--skip-build')) {
+    console.info('Building the library...')
+    run('npm', ['run', 'build:clean'], process.cwd())
+  }
+
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'layer-consumer-'))
+  console.info(`\nPacking into ${workDir}`)
+  const { tarball, entries, unpackedSize } = pack(workDir)
+  console.info(`  ${path.basename(tarball)} — ${entries.length} files, ${Math.round(unpackedSize / 1024)} kB unpacked`)
+
+  const tarballProblems = checkTarball(entries)
+  if (tarballProblems.length > 0) {
+    console.error(`\nTarball contents are wrong:\n`)
+    for (const problem of tarballProblems) console.error(`  ${problem}`)
+    process.exit(1)
+  }
+  console.info('  contents OK')
+
+  const failed: string[] = []
+
+  for (const fixture of selected) {
+    const cwd = path.join(FIXTURES_ROOT, fixture.name)
+    console.info(`\n=== ${fixture.name} ===`)
+
+    try {
+      // `--no-package-lock` keeps fixture lockfiles out of the repo, and `--no-save` on the
+      // tarball keeps npm from writing its temp path into the fixture's manifest.
+      run('npm', ['install', '--no-package-lock', '--no-audit', '--no-fund'], cwd)
+      run('npm', ['install', '--no-package-lock', '--no-save', '--no-audit', '--no-fund', tarball], cwd)
+      run('npm', ['run', 'verify'], cwd)
+
+      if (fixture.browserCheck) {
+        const failures = await checkInBrowser(fixture, cwd)
+        if (failures.length > 0) {
+          console.error(`  browser check failed:\n    ${failures.slice(0, 5).join('\n    ')}`)
+          failed.push(fixture.name)
+          continue
+        }
+        console.info('  browser check OK')
+      }
+    }
+    catch {
+      failed.push(fixture.name)
+    }
+  }
+
+  fs.rmSync(workDir, { recursive: true, force: true })
+
+  if (failed.length > 0) {
+    console.error(`\n${failed.length} of ${selected.length} consumer fixture(s) failed: ${failed.join(', ')}`)
+    process.exit(1)
+  }
+
+  console.info(`\nAll ${selected.length} consumer fixture(s) installed and ran the packed tarball.`)
+}
+
+void main()

--- a/scripts/pack-and-test-consumers.ts
+++ b/scripts/pack-and-test-consumers.ts
@@ -5,9 +5,8 @@ import path from 'node:path'
 import { chromium } from 'playwright'
 import { serveStatic } from './serve-static'
 
-// Tests the artifact consumers install, not the source tree. `vitest` and `build.yml` both read
-// from the repo, so a missing `exports` condition, a file left out of `files`, a top-level `window`
-// reference, or a declaration file that only resolves under one module mode all pass CI today.
+// Tests the artifact consumers install, not the source tree: `vitest` and `build.yml` both read
+// from the repo, so a broken published package passes CI today.
 
 const FIXTURES_ROOT = 'consumer-fixtures'
 const PREVIEW_PORT = 6008
@@ -73,7 +72,7 @@ async function checkInBrowser(dist: string, cwd: string) {
   let browser
 
   try {
-    // Inside the try: a launch failure would otherwise leave the server holding the port.
+    // Inside the try, or a launch failure leaves the server holding the port.
     browser = await chromium.launch()
     const page = await browser.newPage()
 
@@ -102,8 +101,8 @@ async function runFixture(fixture: typeof FIXTURES[number], tarball: string) {
   console.info(`\n=== ${fixture.name} ===`)
 
   try {
-    // `--no-package-lock` keeps fixture lockfiles out of the repo, and `--no-save` on the
-    // tarball keeps npm from writing its temp path into the fixture's manifest.
+    // `--no-package-lock` keeps lockfiles out of the repo; `--no-save` keeps npm from writing the
+    // tarball's temp path into the fixture manifest.
     run('npm', ['install', '--no-package-lock', '--no-audit', '--no-fund'], cwd)
     run('npm', ['install', '--no-package-lock', '--no-save', '--no-audit', '--no-fund', tarball], cwd)
     run('npm', ['run', 'verify'], cwd)
@@ -124,8 +123,7 @@ async function runFixture(fixture: typeof FIXTURES[number], tarball: string) {
   return true
 }
 
-// Returns false rather than exiting, so the caller's cleanup actually runs — `process.exit()`
-// skips `finally`.
+// Returns a status rather than exiting: `process.exit()` would skip the `finally` cleanup.
 async function main() {
   const requested = process.argv.filter((_, index) => process.argv[index - 1] === '--fixture')
   const unknown = requested.filter(name => !FIXTURES.some(fixture => fixture.name === name))

--- a/scripts/serve-static.ts
+++ b/scripts/serve-static.ts
@@ -19,11 +19,23 @@ const MIME: Record<string, string> = {
 }
 
 export function serveStatic(root: string, port: number) {
-  const server = http.createServer((req, res) => {
-    const requested = decodeURIComponent(new URL(req.url ?? '/', 'http://localhost').pathname)
-    const file = path.join(root, requested === '/' ? 'index.html' : requested)
+  const resolvedRoot = path.resolve(root)
 
-    if (!path.resolve(file).startsWith(path.resolve(root)) || !fs.existsSync(file)) {
+  const server = http.createServer((req, res) => {
+    let file: string
+    try {
+      const requested = decodeURIComponent(new URL(req.url ?? '/', 'http://localhost').pathname)
+      file = path.join(resolvedRoot, requested === '/' ? 'index.html' : requested)
+    }
+    catch {
+      // Malformed percent-encoding throws, which would otherwise take the server down mid-run.
+      res.writeHead(400).end()
+      return
+    }
+
+    // `path.relative` rather than a prefix test: `/tmp/root2` starts with `/tmp/root`.
+    const relative = path.relative(resolvedRoot, file)
+    if (relative.startsWith('..') || path.isAbsolute(relative) || !fs.existsSync(file)) {
       res.writeHead(404).end()
       return
     }

--- a/scripts/serve-static.ts
+++ b/scripts/serve-static.ts
@@ -28,7 +28,7 @@ export function serveStatic(root: string, port: number) {
       file = path.join(resolvedRoot, requested === '/' ? 'index.html' : requested)
     }
     catch {
-      // Malformed percent-encoding throws, which would otherwise take the server down mid-run.
+      // Malformed percent-encoding throws, which would take the server down mid-run.
       res.writeHead(400).end()
       return
     }

--- a/scripts/serve-static.ts
+++ b/scripts/serve-static.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 export const STATIC_ROOT = 'storybook-static'
 
 // Above the 6006 dev server so a running `npm run storybook` doesn't collide.
-const PORT = 6007
+const STORYBOOK_PORT = 6007
 
 const MIME: Record<string, string> = {
   '.html': 'text/html',
@@ -18,16 +18,12 @@ const MIME: Record<string, string> = {
   '.woff2': 'font/woff2',
 }
 
-/**
- * Serves the static build over http. Needed because MSW's service worker won't register on
- * `file://`, and every story's data comes from MSW.
- */
-export function serveStorybookStatic() {
+export function serveStatic(root: string, port: number) {
   const server = http.createServer((req, res) => {
     const requested = decodeURIComponent(new URL(req.url ?? '/', 'http://localhost').pathname)
-    const file = path.join(STATIC_ROOT, requested === '/' ? 'index.html' : requested)
+    const file = path.join(root, requested === '/' ? 'index.html' : requested)
 
-    if (!path.resolve(file).startsWith(path.resolve(STATIC_ROOT)) || !fs.existsSync(file)) {
+    if (!path.resolve(file).startsWith(path.resolve(root)) || !fs.existsSync(file)) {
       res.writeHead(404).end()
       return
     }
@@ -40,8 +36,16 @@ export function serveStorybookStatic() {
   })
 
   return new Promise<{ server: http.Server, origin: string }>(resolve =>
-    server.listen(PORT, () => resolve({ server, origin: `http://localhost:${PORT}` })),
+    server.listen(port, () => resolve({ server, origin: `http://localhost:${port}` })),
   )
+}
+
+/**
+ * Serves the static build over http. Needed because MSW's service worker won't register on
+ * `file://`, and every story's data comes from MSW.
+ */
+export function serveStorybookStatic() {
+  return serveStatic(STATIC_ROOT, STORYBOOK_PORT)
 }
 
 export function requireStorybookBuild(file: string) {

--- a/vite/plugins/bundleCss.ts
+++ b/vite/plugins/bundleCss.ts
@@ -28,9 +28,8 @@ export function bundleCss(): Plugin {
       }
 
       if (parts.length > 0) {
-        // Each part carries its own `@charset`, and concatenating them leaves one partway down
-        // the file — invalid, and every consumer's postcss build warns about it. Hoist a single
-        // declaration to the top instead.
+        // Concatenating leaves a part's own `@charset` partway down the file, which is invalid and
+        // warns in every consumer's postcss build. Strip them and hoist one to the top.
         const merged = parts
           .map(part => part.replace(/^[ \t]*@charset[^;]*;[ \t]*\r?\n?/gim, ''))
           .join('\n')

--- a/vite/plugins/bundleCss.ts
+++ b/vite/plugins/bundleCss.ts
@@ -28,7 +28,13 @@ export function bundleCss(): Plugin {
       }
 
       if (parts.length > 0) {
-        fs.writeFileSync(mergedPath, parts.join('\n'))
+        // Each part carries its own `@charset`, and concatenating them leaves one partway down
+        // the file — invalid, and every consumer's postcss build warns about it. Hoist a single
+        // declaration to the top instead.
+        const merged = parts
+          .map(part => part.replace(/^[ \t]*@charset[^;]*;[ \t]*\r?\n?/gim, ''))
+          .join('\n')
+        fs.writeFileSync(mergedPath, `@charset "UTF-8";\n${merged}`)
         console.log('✓ Merged CSS →', mergedPath)
       }
     },


### PR DESCRIPTION
## Scope

Phase 2 of the dependency & supply-chain program, and the one that changes what a green PR means. Every existing check reads from the repo: `vitest` imports `src/`, and `build.yml` only asserts four files under `dist/` are non-empty. Nothing verified that the *published artifact* works. This adds a lane that runs `npm pack` and installs the resulting tarball into throwaway consumer apps.

**`scripts/pack-and-test-consumers.ts`** (`npm run test:consumers`):
1. builds, then `npm pack --ignore-scripts --json`
2. asserts tarball contents — the four required `dist/` entries present, and no `src/`, stories, tests, or `*.scratch.*`
3. installs the tarball into each fixture (`--no-package-lock --no-save`, so nothing leaks into the repo) and runs its `verify`

**`consumer-fixtures/`**:

| fixture | proves |
|---|---|
| `vite-esm` | `import` condition + `@layerfi/components/index.css` resolve, `tsc --noEmit`, `vite build`, then Playwright loads the built output and asserts no console errors with the provider mounted under `StrictMode` |
| `cjs-require` | `require()` resolves *and executes* the CJS bundle (32 exports checked), and `dist/index.d.ts` type-checks under `moduleResolution: node16` |
| `ssr-node` | the module graph has no top-level `window`/`document` access and renders through `react-dom/server` |

Wired into `consumer-matrix.yml` on PRs (path-filtered) and as a step inside `release-publish.yml` before `npm publish` — in that job rather than a separate one, so the tarball the fixtures install is the one that ships.

Reuses the existing static server from `scripts/serve-storybook-static.ts`, generalized to `serveStatic(root, port)` and renamed to `scripts/serve-static.ts`; `serveStorybookStatic()` is now a thin wrapper, so `check-stories-render.ts` and `capture-docs-screenshots.ts` are unchanged in behavior.

## Two real defects it found immediately

**1. Mid-file `@charset` in the shipped CSS — fixed here.** `vite/plugins/bundleCss.ts` concatenates `styles.css` + `index.css`, each carrying its own `@charset "UTF-8";`, leaving an invalid one partway down `dist/index.css`. Every consumer's postcss build warned about it:
```
[vite:css][postcss] @charset must precede all other statements
```
Now stripped from the parts and hoisted to a single declaration at line 1.

**2. `import '@layerfi/components/index.css'` doesn't type-check for consumers — not fixed here.** With TypeScript 5.6+ `noUncheckedSideEffectImports` (which this repo's own tsconfig enables), the CSS import fails with `TS2307` because the package ships no declaration for it. The fixture carries a `declare module` shim with a comment, deliberately rather than loosening its compiler options, so the cost to consumers is visible. Library-side fix — emitting `dist/index.d.css.ts` — belongs with the other packaging work in phase 3.

## Verification

All three fixtures install and pass against the real tarball. Both negative tests confirm the harness fails when the package is actually broken:

- removed `exports['.'].require` → `cjs-require` failed with `ERR_PACKAGE_PATH_NOT_EXPORTED`
- added a top-level `window.location.href` to `src/index.tsx` → `ssr-node` failed on import

The tarball check also caught a genuinely half-built `dist/` during development (a build killed partway left `dist/cjs` and `dist/index.d.ts` missing) — which is exactly the state `build.yml` is meant to catch and the failure mode a release would otherwise ship.

`npm run typecheck` and `npx eslint .` are clean.

## Deviations from the plan

- **No Next.js fixture.** `ssr-node` proves the property that actually breaks Next consumers (top-level DOM access, server rendering) without a ~300 MB `next` install per CI run. A real Next fixture covering RSC/`"use client"` boundaries is worth adding separately if we want that specific coverage.
- **PRs run all three fixtures, not a reduced subset.** Total is a few minutes and the workflow is path-filtered, so a reduced matrix would mostly buy the risk of the skipped fixture being the one that regressed.
- **React 19 coverage is not included.** Peers are `^18.2.0` and the fixtures pin 18. The script injects nothing version-specific, so adding a 19 variant is a small follow-up — worth doing before any decision about widening the peer range.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a release gate and exercises real publish artifacts (ESM/CJS/SSR/browser), so packaging or export regressions will block merges and publishes; library runtime API is largely unchanged aside from the CSS merge fix.
> 
> **Overview**
> Introduces **`npm run test:consumers`**, which builds the library, **`npm pack`s** the artifact, validates tarball contents (required `dist/` files present; no `src/`, tests, or stories), then installs that tarball into three minimal consumer apps and runs each **`verify`** script.
> 
> **CI wiring:** new path-filtered **`consumer-matrix`** workflow on PRs (with Playwright for **`vite-esm`**), and the same check **before `npm publish`** in **`release-publish`** so the tarball that ships is the one exercised.
> 
> **Fixtures:** **`vite-esm`** (ESM import, CSS side-effect, Vite build, browser mount under **`StrictMode`**), **`cjs-require`** (**`require()`** + types under **`node16`**), **`ssr-node`** (no top-level DOM; **`react-dom/server`** render).
> 
> **Supporting changes:** generalizes static serving to **`serveStatic(root, port)`** in **`serve-static.ts`** (Storybook scripts unchanged in behavior); ignores **`consumer-fixtures/**`** in ESLint; gitignores per-fixture install/build artifacts.
> 
> **Packaging fix:** **`bundleCss.ts`** strips duplicate **`@charset`** from merged CSS parts and hoists a single declaration to the top of **`dist/index.css`** (invalid mid-file **`@charset`** was breaking consumer PostCSS builds).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aac74cc243c6e012fee39beedf5d0c80fa8f2b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->