### PR TITLE
[LAY-2596] fix: render docs screenshots in Inter

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -59,6 +59,14 @@ jobs:
     - name: Install Chromium
       run: npx playwright install --with-deps chromium
 
+    # --font-family resolves to Inter, which the runner doesn't ship. Without it every capture
+    # silently falls back to the generic sans and the whole image set changes.
+    - name: Install Inter
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y fonts-inter fonts-inter-variable
+        fc-cache -f
+
     - name: Build Storybook
       run: npm run storybook:build
 

--- a/scripts/capture-docs-screenshots.ts
+++ b/scripts/capture-docs-screenshots.ts
@@ -37,6 +37,36 @@ async function main() {
   const browser = await chromium.launch()
   const failures: string[] = []
 
+  // A host without Inter captures the whole set in the fallback sans, which reads as a diff on
+  // every image. Compare against a family that cannot exist: equal widths mean both fell back.
+  async function requireInter() {
+    const page = await browser.newPage()
+    try {
+      const isAvailable = await page.evaluate(() => {
+        const measure = (family: string) => {
+          const context = document.createElement('canvas').getContext('2d')
+          if (context === null) return 0
+          context.font = `48px ${family}`
+          return context.measureText('Revenue December 2025').width
+        }
+        return measure('Inter') !== measure('__Layer__MissingFont__')
+      })
+
+      if (!isAvailable) {
+        console.error('Inter is not installed on this host, so every capture would use the fallback sans.')
+        console.error('Install it (macOS: `brew install --cask font-inter`, Debian/Ubuntu: `apt-get install fonts-inter`) and re-run.')
+        await browser.close()
+        server.close()
+        process.exit(1)
+      }
+    }
+    finally {
+      await page.close()
+    }
+  }
+
+  await requireInter()
+
   async function capture({ storyId, out: file, viewport, interactAt, maxHeight, captureViewport }: DocsScreenshot) {
     const context = await browser.newContext({
       viewport: { width: DOCS_SCREENSHOT_WIDTHS[interactAt ?? viewport], height: 900 },

--- a/scripts/capture-docs-screenshots.ts
+++ b/scripts/capture-docs-screenshots.ts
@@ -42,17 +42,20 @@ async function main() {
   async function requireInter() {
     const page = await browser.newPage()
     try {
-      const isAvailable = await page.evaluate(() => {
-        const measure = (family: string) => {
-          const context = document.createElement('canvas').getContext('2d')
-          if (context === null) return 0
-          context.font = `48px ${family}`
-          return context.measureText('Revenue December 2025').width
-        }
-        return measure('Inter') !== measure('__Layer__MissingFont__')
-      })
+      // Declaring a helper in here would break the check: tsx compiles with esbuild's keepNames,
+      // which wraps named function bindings in a __name() call that does not exist in the page.
+      const widths = await page.evaluate((sample) => {
+        const context = document.createElement('canvas').getContext('2d')
+        if (context === null) return null
 
-      if (!isAvailable) {
+        context.font = '48px Inter'
+        const inter = context.measureText(sample).width
+        context.font = '48px __Layer__MissingFont__'
+
+        return { inter, fallback: context.measureText(sample).width }
+      }, 'Revenue December 2025')
+
+      if (widths === null || widths.inter === widths.fallback) {
         console.error('Inter is not installed on this host, so every capture would use the fallback sans.')
         console.error('Install it (macOS: `brew install --cask font-inter`, Debian/Ubuntu: `apt-get install fonts-inter`) and re-run.')
         await browser.close()


### PR DESCRIPTION
## Description

Layer-Fi/api-documentation#370 regenerated all 36 docs screenshots and every single one changed — identical dimensions, but 4–28% smaller and visibly different letterforms. The cause is the font, not the UI.

`src/styles/variables.scss:90` sets `--font-family: 'InterVariable', 'Inter', sans-serif`, but nothing in this repo installs or loads Inter — consumers supply it in production, and Storybook never does. So captures render in whatever the host falls back to:

- The images in api-documentation#364 were generated on macOS, in the macOS fallback.
- #370 was the first regeneration from CI, on `ubuntu-latest`, in the Linux fallback.

Neither set was ever Inter. Verified by probing with Playwright: on a Mac without Inter, `48px Inter` and `48px __MissingFont__` measure identically (485.13px) while `48px Arial` does not (547.01px) — the family isn't resolving.

## Changes

- `docs-screenshots.yml`: install `fonts-inter` + `fonts-inter-variable` on the runner before building Storybook.
- `capture-docs-screenshots.ts`: preflight the font before capturing anything and exit non-zero with an install hint when it's missing. A silently-wrong-font regeneration is exactly the failure this just produced, so it should be loud.

The preflight measures both families inline rather than through a helper function. tsx compiles with esbuild's `keepNames`, which wraps named function bindings in a `__name()` call; Playwright serializes the callback into the page, where `__name` is undefined, so a helper would throw `ReferenceError` and abort every run — including when Inter is present.

## Blockers

None for this PR, but note the ordering: api-documentation#370 should be **closed, not merged**. Once this lands and the workflow re-runs, the next regeneration renders in real Inter — which will again change all 36 images, this time to the intended typeface.

## How this has been tested?

- `tsc --noEmit` clean; `scripts/` is outside the eslint scope.
- Both preflight paths exercised locally against the real script and a built Storybook:
  - font missing (Inter, on a Mac without it) → exits 1 with the install hint, captures nothing
  - font present (temporarily probing Arial) → passes the guard and captures `global-month-picker.png` normally
- Confirmed the `keepNames` failure first-hand before fixing it: the helper form threw `ReferenceError: __name is not defined` under tsx 4.20.6 / esbuild 0.28.1.
- Not yet exercised on the runner. Suggested check before merge: `workflow_dispatch` with `ref: main` and `dry_run: true`, then compare the uploaded artifact against the current images — the diff should be a typeface change and nothing else.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the docs screenshot CI workflow and capture script; no production app, auth, or data paths.
> 
> **Overview**
> Docs screenshots were rendering in the host’s fallback sans because **Inter** wasn’t available on CI (or locally), so regenerations looked like full UI diffs even when only typography changed.
> 
> The **docs-screenshots** workflow now installs `fonts-inter` and `fonts-inter-variable` and refreshes the font cache before Storybook build and capture. **`capture-docs-screenshots.ts`** runs a **`requireInter()`** preflight before any captures: it compares canvas text widths for `Inter` vs a guaranteed-missing family and exits with install hints if they match (silent fallback). The check keeps its logic inline in `page.evaluate` so tsx/esbuild `keepNames` doesn’t inject `__name` into the browser context and break the guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f06d9740ee1b462f8403c1254a27a90a4f8de705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->