### PR TITLE
revert: undo the Inter font work, capture docs screenshots on macOS

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -41,7 +41,10 @@ permissions:
 
 jobs:
   screenshots:
-    runs-on: ubuntu-latest
+    # macOS so the captures keep rasterising through CoreText. The docs images live on
+    # macOS renders today; capturing on Linux reruns every PNG through FreeType, which
+    # rewrites all 36 images for no visual gain.
+    runs-on: macos-latest
     timeout-minutes: 30
 
     steps:
@@ -58,7 +61,7 @@ jobs:
       run: npm ci
 
     - name: Install Chromium
-      run: npx playwright install --with-deps chromium
+      run: npx playwright install chromium
 
     - name: Build Storybook
       run: npm run storybook:build

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -49,13 +49,6 @@ const config: StorybookConfig = {
   viteFinal: viteConfig => ({
     ...viteConfig,
     base: process.env.STORYBOOK_BASE_PATH ?? viteConfig.base,
-    build: {
-      ...viteConfig.build,
-      // vite.config.ts targets es2016 for consumers, but Storybook bundles dependencies the
-      // library leaves external — @formatjs/intl-durationformat ships BigInt literals, which
-      // cannot be lowered that far. Storybook only ever runs in a modern browser.
-      target: 'es2020',
-    },
     resolve: {
       ...viteConfig.resolve,
       tsconfigPaths: true,

--- a/scripts/capture-docs-screenshots.ts
+++ b/scripts/capture-docs-screenshots.ts
@@ -1,31 +1,12 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { chromium, type Page } from 'playwright'
+import { chromium } from 'playwright'
 import { type DocsScreenshot, DOCS_SCREENSHOT_WIDTHS, DOCS_SCREENSHOTS } from './docs-screenshots.manifest'
 import { requireStorybookBuild, serveStorybookStatic, STATIC_ROOT } from './serve-storybook-static'
 
 // The story is rendered before its data lands, so settle after the network goes quiet.
 // preview.tsx adds a 250ms floor to every mocked response.
 const SETTLE_MS = 750
-
-// Ceiling on the Inter webfont preflight, so an unresponsive rsms.me fails the run rather
-// than hanging it.
-const FONT_LOAD_TIMEOUT_MS = 30_000
-
-// A stalled font response leaves document.fonts.ready pending forever, and page.evaluate has no
-// timeout of its own — so bound the wait in the page.
-//
-// Declaring a helper inside the callback would break this: tsx compiles with esbuild's keepNames,
-// which wraps named function bindings in a __name() call that does not exist in the page.
-function hasInterLoaded(page: Page) {
-  return page.evaluate(async (timeoutMs) => {
-    await Promise.race([
-      document.fonts.ready,
-      new Promise(resolve => setTimeout(resolve, timeoutMs)),
-    ])
-    return Array.from(document.fonts).some(face => face.family === 'InterVariable' && face.status === 'loaded')
-  }, FONT_LOAD_TIMEOUT_MS)
-}
 
 function parseArgs() {
   const args = process.argv.slice(2)
@@ -55,41 +36,6 @@ async function main() {
   const { server, origin } = await serveStorybookStatic()
   const browser = await chromium.launch()
   const failures: string[] = []
-
-  // src/styles/index.scss pulls Inter from rsms.me, so every capture depends on that host being
-  // reachable. A silent fallback to the generic sans reads as a diff on all 36 images, so fail
-  // fast here rather than after working through the whole manifest. Each capture re-checks in its
-  // own context, which is what actually guarantees the font for a given image.
-  async function requireInterWebFont(storyId: string) {
-    const page = await browser.newPage()
-    let isLoaded = false
-
-    try {
-      // An unreachable rsms.me stalls the stylesheet, which can hold up `load` and time the
-      // navigation out. Any failure in here means the same thing as a missing face, so report it
-      // the same way rather than crashing with a navigation error.
-      await page.goto(`${origin}/iframe.html?viewMode=story&id=${storyId}`, { timeout: FONT_LOAD_TIMEOUT_MS })
-      await page.waitForSelector('#storybook-root > *', { timeout: FONT_LOAD_TIMEOUT_MS })
-
-      isLoaded = await hasInterLoaded(page)
-    }
-    catch (error) {
-      console.error(`Could not verify the Inter webfont: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`)
-    }
-    finally {
-      await page.close()
-    }
-
-    if (!isLoaded) {
-      console.error('The Inter webfont (https://rsms.me/inter/inter.css) did not load, so every capture')
-      console.error('would fall back to the generic sans. Check network access to rsms.me and re-run.')
-      await browser.close()
-      server.close()
-      process.exit(1)
-    }
-  }
-
-  await requireInterWebFont(targets[0].storyId)
 
   async function capture({ storyId, out: file, viewport, interactAt, maxHeight, captureViewport }: DocsScreenshot) {
     const context = await browser.newContext({
@@ -125,14 +71,6 @@ async function main() {
         crashes.push(await page.locator('#error-message').innerText())
       }
       if (crashes.length > 0) throw new Error(crashes.join('\n'))
-
-      // After the crash checks: a face only reaches `loaded` once something renders with it, so a
-      // story that died before mounting any text would look like a font failure. Contexts do not
-      // share a cache, so this story fetched the font itself and could have missed even though the
-      // preflight passed. Throwing here earns the retry below.
-      if (!await hasInterLoaded(page)) {
-        throw new Error('the Inter webfont (https://rsms.me/inter/inter.css) did not load')
-      }
 
       if (interactAt && interactAt !== viewport) {
         await page.setViewportSize({ width: DOCS_SCREENSHOT_WIDTHS[viewport], height: 900 })


### PR DESCRIPTION
## Description

Undoes the font work from #1702/#1703 and #1705, and moves the docs capture to macOS.

**Inter was never broken.** `src/styles/index.scss:8` imports it from `rsms.me`, and Sass leaves remote imports as runtime CSS, so every capture on every host has rendered Inter — before #1702 and after. The api-documentation#370 diff was macOS CoreText giving way to Linux FreeType when the capture moved from a local run to `ubuntu-latest`: same font file, different rasteriser, which is why all 36 PNGs changed and shrank 4–28%.

Confirmed by hash rather than by eye: a capture on macOS with the webfont verified loaded produces `12cac469…` for `pages/unified-reports.png`, **byte-identical to the `#364` image live on the docs site today**. #370/#371 are `326f3815…` — the same story on Linux.

So #1702's `fonts-inter` step was a no-op, and the preflight it shipped guarded against an rsms.me outage that has never occurred.

## Changes

- **Revert the Inter checks** in `capture-docs-screenshots.ts`, restoring it to its pre-#1702 state. All six commits that touched it since were font-thread work.
- **Revert #1705.** The `TOLERATED_TRANSFORM` BigInt warning does not reproduce on `main` — 0 occurrences in both `storybook:build` and `build:js` — so it fixed nothing observable. Whatever emits that warning is another path (a dev server, or `vite build --watch`).
- **Capture on `macos-latest`.** The published images are macOS renders; capturing on Linux rewrites every PNG for no visual gain. Also drops `--with-deps`, which installs Linux system packages and is meaningless on macOS.

Deliberately kept, because they stand on their own merits:

- the `Dry run` input label
- `timeout-minutes: 30` on the job — it was added while chasing a hang in the font check, but bounding the job is worth having regardless

## Blockers

**`macos-latest` billing needs a look before merging.** GitHub-hosted macOS runners carry a 10× minute multiplier. Public repositories get free standard-runner minutes, but I have not confirmed whether that covers macOS on this plan — the org billing endpoint needs `admin:org`, which I don't have. macOS runners also have a much lower concurrency ceiling than Linux. This job runs once per stable publish plus manual dispatches, so the volume is low either way, but please confirm rather than take my word for it.

If macOS turns out to be unacceptable, the alternative is to keep `ubuntu-latest` and accept a one-time 36-image reflow to FreeType — merge api-documentation#370 or #371 and the churn is over, since every future run is then on the same rasteriser.

## How this has been tested?

- `tsc --noEmit` clean; no `hasInterLoaded` / `requireInterWebFont` / `rsms` remnants in the script.
- The restored script runs and captures normally, producing the byte-identical-to-live image above.
- The macOS runner change is unexercised — it can only be verified by dispatching the workflow. Suggested check: `workflow_dispatch` with `ref` pointing at this branch and `Dry run` ticked, then confirm the artifact matches what's in `api-documentation/images` today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> macOS runners change CI cost, concurrency, and billing versus Linux; the workflow itself is low-frequency but should be confirmed before merge.
> 
> **Overview**
> Reverts the **Inter webfont preflight and per-capture checks** in `capture-docs-screenshots.ts`, returning the capture script to its simpler settle-and-screenshot flow without rsms.me verification.
> 
> Switches the **docs-screenshots GitHub Action** from `ubuntu-latest` to **`macos-latest`** so PNGs rasterize with CoreText like the images already on the docs site, avoiding a full 36-image FreeType reflow on Linux. Playwright install drops **`--with-deps`** (Linux-only system packages).
> 
> Removes Storybook’s **`viteFinal` `build.target: 'es2020'`** override in `.storybook/main.ts`, which had been added for a BigInt warning that no longer reproduces on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cec61be09ae562a519664b6a44ba3226831038b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->