### PR TITLE
[LAY-2625] ci: split the dependabot dev lanes back apart, and fix the two checks red on #1719

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,8 @@ updates:
       prefix: 'chore(deps)'
       prefix-development: 'chore(deps-dev)'
 
-    # First matching group wins, so these run most-specific first: a red PR points at one
-    # ecosystem rather than an unattributable pile.
+    # Definition order does not decide overlaps, so dev-tooling excludes the narrow groups by
+    # pattern rather than relying on being declared last.
     groups:
       storybook:
         applies-to: version-updates
@@ -57,6 +57,23 @@ updates:
       dev-tooling:
         applies-to: version-updates
         dependency-type: development
+        exclude-patterns:
+          - storybook
+          - '@storybook/*'
+          - msw-storybook-addon
+          - chromatic
+          - eslint
+          - eslint-*
+          - '@stylistic/*'
+          - stylelint
+          - stylelint-*
+          - typescript-eslint
+          - vitest
+          - '@vitest/*'
+          - '@testing-library/*'
+          - jsdom
+          - playwright
+          - msw
         update-types:
           - minor
           - patch

--- a/.github/workflows/consumer-matrix.yml
+++ b/.github/workflows/consumer-matrix.yml
@@ -1,4 +1,4 @@
-name: Consumer matrix
+name: Consumers
 
 # Installs the packed tarball into throwaway consumer apps and builds them — the only PR check that
 # reads the published artifact rather than the repo.
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   consumers:
+    name: Matrix
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,4 +1,4 @@
-name: Daily npm audit
+name: NPM Audit
 
 on:
   schedule:
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   audit:
-    name: Audit
+    name: Report
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -98,8 +98,15 @@ jobs:
 
             // Both renderers walk this, so neither repeats the prod-available branch.
             const groups = prodAvailable
-              ? [{ title: 'Consumer-facing', rows: runtime }, { title: 'Dev / CI only', rows: dev }]
-              : [{ title: '⚠️ Potentially consumer-facing — prod/dev split unknown', rows: vulns }];
+              ? [
+                { title: 'Consumer-facing', slackTitle: 'Consumer Facing', rows: runtime },
+                { title: 'Dev / CI only', slackTitle: 'Dev / CI', rows: dev },
+              ]
+              : [{
+                title: '⚠️ Potentially consumer-facing — prod/dev split unknown',
+                slackTitle: 'All findings',
+                rows: vulns,
+              }];
 
             // npm repeats a title per dependency path; a bare string is the package, not a title.
             const describeVia = (v) => {
@@ -133,7 +140,8 @@ jobs:
               const openPrs = await github.paginate(github.rest.pulls.list, { ...repo, state: 'open', per_page: 100 });
               for (const pr of openPrs.filter(pr => pr.user?.login === 'dependabot[bot]')) {
                 for (const name of packagesIn(pr)) {
-                  fixPrs.set(name, [...(fixPrs.get(name) ?? []), { number: pr.number, url: pr.html_url }]);
+                  const entry = { number: pr.number, url: pr.html_url, title: pr.title };
+                  fixPrs.set(name, [...(fixPrs.get(name) ?? []), entry]);
                 }
               }
             } catch (error) {
@@ -165,25 +173,59 @@ jobs:
               process.env.ARTIFACT_URL ? `Full audit JSON: ${process.env.ARTIFACT_URL}\n` : '',
             ].filter(Boolean).join('\n')).write();
 
-            // Slack has no table primitive, and code blocks do not reflow on mobile.
-            const EMOJI = { critical: '🚨', high: '🔴', moderate: '🟠', low: '🟡' };
-            const bullets = (rows) => {
-              const lines = [...SEVERITIES].reverse()
-                .map(severity => [severity, rows.filter(v => v.severity === severity).length])
-                .filter(([, count]) => count > 0)
-                .map(([severity, count]) => `• ${EMOJI[severity]} ${count} ${severity}`);
-              return lines.length ? lines : ['• none'];
+            const {
+              SEVERITY_EMOJI, capBlocks, context: contextBlock, group, header, limited, metaLine, prLine,
+              row, section, tally,
+            } = require('./scripts/ci/slackBlocks.cjs');
+
+            const severityTally = rows => tally([...SEVERITIES].reverse()
+              .map(severity => [SEVERITY_EMOJI[severity], rows.filter(v => v.severity === severity).length, severity]))
+              || 'none';
+
+            // Counted per group instead, so only findings that need a decision are annotated.
+            const slackFix = (v) => {
+              if (v.fixAvailable === true) return '';
+              if (!v.fixAvailable?.version) return '_no fix_';
+              const target = `fix \`${v.fixAvailable.name}@${v.fixAvailable.version}\``;
+              return v.fixAvailable.isSemVerMajor ? `${target} *(major)*` : target;
             };
 
-            // Every finding's PRs: a merge-ready dev PR is still work waiting. Severity-ordered.
-            const linked = new Set(vulns.flatMap(v => (fixPrs.get(v.name) ?? []).map(pr => `<${pr.url}|#${pr.number}>`)));
+            const slackPrs = v => (fixPrs.get(v.name) ?? []).map(pr => `<${pr.url}|#${pr.number}>`).join(' ');
 
-            core.setOutput('slack', [
-              `[${slug}] npm audit — ${vulns.length} findings`,
-              ...groups.map(g => [`*${g.title} (${g.rows.length})*`, ...bullets(g.rows)].join('\n')),
-              linked.size ? `Open fix PRs: ${[...linked].join(' ')}` : '',
-              `Details: <${runUrl}|run summary> · <${alerts}|Dependabot alerts>`,
-            ].filter(Boolean).join('\n\n'));
+            const packageLines = rows => limited(
+              rows.map(v => row(SEVERITY_EMOJI[v.severity], v.name, slackFix(v), slackPrs(v))), 40,
+            );
+
+            const fixableNote = (rows) => {
+              const count = rows.filter(v => v.fixAvailable === true).length;
+              return count && `${count} of ${rows.length} clear with \`npm audit fix\``;
+            };
+
+            // Every finding's PRs: a merge-ready dev PR is still work waiting.
+            const prRows = [...new Map(
+              vulns.flatMap(v => fixPrs.get(v.name) ?? []).map(pr => [pr.number, pr]),
+            ).values()].sort((a, b) => a.number - b.number);
+
+            const blocks = capBlocks([
+              header(`npm audit — ${vulns.length} findings`),
+              contextBlock(`*${slug}* · <${runUrl}|run summary>`),
+              ...(prodAvailable
+                ? []
+                : [section('⚠️ The production-only audit produced no usable output, so every finding below is listed as *potentially consumer-facing*.')]),
+              ...groups.flatMap(g => group({
+                title: g.slackTitle ?? g.title,
+                count: g.rows.length,
+                meta: metaLine(severityTally(g.rows), fixableNote(g.rows)),
+                lines: g.rows.length ? packageLines(g.rows) : [],
+              })),
+              ...(prRows.length ? group({ title: 'Open Fix PRs', lines: prRows.map(prLine) }) : []),
+              contextBlock(`<${alerts}|Dependabot alerts> · peer dependencies (\`react\`, \`react-dom\`) are not covered by \`npm audit\``),
+            ]);
+
+            // `runtime` is every finding when the prod audit failed, so the split is not stated.
+            core.setOutput('slack', `[${slug}] npm audit — ${vulns.length} findings, ${
+              prodAvailable ? `${runtime.length} consumer-facing` : 'prod/dev split unknown'}`);
+            core.setOutput('slack_blocks', JSON.stringify(blocks));
 
       # Runs on failure too: a broken audit is when the ping matters most. Counts come from the
       # step above, so the two reports cannot disagree.
@@ -192,6 +234,7 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_TEXT: ${{ steps.report.outputs.slack }}
+          SLACK_BLOCKS: ${{ steps.report.outputs.slack_blocks }}
           RUNTIME: ${{ steps.report.outputs.runtime }}
           TOTAL: ${{ steps.report.outputs.total }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -210,7 +253,13 @@ jobs:
           if [ -z "$SLACK_TEXT" ]; then
             SLACK_TEXT="[$GITHUB_REPOSITORY] npm audit: $RUNTIME consumer-facing, $TOTAL total — <$RUN_URL|run summary>"
           fi
-          PAYLOAD=$(jq -n --arg text "$SLACK_TEXT" '{text: $text}')
+          # Blocks are dropped if the step above never produced them, so a broken summarize
+          # still pages someone.
+          if [ -n "$SLACK_BLOCKS" ]; then
+            PAYLOAD=$(jq -n --arg text "$SLACK_TEXT" --argjson blocks "$SLACK_BLOCKS" '{text: $text, blocks: $blocks}')
+          else
+            PAYLOAD=$(jq -n --arg text "$SLACK_TEXT" '{text: $text}')
+          fi
           # Slack answers a dead webhook with 4xx; plain `curl -s` would swallow that as exit 0.
           curl -sS --fail-with-body -X POST -H 'Content-type: application/json' \
             --data "$PAYLOAD" "$SLACK_WEBHOOK"

--- a/.github/workflows/npm-outdated.yml
+++ b/.github/workflows/npm-outdated.yml
@@ -1,0 +1,174 @@
+name: Weekly npm outdated
+
+# Majors are ignored in dependabot.yml so an open major PR cannot consume the weekly limit. This
+# is what keeps them visible instead: a report, not a PR.
+
+on:
+  schedule:
+    - cron: '0 16 * * 1'   # Mondays 16:00 UTC, after Dependabot's 13:00 lane
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  outdated:
+    name: Outdated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci
+
+      # Exits non-zero whenever anything is outdated, which is the normal case here.
+      - name: Run npm outdated
+        run: npm outdated --long --json > outdated.json || true
+
+      - name: Summarize outdated
+        id: report
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const {
+              capBlocks, context: contextBlock, group, header, limited, metaLine, row, section, tally,
+            } = require('./scripts/ci/slackBlocks.cjs');
+
+            const read = (file) => {
+              try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return null; }
+            };
+
+            const outdated = read('outdated.json');
+            if (!outdated) {
+              core.setOutput('total', 'unknown');
+              core.setFailed('outdated.json missing or unparseable.');
+              return;
+            }
+
+            // Peers are the consumer's choice of version, not ours to bump, and their `@types`
+            // track the peer's major. `typescript` and `@typescript/native` are intentional
+            // aliases Dependabot already ignores.
+            const peers = Object.keys(
+              JSON.parse(fs.readFileSync('package.json', 'utf8')).peerDependencies ?? {},
+            );
+            const EXCLUDED = new Set([
+              'typescript',
+              '@typescript/native',
+              ...peers,
+              ...peers.map(name => `@types/${name.replace('@', '').replace('/', '__')}`),
+            ]);
+
+            // `latest` is a dist-tag, so it can be a prerelease and can even sort below what is
+            // installed. Dependabot would not offer either, so neither does this.
+            const release = v => String(v ?? '').split('-')[0].split('.').map(Number);
+            const rank = v => release(v).slice(0, 3).reduce((acc, n) => acc * 1e5 + (n || 0), 0);
+
+            const rows = Object.entries(outdated)
+              .filter(([name]) => !EXCLUDED.has(name))
+              .filter(([, info]) => info.type === 'dependencies' || info.type === 'devDependencies')
+              // No `current` means the package is not installed — an install problem, not a gap.
+              .filter(([, info]) => info.current && !String(info.latest).includes('-'))
+              .filter(([, info]) => rank(info.latest) > rank(info.current))
+              .map(([name, info]) => ({
+                name,
+                current: info.current,
+                latest: info.latest,
+                where: info.type === 'dependencies' ? 'prod' : 'dev',
+                isMajor: release(info.latest)[0] > release(info.current)[0],
+              }))
+              // Runtime first: it is the half that reaches consumers.
+              .sort((a, b) => (a.where === b.where
+                ? a.name.localeCompare(b.name)
+                : Number(a.where === 'dev') - Number(b.where === 'dev')));
+
+            const majors = rows.filter(r => r.isMajor);
+            const minors = rows.filter(r => !r.isMajor);
+
+            core.setOutput('total', String(rows.length));
+
+            const treeTally = (list) => {
+              const runtime = list.filter(r => r.where === 'prod').length;
+              return tally([['📦', runtime, 'runtime'], ['🔧', list.length - runtime, 'dev']]);
+            };
+
+            const line = r => row(r.where === 'prod' ? '📦' : '🔧', r.name, `${r.current} → ${r.latest}`);
+
+            const table = (title, list) => {
+              if (list.length === 0) return `## ${title}\n\n_None._\n`;
+              const head = '| package | current | latest | tree |\n|---|---|---|---|\n';
+              return `## ${title} — ${list.length}\n\n${head}${
+                list.map(r => `| ${r.name} | ${r.current} | ${r.latest} | ${r.where} |\n`).join('')}`;
+            };
+
+            const slug = `${context.repo.owner}/${context.repo.repo}`;
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${slug}/actions/runs/${context.runId}`;
+
+            await core.summary.addRaw([
+              `**${majors.length}** behind by a major, **${minors.length}** by a minor or patch.\n`,
+              table('Majors — Dependabot will not open these', majors),
+              table('Minors and patches — Dependabot lane', minors),
+            ].join('\n')).write();
+
+            const blocks = capBlocks([
+              header(`npm outdated — ${rows.length} packages`),
+              contextBlock(`*${slug}* · <${runUrl}|run summary>`),
+              ...group({
+                title: 'Major',
+                count: majors.length,
+                meta: metaLine(treeTally(majors), 'ignored by Dependabot — these only move if someone moves them'),
+                lines: majors.length ? limited(majors.map(line), 40) : ['_None._'],
+              }),
+              ...(minors.length
+                ? group({
+                  title: 'Minor / Patch',
+                  count: minors.length,
+                  meta: metaLine(treeTally(minors), 'opened weekly by Dependabot'),
+                  lines: limited(minors.map(line), 20),
+                })
+                : []),
+              contextBlock(`Excluded: ${peers.map(name => `\`${name}\``).join(', ')} and their \`@types\`, \`typescript\`, \`@typescript/native\``),
+            ]);
+
+            core.setOutput('slack', `[${slug}] npm outdated — ${rows.length} packages, ${majors.length} major`);
+            core.setOutput('slack_blocks', JSON.stringify(blocks));
+
+      - name: Send Slack notification
+        if: ${{ !cancelled() }}
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TEXT: ${{ steps.report.outputs.slack }}
+          SLACK_BLOCKS: ${{ steps.report.outputs.slack_blocks }}
+          TOTAL: ${{ steps.report.outputs.total }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK" ]; then
+            echo "ERROR: SLACK_WEBHOOK secret not configured."
+            exit 1
+          fi
+          # Unset if the summarize step died first; `unknown` must not take the "nothing" branch.
+          TOTAL=${TOTAL:-unknown}
+          if [ "$TOTAL" = "0" ]; then
+            echo "Nothing outdated to report to Slack."
+            exit 0
+          fi
+          if [ -z "$SLACK_TEXT" ]; then
+            SLACK_TEXT="[$GITHUB_REPOSITORY] npm outdated — see <$RUN_URL|run summary>"
+          fi
+          # Blocks are dropped if the step above never produced them, so a broken summarize
+          # still pages someone.
+          if [ -n "$SLACK_BLOCKS" ]; then
+            PAYLOAD=$(jq -n --arg text "$SLACK_TEXT" --argjson blocks "$SLACK_BLOCKS" '{text: $text, blocks: $blocks}')
+          else
+            PAYLOAD=$(jq -n --arg text "$SLACK_TEXT" '{text: $text}')
+          fi
+          # Slack answers a dead webhook with 4xx; plain `curl -s` would swallow that as exit 0.
+          curl -sS --fail-with-body -X POST -H 'Content-type: application/json' \
+            --data "$PAYLOAD" "$SLACK_WEBHOOK"

--- a/.github/workflows/npm-outdated.yml
+++ b/.github/workflows/npm-outdated.yml
@@ -1,4 +1,4 @@
-name: Weekly npm outdated
+name: NPM Outdated
 
 # Majors are ignored in dependabot.yml so an open major PR cannot consume the weekly limit. This
 # is what keeps them visible instead: a report, not a PR.
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   outdated:
-    name: Outdated
+    name: Report
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/i18next.config.ts
+++ b/i18next.config.ts
@@ -1,10 +1,12 @@
-import { defineConfig } from 'i18next-cli'
+// Type-only on purpose: a value import makes tsx `require()` i18next-cli's CJS build, which
+// reaches an ESM-only transitive dep and fails to resolve. `defineConfig` is identity.
+import type { I18nextToolkitConfig } from 'i18next-cli'
 
 import conditionalPlugin from './scripts/i18next/conditionalPlugin'
 import pluralPlugin from './scripts/i18next/pluralPlugin'
 import translationKeyPlugin from './scripts/i18next/translationKeyPlugin'
 
-export default defineConfig({
+const config: I18nextToolkitConfig = {
   locales: ['en-US', 'fr-CA'],
   plugins: [conditionalPlugin, pluralPlugin, translationKeyPlugin],
   extract: {
@@ -14,4 +16,6 @@ export default defineConfig({
     ignore: ['src/**/*.{test,spec}.{ts,tsx}', 'src/**/*.stories.tsx', 'src/**/*.storyData.tsx'],
     output: 'src/assets/locales/{{language}}/{{namespace}}.json',
   },
-})
+}
+
+export default config

--- a/scripts/ci/slackBlocks.cjs
+++ b/scripts/ci/slackBlocks.cjs
@@ -1,0 +1,73 @@
+// Shared by the workflows that report to Slack from `actions/github-script`. CommonJS because
+// that is the context github-script's `require` runs in.
+
+const SEVERITY_EMOJI = { critical: '🚨', high: '🔴', moderate: '🟠', low: '🟡' }
+
+const truncate = (text, max) => (text.length > max ? `${text.slice(0, max - 1)}…` : text)
+
+const header = text => ({ type: 'header', text: { type: 'plain_text', text, emoji: true } })
+const section = text => ({ type: 'section', text: { type: 'mrkdwn', text } })
+const context = text => ({ type: 'context', elements: [{ type: 'mrkdwn', text }] })
+const divider = () => ({ type: 'divider' })
+
+// A section's text caps at 3000 chars; splitting keeps a long list from being rejected whole.
+const sections = (lines) => {
+  const chunks = [[]]
+  let size = 0
+  for (const line of lines) {
+    if (size + line.length + 1 > 2800 && chunks.at(-1).length) {
+      chunks.push([])
+      size = 0
+    }
+    chunks.at(-1).push(line)
+    size += line.length + 1
+  }
+  return chunks.filter(chunk => chunk.length).map(chunk => section(chunk.join('\n')))
+}
+
+const group = ({ title, count, meta, lines }) => [
+  divider(),
+  section(`*[${count ?? lines.length}] ${title}*`),
+  ...(meta ? [context(meta)] : []),
+  ...sections(lines),
+]
+
+const prLine = pr => `[<${pr.url}|#${pr.number}>] ${truncate(pr.title, 88)}`
+
+const SEP = '  ·  '
+const ROW_SEP = ' · '
+
+// The group line both reports use: non-zero counts, then whatever note belongs beside them.
+const metaLine = (...parts) => parts.filter(Boolean).join(SEP)
+
+// One finding per line: the package, then whatever facts that report has about it. Only the
+// name is code-formatted — a row of boxes is what the versions used to read as.
+const row = (icon, name, ...facts) => [`${icon} \`${name}\``, ...facts.filter(Boolean)].join(ROW_SEP)
+const tally = entries => entries
+  .filter(([, count]) => count > 0)
+  .map(([emoji, count, label]) => `${emoji} ${count} ${label}`)
+  .join(SEP)
+
+// Slack caps a message at 50 blocks; the footer is worth more than the tail of a list.
+const capBlocks = blocks => (blocks.length > 50 ? [...blocks.slice(0, 49), blocks.at(-1)] : blocks)
+
+// Rows are ordered by urgency, so an overflow drops the least urgent and says so.
+const limited = (lines, max, more = 'in the run summary') =>
+  (lines.length > max ? [...lines.slice(0, max), `_+${lines.length - max} more ${more}._`] : lines)
+
+module.exports = {
+  SEVERITY_EMOJI,
+  capBlocks,
+  context,
+  divider,
+  group,
+  header,
+  limited,
+  metaLine,
+  prLine,
+  row,
+  section,
+  sections,
+  tally,
+  truncate,
+}

--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -5,6 +5,7 @@ import {
   isValidElement,
   type ReactNode,
   type Ref,
+  useCallback,
 } from 'react'
 import type { Placement } from '@floating-ui/react'
 import { FloatingPortal, useMergeRefs } from '@floating-ui/react'
@@ -53,7 +54,9 @@ export const TooltipTrigger = forwardRef<
   const childrenRef = (isValidElement(children) && 'ref' in children)
     ? children.ref as Ref<unknown>
     : null
-  const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef])
+  // Wrapped because floating-ui declares the setters as methods, which reads as an unbound `this`.
+  const setReference = useCallback((node: HTMLElement | null) => context.refs.setReference(node), [context.refs])
+  const ref = useMergeRefs([setReference, propRef, childrenRef])
 
   const dataProperties = toDataProperties({ variant })
 
@@ -91,7 +94,8 @@ export const TooltipContent = forwardRef<
   TooltipContentProps
 >(function TooltipContent({ wordBreak, ...props }, propRef) {
   const context = useTooltipContext()
-  const ref = useMergeRefs([context.refs.setFloating, propRef])
+  const setFloating = useCallback((node: HTMLElement | null) => context.refs.setFloating(node), [context.refs])
+  const ref = useMergeRefs([setFloating, propRef])
 
   const dataProperties = toDataProperties({ 'word-break': wordBreak })
 


### PR DESCRIPTION
## Scope

Five changes, all downstream of the 2026-08-06 Dependabot run.

**1. `dev-tooling` no longer swallows the narrow lanes.** The group declared only
`dependency-type: development` with no patterns, making it a strict superset of `storybook`,
`linting`, and `testing` — every member of those is a devDependency. Declaration order does not
settle the overlap: the first run opened one PR per group (#1714, #1716, #1717, #1718), then a
re-run collapsed all four into a single 23-update PR (#1719) and closed the others as superseded.
23 = 15 + 2 + 3 + 3. `dev-tooling` now excludes the three groups' patterns explicitly.

**2 + 3. The two checks failing on #1719.**

- *Translations.* `i18n:check` runs under tsx, which transpiles `i18next.config.ts` to CJS, so
  `import { defineConfig } from 'i18next-cli'` becomes a `require()` of that package's CJS entry.
  Newer versions reach `execa → npm-run-path → unicorn-magic`, which publishes no `require`
  condition — `ERR_PACKAGE_PATH_NOT_EXPORTED`. Bisected in a throwaway project; tsx version is not
  a factor, i18next-cli ≥ ~1.56 is. `defineConfig` is `config => config`, so a typed const is the
  same object with nothing left to require.
- *ESLint.* typescript-eslint 8.66 flags floating-ui's `refs.setReference` / `setFloating` passed
  to `useMergeRefs` as unbound methods. Wrapped in `useCallback` rather than disabled, because a
  disable directive would report as unused under the version on `main`. `context.refs` is memoized,
  so ref identity stays stable.

**4. The audit Slack message.** It was severity counts and nothing else. It now lists every finding
per category — one package per line with its fix and any open PR — and the open fix PRs one per row
with title and link, as Block Kit rather than a text blob.

**5. `consumer-matrix` job name.** It was the only job in `.github/workflows` without a `name:`.

## Verification

- `i18n:check` passes (1367 keys); `i18next-cli extract --dry-run --sync-primary` still loads the
  config and writes nothing.
- `typecheck` clean, `eslint` clean, 272 tests pass, `actionlint` clean.
- The audit summarize script run against today's real audit output (24 findings, 4 consumer-facing)
  and 14 open Dependabot PRs: 12 blocks, longest section 1068 chars, valid payload through the jq
  assembly on both the with-blocks and fallback branches. The prod-audit-missing path rendered too.
- `consumers` is not a required status check, so the context rename is safe.

## Follow-up

Pushing this re-triggers Dependabot (any push touching `dependabot.yml` does), which should split
#1719 back into four PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly Dependabot/CI and small targeted fixes; Tooltip ref wiring is localized with stable `context.refs` deps.
> 
> **Overview**
> **Dependabot grouping** no longer lets the catch-all `dev-tooling` group absorb Storybook, linting, and testing updates. The broad group now uses **`exclude-patterns`** for those lanes so overlapping dev bumps stay in separate PRs instead of one mega-PR.
> 
> **Check fixes for recent dev-dependency bumps:** `i18next.config.ts` drops the runtime `defineConfig` import from `i18next-cli` (type-only config export) so `i18n:check` under tsx does not `require()` a broken CJS chain. **`Tooltip`** wraps Floating UI’s `setReference` / `setFloating` in **`useCallback`** before `useMergeRefs` to satisfy typescript-eslint unbound-method rules.
> 
> **CI reporting:** New shared **`scripts/ci/slackBlocks.cjs`** builds Slack Block Kit payloads. The daily **npm audit** workflow posts per-package findings (fix hints, linked Dependabot PRs with titles) instead of severity-only bullets, with a text+blocks webhook fallback. A new weekly **NPM Outdated** workflow reports major vs minor/patch gaps Dependabot ignores (majors), also to Slack and the run summary. Minor workflow display names were aligned (`Consumers` / `Matrix`, `NPM Audit` / `Report`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8a7e766480d0813442013ed155d0c80565f28d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->