### PR TITLE
[LAY-2630] fix: check the Inter webfont loaded, not a system font

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -42,6 +42,7 @@ permissions:
 jobs:
   screenshots:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -32,7 +32,7 @@ on:
         type: string
         default: main
       dry_run:
-        description: 'Capture and upload artifacts, but open no PR'
+        description: 'Dry run'
         type: boolean
         default: true
 
@@ -58,14 +58,6 @@ jobs:
 
     - name: Install Chromium
       run: npx playwright install --with-deps chromium
-
-    # --font-family resolves to Inter, which the runner doesn't ship. Without it every capture
-    # silently falls back to the generic sans and the whole image set changes.
-    - name: Install Inter
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y fonts-inter fonts-inter-variable
-        fc-cache -f
 
     - name: Build Storybook
       run: npm run storybook:build

--- a/scripts/capture-docs-screenshots.ts
+++ b/scripts/capture-docs-screenshots.ts
@@ -8,6 +8,10 @@ import { requireStorybookBuild, serveStorybookStatic, STATIC_ROOT } from './serv
 // preview.tsx adds a 250ms floor to every mocked response.
 const SETTLE_MS = 750
 
+// Ceiling on the Inter webfont preflight, so an unresponsive rsms.me fails the run rather
+// than hanging it.
+const FONT_LOAD_TIMEOUT_MS = 30_000
+
 function parseArgs() {
   const args = process.argv.slice(2)
   const out = args[args.indexOf('--out') + 1]
@@ -42,27 +46,41 @@ async function main() {
   // the face actually loaded before capturing anything.
   async function requireInterWebFont(storyId: string) {
     const page = await browser.newPage()
-    try {
-      await page.goto(`${origin}/iframe.html?viewMode=story&id=${storyId}`)
-      await page.waitForSelector('#storybook-root > *', { timeout: 30_000 })
+    let isLoaded = false
 
+    try {
+      // An unreachable rsms.me stalls the stylesheet, which can hold up `load` and time the
+      // navigation out. Any failure in here means the same thing as a missing face, so report it
+      // the same way rather than crashing with a navigation error.
+      await page.goto(`${origin}/iframe.html?viewMode=story&id=${storyId}`, { timeout: FONT_LOAD_TIMEOUT_MS })
+      await page.waitForSelector('#storybook-root > *', { timeout: FONT_LOAD_TIMEOUT_MS })
+
+      // A stalled font response leaves document.fonts.ready pending forever, and page.evaluate
+      // has no timeout of its own — so bound the wait in the page.
+      //
       // Declaring a helper in here would break the check: tsx compiles with esbuild's keepNames,
       // which wraps named function bindings in a __name() call that does not exist in the page.
-      const isLoaded = await page.evaluate(async () => {
-        await document.fonts.ready
+      isLoaded = await page.evaluate(async (timeoutMs) => {
+        await Promise.race([
+          document.fonts.ready,
+          new Promise(resolve => setTimeout(resolve, timeoutMs)),
+        ])
         return Array.from(document.fonts).some(face => face.family === 'InterVariable' && face.status === 'loaded')
-      })
-
-      if (!isLoaded) {
-        console.error('The Inter webfont (https://rsms.me/inter/inter.css) did not load, so every capture')
-        console.error('would fall back to the generic sans. Check network access to rsms.me and re-run.')
-        await browser.close()
-        server.close()
-        process.exit(1)
-      }
+      }, FONT_LOAD_TIMEOUT_MS)
+    }
+    catch (error) {
+      console.error(`Could not verify the Inter webfont: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`)
     }
     finally {
       await page.close()
+    }
+
+    if (!isLoaded) {
+      console.error('The Inter webfont (https://rsms.me/inter/inter.css) did not load, so every capture')
+      console.error('would fall back to the generic sans. Check network access to rsms.me and re-run.')
+      await browser.close()
+      server.close()
+      process.exit(1)
     }
   }
 

--- a/scripts/capture-docs-screenshots.ts
+++ b/scripts/capture-docs-screenshots.ts
@@ -120,17 +120,19 @@ async function main() {
       await page.waitForLoadState('networkidle')
       await page.waitForTimeout(SETTLE_MS)
 
-      // Contexts do not share a cache, so this story fetched the font itself and could have
-      // missed even though the preflight passed. Throwing here earns the retry below.
-      if (!await hasInterLoaded(page)) {
-        throw new Error('the Inter webfont (https://rsms.me/inter/inter.css) did not load')
-      }
-
       // Storybook ships the error display hidden in every iframe; only a shown one is real.
       if (await page.locator('.sb-show-errordisplay').count() > 0) {
         crashes.push(await page.locator('#error-message').innerText())
       }
       if (crashes.length > 0) throw new Error(crashes.join('\n'))
+
+      // After the crash checks: a face only reaches `loaded` once something renders with it, so a
+      // story that died before mounting any text would look like a font failure. Contexts do not
+      // share a cache, so this story fetched the font itself and could have missed even though the
+      // preflight passed. Throwing here earns the retry below.
+      if (!await hasInterLoaded(page)) {
+        throw new Error('the Inter webfont (https://rsms.me/inter/inter.css) did not load')
+      }
 
       if (interactAt && interactAt !== viewport) {
         await page.setViewportSize({ width: DOCS_SCREENSHOT_WIDTHS[viewport], height: 900 })

--- a/scripts/capture-docs-screenshots.ts
+++ b/scripts/capture-docs-screenshots.ts
@@ -37,27 +37,25 @@ async function main() {
   const browser = await chromium.launch()
   const failures: string[] = []
 
-  // A host without Inter captures the whole set in the fallback sans, which reads as a diff on
-  // every image. Compare against a family that cannot exist: equal widths mean both fell back.
-  async function requireInter() {
+  // src/styles/index.scss pulls Inter from rsms.me, so every capture depends on that host being
+  // reachable. A silent fallback to the generic sans reads as a diff on all 36 images, so check
+  // the face actually loaded before capturing anything.
+  async function requireInterWebFont(storyId: string) {
     const page = await browser.newPage()
     try {
+      await page.goto(`${origin}/iframe.html?viewMode=story&id=${storyId}`)
+      await page.waitForSelector('#storybook-root > *', { timeout: 30_000 })
+
       // Declaring a helper in here would break the check: tsx compiles with esbuild's keepNames,
       // which wraps named function bindings in a __name() call that does not exist in the page.
-      const widths = await page.evaluate((sample) => {
-        const context = document.createElement('canvas').getContext('2d')
-        if (context === null) return null
+      const isLoaded = await page.evaluate(async () => {
+        await document.fonts.ready
+        return Array.from(document.fonts).some(face => face.family === 'InterVariable' && face.status === 'loaded')
+      })
 
-        context.font = '48px Inter'
-        const inter = context.measureText(sample).width
-        context.font = '48px __Layer__MissingFont__'
-
-        return { inter, fallback: context.measureText(sample).width }
-      }, 'Revenue December 2025')
-
-      if (widths === null || widths.inter === widths.fallback) {
-        console.error('Inter is not installed on this host, so every capture would use the fallback sans.')
-        console.error('Install it (macOS: `brew install --cask font-inter`, Debian/Ubuntu: `apt-get install fonts-inter`) and re-run.')
+      if (!isLoaded) {
+        console.error('The Inter webfont (https://rsms.me/inter/inter.css) did not load, so every capture')
+        console.error('would fall back to the generic sans. Check network access to rsms.me and re-run.')
         await browser.close()
         server.close()
         process.exit(1)
@@ -68,7 +66,7 @@ async function main() {
     }
   }
 
-  await requireInter()
+  await requireInterWebFont(targets[0].storyId)
 
   async function capture({ storyId, out: file, viewport, interactAt, maxHeight, captureViewport }: DocsScreenshot) {
     const context = await browser.newContext({

--- a/scripts/capture-docs-screenshots.ts
+++ b/scripts/capture-docs-screenshots.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { chromium } from 'playwright'
+import { chromium, type Page } from 'playwright'
 import { type DocsScreenshot, DOCS_SCREENSHOT_WIDTHS, DOCS_SCREENSHOTS } from './docs-screenshots.manifest'
 import { requireStorybookBuild, serveStorybookStatic, STATIC_ROOT } from './serve-storybook-static'
 
@@ -11,6 +11,21 @@ const SETTLE_MS = 750
 // Ceiling on the Inter webfont preflight, so an unresponsive rsms.me fails the run rather
 // than hanging it.
 const FONT_LOAD_TIMEOUT_MS = 30_000
+
+// A stalled font response leaves document.fonts.ready pending forever, and page.evaluate has no
+// timeout of its own — so bound the wait in the page.
+//
+// Declaring a helper inside the callback would break this: tsx compiles with esbuild's keepNames,
+// which wraps named function bindings in a __name() call that does not exist in the page.
+function hasInterLoaded(page: Page) {
+  return page.evaluate(async (timeoutMs) => {
+    await Promise.race([
+      document.fonts.ready,
+      new Promise(resolve => setTimeout(resolve, timeoutMs)),
+    ])
+    return Array.from(document.fonts).some(face => face.family === 'InterVariable' && face.status === 'loaded')
+  }, FONT_LOAD_TIMEOUT_MS)
+}
 
 function parseArgs() {
   const args = process.argv.slice(2)
@@ -42,8 +57,9 @@ async function main() {
   const failures: string[] = []
 
   // src/styles/index.scss pulls Inter from rsms.me, so every capture depends on that host being
-  // reachable. A silent fallback to the generic sans reads as a diff on all 36 images, so check
-  // the face actually loaded before capturing anything.
+  // reachable. A silent fallback to the generic sans reads as a diff on all 36 images, so fail
+  // fast here rather than after working through the whole manifest. Each capture re-checks in its
+  // own context, which is what actually guarantees the font for a given image.
   async function requireInterWebFont(storyId: string) {
     const page = await browser.newPage()
     let isLoaded = false
@@ -55,18 +71,7 @@ async function main() {
       await page.goto(`${origin}/iframe.html?viewMode=story&id=${storyId}`, { timeout: FONT_LOAD_TIMEOUT_MS })
       await page.waitForSelector('#storybook-root > *', { timeout: FONT_LOAD_TIMEOUT_MS })
 
-      // A stalled font response leaves document.fonts.ready pending forever, and page.evaluate
-      // has no timeout of its own — so bound the wait in the page.
-      //
-      // Declaring a helper in here would break the check: tsx compiles with esbuild's keepNames,
-      // which wraps named function bindings in a __name() call that does not exist in the page.
-      isLoaded = await page.evaluate(async (timeoutMs) => {
-        await Promise.race([
-          document.fonts.ready,
-          new Promise(resolve => setTimeout(resolve, timeoutMs)),
-        ])
-        return Array.from(document.fonts).some(face => face.family === 'InterVariable' && face.status === 'loaded')
-      }, FONT_LOAD_TIMEOUT_MS)
+      isLoaded = await hasInterLoaded(page)
     }
     catch (error) {
       console.error(`Could not verify the Inter webfont: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`)
@@ -114,6 +119,12 @@ async function main() {
       })
       await page.waitForLoadState('networkidle')
       await page.waitForTimeout(SETTLE_MS)
+
+      // Contexts do not share a cache, so this story fetched the font itself and could have
+      // missed even though the preflight passed. Throwing here earns the retry below.
+      if (!await hasInterLoaded(page)) {
+        throw new Error('the Inter webfont (https://rsms.me/inter/inter.css) did not load')
+      }
 
       // Storybook ships the error display hidden in every iframe; only a shown one is real.
       if (await page.locator('.sb-show-errordisplay').count() > 0) {


### PR DESCRIPTION
## Description

Corrects #1702, which was based on a wrong diagnosis of the api-documentation#370 screenshot diff.

Inter is **not** a system font in this project. `src/styles/index.scss:8` is `@import 'https://rsms.me/inter/inter.css'`, and Sass leaves remote imports as runtime CSS imports — so Inter loads as a webfont during every capture, in Chromatic, and in every consumer's app (`dist/index.css` and published `0.1.144` both begin with that line).

That means the captures were always rendering Inter. The #370 diff was macOS CoreText vs Linux FreeType rasterizing the same font — same glyphs, different antialiasing, which changes every pixel and shrinks the PNGs.

Verified by reproducing the capture in `mcr.microsoft.com/playwright:v1.62.1-noble` against the built Storybook:

- the story requests `https://rsms.me/inter/font-files/InterVariable.woff2`, and `document.fonts` reports `InterVariable loaded`
- the resulting screenshot hashes to `326f3815…`, matching the CI artifact and api-documentation#370/#371 exactly
- that hash is identical with and without `fonts-inter` installed, i.e. the apt step added in #1702 has no effect on rendering

## Changes

- Drop the `Install Inter` apt step — it changed nothing.
- Replace the system-font preflight with one that asserts the `InterVariable` face actually loaded, which is the failure that would really produce a silent 36-image diff (rsms.me unreachable or slow).
- Shorten the `dry_run` input label to `Dry run`.

The preflight in #1702 was a hazard as merged: it probed for a system Inter that nothing uses, so it passed on CI only because of the apt step, and failed on any host without one — including a dev Mac — even though the capture there is correct.

## Blockers

None. api-documentation#370 and #371 are byte-identical to each other and are correct Inter renders on Linux; merge either one and close the other. Future regenerations are stable now that they always run on the same rasterizer.

## How this has been tested?

- `tsc --noEmit` clean.
- Both preflight paths run locally against the real script and a built Storybook:
  - webfont loads → passes and captures `global-month-picker.png` (this is the case the merged #1702 preflight incorrectly failed on this machine)
  - face name forced to a value that cannot match → exits 1 with the rsms.me message, captures nothing

## Follow-up worth considering

The `@import` ships to consumers, so every embedder's app fetches rsms.me at runtime — a third-party dependency on the render path, plus a privacy and availability consideration. Self-hosting the woff2 would remove it from the published CSS and from the capture path in one move. Not done here since it changes the shipped bundle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the docs screenshot automation and CI workflow, not runtime product code; they reduce false failures and hung jobs.
> 
> **Overview**
> **Docs screenshot capture** now treats Inter as the **rsms.me webfont** the app already uses, not a system font. The GitHub workflow **removes** the `fonts-inter` apt step, adds a **30-minute job timeout**, and shortens the manual `dry_run` input label.
> 
> In `capture-docs-screenshots.ts`, the old canvas width comparison preflight is replaced by **`hasInterLoaded`**, which races `document.fonts.ready` against a **30s** deadline and checks for **`InterVariable` loaded**. A **preflight** navigates to the first story with the same timeout bounds and exits with a clear rsms.me diagnostic on total outage. **Each capture** re-checks the font in its own Playwright context before screenshotting so a silent fallback sans cannot be written; misses throw and use the existing one-shot retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af8c6c368963dcaf31efd635c76a23f54c0bb9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Update — preflight hang fixed

Review caught that `page.evaluate` has no timeout of its own, so a font response that stalls *after* the iframe renders would leave `document.fonts.ready` pending forever and hang the job rather than producing the rsms.me diagnostic. Confirmed against Playwright 1.62: `page.evaluate(() => new Promise(() => {}))` was still pending after 20s, and the `screenshots` job had no `timeout-minutes`, so a hang would have burned the 6-hour default.

Fixed by racing the readiness wait against a 30s deadline inside the page, bounding the navigation to the same deadline, treating any preflight failure as a missing face so the intended diagnostic is what surfaces, and capping the job at 30 minutes.

All three paths verified locally against the real script and a built Storybook:

| scenario | result |
| --- | --- |
| healthy | exit 0, captures normally, 4.5s |
| rsms.me stalls (route never resolves) | exit 1 with the diagnostic, 6.0s |
| rsms.me unreachable (request aborted) | exit 1 with the diagnostic, 1.1s |

## Update — per-capture verification

Second review comment: the preflight ran in the browser's implicit default context while each `capture()` creates its own via `browser.newContext()`. Playwright contexts don't share a cache, so all 36 captures re-fetch the font independently and the preflight guaranteed nothing about them — any single miss would have silently produced a fallback-rendered image.

Now each capture checks the face in its own context before screenshotting. A miss throws, so it picks up the existing one-shot retry (a transient CDN blip self-heals) and otherwise lands in the failure list rather than being written to disk. The preflight stays as the fast fail for a total outage, so a dead rsms.me still fails in seconds instead of after working through the manifest.

The bounded readiness check is now shared by both paths as `hasInterLoaded`.

Verified locally:

| scenario | result |
| --- | --- |
| healthy, 3 unified-reports stories | exit 0, all captured, 6.6s |
| font aborted only in capture contexts (preflight passes) | exit 1, `the Inter webfont … did not load` in the failure list, nothing written |

## Update — crash diagnostics no longer masked

Third review comment, and correct: a `FontFace` only reaches `status === 'loaded'` once something actually renders with it. A story that errors before mounting any Layer UI text therefore leaves the face unloaded, so the per-capture font check fired first and reported a webfont failure — hiding the crash that caused it.

Moved the check below the `.sb-show-errordisplay` and `pageerror` handling, so a real crash always wins.

Verified with a story forced to both crash and miss the font (`pageerror` injected, rsms.me aborted):

| | reported failure |
| --- | --- |
| before | `the Inter webfont … did not load` |
| after | `simulated story crash` |

Healthy captures still pass unchanged.
