### PR TITLE
[LAY-2626] docs: add AI code review instructions for Bugbot and Augment

### DIFF
--- a/.augment/code_review_guidelines.yaml
+++ b/.augment/code_review_guidelines.yaml
@@ -7,9 +7,10 @@
 # already fails the PR on: import order and boundaries, react-hooks/exhaustive-deps,
 # inline type imports, unused vars, quotes, semicolons, indent, CSS property order.
 
+# src/assets/locales/** is deliberately NOT ignored: a hand edit there is a bug we want
+# flagged. The generated diffs land on the i18n/extract-keys and Crowdin bot branches.
 file_paths_to_ignore:
   - "src/fixtures/generated/**"
-  - "src/assets/locales/**"
   - "consumer-fixtures/**"
   - "dist/**"
   - "storybook-static/**"
@@ -44,6 +45,7 @@ areas:
     globs:
       - "src/**/*.ts"
       - "src/**/*.tsx"
+      - "src/assets/locales/**"
     rules:
       - id: "all_strings_translated"
         description: "Every user-visible string goes through t('ns:category.key', 'Default') with an inline default — including aria-label, title, placeholder, table headers, and empty-state copy. A hardcoded string is untranslatable for consumers."
@@ -58,6 +60,7 @@ areas:
     globs:
       - "src/schemas/**"
       - "src/hooks/api/**"
+      - "src/types/**"
     rules:
       - id: "nullish_or_by_default"
         description: "Optional or nullable API fields use Schema.NullishOr, not NullOr or optional alone. The backend omits a field on one endpoint and returns null on another; anything narrower has broken decoding before."
@@ -76,13 +79,17 @@ areas:
         severity: "medium"
 
   mocks_and_fixtures:
-    description: "MSW mocks and generated fixture data"
+    description: "MSW mocks, generated fixture data, and the test payloads that use them"
     globs:
       - "src/msw/**"
       - "src/fixtures/**"
+      - "src/testUtils/**"
+      - "**/*.test.ts"
+      - "**/*.test.tsx"
+      - "**/*.storyData.tsx"
     rules:
       - id: "no_handwritten_snake_case"
-        description: "Never hand-write snake_case JSON in mocks or fixtures. Mocks hold decoded values and encode through the schema, so wire-format changes propagate automatically. Hand-written wire JSON silently rots."
+        description: "Never hand-write snake_case JSON in mocks, fixtures, or tests. Mocks hold decoded values and encode through the schema, so wire-format changes propagate automatically. Hand-written wire JSON silently rots."
         severity: "high"
 
       - id: "msw_no_runtime_hook_imports"

--- a/.augment/code_review_guidelines.yaml
+++ b/.augment/code_review_guidelines.yaml
@@ -46,14 +46,16 @@ areas:
     globs:
       - "src/**/*.ts"
       - "src/**/*.tsx"
-      - "src/assets/locales/**"
+      # The generated translation output only — src/assets/locales/SKILL.md is hand-maintained.
+      - "src/assets/locales/**/*.json"
+      - "src/assets/locales/**/index.ts"
     rules:
       - id: "all_strings_translated"
         description: "Every user-visible string goes through t('ns:category.key', 'Default') with an inline default — including aria-label, title, placeholder, table headers, and empty-state copy. A hardcoded string is untranslatable for consumers."
         severity: "high"
 
       - id: "no_locale_file_edits"
-        description: "Never edit src/assets/locales/**. Those files are generated from the t() inline defaults and Crowdin. The string belongs in the t() call."
+        description: "Never hand-edit the translation JSON under src/assets/locales. It is generated from the t() inline defaults and Crowdin, so an edit here is overwritten on the next extract. The string belongs in the t() call."
         severity: "high"
 
   api_contracts:
@@ -90,7 +92,7 @@ areas:
       - "**/*.storyData.tsx"
     rules:
       - id: "no_handwritten_snake_case"
-        description: "Never hand-write snake_case JSON in mocks, fixtures, or tests. Mocks hold decoded values and encode through the schema, so wire-format changes propagate automatically. Hand-written wire JSON silently rots."
+        description: "Never hand-write snake_case JSON where a decoded value belongs — mocks, fixtures, storyData, and component tests. Mocks hold decoded values and encode through the schema, so wire-format changes propagate automatically. Do NOT flag schema decoder tests under src/schemas: those must supply encoded wire payloads to exercise decoding, and snake_case there is correct."
         severity: "high"
 
       - id: "msw_no_runtime_hook_imports"

--- a/.augment/code_review_guidelines.yaml
+++ b/.augment/code_review_guidelines.yaml
@@ -1,0 +1,214 @@
+# Augment Code Review guidelines for @layerfi/components
+#
+# Companion to .cursor/BUGBOT.md — same rules, Augment's schema. Both are distilled from
+# AGENTS.md and the colocated SKILL.md files; update all three together.
+#
+# Deliberately omits anything eslint.config.mjs, stylelint.config.mjs, or `tsc --noEmit`
+# already fails the PR on: import order and boundaries, react-hooks/exhaustive-deps,
+# inline type imports, unused vars, quotes, semicolons, indent, CSS property order.
+
+file_paths_to_ignore:
+  - "src/fixtures/generated/**"
+  - "src/assets/locales/**"
+  - "consumer-fixtures/**"
+  - "dist/**"
+  - "storybook-static/**"
+  - "package-lock.json"
+  - ".claude/**"
+
+areas:
+  formatting_and_money:
+    description: "Money, number, and date formatting in an embeddable, localizable library"
+    globs:
+      - "src/**/*.ts"
+      - "src/**/*.tsx"
+    rules:
+      - id: "currency_values_are_cents"
+        description: "Currency values are cents and percent values are fractions, everywhere in this codebase. A currency input handed dollars, or a percent input handed 7 instead of 0.07, is a real bug. Check unit consistency whenever a monetary or percentage value crosses a boundary."
+        severity: "high"
+
+      - id: "no_hand_formatting"
+        description: "Never format currency, percentages, numbers, or dates by hand — no string concatenation, toFixed, inline Intl.NumberFormat, or toLocaleDateString. Use useIntlFormatter() or <MoneySpan>. Hand-formatting breaks localization for consumers."
+        severity: "high"
+
+      - id: "date_format_enum"
+        description: "Date formatters take a DateFormat enum value, never a format string."
+        severity: "medium"
+
+      - id: "no_raw_bigdecimal_in_state"
+        description: "Raw BigDecimal held in form or React state triggers TypeScript error TS2589 (excessively deep type instantiation). Use NonRecursiveBigDecimal and thread the rich type as a prop instead."
+        severity: "high"
+
+  internationalization:
+    description: "Every user-visible string must be translatable"
+    globs:
+      - "src/**/*.ts"
+      - "src/**/*.tsx"
+    rules:
+      - id: "all_strings_translated"
+        description: "Every user-visible string goes through t('ns:category.key', 'Default') with an inline default — including aria-label, title, placeholder, table headers, and empty-state copy. A hardcoded string is untranslatable for consumers."
+        severity: "high"
+
+      - id: "no_locale_file_edits"
+        description: "Never edit src/assets/locales/**. Those files are generated from the t() inline defaults and Crowdin. The string belongs in the t() call."
+        severity: "high"
+
+  api_contracts:
+    description: "Effect Schema definitions are the source of truth for every API contract"
+    globs:
+      - "src/schemas/**"
+      - "src/hooks/api/**"
+    rules:
+      - id: "nullish_or_by_default"
+        description: "Optional or nullable API fields use Schema.NullishOr, not NullOr or optional alone. The backend omits a field on one endpoint and returns null on another; anything narrower has broken decoding before."
+        severity: "high"
+
+      - id: "msw_handler_required"
+        description: "Every method file under src/hooks/api/** needs a matching MSW handler at the mirrored path in src/msw/api/**, registered in the enclosing handlers.ts. Unhandled layerfi.com requests hard-fail Vitest and Storybook, and CI enforces coverage via npm run msw:check-coverage."
+        severity: "high"
+
+      - id: "schema_before_guessing"
+        description: "Do not invent a schema for a backend response. If the PR adds a schema for an endpoint whose contract is not obviously established, flag that the API contract should be confirmed first."
+        severity: "medium"
+
+      - id: "no_wire_types_in_types_dir"
+        description: "src/types/** is for internal-only types with no wire format. Anything the API sends or receives belongs in src/schemas as an Effect schema."
+        severity: "medium"
+
+  mocks_and_fixtures:
+    description: "MSW mocks and generated fixture data"
+    globs:
+      - "src/msw/**"
+      - "src/fixtures/**"
+    rules:
+      - id: "no_handwritten_snake_case"
+        description: "Never hand-write snake_case JSON in mocks or fixtures. Mocks hold decoded values and encode through the schema, so wire-format changes propagate automatically. Hand-written wire JSON silently rots."
+        severity: "high"
+
+      - id: "msw_no_runtime_hook_imports"
+        description: "src/msw may not value-import @api/* or @hooks/*. Type imports are fine. Handlers load before per-test mocks apply, so a runtime import breaks unrelated Vitest suites."
+        severity: "high"
+
+      - id: "regenerate_committed_fixtures"
+        description: "A change to a fixture schema or generator must come with regenerated, committed src/fixtures/generated/*.gen.ts from npm run fixtures:generate. CI fails on staleness."
+        severity: "high"
+
+  state_and_data:
+    description: "SWR owns server state, Zustand owns UI state, Context is dependency injection"
+    globs:
+      - "src/hooks/**"
+      - "src/providers/**"
+      - "src/components/**"
+      - "src/views/**"
+    rules:
+      - id: "no_raw_swr_or_fetch"
+        description: "No useSWR or fetch in feature code. Use the factories in @hooks/utils/swr — createQueryHook, createInfiniteQueryHook, createMutationHook. They own auth, businessId, locale cache keying, and error handling."
+        severity: "high"
+
+      - id: "no_threaded_business_id"
+        description: "businessId and auth are injected by the provider stack. A component passing either down as a prop is working around the injection."
+        severity: "medium"
+
+      - id: "no_server_state_in_stores"
+        description: "Never mirror server data into a Zustand store. SWR owns server state. Duplicated server state goes stale and diverges from the cache."
+        severity: "high"
+
+      - id: "no_setstate_during_render"
+        description: "Never call setState during render. Use an effect, or derive the value."
+        severity: "high"
+
+      - id: "derive_dont_synchronize"
+        description: "Do not use useEffect plus setState to produce a value that can be derived during render from props or existing state. Derived values are always consistent and skip the extra render."
+        severity: "high"
+
+      - id: "invalidate_after_writes"
+        description: "A mutation must invalidate the caches it affects — createResourceGlobalCacheActions plus useOnTriggerSuccess. A write with no invalidation leaves stale data on screen."
+        severity: "medium"
+
+      - id: "memoize_deliberately"
+        description: "useCallback and useMemo only for props to memo()ed children, dependency-array entries, or genuinely expensive computations. Never memoize primitives. Do memoize object and array literals returned from a custom hook — unmemoized returns break every consumer's dependency arrays."
+        severity: "medium"
+
+  components_and_styling:
+    description: "Design-system primitives and themeable CSS for a library that must be brandable and mountable more than once per page"
+    globs:
+      - "src/components/**"
+      - "src/views/**"
+      - "src/styles/**"
+      - "**/*.scss"
+    rules:
+      - id: "build_on_ui_primitives"
+        description: "Build on @ui before writing new markup. Reach for HStack/VStack instead of raw div, and Span/P/Label/Header instead of raw text elements. Genuinely new reusable primitives go in src/components/ui, not inside a feature."
+        severity: "medium"
+
+      - id: "no_inline_styles_or_class_concat"
+        description: "No style prop, no inline styles, no utility class strings, and no class names built by concatenation. Consumers restyle us by class name; concatenated names are ungreppable and unthemeable."
+        severity: "high"
+
+      - id: "tokens_not_hardcoded_values"
+        description: "Colors and spacing come from src/styles/variables.scss. Hardcoded hex values or pixel spacing break consumer theming."
+        severity: "high"
+
+      - id: "variants_as_data_attributes"
+        description: "Express component variants as data-* attributes via toDataProperties and select on them in SCSS, rather than adding conditional class names."
+        severity: "medium"
+
+      - id: "flat_greppable_selectors"
+        description: "Write flat, greppable SCSS selectors. Nest only modifiers of the current selector; never build element names with &__Element, since the resulting class cannot be found by searching for it."
+        severity: "medium"
+
+      - id: "responsive_in_js_not_css"
+        description: "Responsiveness is measured in JavaScript, not media queries, because the library is embedded at arbitrary widths inside consumer layouts. Use ResponsiveComponent."
+        severity: "high"
+
+      - id: "css_variables_need_layer_root"
+        description: "CSS variables only exist under the design-system root classes (.Layer__component, .Layer__Portal). Portals and bare primitives rendered outside one will silently lose all theming."
+        severity: "high"
+
+      - id: "reuse_state_and_table_abstractions"
+        description: "Do not hand-roll loading, empty, or error branches — use ConditionalBlock for one object, ConditionalList for an array, plus DataState, SkeletonLoader, SkeletonTableLoader. Do not hand-build tables; use SimpleDataTable, DataTable, PaginatedDataTable, ExpandableDataTable, or VirtualizedDataTable. Do not hand-roll pagination state; use @hooks/utils/pagination."
+        severity: "medium"
+
+      - id: "forms_use_app_form"
+        description: "Forms are built on useAppForm plus the Form*Field components, with validators from @utils/shared/form/validators rather than reimplemented inline."
+        severity: "medium"
+
+  typescript:
+    description: "Type safety across the library"
+    globs:
+      - "src/**/*.ts"
+      - "src/**/*.tsx"
+    rules:
+      - id: "no_any"
+        description: "No any. Use unknown and narrow it."
+        severity: "high"
+
+      - id: "explain_casts"
+        description: "An `as` cast needs a short comment saying why it is safe. Unexplained casts at boundaries hide decoding bugs."
+        severity: "medium"
+
+      - id: "derive_types"
+        description: "Derive types rather than restating them by hand: typeof Schema.Type, Parameters<typeof useHook>[0], Pick<...>, ReturnType<...>. Hand-restated types drift from their source."
+        severity: "medium"
+
+  published_api:
+    description: "The npm package surface"
+    globs:
+      - "src/index.tsx"
+    rules:
+      - id: "index_exports_are_public_api"
+        description: "Anything exported from src/index.tsx is public API for @layerfi/components consumers. Flag any addition, removal, or rename here and state plainly that it is a public API change that must be called out in the PR description."
+        severity: "high"
+
+  stories:
+    description: "Storybook stories, each of which is a Chromatic snapshot"
+    globs:
+      - "**/*.stories.tsx"
+    rules:
+      - id: "gallery_over_per_variant_stories"
+        description: "Every story is a billed Chromatic snapshot. Pack primitive variants into a single gallery story instead of adding one story per variant."
+        severity: "low"
+
+      - id: "no_scratch_stories_on_branch"
+        description: "*scratch.stories.tsx files are local-only and must not reach the branch. CI has a guard for this."
+        severity: "medium"

--- a/.augment/code_review_guidelines.yaml
+++ b/.augment/code_review_guidelines.yaml
@@ -224,7 +224,3 @@ areas:
       - id: "gallery_over_per_variant_stories"
         description: "Every story is a billed Chromatic snapshot. Pack primitive variants into a single gallery story instead of adding one story per variant."
         severity: "low"
-
-      - id: "no_scratch_stories_on_branch"
-        description: "*scratch.stories.tsx files are local-only and must not reach the branch. CI has a guard for this."
-        severity: "medium"

--- a/.augment/code_review_guidelines.yaml
+++ b/.augment/code_review_guidelines.yaml
@@ -5,7 +5,8 @@
 #
 # Deliberately omits anything eslint.config.mjs, stylelint.config.mjs, or `tsc --noEmit`
 # already fails the PR on: import order and boundaries, react-hooks/exhaustive-deps,
-# inline type imports, unused vars, quotes, semicolons, indent, CSS property order.
+# no-explicit-any and the no-unsafe-* family, inline type imports, unused vars, quotes,
+# semicolons, indent, CSS property order.
 
 # src/assets/locales/** is deliberately NOT ignored: a hand edit there is a bug we want
 # flagged. The generated diffs land on the i18n/extract-keys and Crowdin bot branches.
@@ -164,16 +165,28 @@ areas:
         description: "Write flat, greppable SCSS selectors. Nest only modifiers of the current selector; never build element names with &__Element, since the resulting class cannot be found by searching for it."
         severity: "medium"
 
-      - id: "responsive_in_js_not_css"
-        description: "Responsiveness is measured in JavaScript, not media queries, because the library is embedded at arbitrary widths inside consumer layouts. Use ResponsiveComponent."
+      - id: "mobile_variant_required"
+        description: "Any new data-dense surface — a table, a list, a selection or filter UI — needs a mobile variant, not just a desktop one that reflows. The library is embedded at arbitrary widths inside consumer layouts, so a desktop-only surface is broken for a real subset of users. Render per-size variants with ResponsiveComponent (@components/utility/ResponsiveComponent) using a slots record and a resolveVariant function."
         severity: "high"
+
+      - id: "use_existing_mobile_surfaces"
+        description: "Do not reimplement a mobile list or a mobile drawer. MobileList, PaginatedMobileList, MobileListItem, and MobileListSection live in @blocks/MobileList; MobileSelectionDrawer and MobileSelectionDrawerWithTrigger live in @blocks/MobileSelectionDrawer. A bespoke card list or bottom sheet diverges from the rest of the library's mobile behavior."
+        severity: "medium"
+
+      - id: "size_classes_from_breakpoints"
+        description: "Responsiveness is JS-driven off measured width, not CSS media queries alone. Size classes come from BREAKPOINTS in @utils/shared/size/screenSizeBreakpoints (mobile under 500, tablet under 760, desktop above). Read element size with @hooks/utils/size/useElementSize or useElementViewSize. Flag hardcoded pixel thresholds and inline width ternaries scattered through JSX."
+        severity: "medium"
 
       - id: "css_variables_need_layer_root"
         description: "CSS variables only exist under the design-system root classes (.Layer__component, .Layer__Portal). Portals and bare primitives rendered outside one will silently lose all theming."
         severity: "high"
 
-      - id: "reuse_state_and_table_abstractions"
-        description: "Do not hand-roll loading, empty, or error branches — use ConditionalBlock for one object, ConditionalList for an array, plus DataState, SkeletonLoader, SkeletonTableLoader. Do not hand-build tables; use SimpleDataTable, DataTable, PaginatedDataTable, ExpandableDataTable, or VirtualizedDataTable. Do not hand-roll pagination state; use @hooks/utils/pagination."
+      - id: "reuse_conditional_render_abstractions"
+        description: "Do not hand-roll loading, empty, or error branches. Use ConditionalBlock for a single data object and ConditionalList for an array, with DataState, SkeletonLoader, and SkeletonTableLoader for the visuals. Hand-rolled branches drift from the rest of the library's loading and empty UX."
+        severity: "medium"
+
+      - id: "reuse_table_abstractions"
+        description: "Do not hand-build tables. Use SimpleDataTable, DataTable, PaginatedDataTable, ExpandableDataTable, or VirtualizedDataTable, and take pagination state from @hooks/utils/pagination rather than managing it by hand."
         severity: "medium"
 
       - id: "forms_use_app_form"
@@ -186,10 +199,6 @@ areas:
       - "src/**/*.ts"
       - "src/**/*.tsx"
     rules:
-      - id: "no_any"
-        description: "No any. Use unknown and narrow it."
-        severity: "high"
-
       - id: "explain_casts"
         description: "An `as` cast needs a short comment saying why it is safe. Unexplained casts at boundaries hide decoding bugs."
         severity: "medium"

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -73,8 +73,15 @@ in each directory.
 - Variants expressed as extra class names instead of `data-*` attributes via `toDataProperties`.
 - `&__Element` nesting in SCSS. Write flat, greppable selectors; nest only modifiers of the
   current selector.
-- Media queries for responsive behavior. Responsiveness is measured in JS — use
-  `ResponsiveComponent`.
+- A new data-dense surface — table, list, selection or filter UI — with no mobile variant. We are
+  embedded at arbitrary widths inside consumer layouts; desktop-only is broken for real users.
+  Render per-size variants with `ResponsiveComponent` (`slots` + `resolveVariant`).
+- A hand-built mobile card list or bottom sheet. Use `@blocks/MobileList`
+  (`MobileList`, `PaginatedMobileList`, `MobileListItem`, `MobileListSection`) and
+  `@blocks/MobileSelectionDrawer`.
+- Hardcoded pixel thresholds or inline width ternaries scattered through JSX. Size classes come
+  from `BREAKPOINTS` in `@utils/shared/size/screenSizeBreakpoints`; read size with
+  `useElementSize` / `useElementViewSize`.
 - CSS variables referenced outside a `.Layer__component` / `.Layer__Portal` ancestor. Portals and
   bare primitives in stories need one.
 
@@ -83,14 +90,13 @@ in each directory.
 - Hand-rolled loading, empty, or error branches instead of `ConditionalBlock` (one object),
   `ConditionalList` (an array), `DataState`, `SkeletonLoader`, or `SkeletonTableLoader`.
 - A hand-built table instead of `SimpleDataTable` / `DataTable` / `PaginatedDataTable` /
-  `ExpandableDataTable` / `VirtualizedDataTable`.
+  `ExpandableDataTable` / `VirtualizedDataTable`, or pagination state managed by hand instead of
+  `@hooks/utils/pagination`.
 - A form not built on `useAppForm` + the `Form*Field` components, or a validator duplicated
   instead of taken from `@utils/shared/form/validators`.
-- Pagination state managed by hand instead of `@hooks/utils/pagination`.
 
 ### TypeScript
 
-- `any`. Use `unknown` and narrow.
 - An `as` cast with no short comment explaining why it is safe.
 - A type restated by hand where it could be derived: `typeof Schema.Type`,
   `Parameters<typeof useHook>[0]`, `Pick<…>`, `ReturnType<…>`.
@@ -112,8 +118,9 @@ in each directory.
 ## What to leave alone
 
 - Anything ESLint, stylelint, or `tsc --noEmit` already fails the PR on. Do not comment on import
-  order, import boundaries, relative-parent imports, `react-hooks/exhaustive-deps`, inline type
-  imports, unused variables, quotes, semicolons, indentation, line length, or CSS property order.
+  order, import boundaries, relative-parent imports, `react-hooks/exhaustive-deps`,
+  `no-explicit-any` and the `no-unsafe-*` family, inline type imports, unused variables, quotes,
+  semicolons, indentation, line length, or CSS property order.
 - `src/fixtures/generated/*.gen.ts` — generated output, committed on purpose.
 - `consumer-fixtures/**` — deliberately minimal smoke apps, outside the lint config.
 - `dist/`, `storybook-static/`, `package-lock.json`.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,126 @@
+# Bugbot review rules for `@layerfi/components`
+
+## Context
+
+`@layerfi/components` is Layer's embeddable React accounting component library, published to npm
+from `src/index.tsx`. Consumers nest our components under `LayerProvider` and brand them with CSS
+variables, so **everything must be themeable, localizable, and mountable more than once on a
+page**. Most rules below exist to protect one of those three properties.
+
+Stack: React 18, SWR (server state), Zustand (UI state), Effect `Schema` (every API contract),
+TanStack Form/Table, SCSS. Tests run on Vitest with MSW; UI coverage is mostly Storybook +
+Chromatic. Full conventions live in [`AGENTS.md`](../AGENTS.md) and the colocated `SKILL.md` file
+in each directory.
+
+## What to flag
+
+### Money, numbers, and dates
+
+- Currency, percentage, number, or date values formatted by hand — string concatenation,
+  `toFixed`, `Intl.NumberFormat` inline, `toLocaleDateString`. Use `useIntlFormatter()` or
+  `<MoneySpan>`.
+- Currency values that are not **cents**, or percent values that are not **fractions**. A
+  currency input handed dollars, or a percent input handed `7` instead of `0.07`, is a bug.
+- A date formatter given a format string instead of a `DateFormat` enum value.
+
+### Strings
+
+- Any user-visible string not routed through `t('ns:category.key', 'Default')` with an inline
+  default — including `aria-label`, `title`, `placeholder`, table headers, and empty-state copy.
+- Edits to `src/assets/locales/**`. Those files are generated from code and Crowdin; the string
+  belongs in the `t()` call's inline default.
+
+### Schemas and mocks
+
+- Optional or nullable API fields declared as anything other than `Schema.NullishOr`. The backend
+  omits a field on one endpoint and returns `null` on another.
+- Hand-written snake_case JSON in mocks, fixtures, or tests. Mocks hold decoded values and encode
+  through the schema.
+- A new or renamed method file under `src/hooks/api/**` with no MSW handler at the mirrored path
+  in `src/msw/api/**` — and the handler must be **registered in the enclosing `handlers.ts`**.
+  Unhandled `layerfi.com` requests fail Vitest and Storybook.
+- A changed fixture schema or generator without regenerated, committed
+  `src/fixtures/generated/*.gen.ts`.
+- Value imports of `@api/*` or `@hooks/*` inside `src/msw`. Handlers load before per-test mocks
+  apply and would break unrelated suites. Share contracts through `@schemas`.
+
+### State and data
+
+- `useSWR` or `fetch` called directly in feature code. Use the factories in `@hooks/utils/swr`
+  (`createQueryHook`, `createInfiniteQueryHook`, `createMutationHook`).
+- `businessId` or auth passed down from a component. Both are injected.
+- Server data mirrored into a Zustand store. SWR owns server state, Zustand owns UI state,
+  Context is dependency injection.
+- `setState` called during render.
+- `useEffect` + `setState` producing a value that could be derived during render instead.
+- A write with no corresponding cache invalidation (`createResourceGlobalCacheActions` +
+  `useOnTriggerSuccess`).
+
+### Memoization
+
+- `useCallback` or `useMemo` wrapping a primitive, or wrapping a value that is neither a prop to
+  a `memo()`ed child nor a dependency-array entry nor an expensive computation.
+- An object or array literal returned from a custom hook without `useMemo`.
+
+### Components and styling
+
+- New markup that reimplements something already in `@ui`. Build on the primitive; genuinely new
+  primitives go in `src/components/ui`.
+- Raw `<div>` where `<HStack>`/`<VStack>` fits; raw `<span>`/`<p>`/`<label>` where
+  `<Span>`/`<P>`/`<Label>` fits.
+- The `style` prop, inline styles, utility class strings, or class names built by concatenation.
+- Hard-coded colors or spacing. Both come from `src/styles/variables.scss`.
+- Variants expressed as extra class names instead of `data-*` attributes via `toDataProperties`.
+- `&__Element` nesting in SCSS. Write flat, greppable selectors; nest only modifiers of the
+  current selector.
+- Media queries for responsive behavior. Responsiveness is measured in JS — use
+  `ResponsiveComponent`.
+- CSS variables referenced outside a `.Layer__component` / `.Layer__Portal` ancestor. Portals and
+  bare primitives in stories need one.
+
+### Reuse before reinvention
+
+- Hand-rolled loading, empty, or error branches instead of `ConditionalBlock` (one object),
+  `ConditionalList` (an array), `DataState`, `SkeletonLoader`, or `SkeletonTableLoader`.
+- A hand-built table instead of `SimpleDataTable` / `DataTable` / `PaginatedDataTable` /
+  `ExpandableDataTable` / `VirtualizedDataTable`.
+- A form not built on `useAppForm` + the `Form*Field` components, or a validator duplicated
+  instead of taken from `@utils/shared/form/validators`.
+- Pagination state managed by hand instead of `@hooks/utils/pagination`.
+
+### TypeScript
+
+- `any`. Use `unknown` and narrow.
+- An `as` cast with no short comment explaining why it is safe.
+- A type restated by hand where it could be derived: `typeof Schema.Type`,
+  `Parameters<typeof useHook>[0]`, `Pick<…>`, `ReturnType<…>`.
+- Raw `BigDecimal` held in form or React state. It triggers TS2589 — use
+  `NonRecursiveBigDecimal`.
+- A wire-format type added under `src/types/**`. Anything the API sends or receives is a schema.
+
+### Published surface
+
+- Any change to the exports in `src/index.tsx`. Say plainly that this is a public API change and
+  must be called out in the PR description.
+
+### Stories
+
+- One story per primitive variant. Every story is a Chromatic snapshot — pack variants into a
+  single gallery story.
+- A `*scratch.stories.tsx` file reaching the branch.
+
+## What to leave alone
+
+- Anything ESLint, stylelint, or `tsc --noEmit` already fails the PR on. Do not comment on import
+  order, import boundaries, relative-parent imports, `react-hooks/exhaustive-deps`, inline type
+  imports, unused variables, quotes, semicolons, indentation, line length, or CSS property order.
+- `src/fixtures/generated/*.gen.ts` — generated output, committed on purpose.
+- `src/assets/locales/**` — generated from code and Crowdin.
+- `consumer-fixtures/**` — deliberately minimal smoke apps, outside the lint config.
+- `dist/`, `storybook-static/`, `package-lock.json`.
+- `.claude/worktrees/**`.
+
+## Tone
+
+Be direct. Name the line. Suggest a specific fix. Do not write "consider," do not write "you may
+want to," do not summarize the PR. If nothing is worth flagging, say nothing.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -34,8 +34,8 @@ in each directory.
 
 - Optional or nullable API fields declared as anything other than `Schema.NullishOr`. The backend
   omits a field on one endpoint and returns `null` on another.
-- Hand-written snake_case JSON in mocks, fixtures, or tests. Mocks hold decoded values and encode
-  through the schema.
+- Hand-written snake_case JSON anywhere it stands in for a wire payload — mocks, fixtures, tests,
+  `*.storyData.tsx`. Mocks hold decoded values and encode through the schema.
 - A new or renamed method file under `src/hooks/api/**` with no MSW handler at the mirrored path
   in `src/msw/api/**` — and the handler must be **registered in the enclosing `handlers.ts`**.
   Unhandled `layerfi.com` requests fail Vitest and Storybook.
@@ -115,7 +115,6 @@ in each directory.
   order, import boundaries, relative-parent imports, `react-hooks/exhaustive-deps`, inline type
   imports, unused variables, quotes, semicolons, indentation, line length, or CSS property order.
 - `src/fixtures/generated/*.gen.ts` — generated output, committed on purpose.
-- `src/assets/locales/**` — generated from code and Crowdin.
 - `consumer-fixtures/**` — deliberately minimal smoke apps, outside the lint config.
 - `dist/`, `storybook-static/`, `package-lock.json`.
 - `.claude/worktrees/**`.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -34,8 +34,9 @@ is this same rule set in Augment's format — keep the two in sync.
 - A user-visible string that does not go through `t('ns:category.key', 'Default')` with an inline
   default. This includes `aria-label`, `title`, `placeholder`, table headers, and empty-state copy.
   A hardcoded string is untranslatable for consumers.
-- Any edit to `src/assets/locales/**`. Those files are generated from the `t()` inline defaults and
-  Crowdin. The string belongs in the `t()` call.
+- A hand edit to the translation JSON under `src/assets/locales`. It is generated from the `t()`
+  inline defaults and Crowdin, so the edit is overwritten on the next extract; the string belongs
+  in the `t()` call. (`src/assets/locales/SKILL.md` is hand-maintained — leave it alone.)
 
 ### API contracts
 
@@ -52,9 +53,10 @@ is this same rule set in Augment's format — keep the two in sync.
 
 ### Mocks, fixtures, and test payloads
 
-- Hand-written snake_case JSON in mocks, fixtures, tests, or `*.storyData.tsx`. Mocks hold decoded
-  values and encode through the schema, so wire-format changes propagate automatically.
-  Hand-written wire JSON silently rots.
+- Hand-written snake_case JSON where a decoded value belongs — mocks, fixtures, `*.storyData.tsx`,
+  component tests. Mocks hold decoded values and encode through the schema, so wire-format changes
+  propagate automatically. Schema decoder tests under `src/schemas` are the exception: they must
+  supply encoded wire payloads to exercise decoding, so snake_case there is correct.
 - A value import of `@api/*` or `@hooks/*` inside `src/msw`. Type imports are fine. Handlers load
   before per-test mocks apply, so a runtime import breaks unrelated Vitest suites.
 - A change to a fixture schema or generator without regenerated, committed

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -3,128 +3,146 @@
 ## Context
 
 `@layerfi/components` is Layer's embeddable React accounting component library, published to npm
-from `src/index.tsx`. Consumers nest our components under `LayerProvider` and brand them with CSS
-variables, so **everything must be themeable, localizable, and mountable more than once on a
-page**. Most rules below exist to protect one of those three properties.
+from `src/index.tsx`. Consumers nest our components under `LayerProvider`, brand them with CSS
+variables, and embed them at arbitrary widths inside their own layouts. Everything here must be
+themeable, localizable, responsive, and mountable more than once on a page. Most rules below exist
+to protect one of those four properties.
 
 Stack: React 18, SWR (server state), Zustand (UI state), Effect `Schema` (every API contract),
-TanStack Form/Table, SCSS. Tests run on Vitest with MSW; UI coverage is mostly Storybook +
-Chromatic. Full conventions live in [`AGENTS.md`](../AGENTS.md) and the colocated `SKILL.md` file
-in each directory.
+TanStack Form/Table, SCSS. Tests run on Vitest with MSW; UI coverage is mostly Storybook and
+Chromatic. Full conventions live in [`AGENTS.md`](../AGENTS.md) and the colocated `SKILL.md` in
+each directory. [`.augment/code_review_guidelines.yaml`](../.augment/code_review_guidelines.yaml)
+is this same rule set in Augment's format — keep the two in sync.
 
 ## What to flag
 
 ### Money, numbers, and dates
 
-- Currency, percentage, number, or date values formatted by hand — string concatenation,
-  `toFixed`, `Intl.NumberFormat` inline, `toLocaleDateString`. Use `useIntlFormatter()` or
-  `<MoneySpan>`.
-- Currency values that are not **cents**, or percent values that are not **fractions**. A
-  currency input handed dollars, or a percent input handed `7` instead of `0.07`, is a bug.
-- A date formatter given a format string instead of a `DateFormat` enum value.
+- Currency values that are not cents, or percent values that are not fractions. Everything in this
+  codebase uses cents and fractions. A currency input handed dollars, or a percent input handed
+  `7` instead of `0.07`, is a real bug — check unit consistency wherever a monetary or percentage
+  value crosses a boundary.
+- Currency, percentages, numbers, or dates formatted by hand: string concatenation, `toFixed`,
+  inline `Intl.NumberFormat`, `toLocaleDateString`. Use `useIntlFormatter()` or `<MoneySpan>`.
+  Hand-formatting breaks localization for consumers.
+- A date formatter given a format string. Pass a `DateFormat` enum value.
+- Raw `BigDecimal` held in form or React state. It triggers TS2589 (excessively deep type
+  instantiation). Use `NonRecursiveBigDecimal` and thread the rich type as a prop.
 
 ### Strings
 
-- Any user-visible string not routed through `t('ns:category.key', 'Default')` with an inline
-  default — including `aria-label`, `title`, `placeholder`, table headers, and empty-state copy.
-- Edits to `src/assets/locales/**`. Those files are generated from code and Crowdin; the string
-  belongs in the `t()` call's inline default.
+- A user-visible string that does not go through `t('ns:category.key', 'Default')` with an inline
+  default. This includes `aria-label`, `title`, `placeholder`, table headers, and empty-state copy.
+  A hardcoded string is untranslatable for consumers.
+- Any edit to `src/assets/locales/**`. Those files are generated from the `t()` inline defaults and
+  Crowdin. The string belongs in the `t()` call.
 
-### Schemas and mocks
+### API contracts
 
-- Optional or nullable API fields declared as anything other than `Schema.NullishOr`. The backend
-  omits a field on one endpoint and returns `null` on another.
-- Hand-written snake_case JSON anywhere it stands in for a wire payload — mocks, fixtures, tests,
-  `*.storyData.tsx`. Mocks hold decoded values and encode through the schema.
-- A new or renamed method file under `src/hooks/api/**` with no MSW handler at the mirrored path
-  in `src/msw/api/**` — and the handler must be **registered in the enclosing `handlers.ts`**.
-  Unhandled `layerfi.com` requests fail Vitest and Storybook.
-- A changed fixture schema or generator without regenerated, committed
-  `src/fixtures/generated/*.gen.ts`.
-- Value imports of `@api/*` or `@hooks/*` inside `src/msw`. Handlers load before per-test mocks
-  apply and would break unrelated suites. Share contracts through `@schemas`.
+- An optional or nullable API field declared as anything other than `Schema.NullishOr`. The backend
+  omits a field on one endpoint and returns `null` on another; anything narrower has broken
+  decoding before.
+- A method file under `src/hooks/api/**` with no matching MSW handler at the mirrored path in
+  `src/msw/api/**`, registered in the enclosing `handlers.ts`. Unhandled `layerfi.com` requests
+  hard-fail Vitest and Storybook, and `npm run msw:check-coverage` fails CI.
+- A schema that looks invented rather than derived from a known contract. Say the API contract
+  should be confirmed before the schema lands.
+- A wire-format type added under `src/types/**`. That directory is internal-only types. Anything
+  the API sends or receives is an Effect schema in `src/schemas`.
+
+### Mocks, fixtures, and test payloads
+
+- Hand-written snake_case JSON in mocks, fixtures, tests, or `*.storyData.tsx`. Mocks hold decoded
+  values and encode through the schema, so wire-format changes propagate automatically.
+  Hand-written wire JSON silently rots.
+- A value import of `@api/*` or `@hooks/*` inside `src/msw`. Type imports are fine. Handlers load
+  before per-test mocks apply, so a runtime import breaks unrelated Vitest suites.
+- A change to a fixture schema or generator without regenerated, committed
+  `src/fixtures/generated/*.gen.ts`. Run `npm run fixtures:generate`; CI fails on staleness.
 
 ### State and data
 
-- `useSWR` or `fetch` called directly in feature code. Use the factories in `@hooks/utils/swr`
-  (`createQueryHook`, `createInfiniteQueryHook`, `createMutationHook`).
-- `businessId` or auth passed down from a component. Both are injected.
-- Server data mirrored into a Zustand store. SWR owns server state, Zustand owns UI state,
-  Context is dependency injection.
-- `setState` called during render.
-- `useEffect` + `setState` producing a value that could be derived during render instead.
-- A write with no corresponding cache invalidation (`createResourceGlobalCacheActions` +
-  `useOnTriggerSuccess`).
-
-### Memoization
-
-- `useCallback` or `useMemo` wrapping a primitive, or wrapping a value that is neither a prop to
-  a `memo()`ed child nor a dependency-array entry nor an expensive computation.
-- An object or array literal returned from a custom hook without `useMemo`.
+- `useSWR` or `fetch` in feature code. Use the factories in `@hooks/utils/swr` —
+  `createQueryHook`, `createInfiniteQueryHook`, `createMutationHook`. They own auth, `businessId`,
+  locale cache keying, and error handling.
+- `businessId` or auth passed down as a prop. Both are injected by the provider stack; threading
+  them works around the injection.
+- Server data mirrored into a Zustand store. SWR owns server state. A duplicate goes stale and
+  diverges from the cache.
+- `setState` called during render. Use an effect, or derive the value.
+- `useEffect` plus `setState` producing a value that could be derived during render from props or
+  existing state. Derived values are always consistent and skip the extra render.
+- A mutation that does not invalidate the caches it affects. Use
+  `createResourceGlobalCacheActions` with `useOnTriggerSuccess`; an uninvalidated write leaves
+  stale data on screen.
+- `useCallback` or `useMemo` on a primitive, or on anything that is not a prop to a `memo()`ed
+  child, a dependency-array entry, or a genuinely expensive computation. Conversely, flag an
+  unmemoized object or array literal returned from a custom hook — it breaks every consumer's
+  dependency arrays.
 
 ### Components and styling
 
-- New markup that reimplements something already in `@ui`. Build on the primitive; genuinely new
-  primitives go in `src/components/ui`.
-- Raw `<div>` where `<HStack>`/`<VStack>` fits; raw `<span>`/`<p>`/`<label>` where
-  `<Span>`/`<P>`/`<Label>` fits.
+- New markup that duplicates an existing `@ui` primitive. Reach for `HStack`/`VStack` instead of a
+  raw `div`, and `Span`/`P`/`Label`/`Header` instead of raw text elements. Genuinely new reusable
+  primitives go in `src/components/ui`, not inside a feature.
 - The `style` prop, inline styles, utility class strings, or class names built by concatenation.
-- Hard-coded colors or spacing. Both come from `src/styles/variables.scss`.
-- Variants expressed as extra class names instead of `data-*` attributes via `toDataProperties`.
-- `&__Element` nesting in SCSS. Write flat, greppable selectors; nest only modifiers of the
-  current selector.
-- A new data-dense surface — table, list, selection or filter UI — with no mobile variant. We are
-  embedded at arbitrary widths inside consumer layouts; desktop-only is broken for real users.
-  Render per-size variants with `ResponsiveComponent` (`slots` + `resolveVariant`).
-- A hand-built mobile card list or bottom sheet. Use `@blocks/MobileList`
-  (`MobileList`, `PaginatedMobileList`, `MobileListItem`, `MobileListSection`) and
-  `@blocks/MobileSelectionDrawer`.
+  Consumers restyle us by class name; concatenated names are ungreppable and unthemeable.
+- Hardcoded hex colors or pixel spacing. Both come from `src/styles/variables.scss`, or consumer
+  theming breaks.
+- A variant expressed as a conditional class name. Use `data-*` attributes via `toDataProperties`
+  and select on them in SCSS.
+- `&__Element` nesting in SCSS. Nest only modifiers of the current selector — a name built by
+  concatenation cannot be found by searching for it.
+- A new data-dense surface — table, list, selection or filter UI — with only a desktop layout that
+  reflows. We are embedded at arbitrary widths, so desktop-only is broken for a real subset of
+  users. Render per-size variants with `ResponsiveComponent`
+  (`@components/utility/ResponsiveComponent`) using a `slots` record and a `resolveVariant`
+  function.
+- A hand-built mobile card list or bottom sheet. `MobileList`, `PaginatedMobileList`,
+  `MobileListItem`, and `MobileListSection` are in `@blocks/MobileList`; `MobileSelectionDrawer`
+  and `MobileSelectionDrawerWithTrigger` are in `@blocks/MobileSelectionDrawer`. A bespoke one
+  diverges from the rest of the library's mobile behavior.
 - Hardcoded pixel thresholds or inline width ternaries scattered through JSX. Size classes come
-  from `BREAKPOINTS` in `@utils/shared/size/screenSizeBreakpoints`; read size with
-  `useElementSize` / `useElementViewSize`.
-- CSS variables referenced outside a `.Layer__component` / `.Layer__Portal` ancestor. Portals and
-  bare primitives in stories need one.
-
-### Reuse before reinvention
-
-- Hand-rolled loading, empty, or error branches instead of `ConditionalBlock` (one object),
-  `ConditionalList` (an array), `DataState`, `SkeletonLoader`, or `SkeletonTableLoader`.
-- A hand-built table instead of `SimpleDataTable` / `DataTable` / `PaginatedDataTable` /
-  `ExpandableDataTable` / `VirtualizedDataTable`, or pagination state managed by hand instead of
-  `@hooks/utils/pagination`.
-- A form not built on `useAppForm` + the `Form*Field` components, or a validator duplicated
-  instead of taken from `@utils/shared/form/validators`.
+  from `BREAKPOINTS` in `@utils/shared/size/screenSizeBreakpoints` (mobile under 500, tablet under
+  760, desktop above); read element size with `useElementSize` or `useElementViewSize`.
+- CSS variables referenced outside a `.Layer__component` or `.Layer__Portal` ancestor. Portals and
+  bare primitives rendered outside one silently lose all theming.
+- Hand-rolled loading, empty, or error branches. Use `ConditionalBlock` for a single data object
+  and `ConditionalList` for an array, with `DataState`, `SkeletonLoader`, and
+  `SkeletonTableLoader` for the visuals.
+- A hand-built table, or pagination state managed by hand. Use `SimpleDataTable`, `DataTable`,
+  `PaginatedDataTable`, `ExpandableDataTable`, or `VirtualizedDataTable`, and take pagination
+  state from `@hooks/utils/pagination`.
+- A form not built on `useAppForm` plus the `Form*Field` components, or a validator reimplemented
+  inline instead of taken from `@utils/shared/form/validators`.
 
 ### TypeScript
 
-- An `as` cast with no short comment explaining why it is safe.
+- An `as` cast with no short comment saying why it is safe. Unexplained casts at boundaries hide
+  decoding bugs.
 - A type restated by hand where it could be derived: `typeof Schema.Type`,
-  `Parameters<typeof useHook>[0]`, `Pick<…>`, `ReturnType<…>`.
-- Raw `BigDecimal` held in form or React state. It triggers TS2589 — use
-  `NonRecursiveBigDecimal`.
-- A wire-format type added under `src/types/**`. Anything the API sends or receives is a schema.
+  `Parameters<typeof useHook>[0]`, `Pick<…>`, `ReturnType<…>`. Restated types drift from their
+  source.
 
-### Published surface
+### Published API and stories
 
-- Any change to the exports in `src/index.tsx`. Say plainly that this is a public API change and
-  must be called out in the PR description.
-
-### Stories
-
-- One story per primitive variant. Every story is a Chromatic snapshot — pack variants into a
-  single gallery story.
-- A `*scratch.stories.tsx` file reaching the branch.
+- Any addition, removal, or rename in the exports of `src/index.tsx`. Say plainly that this is a
+  public API change for `@layerfi/components` consumers and must be called out in the PR
+  description.
+- One story per primitive variant. Every story is a billed Chromatic snapshot — pack variants into
+  a single gallery story.
 
 ## What to leave alone
 
-- Anything ESLint, stylelint, or `tsc --noEmit` already fails the PR on. Do not comment on import
+- Anything ESLint, stylelint, or `tsc --noEmit` already fails the PR on. Say nothing about import
   order, import boundaries, relative-parent imports, `react-hooks/exhaustive-deps`,
   `no-explicit-any` and the `no-unsafe-*` family, inline type imports, unused variables, quotes,
   semicolons, indentation, line length, or CSS property order.
 - `src/fixtures/generated/*.gen.ts` — generated output, committed on purpose.
 - `consumer-fixtures/**` — deliberately minimal smoke apps, outside the lint config.
-- `dist/`, `storybook-static/`, `package-lock.json`.
-- `.claude/worktrees/**`.
+- `*scratch.stories.tsx` — these are expected on a branch and are stripped automatically on
+  approval.
+- `dist/`, `storybook-static/`, `package-lock.json`, `.claude/`.
 
 ## Tone
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,11 @@ Each area has a colocated `SKILL.md`. **Read the relevant one(s) before making c
 Those skills plus this file are the only convention docs — each is the single source of truth
 for its area, so update the relevant one when a convention changes rather than describing it
 somewhere new. Cross-cutting rules (TypeScript, imports, lint, commands, CI) live here, because
-they belong to no single directory. The remaining root docs are not agent instructions:
+they belong to no single directory. [`.cursor/BUGBOT.md`](.cursor/BUGBOT.md) and
+[`.augment/code_review_guidelines.yaml`](.augment/code_review_guidelines.yaml) are the same idea
+for the PR reviewers — the two say the same thing in each tool's format, so update both whenever a
+non-negotiable here changes, or they drift silently.
+The remaining root docs are not agent instructions:
 [`README.md`](README.md) is consumer-facing usage and [`PUBLISHING.md`](PUBLISHING.md) is the
 release process.
 


### PR DESCRIPTION
## Description

Cursor Bugbot and Augment Code Review both review our PRs with no repo-specific instructions, so they run on generic priors: they re-flag things `eslint` / `stylelint` / `tsc` already fail the PR on, they review generated files, and they miss the conventions that actually break this library — money units, i18n coverage, MSW handler registration, state ownership, mobile responsiveness, public API surface.

We already have the convention corpus in `AGENTS.md` plus the 18 colocated `SKILL.md` files, but neither reviewer reads it. This distills the *non-lintable, has-broken-us-before* subset into each tool's instructions format. Same 36 rules, two syntaxes.

Structure for `.cursor/BUGBOT.md` follows [Tuning Bugbot for your codebase](https://stevekinney.com/courses/self-testing-ai-agents/tuning-bugbot-for-your-codebase); `.augment/code_review_guidelines.yaml` follows [Augment's review guidelines schema](https://docs.augmentcode.com/codereview/review-guidelines).

Both files deliberately say nothing about import order, import boundaries, `react-hooks/exhaustive-deps`, `no-explicit-any` and the `no-unsafe-*` family, inline type imports, unused vars, quotes, semicolons, indentation, or CSS property order — CI already gates all of that, and re-reporting it is what makes bot review noise.

## Changes

- **`.augment/code_review_guidelines.yaml`** — 9 areas, 36 rules, each with globs and a severity. Augment uses YAML rather than markdown so the agent can cite a rule `id` on a comment and compute per-rule analytics, which gives us data for tuning instead of impressions. File exclusions (generated fixtures, `consumer-fixtures/`, `dist/`, `storybook-static/`, lockfile) live in `file_paths_to_ignore`.
- **`.cursor/BUGBOT.md`** — the same 36 rules in Bugbot's Context / What to flag / What to leave alone / Tone form, written from the YAML so the two stay aligned.
- **`AGENTS.md`** — cross-references both reviewer files and notes they must be updated together when a non-negotiable changes, so they don't drift.

Rule groups: money units (cents and fractions), i18n incl. `aria-label`, `Schema.NullishOr` + MSW handler registration + stale `.gen.ts`, state ownership, memoization, `@ui` primitives and styling, **mobile responsiveness** (`ResponsiveComponent`, `@blocks/MobileList`, `@blocks/MobileSelectionDrawer`, `BREAKPOINTS`), reuse of `ConditionalBlock` / `*DataTable` / `useAppForm`, TypeScript, `src/index.tsx` as public API, Chromatic story cost.

Deliberately **not** included: the `.lrclint.json` rules. That tool stays separate.

## Blockers

None.

## How this has been tested?

- **Augment reviewed its own instructions and found two real bugs**, both fixed in 8e8bb05: `no_wire_types_in_types_dir` cited `src/types/**` while its area only globbed schemas and `hooks/api`, and `no_handwritten_snake_case` was meant to cover tests but its area only globbed `msw` and `fixtures`. Auditing for the same defect turned up a third — `no_locale_file_edits` cited a path that sat in `file_paths_to_ignore`, so the reviewer could never see the file it forbids editing.
- Verified by probe that `@typescript-eslint/no-explicit-any` and `no-unsafe-return` error on a file containing `any`, so the `no_any` rule was pure CI duplication and was removed.
- Confirmed `scratch-stories-cleanup.yml` strips `*scratch.stories.tsx` automatically on approval rather than blocking, so that rule was wrong on both counts and moved to the leave-alone list.
- Validated the YAML parses, all 9 areas and 36 rules match Augment's documented schema (`description`/`globs`/`rules` per area; `id`/`description`/`severity` in `high|medium|low` per rule), rule ids are unique, and no rule cites a path outside its own area globs.
- Verified every helper, alias, and path referenced exists in the tree: `useIntlFormatter`, `MoneySpan`, `toDataProperties`, `ConditionalBlock`, `ConditionalList`, `NonRecursiveBigDecimal`, `NonRecursiveBigDecimal`, `@hooks/utils/swr`, `@blocks/MobileList`, `@blocks/MobileSelectionDrawer`, `@utils/shared/size/screenSizeBreakpoints`, `src/msw/api/`, `src/fixtures/generated/`, `src/styles/variables.scss`.
- `npm run lint` and `npm run typecheck` pass (documentation-only change; `.cursor/` and `.augment/` are outside every lint glob).
- Real signal comes from the bots themselves, and this PR is the first live test. Per the article's "rule of three", expect a tuning pass after a couple more PRs of observed false positives and misses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or dependency impact; main risk is reviewer rule drift if future convention updates omit one of the two files.
> 
> **Overview**
> Adds **repo-specific PR review instructions** for Cursor Bugbot and Augment by distilling the non-lintable conventions from `AGENTS.md` and the colocated `SKILL.md` files into two parallel artifacts that must stay in sync.
> 
> **`.augment/code_review_guidelines.yaml`** defines **9 areas and 36 rules** with globs, severities, and `file_paths_to_ignore` (generated fixtures, `dist/`, etc.) while **deliberately not** ignoring `src/assets/locales/**` so hand-edits to generated translation JSON can be flagged. **`.cursor/BUGBOT.md`** carries the same rule set in Bugbot’s Context / What to flag / What to leave alone / Tone shape. Both **omit** issues already gated by ESLint, stylelint, and `tsc`, and focus on library-specific failure modes: **cents/fraction money units**, **`t()` i18n**, **`Schema.NullishOr` + MSW coverage**, mock/fixture encoding, **SWR vs Zustand** ownership, **mobile surfaces** (`ResponsiveComponent`, shared mobile blocks), styling/theming, **`src/index.tsx` public API**, and Chromatic story cost.
> 
> **`AGENTS.md`** now cross-links both reviewer files and states they should be updated together when a non-negotiable convention changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5553f161d1b89c85b08ea6739439d7ee202cda5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->