### PR TITLE
fix: stop the data table pinning observer from re-triggering itself

### DIFF
--- a/src/components/blocks/Table/DataTable/useColumnPinningStyles.ts
+++ b/src/components/blocks/Table/DataTable/useColumnPinningStyles.ts
@@ -69,16 +69,33 @@ export const useColumnPinningStyles = <TData>(
     const container = containerRef.current
     if (!container) return
 
-    const resizeObserver = new ResizeObserver(() => measure())
+    let frame: number | null = null
+    let observedCells: HTMLElement[] = []
+
+    // Measuring writes sticky offsets back onto the observed cells, so defer out of the
+    // observer callback to avoid "ResizeObserver loop completed with undelivered notifications".
+    const scheduleMeasure = () => {
+      if (frame !== null) return
+      frame = requestAnimationFrame(() => {
+        frame = null
+        measure()
+      })
+    }
+
+    const resizeObserver = new ResizeObserver(scheduleMeasure)
 
     // Measure and compute sticky offsets before paint so pinned columns move together.
     const measure = () => {
       const cells = getLeafHeaderCells(container)
       if (cells.length === 0) return
 
-      // Keep offsets in sync when column widths change after the initial layout.
-      resizeObserver.disconnect()
-      cells.forEach(cell => resizeObserver.observe(cell))
+      // Keep offsets in sync when column widths change after the initial layout. Re-observing the
+      // same cells re-fires the observer, so only resubscribe when the cell set actually changes.
+      if (cells.length !== observedCells.length || cells.some((cell, index) => cell !== observedCells[index])) {
+        resizeObserver.disconnect()
+        cells.forEach(cell => resizeObserver.observe(cell))
+        observedCells = cells
+      }
 
       const widths = getColumnHeaderWidths(leafColumnIds, cells)
       const nextPinningStyles = computePinningStyles(headerGroups, widths)
@@ -89,10 +106,11 @@ export const useColumnPinningStyles = <TData>(
 
     // react-aria builds its collection after the first commit, so the header cells this measures
     // don't exist yet on the ARIA path — watch for them instead of measuring once.
-    const mutationObserver = new MutationObserver(() => measure())
+    const mutationObserver = new MutationObserver(scheduleMeasure)
     mutationObserver.observe(container, { childList: true, subtree: true })
 
     return () => {
+      if (frame !== null) cancelAnimationFrame(frame)
       resizeObserver.disconnect()
       mutationObserver.disconnect()
     }

--- a/src/components/blocks/Table/DataTable/useColumnPinningStyles.ts
+++ b/src/components/blocks/Table/DataTable/useColumnPinningStyles.ts
@@ -69,48 +69,56 @@ export const useColumnPinningStyles = <TData>(
     const container = containerRef.current
     if (!container) return
 
-    let frame: number | null = null
-    let observedCells: HTMLElement[] = []
+    let measureFrame: number | null = null
+    let subscribeFrame: number | null = null
 
-    // Measuring writes sticky offsets back onto the observed cells, so defer out of the
-    // observer callback to avoid "ResizeObserver loop completed with undelivered notifications".
-    const scheduleMeasure = () => {
-      if (frame !== null) return
-      frame = requestAnimationFrame(() => {
-        frame = null
-        measure()
-      })
+    const onNextFrame = (frame: number | null, run: () => void) => {
+      if (frame !== null) return frame
+      return requestAnimationFrame(run)
     }
 
-    const resizeObserver = new ResizeObserver(scheduleMeasure)
-
-    // Measure and compute sticky offsets before paint so pinned columns move together.
     const measure = () => {
       const cells = getLeafHeaderCells(container)
       if (cells.length === 0) return
-
-      // Keep offsets in sync when column widths change after the initial layout. Re-observing the
-      // same cells re-fires the observer, so only resubscribe when the cell set actually changes.
-      if (cells.length !== observedCells.length || cells.some((cell, index) => cell !== observedCells[index])) {
-        resizeObserver.disconnect()
-        cells.forEach(cell => resizeObserver.observe(cell))
-        observedCells = cells
-      }
 
       const widths = getColumnHeaderWidths(leafColumnIds, cells)
       const nextPinningStyles = computePinningStyles(headerGroups, widths)
       setPinningStyles(current => arePinningStylesEqual(current, nextPinningStyles) ? current : nextPinningStyles)
     }
 
+    // Measuring writes sticky offsets back onto the observed cells, so defer out of the observer
+    // callback to avoid "ResizeObserver loop completed with undelivered notifications".
+    const resizeObserver = new ResizeObserver(() => {
+      measureFrame = onNextFrame(measureFrame, () => {
+        measureFrame = null
+        measure()
+      })
+    })
+
+    // Subscribing fires an initial observation, which is what drives the measure. Only the mutation
+    // observer may call this — resizing into it would re-arm the observer on every callback.
+    const subscribeToHeaderCells = () => {
+      resizeObserver.disconnect()
+      getLeafHeaderCells(container).forEach(cell => resizeObserver.observe(cell))
+    }
+
+    // Compute sticky offsets before paint so pinned columns land in place on the first frame.
     measure()
+    subscribeToHeaderCells()
 
     // react-aria builds its collection after the first commit, so the header cells this measures
-    // don't exist yet on the ARIA path — watch for them instead of measuring once.
-    const mutationObserver = new MutationObserver(scheduleMeasure)
+    // don't exist yet on the ARIA path — resubscribe as they appear and change.
+    const mutationObserver = new MutationObserver(() => {
+      subscribeFrame = onNextFrame(subscribeFrame, () => {
+        subscribeFrame = null
+        subscribeToHeaderCells()
+      })
+    })
     mutationObserver.observe(container, { childList: true, subtree: true })
 
     return () => {
-      if (frame !== null) cancelAnimationFrame(frame)
+      if (measureFrame !== null) cancelAnimationFrame(measureFrame)
+      if (subscribeFrame !== null) cancelAnimationFrame(subscribeFrame)
       resizeObserver.disconnect()
       mutationObserver.disconnect()
     }


### PR DESCRIPTION
## Description

Fixes the `ResizeObserver loop completed with undelivered notifications` error thrown when a data table with pinned columns populates with rows.

`useColumnPinningStyles` observed the leaf header cells and, from inside the callback, wrote `position: sticky` + `left`/`right` back onto those same cells. On top of that, `measure()` unconditionally called `resizeObserver.disconnect()` and re-observed every cell on each invocation — and `observe()` always fires an initial observation — so each measure re-armed the observer to fire again. The `MutationObserver` on `{ childList: true, subtree: true }` fires on every row insert, which is why it surfaces once the table has data rather than while it's empty.

## Changes

- Split the two observers by responsibility: the `MutationObserver` resubscribes the `ResizeObserver` to the current leaf header cells, and the `ResizeObserver` only measures. The resubscribe's initial observation is what drives the measure, so nothing re-arms itself.
- Defer both observer callbacks to `requestAnimationFrame`, coalesced per observer, so layout writes happen after the observer finishes delivering notifications.
- Keep a synchronous `measure()` on mount so pinned columns still land in place before the first paint.
- Cancel any pending frames on effect cleanup.

## How this has been tested?

`tsc --noEmit` and `eslint` are clean. There are no existing tests for this hook, so verification is static — needs a manual pass on both consumers before merge:

- `BankTransactionsTable` (two right-pinned columns)
- a unified report with pinned columns and a group-by expanded, since those columns are server-driven and change identity on reload

Checking that the error is gone, the pinned offsets are correct, and there's no visible frame of unpinned columns on load.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to data-table column pinning layout timing; behavior should be unchanged aside from eliminating the observer error.
> 
> **Overview**
> Fixes the **`ResizeObserver loop completed with undelivered notifications`** error when pinned-column data tables load rows.
> 
> In **`useColumnPinningStyles`**, resize and mutation observer callbacks no longer run **`measure()`** synchronously. Work is **coalesced on `requestAnimationFrame`** so sticky offset updates happen after the observer finishes. **`disconnect()` / re-`observe()`** on leaf header cells was removed from every measure and moved into **`subscribeToHeaderCells`**, which runs on initial setup and when the **mutation observer** sees DOM changes (e.g. react-aria header cells appearing), avoiding a feedback loop where each measure re-armed the resize observer. Effect cleanup **cancels pending animation frames**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 115d42eea0f4f22e93b2ad59ede8664410405766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->