### PR TITLE
[LAY-2619] Enabling deep linking

### DIFF
--- a/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.test.tsx
+++ b/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.test.tsx
@@ -1,8 +1,7 @@
-import { type PropsWithChildren } from 'react'
-import { act, waitFor } from '@testing-library/react'
+import { type ComponentProps, type PropsWithChildren } from 'react'
+import { waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { type UnifiedReportsDefaultState } from '@internal-types/features/unifiedReports/defaultState'
 import { type ReportConfig } from '@schemas/features/unifiedReports/reportConfig'
 import {
   UnifiedReportStoreProvider,
@@ -15,7 +14,7 @@ import { renderHookWithAuth } from '@testUtils/render/renderHookWithAuth'
 
 // `renderHookWithAuth` spreads options over its own default wrapper, so this has to nest
 // `LayerTestProvider` itself or auth never lands.
-const renderWithReportStore = (props?: { defaultState?: UnifiedReportsDefaultState }) =>
+const renderUnifiedReportStore = (props: Partial<ComponentProps<typeof UnifiedReportStoreProvider>> = {}) =>
   renderHookWithAuth(useBaseUnifiedReport, {
     wrapper: ({ children }: PropsWithChildren) => (
       <LayerTestProvider>
@@ -34,13 +33,13 @@ afterEach(() => vi.restoreAllMocks())
 
 describe('UnifiedReportStoreProvider', () => {
   it('hydrates to the server default report when no key is requested', async () => {
-    const { result } = await renderWithReportStore()
+    const { result } = await renderUnifiedReportStore()
 
     await waitFor(() => expect(result.current.baseReport?.key).toBe('PROFIT_AND_LOSS'))
   })
 
   it('hydrates to the requested report', async () => {
-    const { result } = await renderWithReportStore({ defaultState: { reportKey: 'BALANCE_SHEET' } })
+    const { result } = await renderUnifiedReportStore({ defaultState: { reportKey: 'BALANCE_SHEET' } })
 
     await waitFor(() => expect(result.current.baseReport?.key).toBe('BALANCE_SHEET'))
   })
@@ -48,21 +47,18 @@ describe('UnifiedReportStoreProvider', () => {
   it('warns and falls back to the default report when the requested key is unknown', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    const { result } = await renderWithReportStore({ defaultState: { reportKey: 'NOT_A_REPORT' } })
+    const { result } = await renderUnifiedReportStore({ defaultState: { reportKey: 'NOT_A_REPORT' } })
 
     await waitFor(() => expect(result.current.baseReport?.key).toBe('PROFIT_AND_LOSS'))
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('NOT_A_REPORT'))
   })
 
   it('does not re-assert the requested report over user navigation', async () => {
-    const { result, rerender } = await renderWithReportStore({ defaultState: { reportKey: 'BALANCE_SHEET' } })
+    const { result } = await renderUnifiedReportStore({ defaultState: { reportKey: 'BALANCE_SHEET' } })
 
     await waitFor(() => expect(result.current.baseReport?.key).toBe('BALANCE_SHEET'))
 
-    act(() => result.current.setBaseReport(fixtureReport('TRIAL_BALANCE')))
-    expect(result.current.baseReport?.key).toBe('TRIAL_BALANCE')
-
-    rerender()
-    expect(result.current.baseReport?.key).toBe('TRIAL_BALANCE')
+    result.current.setBaseReport(fixtureReport('TRIAL_BALANCE'))
+    await waitFor(() => expect(result.current.baseReport?.key).toBe('TRIAL_BALANCE'))
   })
 })

--- a/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.test.tsx
+++ b/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.test.tsx
@@ -2,6 +2,7 @@ import { type PropsWithChildren } from 'react'
 import { act, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { type UnifiedReportsDefaultState } from '@internal-types/features/unifiedReports/defaultState'
 import { type ReportConfig } from '@schemas/features/unifiedReports/reportConfig'
 import {
   UnifiedReportStoreProvider,
@@ -14,7 +15,7 @@ import { renderHookWithAuth } from '@testUtils/render/renderHookWithAuth'
 
 // `renderHookWithAuth` spreads options over its own default wrapper, so this has to nest
 // `LayerTestProvider` itself or auth never lands.
-const renderWithReportStore = (props?: { defaultReportKey?: string }) =>
+const renderWithReportStore = (props?: { defaultState?: UnifiedReportsDefaultState }) =>
   renderHookWithAuth(useBaseUnifiedReport, {
     wrapper: ({ children }: PropsWithChildren) => (
       <LayerTestProvider>
@@ -39,7 +40,7 @@ describe('UnifiedReportStoreProvider', () => {
   })
 
   it('hydrates to the requested report', async () => {
-    const { result } = await renderWithReportStore({ defaultReportKey: 'BALANCE_SHEET' })
+    const { result } = await renderWithReportStore({ defaultState: { reportKey: 'BALANCE_SHEET' } })
 
     await waitFor(() => expect(result.current.baseReport?.key).toBe('BALANCE_SHEET'))
   })
@@ -47,14 +48,14 @@ describe('UnifiedReportStoreProvider', () => {
   it('warns and falls back to the default report when the requested key is unknown', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    const { result } = await renderWithReportStore({ defaultReportKey: 'NOT_A_REPORT' })
+    const { result } = await renderWithReportStore({ defaultState: { reportKey: 'NOT_A_REPORT' } })
 
     await waitFor(() => expect(result.current.baseReport?.key).toBe('PROFIT_AND_LOSS'))
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('NOT_A_REPORT'))
   })
 
   it('does not re-assert the requested report over user navigation', async () => {
-    const { result, rerender } = await renderWithReportStore({ defaultReportKey: 'BALANCE_SHEET' })
+    const { result, rerender } = await renderWithReportStore({ defaultState: { reportKey: 'BALANCE_SHEET' } })
 
     await waitFor(() => expect(result.current.baseReport?.key).toBe('BALANCE_SHEET'))
 

--- a/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.test.tsx
+++ b/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.test.tsx
@@ -1,0 +1,129 @@
+import { type PropsWithChildren } from 'react'
+import { act, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ReportingBasis } from '@schemas/features/business/accountingConfiguration'
+import { type TagDimension } from '@schemas/features/tags/tagDimension'
+import { type ReportConfig, ReportControl, type ReportGroup } from '@schemas/features/unifiedReports/reportConfig'
+import {
+  UnifiedReportStoreProvider,
+  useBaseUnifiedReport,
+  useUnifiedReportReportingBasisParam,
+  useUnifiedReportTagSelection,
+} from '@providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider'
+
+import { makeTagValueDefinition } from '@fixtures/tagDimensions/mocks'
+import { defaultReportGroups } from '@fixtures/unifiedReports/reportConfig'
+import { get as getReportConfig } from '@msw/api/businesses/[business-id]/reports/config/get'
+import { server } from '@msw/node'
+import { LayerTestProvider } from '@testUtils/render/LayerTestProvider'
+import { renderHookWithAuth } from '@testUtils/render/renderHookWithAuth'
+
+const useUnifiedReportStoreForTest = () => ({
+  ...useBaseUnifiedReport(),
+  ...useUnifiedReportReportingBasisParam(),
+  ...useUnifiedReportTagSelection(),
+})
+
+// `renderHookWithAuth` spreads options over its own default wrapper, so this has to nest
+// `LayerTestProvider` itself or auth never lands.
+const renderWithReportStore = (props?: { defaultReportKey?: string }) =>
+  renderHookWithAuth(useUnifiedReportStoreForTest, {
+    wrapper: ({ children }: PropsWithChildren) => (
+      <LayerTestProvider>
+        <UnifiedReportStoreProvider {...props}>{children}</UnifiedReportStoreProvider>
+      </LayerTestProvider>
+    ),
+  })
+
+const fixtureReport = (key: string): ReportConfig => {
+  const report = defaultReportGroups.flatMap(({ reports }) => reports).find(report => report.key === key)
+  if (!report) throw new Error(`Missing fixture report: ${key}`)
+  return report
+}
+
+const TAG_DIMENSION: TagDimension = {
+  id: '00000000-0000-4000-8000-000000000401',
+  key: 'job',
+  displayName: 'Job',
+  strictness: 'NON_BALANCING',
+  definedValues: [],
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+  userVisible: true,
+}
+
+const INITIAL_TAG_VALUE = makeTagValueDefinition({
+  id: '00000000-0000-4000-8000-000000000411',
+  key: 'job',
+  value: 'smith-kitchen-remodel',
+  displayName: 'Smith – Kitchen Remodel',
+})
+
+// The shared fixtures carry no reporting basis or tags, so the store's initial values would pass
+// the assertions below either way; this config makes `setBaseReport`'s coupled resets observable.
+const CONFIG_WITH_CONTROLS: readonly ReportGroup[] = [
+  {
+    groupType: 'accounting',
+    displayName: 'Accounting',
+    reports: [
+      {
+        key: 'PROFIT_AND_LOSS',
+        reportRoute: 'profit-and-loss',
+        displayName: 'Profit & Loss',
+        controls: [ReportControl.DateRange, ReportControl.ReportingBasis],
+        baseQueryParameters: {},
+        isDefaultReport: true,
+      },
+      {
+        key: 'BALANCE_SHEET',
+        reportRoute: 'balance-sheet',
+        displayName: 'Balance Sheet',
+        controls: [ReportControl.Date, ReportControl.ReportingBasis],
+        baseQueryParameters: { reporting_basis: ReportingBasis.Cash },
+        tagControl: { tagDimension: TAG_DIMENSION, initialSelectedTags: [INITIAL_TAG_VALUE] },
+      },
+    ],
+  },
+]
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('UnifiedReportStoreProvider', () => {
+  it('hydrates to the server default report when no key is requested', async () => {
+    const { result } = await renderWithReportStore()
+
+    await waitFor(() => expect(result.current.baseReport?.key).toBe('PROFIT_AND_LOSS'))
+  })
+
+  it('hydrates to the requested report and initializes its controls', async () => {
+    server.use(getReportConfig.mock(CONFIG_WITH_CONTROLS))
+
+    const { result } = await renderWithReportStore({ defaultReportKey: 'BALANCE_SHEET' })
+
+    await waitFor(() => expect(result.current.baseReport?.key).toBe('BALANCE_SHEET'))
+    expect(result.current.reportingBasis).toBe(ReportingBasis.Cash)
+    expect(result.current.selectedTagValues).toEqual([INITIAL_TAG_VALUE])
+  })
+
+  it('warns and falls back to the default report when the requested key is unknown', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { result } = await renderWithReportStore({ defaultReportKey: 'NOT_A_REPORT' })
+
+    await waitFor(() => expect(result.current.baseReport?.key).toBe('PROFIT_AND_LOSS'))
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('NOT_A_REPORT'))
+  })
+
+  it('does not re-assert the requested report over user navigation', async () => {
+    const { result, rerender } = await renderWithReportStore({ defaultReportKey: 'BALANCE_SHEET' })
+
+    await waitFor(() => expect(result.current.baseReport?.key).toBe('BALANCE_SHEET'))
+
+    act(() => result.current.setBaseReport(fixtureReport('TRIAL_BALANCE')))
+    expect(result.current.baseReport?.key).toBe('TRIAL_BALANCE')
+
+    rerender()
+    expect(result.current.baseReport?.key).toBe('TRIAL_BALANCE')
+  })
+})

--- a/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.test.tsx
+++ b/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.test.tsx
@@ -39,7 +39,7 @@ describe('UnifiedReportStoreProvider', () => {
   })
 
   it('hydrates to the requested report', async () => {
-    const { result } = await renderUnifiedReportStore({ defaultState: { reportKey: 'BALANCE_SHEET' } })
+    const { result } = await renderUnifiedReportStore({ initialState: { reportKey: 'BALANCE_SHEET' } })
 
     await waitFor(() => expect(result.current.baseReport?.key).toBe('BALANCE_SHEET'))
   })
@@ -47,14 +47,14 @@ describe('UnifiedReportStoreProvider', () => {
   it('warns and falls back to the default report when the requested key is unknown', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    const { result } = await renderUnifiedReportStore({ defaultState: { reportKey: 'NOT_A_REPORT' } })
+    const { result } = await renderUnifiedReportStore({ initialState: { reportKey: 'NOT_A_REPORT' } })
 
     await waitFor(() => expect(result.current.baseReport?.key).toBe('PROFIT_AND_LOSS'))
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('NOT_A_REPORT'))
   })
 
   it('does not re-assert the requested report over user navigation', async () => {
-    const { result } = await renderUnifiedReportStore({ defaultState: { reportKey: 'BALANCE_SHEET' } })
+    const { result } = await renderUnifiedReportStore({ initialState: { reportKey: 'BALANCE_SHEET' } })
 
     await waitFor(() => expect(result.current.baseReport?.key).toBe('BALANCE_SHEET'))
 

--- a/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.test.tsx
+++ b/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.test.tsx
@@ -2,33 +2,20 @@ import { type PropsWithChildren } from 'react'
 import { act, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { ReportingBasis } from '@schemas/features/business/accountingConfiguration'
-import { type TagDimension } from '@schemas/features/tags/tagDimension'
-import { type ReportConfig, ReportControl, type ReportGroup } from '@schemas/features/unifiedReports/reportConfig'
+import { type ReportConfig } from '@schemas/features/unifiedReports/reportConfig'
 import {
   UnifiedReportStoreProvider,
   useBaseUnifiedReport,
-  useUnifiedReportReportingBasisParam,
-  useUnifiedReportTagSelection,
 } from '@providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider'
 
-import { makeTagValueDefinition } from '@fixtures/tagDimensions/mocks'
 import { defaultReportGroups } from '@fixtures/unifiedReports/reportConfig'
-import { get as getReportConfig } from '@msw/api/businesses/[business-id]/reports/config/get'
-import { server } from '@msw/node'
 import { LayerTestProvider } from '@testUtils/render/LayerTestProvider'
 import { renderHookWithAuth } from '@testUtils/render/renderHookWithAuth'
-
-const useUnifiedReportStoreForTest = () => ({
-  ...useBaseUnifiedReport(),
-  ...useUnifiedReportReportingBasisParam(),
-  ...useUnifiedReportTagSelection(),
-})
 
 // `renderHookWithAuth` spreads options over its own default wrapper, so this has to nest
 // `LayerTestProvider` itself or auth never lands.
 const renderWithReportStore = (props?: { defaultReportKey?: string }) =>
-  renderHookWithAuth(useUnifiedReportStoreForTest, {
+  renderHookWithAuth(useBaseUnifiedReport, {
     wrapper: ({ children }: PropsWithChildren) => (
       <LayerTestProvider>
         <UnifiedReportStoreProvider {...props}>{children}</UnifiedReportStoreProvider>
@@ -42,51 +29,6 @@ const fixtureReport = (key: string): ReportConfig => {
   return report
 }
 
-const TAG_DIMENSION: TagDimension = {
-  id: '00000000-0000-4000-8000-000000000401',
-  key: 'job',
-  displayName: 'Job',
-  strictness: 'NON_BALANCING',
-  definedValues: [],
-  createdAt: new Date('2024-01-01T00:00:00.000Z'),
-  updatedAt: new Date('2024-01-01T00:00:00.000Z'),
-  userVisible: true,
-}
-
-const INITIAL_TAG_VALUE = makeTagValueDefinition({
-  id: '00000000-0000-4000-8000-000000000411',
-  key: 'job',
-  value: 'smith-kitchen-remodel',
-  displayName: 'Smith – Kitchen Remodel',
-})
-
-// The shared fixtures carry no reporting basis or tags, so the store's initial values would pass
-// the assertions below either way; this config makes `setBaseReport`'s coupled resets observable.
-const CONFIG_WITH_CONTROLS: readonly ReportGroup[] = [
-  {
-    groupType: 'accounting',
-    displayName: 'Accounting',
-    reports: [
-      {
-        key: 'PROFIT_AND_LOSS',
-        reportRoute: 'profit-and-loss',
-        displayName: 'Profit & Loss',
-        controls: [ReportControl.DateRange, ReportControl.ReportingBasis],
-        baseQueryParameters: {},
-        isDefaultReport: true,
-      },
-      {
-        key: 'BALANCE_SHEET',
-        reportRoute: 'balance-sheet',
-        displayName: 'Balance Sheet',
-        controls: [ReportControl.Date, ReportControl.ReportingBasis],
-        baseQueryParameters: { reporting_basis: ReportingBasis.Cash },
-        tagControl: { tagDimension: TAG_DIMENSION, initialSelectedTags: [INITIAL_TAG_VALUE] },
-      },
-    ],
-  },
-]
-
 afterEach(() => vi.restoreAllMocks())
 
 describe('UnifiedReportStoreProvider', () => {
@@ -96,14 +38,10 @@ describe('UnifiedReportStoreProvider', () => {
     await waitFor(() => expect(result.current.baseReport?.key).toBe('PROFIT_AND_LOSS'))
   })
 
-  it('hydrates to the requested report and initializes its controls', async () => {
-    server.use(getReportConfig.mock(CONFIG_WITH_CONTROLS))
-
+  it('hydrates to the requested report', async () => {
     const { result } = await renderWithReportStore({ defaultReportKey: 'BALANCE_SHEET' })
 
     await waitFor(() => expect(result.current.baseReport?.key).toBe('BALANCE_SHEET'))
-    expect(result.current.reportingBasis).toBe(ReportingBasis.Cash)
-    expect(result.current.selectedTagValues).toEqual([INITIAL_TAG_VALUE])
   })
 
   it('warns and falls back to the default report when the requested key is unknown', async () => {

--- a/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.tsx
+++ b/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.tsx
@@ -239,16 +239,11 @@ const findDefaultReport = (groups: ReadonlyArray<ReportGroup>): ReportConfig | n
   return firstReport
 }
 
-const hasReportWithKey = (groups: ReadonlyArray<ReportGroup>, key: string): boolean =>
-  groups.some(group => group.reports.some(report => report.key === key))
+const findReportByKey = (groups: ReadonlyArray<ReportGroup>, key: string): ReportConfig | null =>
+  groups.flatMap(({ reports }) => reports).find(report => report.key === key) ?? null
 
-const findReportByKey = (groups: ReadonlyArray<ReportGroup>, key: string): ReportConfig | null => {
-  for (const group of groups) {
-    const match = group.reports.find(report => report.key === key)
-    if (match) return match
-  }
-  return null
-}
+const hasReportWithKey = (groups: ReadonlyArray<ReportGroup>, key: string): boolean =>
+  findReportByKey(groups, key) != null
 
 const createUnifiedReportStore = (dateSelectionMode: DateSelectionMode) =>
   createStore<UnifiedReportStoreShape>(set => ({

--- a/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.tsx
+++ b/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.tsx
@@ -241,6 +241,14 @@ const findDefaultReport = (groups: ReadonlyArray<ReportGroup>): ReportConfig | n
 const hasReportWithKey = (groups: ReadonlyArray<ReportGroup>, key: string): boolean =>
   groups.some(group => group.reports.some(report => report.key === key))
 
+const findReportByKey = (groups: ReadonlyArray<ReportGroup>, key: string): ReportConfig | null => {
+  for (const group of groups) {
+    const match = group.reports.find(report => report.key === key)
+    if (match) return match
+  }
+  return null
+}
+
 const createUnifiedReportStore = (dateSelectionMode: DateSelectionMode) =>
   createStore<UnifiedReportStoreShape>(set => ({
     baseReport: null,
@@ -266,7 +274,7 @@ const createUnifiedReportStore = (dateSelectionMode: DateSelectionMode) =>
     },
   }))
 
-function useHydrateUnifiedReportStore(store: StoreApi<UnifiedReportStoreShape>) {
+function useHydrateUnifiedReportStore(store: StoreApi<UnifiedReportStoreShape>, defaultReportKey?: string) {
   const { data } = useGetReportConfig()
   const baseReport = useStore(store, state => state.baseReport)
   const setBaseReport = useStore(store, state => state.actions.setBaseReport)
@@ -275,9 +283,14 @@ function useHydrateUnifiedReportStore(store: StoreApi<UnifiedReportStoreShape>) 
     if (!data) return
     if (baseReport && hasReportWithKey(data, baseReport.key)) return
 
-    const defaultReport = findDefaultReport(data)
-    if (defaultReport) setBaseReport(defaultReport)
-  }, [data, baseReport, setBaseReport])
+    const requestedReport = defaultReportKey != null ? findReportByKey(data, defaultReportKey) : null
+    if (defaultReportKey != null && requestedReport == null) {
+      console.warn(`UnifiedReports: no report with key "${defaultReportKey}" in this business's report config; falling back to the default report.`)
+    }
+
+    const report = requestedReport ?? findDefaultReport(data)
+    if (report) setBaseReport(report)
+  }, [data, baseReport, setBaseReport, defaultReportKey])
 }
 
 function useSyncExternalDateSelectionMode(store: StoreApi<UnifiedReportStoreShape>, dateSelectionMode: DateSelectionMode) {
@@ -288,11 +301,16 @@ function useSyncExternalDateSelectionMode(store: StoreApi<UnifiedReportStoreShap
 
 type UnifiedReportStoreProviderProps = {
   dateSelectionMode?: DateSelectionMode
+  defaultReportKey?: string
 }
 
-export function UnifiedReportStoreProvider({ children, dateSelectionMode = 'full' }: PropsWithChildren<UnifiedReportStoreProviderProps>) {
+export function UnifiedReportStoreProvider({
+  children,
+  dateSelectionMode = 'full',
+  defaultReportKey,
+}: PropsWithChildren<UnifiedReportStoreProviderProps>) {
   const [store] = useState(() => createUnifiedReportStore(dateSelectionMode))
-  useHydrateUnifiedReportStore(store)
+  useHydrateUnifiedReportStore(store, defaultReportKey)
   useSyncExternalDateSelectionMode(store, dateSelectionMode)
 
   return (

--- a/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.tsx
+++ b/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.tsx
@@ -2,6 +2,7 @@ import { createContext, type PropsWithChildren, useCallback, useContext, useEffe
 import { getYear } from 'date-fns'
 import { createStore, type StoreApi, useStore } from 'zustand'
 
+import type { UnifiedReportsDefaultState } from '@internal-types/features/unifiedReports/defaultState'
 import { LayerEventComponent, LayerEventType } from '@schemas/common/layerEvents'
 import { isActiveTagValueDefinition, type TagValueDefinition } from '@schemas/features/tags/tagValueDefinition'
 import {
@@ -274,10 +275,11 @@ const createUnifiedReportStore = (dateSelectionMode: DateSelectionMode) =>
     },
   }))
 
-function useHydrateUnifiedReportStore(store: StoreApi<UnifiedReportStoreShape>, defaultReportKey?: string) {
+function useHydrateUnifiedReportStore(store: StoreApi<UnifiedReportStoreShape>, defaultState?: UnifiedReportsDefaultState) {
   const { data } = useGetReportConfig()
   const baseReport = useStore(store, state => state.baseReport)
   const setBaseReport = useStore(store, state => state.actions.setBaseReport)
+  const defaultReportKey = defaultState?.reportKey
 
   useEffect(() => {
     if (!data) return
@@ -301,16 +303,16 @@ function useSyncExternalDateSelectionMode(store: StoreApi<UnifiedReportStoreShap
 
 type UnifiedReportStoreProviderProps = {
   dateSelectionMode?: DateSelectionMode
-  defaultReportKey?: string
+  defaultState?: UnifiedReportsDefaultState
 }
 
 export function UnifiedReportStoreProvider({
   children,
   dateSelectionMode = 'full',
-  defaultReportKey,
+  defaultState,
 }: PropsWithChildren<UnifiedReportStoreProviderProps>) {
   const [store] = useState(() => createUnifiedReportStore(dateSelectionMode))
-  useHydrateUnifiedReportStore(store, defaultReportKey)
+  useHydrateUnifiedReportStore(store, defaultState)
   useSyncExternalDateSelectionMode(store, dateSelectionMode)
 
   return (

--- a/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.tsx
+++ b/src/providers/features/unifiedReports/UnifiedReportStore/UnifiedReportStoreProvider.tsx
@@ -2,7 +2,7 @@ import { createContext, type PropsWithChildren, useCallback, useContext, useEffe
 import { getYear } from 'date-fns'
 import { createStore, type StoreApi, useStore } from 'zustand'
 
-import type { UnifiedReportsDefaultState } from '@internal-types/features/unifiedReports/defaultState'
+import type { UnifiedReportsInitialState } from '@internal-types/features/unifiedReports/initialState'
 import { LayerEventComponent, LayerEventType } from '@schemas/common/layerEvents'
 import { isActiveTagValueDefinition, type TagValueDefinition } from '@schemas/features/tags/tagValueDefinition'
 import {
@@ -270,11 +270,11 @@ const createUnifiedReportStore = (dateSelectionMode: DateSelectionMode) =>
     },
   }))
 
-function useHydrateUnifiedReportStore(store: StoreApi<UnifiedReportStoreShape>, defaultState?: UnifiedReportsDefaultState) {
+function useHydrateUnifiedReportStore(store: StoreApi<UnifiedReportStoreShape>, initialState?: UnifiedReportsInitialState) {
   const { data } = useGetReportConfig()
   const baseReport = useStore(store, state => state.baseReport)
   const setBaseReport = useStore(store, state => state.actions.setBaseReport)
-  const defaultReportKey = defaultState?.reportKey
+  const defaultReportKey = initialState?.reportKey
 
   useEffect(() => {
     if (!data) return
@@ -298,16 +298,16 @@ function useSyncExternalDateSelectionMode(store: StoreApi<UnifiedReportStoreShap
 
 type UnifiedReportStoreProviderProps = {
   dateSelectionMode?: DateSelectionMode
-  defaultState?: UnifiedReportsDefaultState
+  initialState?: UnifiedReportsInitialState
 }
 
 export function UnifiedReportStoreProvider({
   children,
   dateSelectionMode = 'full',
-  defaultState,
+  initialState,
 }: PropsWithChildren<UnifiedReportStoreProviderProps>) {
   const [store] = useState(() => createUnifiedReportStore(dateSelectionMode))
-  useHydrateUnifiedReportStore(store, defaultState)
+  useHydrateUnifiedReportStore(store, initialState)
   useSyncExternalDateSelectionMode(store, dateSelectionMode)
 
   return (

--- a/src/types/features/unifiedReports/defaultState.ts
+++ b/src/types/features/unifiedReports/defaultState.ts
@@ -1,3 +1,0 @@
-export type UnifiedReportsDefaultState = {
-  reportKey?: string
-}

--- a/src/types/features/unifiedReports/defaultState.ts
+++ b/src/types/features/unifiedReports/defaultState.ts
@@ -1,0 +1,3 @@
+export type UnifiedReportsDefaultState = {
+  reportKey?: string
+}

--- a/src/types/features/unifiedReports/initialState.ts
+++ b/src/types/features/unifiedReports/initialState.ts
@@ -1,0 +1,3 @@
+export type UnifiedReportsInitialState = {
+  reportKey?: string
+}

--- a/src/views/UnifiedReports/UnifiedReports.stories.tsx
+++ b/src/views/UnifiedReports/UnifiedReports.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
 import { userEvent, within } from 'storybook/test'
 
-import { type UnifiedReportsDefaultState } from '@internal-types/features/unifiedReports/defaultState'
+import { type UnifiedReportsInitialState } from '@internal-types/features/unifiedReports/initialState'
 import { type UnifiedReportNavigationVariant } from '@internal-types/features/unifiedReports/navigationVariant'
 import { type DateSelectionMode } from '@utils/shared/date/dateRange'
 import { UnifiedReports } from '@views/UnifiedReports/UnifiedReports'
@@ -10,7 +10,7 @@ type UnifiedReportsStoryArgs = {
   navigationVariant: UnifiedReportNavigationVariant
   showTitle: boolean
   dateSelectionMode: DateSelectionMode
-  defaultState?: UnifiedReportsDefaultState
+  initialState?: UnifiedReportsInitialState
 }
 
 const meta: Meta<UnifiedReportsStoryArgs> = {
@@ -18,7 +18,7 @@ const meta: Meta<UnifiedReportsStoryArgs> = {
   tags: ['public-api'],
   component: UnifiedReports,
   parameters: {
-    controls: { include: ['navigationVariant', 'showTitle', 'dateSelectionMode', 'defaultState'] },
+    controls: { include: ['navigationVariant', 'showTitle', 'dateSelectionMode', 'initialState'] },
   },
   args: {
     navigationVariant: 'sidebar',
@@ -40,7 +40,7 @@ const meta: Meta<UnifiedReportsStoryArgs> = {
       options: ['full', 'month', 'year'] satisfies DateSelectionMode[],
       description: 'How report controls read from the global date store.',
     },
-    defaultState: {
+    initialState: {
       control: false,
       description: 'Initial landing state (e.g. `{ reportKey: "BALANCE_SHEET" }`), applied when the report configuration first loads. See the `DeepLinkedReport` story.',
     },
@@ -60,7 +60,7 @@ export const MenuNavigation: Story = {
 }
 
 export const DeepLinkedReport: Story = {
-  args: { defaultState: { reportKey: 'BALANCE_SHEET' } },
+  args: { initialState: { reportKey: 'BALANCE_SHEET' } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 

--- a/src/views/UnifiedReports/UnifiedReports.stories.tsx
+++ b/src/views/UnifiedReports/UnifiedReports.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
 import { userEvent, within } from 'storybook/test'
 
+import { type UnifiedReportsDefaultState } from '@internal-types/features/unifiedReports/defaultState'
 import { type UnifiedReportNavigationVariant } from '@internal-types/features/unifiedReports/navigationVariant'
 import { type DateSelectionMode } from '@utils/shared/date/dateRange'
 import { UnifiedReports } from '@views/UnifiedReports/UnifiedReports'
@@ -9,17 +10,15 @@ type UnifiedReportsStoryArgs = {
   navigationVariant: UnifiedReportNavigationVariant
   showTitle: boolean
   dateSelectionMode: DateSelectionMode
-  defaultReportKey?: string
+  defaultState?: UnifiedReportsDefaultState
 }
-
-const REPORT_KEYS = ['PROFIT_AND_LOSS', 'BALANCE_SHEET', 'CASHFLOW_STATEMENT', 'TRIAL_BALANCE', 'AR_AGING']
 
 const meta: Meta<UnifiedReportsStoryArgs> = {
   title: 'Components/UnifiedReports',
   tags: ['public-api'],
   component: UnifiedReports,
   parameters: {
-    controls: { include: ['navigationVariant', 'showTitle', 'dateSelectionMode', 'defaultReportKey'] },
+    controls: { include: ['navigationVariant', 'showTitle', 'dateSelectionMode', 'defaultState'] },
   },
   args: {
     navigationVariant: 'sidebar',
@@ -41,10 +40,9 @@ const meta: Meta<UnifiedReportsStoryArgs> = {
       options: ['full', 'month', 'year'] satisfies DateSelectionMode[],
       description: 'How report controls read from the global date store.',
     },
-    defaultReportKey: {
-      control: 'select',
-      options: REPORT_KEYS,
-      description: 'Report to land on instead of the default report. Read once when the report configuration loads, so changing this control does not switch the report — reload the story to see it apply.',
+    defaultState: {
+      control: 'object',
+      description: 'Initial landing state (e.g. `{ reportKey: "BALANCE_SHEET" }`). Read once when the report configuration loads, so changing this control does not switch the report — reload the story to see it apply.',
     },
   },
 }
@@ -61,10 +59,10 @@ export const MenuNavigation: Story = {
   args: { navigationVariant: 'menu' },
 }
 
-// `defaultReportKey` is read once at hydration, so changing the control on `Default` re-renders
+// `defaultState` is read once at hydration, so changing the control on `Default` re-renders
 // without switching the report — only a fresh mount shows the behavior.
 export const DeepLinkedReport: Story = {
-  args: { defaultReportKey: 'BALANCE_SHEET' },
+  args: { defaultState: { reportKey: 'BALANCE_SHEET' } },
   // The report heading only renders in the desktop base header, so the play function
   // needs a desktop width to assert against.
   parameters: { chromatic: { viewports: [1280] } },

--- a/src/views/UnifiedReports/UnifiedReports.stories.tsx
+++ b/src/views/UnifiedReports/UnifiedReports.stories.tsx
@@ -9,14 +9,17 @@ type UnifiedReportsStoryArgs = {
   navigationVariant: UnifiedReportNavigationVariant
   showTitle: boolean
   dateSelectionMode: DateSelectionMode
+  defaultReportKey?: string
 }
+
+const REPORT_KEYS = ['PROFIT_AND_LOSS', 'BALANCE_SHEET', 'CASHFLOW_STATEMENT', 'TRIAL_BALANCE', 'AR_AGING']
 
 const meta: Meta<UnifiedReportsStoryArgs> = {
   title: 'Components/UnifiedReports',
   tags: ['public-api'],
   component: UnifiedReports,
   parameters: {
-    controls: { include: ['navigationVariant', 'showTitle', 'dateSelectionMode'] },
+    controls: { include: ['navigationVariant', 'showTitle', 'dateSelectionMode', 'defaultReportKey'] },
   },
   args: {
     navigationVariant: 'sidebar',
@@ -38,6 +41,11 @@ const meta: Meta<UnifiedReportsStoryArgs> = {
       options: ['full', 'month', 'year'] satisfies DateSelectionMode[],
       description: 'How report controls read from the global date store.',
     },
+    defaultReportKey: {
+      control: 'select',
+      options: REPORT_KEYS,
+      description: 'Report to land on instead of the default report. Read once when the report configuration loads, so changing this control does not switch the report — reload the story to see it apply.',
+    },
   },
 }
 
@@ -51,6 +59,17 @@ export const Default: Story = {
 
 export const MenuNavigation: Story = {
   args: { navigationVariant: 'menu' },
+}
+
+// `defaultReportKey` is read once at hydration, so changing the control on `Default` re-renders
+// without switching the report — only a fresh mount shows the behavior.
+export const DeepLinkedReport: Story = {
+  args: { defaultReportKey: 'BALANCE_SHEET' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await canvas.findByRole('heading', { name: 'Balance Sheet' }, { timeout: 10_000 })
+  },
 }
 
 export const MegaMenuOpen: Story = {

--- a/src/views/UnifiedReports/UnifiedReports.stories.tsx
+++ b/src/views/UnifiedReports/UnifiedReports.stories.tsx
@@ -65,6 +65,9 @@ export const MenuNavigation: Story = {
 // without switching the report — only a fresh mount shows the behavior.
 export const DeepLinkedReport: Story = {
   args: { defaultReportKey: 'BALANCE_SHEET' },
+  // The report heading only renders in the desktop base header, so the play function
+  // needs a desktop width to assert against.
+  parameters: { chromatic: { viewports: [1280] } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 

--- a/src/views/UnifiedReports/UnifiedReports.stories.tsx
+++ b/src/views/UnifiedReports/UnifiedReports.stories.tsx
@@ -41,8 +41,8 @@ const meta: Meta<UnifiedReportsStoryArgs> = {
       description: 'How report controls read from the global date store.',
     },
     defaultState: {
-      control: 'object',
-      description: 'Initial landing state (e.g. `{ reportKey: "BALANCE_SHEET" }`). Read once when the report configuration loads, so changing this control does not switch the report — reload the story to see it apply.',
+      control: false,
+      description: 'Initial landing state (e.g. `{ reportKey: "BALANCE_SHEET" }`), applied when the report configuration first loads. See the `DeepLinkedReport` story.',
     },
   },
 }
@@ -59,13 +59,8 @@ export const MenuNavigation: Story = {
   args: { navigationVariant: 'menu' },
 }
 
-// `defaultState` is read once at hydration, so changing the control on `Default` re-renders
-// without switching the report — only a fresh mount shows the behavior.
 export const DeepLinkedReport: Story = {
   args: { defaultState: { reportKey: 'BALANCE_SHEET' } },
-  // The report heading only renders in the desktop base header, so the play function
-  // needs a desktop width to assert against.
-  parameters: { chromatic: { viewports: [1280] } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 

--- a/src/views/UnifiedReports/UnifiedReports.tsx
+++ b/src/views/UnifiedReports/UnifiedReports.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
+import type { UnifiedReportsDefaultState } from '@internal-types/features/unifiedReports/defaultState'
 import type { UnifiedReportNavigationVariant } from '@internal-types/features/unifiedReports/navigationVariant'
 import type { DateSelectionMode } from '@providers/global/GlobalDateStore/GlobalDateStoreProvider'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
@@ -18,12 +19,12 @@ type UnifiedReportProps = {
   navigationVariant?: UnifiedReportNavigationVariant
   showTitle?: boolean
   /**
-   * Report key (e.g. `PROFIT_AND_LOSS`) to land on instead of the default report.
+   * Initial landing state (e.g. `{ reportKey: 'PROFIT_AND_LOSS' }`) instead of the server default.
    * Read when the report configuration loads — later changes do not switch the report
-   * (`defaultValue` semantics). Unknown keys fall back to the default report with a console warning.
+   * (`defaultValue` semantics). Unknown report keys fall back to the default report with a console warning.
    * Report switches are observable via the `ReportsNavigated` event.
    */
-  defaultReportKey?: string
+  defaultState?: UnifiedReportsDefaultState
 }
 
 const UnifiedReportContent = ({
@@ -50,9 +51,9 @@ const UnifiedReportContent = ({
   )
 }
 
-export const UnifiedReports = ({ dateSelectionMode, navigationVariant, showTitle = true, defaultReportKey }: UnifiedReportProps) => {
+export const UnifiedReports = ({ dateSelectionMode, navigationVariant, showTitle = true, defaultState }: UnifiedReportProps) => {
   return (
-    <UnifiedReportStoreProvider dateSelectionMode={dateSelectionMode} defaultReportKey={defaultReportKey}>
+    <UnifiedReportStoreProvider dateSelectionMode={dateSelectionMode} defaultState={defaultState}>
       <ExpandableDataTableProvider>
         <UnifiedReportContent navigationVariant={navigationVariant} showTitle={showTitle} />
       </ExpandableDataTableProvider>

--- a/src/views/UnifiedReports/UnifiedReports.tsx
+++ b/src/views/UnifiedReports/UnifiedReports.tsx
@@ -18,12 +18,7 @@ type UnifiedReportProps = {
   dateSelectionMode?: DateSelectionMode
   navigationVariant?: UnifiedReportNavigationVariant
   showTitle?: boolean
-  /**
-   * Initial landing state (e.g. `{ reportKey: 'PROFIT_AND_LOSS' }`) instead of the server default.
-   * Read when the report configuration loads — later changes do not switch the report
-   * (`defaultValue` semantics). Unknown report keys fall back to the default report with a console warning.
-   * Report switches are observable via the `ReportsNavigated` event.
-   */
+  /** Report to land on instead of the server default; applied once, when the report configuration loads. */
   defaultState?: UnifiedReportsDefaultState
 }
 

--- a/src/views/UnifiedReports/UnifiedReports.tsx
+++ b/src/views/UnifiedReports/UnifiedReports.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import type { UnifiedReportsDefaultState } from '@internal-types/features/unifiedReports/defaultState'
+import type { UnifiedReportsInitialState } from '@internal-types/features/unifiedReports/initialState'
 import type { UnifiedReportNavigationVariant } from '@internal-types/features/unifiedReports/navigationVariant'
 import type { DateSelectionMode } from '@providers/global/GlobalDateStore/GlobalDateStoreProvider'
 import { useSizeClass } from '@hooks/utils/size/useWindowSize'
@@ -19,7 +19,7 @@ type UnifiedReportProps = {
   navigationVariant?: UnifiedReportNavigationVariant
   showTitle?: boolean
   /** Report to land on instead of the server default; applied once, when the report configuration loads. */
-  defaultState?: UnifiedReportsDefaultState
+  initialState?: UnifiedReportsInitialState
 }
 
 const UnifiedReportContent = ({
@@ -46,9 +46,9 @@ const UnifiedReportContent = ({
   )
 }
 
-export const UnifiedReports = ({ dateSelectionMode, navigationVariant, showTitle = true, defaultState }: UnifiedReportProps) => {
+export const UnifiedReports = ({ dateSelectionMode, navigationVariant, showTitle = true, initialState }: UnifiedReportProps) => {
   return (
-    <UnifiedReportStoreProvider dateSelectionMode={dateSelectionMode} defaultState={defaultState}>
+    <UnifiedReportStoreProvider dateSelectionMode={dateSelectionMode} initialState={initialState}>
       <ExpandableDataTableProvider>
         <UnifiedReportContent navigationVariant={navigationVariant} showTitle={showTitle} />
       </ExpandableDataTableProvider>

--- a/src/views/UnifiedReports/UnifiedReports.tsx
+++ b/src/views/UnifiedReports/UnifiedReports.tsx
@@ -17,6 +17,13 @@ type UnifiedReportProps = {
   dateSelectionMode?: DateSelectionMode
   navigationVariant?: UnifiedReportNavigationVariant
   showTitle?: boolean
+  /**
+   * Report key (e.g. `PROFIT_AND_LOSS`) to land on instead of the default report.
+   * Read when the report configuration loads — later changes do not switch the report
+   * (`defaultValue` semantics). Unknown keys fall back to the default report with a console warning.
+   * Report switches are observable via the `ReportsNavigated` event.
+   */
+  defaultReportKey?: string
 }
 
 const UnifiedReportContent = ({
@@ -43,9 +50,9 @@ const UnifiedReportContent = ({
   )
 }
 
-export const UnifiedReports = ({ dateSelectionMode, navigationVariant, showTitle = true }: UnifiedReportProps) => {
+export const UnifiedReports = ({ dateSelectionMode, navigationVariant, showTitle = true, defaultReportKey }: UnifiedReportProps) => {
   return (
-    <UnifiedReportStoreProvider dateSelectionMode={dateSelectionMode}>
+    <UnifiedReportStoreProvider dateSelectionMode={dateSelectionMode} defaultReportKey={defaultReportKey}>
       <ExpandableDataTableProvider>
         <UnifiedReportContent navigationVariant={navigationVariant} showTitle={showTitle} />
       </ExpandableDataTableProvider>


### PR DESCRIPTION
## Description

Adds an optional `initialState` prop to `UnifiedReports` so consumers can deep link to a specific report instead of always landing on P&L. Public API change. Shaped as an object so more landing params can be added later without new top-level props.

## Changes

* Hydration prefers `initialState.reportKey` over the server default; unknown keys warn and fall back
* Read once when config loads, never overrides user navigation
* Provider tests + `DeepLinkedReport` story

Consumers pass `{ reportKey }` at mount. Valid keys come from `/v1/businesses/{id}/reports/config`, which is per business.

## Blockers

None.

## How this has been tested?

* `npm test -- --run` (4 new tests), typecheck, lint
* Storybook: `DeepLinkedReport` lands on Balance Sheet, `Default` still on P&L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small public API addition with guarded hydration and tests; no auth or data-path changes.
> 
> **Overview**
> Adds optional **`initialState`** on **`UnifiedReports`** (and the store provider) so embedders can open a specific report instead of the server default—e.g. `{ reportKey: "BALANCE_SHEET" }` for deep links.
> 
> On first load after report config arrives, hydration picks **`initialState.reportKey`** when it exists in the business config; otherwise behavior is unchanged. Unknown keys **`console.warn`** and fall back to the default report. The requested key is applied only for initial hydration—it does not fight later user navigation.
> 
> Provider tests cover default hydration, requested key, invalid key fallback, and navigation after hydrate. Storybook adds **`DeepLinkedReport`** for Balance Sheet landing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8ff0b10b462040c0fce87923e8368da76b8e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->