### PR TITLE
fix: scope the Crowdin sync to manifest files

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -39,7 +39,8 @@ on:
     branches:
       - main
     paths:
-      - src/assets/locales/**
+      # Manifests only — SKILL.md lives here too and must not reach Crowdin.
+      - src/assets/locales/**/*.json
 
 permissions:
   contents: write
@@ -74,8 +75,8 @@ jobs:
         ENGLISH=true
         TRANSLATIONS=true
         if git cat-file -e "$BEFORE_SHA" 2>/dev/null; then
-          git diff --quiet "$BEFORE_SHA" HEAD -- src/assets/locales/en-US && ENGLISH=false
-          git diff --quiet "$BEFORE_SHA" HEAD -- src/assets/locales ':!src/assets/locales/en-US' && TRANSLATIONS=false
+          git diff --quiet "$BEFORE_SHA" HEAD -- 'src/assets/locales/en-US/*.json' && ENGLISH=false
+          git diff --quiet "$BEFORE_SHA" HEAD -- 'src/assets/locales/*/*.json' ':!src/assets/locales/en-US' && TRANSLATIONS=false
         fi
         echo "english=$ENGLISH" >> "$GITHUB_OUTPUT"
         echo "translations=$TRANSLATIONS" >> "$GITHUB_OUTPUT"
@@ -83,7 +84,7 @@ jobs:
     # Before the translations below: Crowdin only accepts a translation for a source string it
     # already has, so a push that adds or renames a namespace file fails without this.
     - name: Upload sources to Crowdin
-      if: ${{ github.event_name == 'push' || inputs.pretranslate || inputs.prune }}
+      if: ${{ steps.changed.outputs.english == 'true' || steps.changed.outputs.translations == 'true' || inputs.pretranslate || inputs.prune }}
       uses: crowdin/github-action@v2
       with:
         upload_sources: true


### PR DESCRIPTION
Two follow-ups to #1691, both in `crowdin-sync.yml`.

## A markdown edit uploads translations to Crowdin

The push filter and the classifier both matched everything under `src/assets/locales`, but `SKILL.md` lives there too. So a docs-only change counts as an `fr-CA` change and runs `crowdin upload translations`.

This is not hypothetical — **merging #1691 did exactly that.** That PR touched only workflows and `src/assets/locales/SKILL.md`, and [run 31058209114](https://github.com/Layer-Fi/layer-react/actions/runs/31058209114) uploaded translations off the back of it.

Both the filter and the two diffs now match only `<locale>/<namespace>.json`:

```yaml
paths:
  - src/assets/locales/**/*.json
```

```sh
git diff --quiet "$BEFORE_SHA" HEAD -- 'src/assets/locales/en-US/*.json' && ENGLISH=false
git diff --quiet "$BEFORE_SHA" HEAD -- 'src/assets/locales/*/*.json' ':!src/assets/locales/en-US' && TRANSLATIONS=false
```

`*/*.json` matches `<locale>/<namespace>.json` and nothing at the `locales/` root, which is what excludes `SKILL.md`.

## The source upload tested the event, not the classifier

`Upload sources` was gated on `github.event_name == 'push'` while every other push-driven step keyed off `steps.changed.outputs.*`. Same outcome today, but two ways of asking the same question, and only one of them notices the scoping fix above. It now reads from the same flags as its neighbours.

## Verification

Run against real commits as fixtures, checking the classifier resolves correctly in both directions:

| range | `english` | `translations` | |
|---|---|---|---|
| #1689 merge — renamed every manifest | `true` | `true` | ✓ |
| #1691 merge — `SKILL.md` + workflows only | `false` | `false` | ✓ was `translations=true` |

The second row is the bug. Workflow parses, and the full step/condition table is unchanged apart from step 4.

Not carried on #1692 deliberately: that branch is force-pushed by this workflow (`git checkout -B` + `git push -f`), so anything added to it is destroyed on the next sync run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow path and condition changes only; no app runtime or Crowdin credentials behavior change beyond when sync runs.
> 
> **Overview**
> **Fixes accidental Crowdin runs** when only docs under `src/assets/locales` change (e.g. `SKILL.md`), which previously could upload translations after a workflow-only merge.
> 
> The **push `paths` filter** and the **classify step** now diff only `<locale>/<namespace>.json` files (`en-US/*.json` for English, `*/*.json` excluding `en-US` for translations), not the whole `locales/` tree.
> 
> **Upload sources to Crowdin** no longer runs on every `push`; it uses the same `steps.changed.outputs.english` / `translations` flags (plus manual `pretranslate` / `prune`) as the other push-driven steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54a0819dee90f51f216630e805e20b04c3368e03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->