### PR TITLE
chore: harden the release path (deps program 6/6)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Review requirements for files that can ship code to consumers or hold credentials.
+#
+# NOTE: this file is inert on its own. `main`'s branch protection currently has
+# `required_approving_review_count: 0` and `require_code_owner_reviews: false`, so nothing here is
+# enforced until "Require review from Code Owners" is enabled in repository settings.
+
+# Anything that runs in CI with a write token or a secret. The release workflows publish to npm via
+# OIDC; docs-screenshots holds a GitHub App token and opens PRs in another repo.
+/.github/                       @Layer-Fi/layer-engineering
+
+# The published surface: what gets built, what gets packed, and what consumers resolve against.
+/package.json                   @Layer-Fi/layer-engineering
+/package-lock.json              @Layer-Fi/layer-engineering
+/vite.config.ts                 @Layer-Fi/layer-engineering
+/vite/                          @Layer-Fi/layer-engineering
+/rollup.dts.config.mjs          @Layer-Fi/layer-engineering
+/scripts/build-types.ts         @Layer-Fi/layer-engineering
+/src/index.tsx                  @Layer-Fi/layer-engineering

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -20,12 +20,12 @@ jobs:
         shell: bash
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         # Chromatic's TurboSnap needs full git history to diff against baselines.
         fetch-depth: 0
@@ -74,7 +74,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'
@@ -84,7 +84,7 @@ jobs:
 
     - name: Run Chromatic
       id: chromatic
-      uses: chromaui/action@v18
+      uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
       with:
         projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
         buildScriptName: storybook:build

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: main
         fetch-depth: 0
@@ -69,7 +69,7 @@ jobs:
 
     - name: Upload translation changes from this push to Crowdin
       if: ${{ steps.pushed_translations.outputs.changed == 'true' }}
-      uses: crowdin/github-action@v2
+      uses: crowdin/github-action@c7af9bc98b01694653031fef2a0dc6c7888ce9bc # v2.17.0
       with:
         command: upload translations
         command_args: --auto-approve-imported
@@ -93,7 +93,7 @@ jobs:
 
     - name: Upload sources to Crowdin
       if: ${{ github.event_name == 'push' || inputs.pretranslate }}
-      uses: crowdin/github-action@v2
+      uses: crowdin/github-action@c7af9bc98b01694653031fef2a0dc6c7888ce9bc # v2.17.0
       with:
         upload_sources: true
         upload_translations: false
@@ -106,7 +106,7 @@ jobs:
 
     - name: Pre-translate fr-CA from translation memory
       if: ${{ github.event_name == 'push' || inputs.pretranslate }}
-      uses: crowdin/github-action@v2
+      uses: crowdin/github-action@c7af9bc98b01694653031fef2a0dc6c7888ce9bc # v2.17.0
       with:
         command: pre-translate
         command_args: -l fr-CA --method tm --translate-untranslated-only
@@ -126,7 +126,7 @@ jobs:
 
     - name: Pre-translate fr-CA with AI
       if: ${{ github.event_name == 'push' || inputs.pretranslate }}
-      uses: crowdin/github-action@v2
+      uses: crowdin/github-action@c7af9bc98b01694653031fef2a0dc6c7888ce9bc # v2.17.0
       with:
         command: pre-translate
         command_args: -l fr-CA --method ai --ai-prompt ${{ vars.CROWDIN_AI_PROMPT_ID }} --translate-untranslated-only
@@ -138,7 +138,7 @@ jobs:
       run: cp -R src/assets/locales/fr-CA "$RUNNER_TEMP/fr-CA-before-crowdin"
 
     - name: Download fr-CA translations
-      uses: crowdin/github-action@v2
+      uses: crowdin/github-action@c7af9bc98b01694653031fef2a0dc6c7888ce9bc # v2.17.0
       with:
         upload_sources: false
         upload_translations: false

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Upload sources to Crowdin
-      uses: crowdin/github-action@v2
+      uses: crowdin/github-action@c7af9bc98b01694653031fef2a0dc6c7888ce9bc # v2.17.0
       with:
         upload_sources: true
         upload_translations: false
@@ -39,7 +39,7 @@ jobs:
         CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
     - name: Upload translations to Crowdin
-      uses: crowdin/github-action@v2
+      uses: crowdin/github-action@c7af9bc98b01694653031fef2a0dc6c7888ce9bc # v2.17.0
       with:
         command: upload translations
         command_args: --auto-approve-imported

--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -44,11 +44,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: ${{ inputs.ref }}
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'
@@ -68,7 +68,7 @@ jobs:
     - name: Capture screenshots
       run: npm run screenshots:capture -- --out "$RUNNER_TEMP/shots"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: docs-screenshots
         path: ${{ runner.temp }}/shots
@@ -76,7 +76,7 @@ jobs:
     - name: Mint a token for api-documentation
       if: ${{ !inputs.dry_run }}
       id: docs_token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
       with:
         app-id: ${{ secrets.DOCS_BOT_APP_ID }}
         private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
@@ -85,7 +85,7 @@ jobs:
 
     - name: Check out api-documentation
       if: ${{ !inputs.dry_run }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         repository: Layer-Fi/api-documentation
         token: ${{ steps.docs_token.outputs.token }}
@@ -119,7 +119,7 @@ jobs:
 
     - name: Open the docs PR
       if: ${{ !inputs.dry_run }}
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
       with:
         path: api-documentation
         token: ${{ steps.docs_token.outputs.token }}

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/i18n-extract-keys.yml
+++ b/.github/workflows/i18n-extract-keys.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: main
         fetch-depth: 0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0  # full history so the commit scan can reach the previous release
 
     - name: Sync current in-progress release
-      uses: linear/linear-release-action@v0
+      uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v0.15.0
       with:
         access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
         command: sync

--- a/.github/workflows/msw-coverage.yml
+++ b/.github/workflows/msw-coverage.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -5,15 +5,19 @@ on:
     - cron: '0 16 * * *'   # daily at 08:00 UTC (adjust to your preferred time)
   workflow_dispatch: {}   # manual run option
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Use Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18'
           cache: 'npm'
@@ -25,7 +29,7 @@ jobs:
         run: npm audit --json > audit.json || true
 
       - name: Create/update daily vulnerability issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -45,12 +45,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: main
         fetch-depth: 0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -44,7 +44,7 @@ jobs:
       type: ${{ steps.r.outputs.type }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: main
         fetch-depth: 0
@@ -94,7 +94,7 @@ jobs:
         fi
 
     # No registry-url: it writes an empty _authToken that makes npm skip OIDC.
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'
@@ -106,11 +106,13 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    # --provenance is implied by trusted publishing, but stating it means it can't silently
+    # disappear if the auth mechanism ever changes.
     - name: Publish to npm
-      run: npm publish --access public --tag ${{ steps.r.outputs.type == 'alpha' && 'alpha' || 'latest' }} ${{ inputs.dry_run && '--dry-run' || '' }}
+      run: npm publish --access public --provenance --tag ${{ steps.r.outputs.type == 'alpha' && 'alpha' || 'latest' }} ${{ inputs.dry_run && '--dry-run' || '' }}
 
     - name: Sync release in Linear
-      uses: linear/linear-release-action@v0
+      uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v0.15.0
       with:
         access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
         command: sync
@@ -120,7 +122,7 @@ jobs:
 
     - name: Complete release in Linear
       if: ${{ steps.r.outputs.type == 'stable' }}
-      uses: linear/linear-release-action@v0
+      uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v0.15.0
       with:
         access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
         command: complete
@@ -131,7 +133,7 @@ jobs:
     # (CLI can only create it In Progress, not Planned.)
     - name: Queue the next release in Linear
       if: ${{ steps.r.outputs.type == 'stable' }}
-      uses: linear/linear-release-action@v0
+      uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v0.15.0
       with:
         access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
         command: sync

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: main
         fetch-depth: 0

--- a/.github/workflows/scratch-stories-cleanup.yml
+++ b/.github/workflows/scratch-stories-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
       statuses: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/scratch-stories-guard.yml
+++ b/.github/workflows/scratch-stories-guard.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -30,13 +30,13 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: ${{ inputs.ref }}
         persist-credentials: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'
@@ -51,7 +51,7 @@ jobs:
         STORYBOOK_SCOPE: ${{ inputs.public_only && 'public' || '' }}
 
     - name: Upload Pages artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
       with:
         path: storybook-static
 
@@ -71,4 +71,4 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -4,15 +4,18 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   stylelint:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,70 +1,110 @@
-# Publishing This Module
+# Publishing this package
 
-The @layerfi/components module is [available on
-NPM](https://www.npmjs.com/package/@layerfi/components).
+[`@layerfi/components`](https://www.npmjs.com/package/@layerfi/components) is published from CI
+only. There is no manual `npm publish` step, and there is no npm token to hold — the release
+workflow authenticates to npm with OIDC trusted publishing.
 
-NOTE: This module is available to and accessible by anyone in the world, even if
-they do not have the credentials to access the LayerFi service itself. Please
-make sure no access tokens or keys get put into it accidentally.
+> The published package is public and readable by anyone, whether or not they have credentials for
+> the Layer service. Nothing secret may end up in `dist/`.
 
-## Development
+## The release flow
 
-Developing on this module is possible via `npm link`. This assumes that the
-demonstration app `demo` and the module `components` live in the same directory.
+Three workflows, in order. The first and last are manual buttons; the middle one is a hook.
 
-# Do not add the module to package.json of `demo`.
-# `cd ../demo`
-# `npm link ../components`
-# `cd ../components`
-# `npm install`
-# `rm -rf node_modules/react node_modules/react-dom`
-# `npm run build`
-# `cd ../demo`
-# Stop the server if it's currently running.
-# `npm install`
-# `npm start`
+### 1. Release — Prepare (`release-prepare.yml`, manual)
 
-When making changes that you want to see appear in the app, you should only need
-to run `npm run build`. You may need to refresh the browser page if the change
-was more than just a little styling.
+Inputs: `release_type` (`alpha` | `stable`) and `increment` (`patch` | `minor` | `major`).
 
-Making changes to the dependencies of the module requires that it be installed.
-Start at Step 4 above (`cd ../components`).
+Computes the next version, pushes a `release/vX.Y.Z` branch, and opens a `chore(release): vX.Y.Z`
+PR that bumps `package.json`. It does not merge, tag, publish, or touch Linear. Review and merge
+that PR like any other.
 
-## Production
+Versioning is "model A": the cycle target is fixed at the first alpha, and stable drops the suffix.
 
-The module is published with `npm publish`.
+| starting from | `release_type` | result |
+|---|---|---|
+| `0.1.143` (stable) | `alpha`, patch | `0.1.144-alpha.0` |
+| `0.1.144-alpha.0` | `alpha` | `0.1.144-alpha.1` (`increment` ignored) |
+| `0.1.144-alpha.1` | `stable` | `0.1.144` (`increment` ignored) |
+| `0.1.143` (stable) | `stable`, minor | `0.2.0` |
 
-In order to see what will happen before publishing, use `npm publish --dry-run`.
-This will show what the command will do, but will not actually publish the
-module. You can use this output to check for oversights before publishing.
-Similarly, you can run `npm pack` to build a local tarball of the package.
+### 2. Release — Tag (`release-tag.yml`, automatic)
 
-Running `npm publish`/`npm pack` in the module will put everything that is in
-the directory into the module _except_ the files disallowed by `.npmignore`. All
-that is necessary are the files in `dist` after being generated with `npm run
-build`. Therefore, you must run `npm run build` before packing/publishing.
-However, this should run automatically via the `prepack` script.
+Fires when a `release/v*` PR is merged. Creates the `vX.Y.Z` tag and a GitHub Release with generated
+notes. Alphas are marked prerelease and are not made "latest". Nothing else tags; don't tag by hand.
 
-### Version Numbers
+### 3. Release — Publish (`release-publish.yml`, manual)
 
-The version number must be incremented in order to be put on NPM. That is,
-version numbers refer to a specific and unique set of code. Once a version
-number is taken, it cannot be reused, even if that version is "unpublished".
+Inputs: `next_linear_release` (stable only) and `dry_run`, **which defaults to `true`**.
 
-In Semantic Versioning, the version numbers mean things: the version is split
-into `Major.Minor.Patch` numbers. From [semver.org](https://semver.org/):
+Reads the version from `package.json` on `main`, checks out the matching tag, verifies the packed
+tarball, publishes, then updates Linear:
 
-> Given a version number MAJOR.MINOR.PATCH, increment the:
->
-> * MAJOR version when you make incompatible API changes
-> * MINOR version when you add functionality in a backward compatible manner
-> * PATCH version when you make backward compatible bug fixes
->
-> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
+- **alpha** → `npm publish --tag alpha`, and syncs the Linear release
+- **stable** → `npm publish` (dist-tag `latest`), syncs and completes the Linear release, queues the
+  next one, and refreshes the screenshots in `Layer-Fi/api-documentation`
 
-Versions with a Major version of 0 are allowed to basically do whatever they
-want, as that is considered "prerelease".
+Because `dry_run` defaults to true, the first click is always a rehearsal: `npm publish --dry-run`,
+Linear read-only, and the tag isn't required. Untick it to ship.
 
-NOTE: The `version` field of package.json must be incremented in at least one of these
-numbers in order to publish a new version.
+## What gates a publish
+
+Before `npm publish` runs, the job packs the tarball and installs it into the consumer fixtures under
+`consumer-fixtures/` — Vite/ESM, CJS `require`, and SSR. This runs in the publish job against the
+exact tree being published, not as a separate job against `main`, so the tarball that gets verified
+is the one that ships. See [docs/dependency-policy.md](docs/dependency-policy.md) for the full list
+of gates and what each one covers.
+
+`prepack` (`npm run typecheck && npm run build:clean`) rebuilds `dist/` on any `npm pack` or
+`npm publish`, so a stale or half-built `dist/` cannot be published.
+
+Only the `files` field decides what ships — currently `dist/` only. There is no `.npmignore`.
+
+## Supply-chain posture
+
+- **No npm token.** Auth is OIDC trusted publishing, configured for the package on npmjs.com.
+  `release-publish.yml` needs `id-token: write` and deliberately omits `registry-url` on
+  `setup-node`, which would otherwise write an empty `_authToken` and make npm skip OIDC.
+- **npm is pinned** to 11.5.1 in the workflow; trusted publishing needs ≥ 11.5.1.
+- **Provenance** is published (`--provenance`), so consumers can verify which repo, workflow, and
+  commit built the tarball.
+- **Actions are pinned to commit SHAs**, with the version in a trailing comment. The
+  `github-actions` Dependabot lane moves them. Never reintroduce a floating tag like `@v4` — a tag
+  is a pointer the action's author can move, and these workflows hold secrets and write tokens.
+- **`.github/CODEOWNERS`** covers the workflows and the files that define the published surface.
+
+## Local development against a consumer app
+
+`npm link` works, but it makes React resolve twice, so it needs the extra step below. Packing the
+tarball is closer to what a consumer actually gets:
+
+```bash
+npm pack                     # runs prepack: typecheck + clean build
+cd ../your-app
+npm install ../layer-react/layerfi-components-<version>.tgz
+```
+
+For an iterative loop, `npm run dev` rebuilds `dist/` on change (JS and types in parallel). With
+`npm link`, run `npm run clear:react` in this repo afterwards to drop the duplicate React copies:
+
+```bash
+cd ../your-app && npm link ../layer-react
+cd ../layer-react && npm run clear:react && npm run dev
+```
+
+To check what a publish would contain without publishing:
+
+```bash
+npm pack --dry-run       # file list
+npm run test:consumers   # packs, then builds real consumer apps against the tarball
+npm run lint:package     # publint + attw on the packed result
+```
+
+## Version numbers
+
+Once a version is published it can never be reused, even if unpublished. The `version` field is
+bumped by Release — Prepare, not by hand.
+
+`0.x` versions are pre-1.0, so breaking changes can land in a minor — but the peer range in
+`package.json` is a promise, and widening or narrowing it needs the consumer fixtures run across the
+range first.


### PR DESCRIPTION
## Scope

Phase 6, the last of the dependency & supply-chain program. Dependency hygiene is one half of npm security; the other is that only our CI can publish. `release-publish.yml` already gets the hardest part right — OIDC trusted publishing, no long-lived `NPM_TOKEN`, npm pinned to 11.5.1 — so this closes the gaps around it.

### Actions pinned to commit SHAs

**57 `uses:` lines across all 22 workflows**, every one previously a floating major tag. A tag is a pointer the action's author can move, so `@v4` today and `@v4` tomorrow can be different code — and these workflows hold real capability: `release-publish.yml` has `id-token: write` and publishes to npm, `docs-screenshots.yml` holds a GitHub App token and opens PRs in `Layer-Fi/api-documentation`, `crowdin-sync.yml` has secrets, and `scratch-stories-cleanup.yml` force-pushes to PR branches.

Each pin carries the version in a trailing comment. Worth noting: resolving these by hand is error-prone because tag lists sort lexicographically, so I resolved each `@major` tag to its SHA and then asked GitHub which tags point at that SHA. Three of my first guesses were wrong that way — `create-github-app-token` is v1.12.0 (not v1.9.3), `crowdin/github-action` v2.17.0 (not v2.9.1), `linear-release-action` v0.15.0 (not v0.9.0). The comments reflect the verified answers.

The `github-actions` Dependabot lane from #1683 is what keeps these from rotting; without it, pinning just freezes us. Accepted trade-off, stated plainly: this turns action updates into routine merge traffic, and it pins `linear/linear-release-action` to one build of a still-moving `v0`.

### Provenance made explicit

Added `--provenance` to `npm publish`. Trusted publishing already generates it implicitly on npm ≥ 11.5.1, so this changes no behavior today — the point is that it can't silently disappear if the auth mechanism changes.

### Permissions

`stylelint.yml` and `npm-audit.yml` had no `permissions:` block and were running with the default write-all token. Both now `contents: read` (plus `issues: write` for the audit reporter). Every other workflow already had one, at the top level or the job level.

### CODEOWNERS

New `.github/CODEOWNERS` assigning `@Layer-Fi/layer-engineering` to `/.github/` and to the files that define the published surface (`package.json`, the vite/rollup configs, `scripts/build-types.ts`, `src/index.tsx`).

**This file is currently inert, and I can't fix that from a PR.** `main`'s branch protection has `required_approving_review_count: 0` and `require_code_owner_reviews: false`, so nothing in CODEOWNERS is enforced until "Require review from Code Owners" is switched on in repository settings. The header comment says so, but it needs an admin to action. Flagging it rather than letting it look like a control that exists.

### PUBLISHING.md rewritten

The old version was actively dangerous, not just stale: it documented manual `npm publish`, hand-editing `version`, and an `.npmignore` that no longer exists, and never mentioned the three release workflows or OIDC. Anyone following it would have published outside the protected pipeline.

Replaced with the actual Prepare → merge → Tag → Publish flow, including the model-A versioning table, the `dry_run: true` default, alpha vs stable dist-tag behavior, what gates a publish, the supply-chain posture (including "never reintroduce a floating tag"), and a local-development section that leads with `npm pack` and keeps the `npm link` + `clear:react` dance as the secondary path.

## Verification

- all 22 workflow files parse (`js-yaml`)
- zero unpinned third-party actions remain (`grep` for `uses: …@` not matching a 40-char SHA returns nothing)
- spot-checked that the pinned SHAs are real commits in their repos via the GitHub API
- `--provenance` present in the publish command; `registry-url` still deliberately absent from `setup-node` (a comment there explains it writes an empty `_authToken` that breaks OIDC)

The real end-to-end check is a `dry_run: true` Release — Publish run after this merges, which also exercises the consumer-matrix gate from #1684. I haven't run it — that's a workflow dispatch against `main`, so it belongs after merge.

## Merge-order note

This and #1683 both touch `.github/workflows/npm-audit.yml` — that PR bumps its `github-script` to v7 and rewrites the audit step, this one pins its actions and adds `permissions`. Expect a conflict; merge #1683 first and rebase this. That's also why `github-script` is pinned at v6.4.1 here rather than bumped: v6 runs on the deprecated node16 runtime, and npm-audit is its only usage, so #1683's bump to v7 is the right place to fix it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every workflow and the npm publish command; mis-pinned actions or permission changes could break CI or releases, though behavior is intended to stay the same aside from supply-chain hardening.
> 
> **Overview**
> **Hardens the npm release and CI supply chain** (dependency program phase 6): third-party Actions no longer use floating `@v4`-style tags, publish provenance is explicit, and docs match how shipping actually works.
> 
> All **22 workflows** now pin every third-party `uses:` to a **commit SHA** (version in a comment), including release, Crowdin, Chromatic, docs-screenshots, and Linear steps. **`release-publish.yml`** adds **`--provenance`** on `npm publish` so provenance stays on even if OIDC behavior changes.
> 
> **Least-privilege tokens:** `stylelint.yml` and `npm-audit.yml` get explicit `permissions` (`contents: read`; audit also `issues: write`) instead of the default broad token.
> 
> New **`.github/CODEOWNERS`** routes `/.github/` and publish-surface files (`package.json`, Vite/rollup entrypoints, `src/index.tsx`, etc.) to `@Layer-Fi/layer-engineering`, with a note that enforcement needs branch protection “Require review from Code Owners.”
> 
> **`PUBLISHING.md`** is rewritten for CI-only OIDC publishing (Prepare → Tag → Publish), consumer tarball gates, SHA pinning policy, and local `npm pack` / link guidance—replacing obsolete manual publish and `.npmignore` instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb7fb9eb72b94c8f2aca3363610bc8be3b3cee49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->