### PR TITLE
[LAY-2628] fix: build Storybook for es2020

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -49,6 +49,13 @@ const config: StorybookConfig = {
   viteFinal: viteConfig => ({
     ...viteConfig,
     base: process.env.STORYBOOK_BASE_PATH ?? viteConfig.base,
+    build: {
+      ...viteConfig.build,
+      // vite.config.ts targets es2016 for consumers, but Storybook bundles dependencies the
+      // library leaves external — @formatjs/intl-durationformat ships BigInt literals, which
+      // cannot be lowered that far. Storybook only ever runs in a modern browser.
+      target: 'es2020',
+    },
     resolve: {
       ...viteConfig.resolve,
       tsconfigPaths: true,


### PR DESCRIPTION
## Description

Storybook builds emit:

```
▲ Vite [TOLERATED_TRANSFORM] Warning: Big integer literals are not available in the configured
  target environment.
  ╭─[ node_modules/@formatjs/intl-durationformat/index.js:716:43 ]
```

`vite.config.ts:63` sets `target: 'es2016'` for the published bundle. Storybook's react-vite builder merges the project Vite config, and `.storybook/main.ts`'s `viteFinal` did not override `build`, so Storybook inherited that target too.

It only shows up in Storybook because the library build externalises every direct dependency (`buildExternalDeps`), so `@formatjs/intl-durationformat` is never transformed there. Storybook bundles it, hits its BigInt literals, and can't lower them to ES2016 — `TOLERATED_TRANSFORM` means it emitted them unchanged, so the target was already being violated in the output.

## Changes

- Override `build.target` to `es2020` in `viteFinal`. The published bundle stays at `es2016`; only Storybook's own build moves.

## How this has been tested?

`tsc --noEmit` is clean.

**The Storybook build itself is unverified locally** — this checkout has no `react`/`react-dom` (they're peer dependencies and aren't installed), so `npm run storybook:build` fails with `Cannot find package 'react'` before reaching the point of interest. Confirmed that failure is pre-existing by stashing the change and reproducing it identically, so it is unrelated to this diff.

The `Storybook` workflow builds Storybook on every PR that touches `src/**` or `.storybook/**`, so CI on this PR is the real verification: the `TOLERATED_TRANSFORM` warning should be absent from the build log.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storybook-only Vite build configuration; no runtime or published package target changes.
> 
> **Overview**
> **Storybook’s Vite build** now sets `build.target` to **`es2020`** in `.storybook/main.ts`’s `viteFinal`, instead of inheriting **`es2016`** from the root `vite.config.ts`.
> 
> That removes the **`TOLERATED_TRANSFORM`** warning when Storybook bundles **`@formatjs/intl-durationformat`** (BigInt literals can’t be lowered to ES2016). The **published library bundle** is unchanged and still targets **es2016**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8454cacb8b5e520395261898fc80b65b921681e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->