### PR TITLE
[LAY-2618] Chart config (1/3): make the shared donut and P&L line stylable

### DIFF
--- a/src/components/blocks/DetailedChart/DetailedChart.tsx
+++ b/src/components/blocks/DetailedChart/DetailedChart.tsx
@@ -29,11 +29,17 @@ export type DetailedChartProps<T extends SeriesData> = {
   stylingProps: {
     colorSelector: ColorSelector<T>
     fallbackFillSelector?: FallbackFillSelector<T>
+    fallbackFillColor?: string
+    innerRadius?: string | number
+    outerRadius?: string | number
   }
   slots?: {
     Header?: React.ReactNode
   }
 }
+
+const DEFAULT_INNER_RADIUS = '91%'
+const DEFAULT_OUTER_RADIUS = '100%'
 
 export const DetailedChart = <T extends SeriesData>({
   data,
@@ -45,6 +51,9 @@ export const DetailedChart = <T extends SeriesData>({
   const { t } = useTranslation()
   const { formatPercent, formatCurrencyFromCents } = useIntlFormatter()
   const { data: chartData, total } = data
+
+  const innerRadius = stylingProps.innerRadius ?? DEFAULT_INNER_RADIUS
+  const outerRadius = stylingProps.outerRadius ?? DEFAULT_OUTER_RADIUS
 
   const normalizedChartData = useMemo(() => chartData.map(x => ({
     ...x,
@@ -169,8 +178,8 @@ export const DetailedChart = <T extends SeriesData>({
                   nameKey='displayName'
                   cx='50%'
                   cy='50%'
-                  innerRadius='91%'
-                  outerRadius='100%'
+                  innerRadius={innerRadius}
+                  outerRadius={outerRadius}
                   paddingAngle={0}
                   fill='#F8F8FA'
                   animationDuration={200}
@@ -186,8 +195,8 @@ export const DetailedChart = <T extends SeriesData>({
                   nameKey='displayName'
                   cx='50%'
                   cy='50%'
-                  innerRadius='91%'
-                  outerRadius='100%'
+                  innerRadius={innerRadius}
+                  outerRadius={outerRadius}
                   paddingAngle={0.5}
                   fill='#8884d8'
                   animationDuration={200}
@@ -211,7 +220,7 @@ export const DetailedChart = <T extends SeriesData>({
                           interactionProps.hoveredItem && !active && 'Layer__DetailedChart__Slice--inactive',
                         )}
                         fill={isFallbackSlice && fill
-                          ? 'url(#layer-pie-dots-pattern)'
+                          ? stylingProps.fallbackFillColor ?? 'url(#layer-pie-dots-pattern)'
                           : fill}
                         opacity={colorMapping.opacity}
                         onMouseEnter={() => interactionProps.setHoveredItem(entry)}

--- a/src/components/blocks/DetailedTable/DetailedTable.tsx
+++ b/src/components/blocks/DetailedTable/DetailedTable.tsx
@@ -34,6 +34,7 @@ interface DetailedTableBaseProps<T extends SeriesData> {
   stylingProps: {
     colorSelector: ColorSelector<T>
     fallbackFillSelector?: FallbackFillSelector<T>
+    fallbackFillColor?: string
   }
   interactionProps: {
     hoveredItem: T | undefined

--- a/src/components/blocks/DetailedTable/ValueIcon.tsx
+++ b/src/components/blocks/DetailedTable/ValueIcon.tsx
@@ -7,12 +7,17 @@ export const ValueIcon = <T extends SeriesData>({
   item,
   colorSelector,
   fallbackFillSelector,
+  fallbackFillColor,
 }: {
   item: T
   colorSelector: ColorSelector<T>
   fallbackFillSelector?: FallbackFillSelector<T>
+  fallbackFillColor?: string
 }) => {
   if (fallbackFillSelector?.(item)) {
+    if (fallbackFillColor) {
+      return <RegularValueIcon colorMapping={{ color: fallbackFillColor, opacity: 1 }} />
+    }
     return <UncategorizedValueIcon />
   }
   return <RegularValueIcon colorMapping={colorSelector(item)} />

--- a/src/components/features/profitAndLoss/ProfitAndLossChart/ProfitAndLossChart.tsx
+++ b/src/components/features/profitAndLoss/ProfitAndLossChart/ProfitAndLossChart.tsx
@@ -183,7 +183,6 @@ export const ProfitAndLossChart = ({ tagFilter, hideLegend = false }: ProfitAndL
               fill: 'var(--color-base-0)',
               stroke: 'var(--color-base-1000)',
             }}
-            strokeWidth={1}
             type='linear'
             dataKey='netProfit'
             stroke='var(--pnl-chart-line-color, var(--color-base-1000))'

--- a/src/components/features/profitAndLoss/ProfitAndLossChart/profitAndLossChart.scss
+++ b/src/components/features/profitAndLoss/ProfitAndLossChart/profitAndLossChart.scss
@@ -10,6 +10,11 @@
   font-size: 0.75rem;
 }
 
+/* Pairs with --pnl-chart-line-color; overrides the stroke-width attribute recharts renders. */
+.Layer__profit-and-loss-chart .recharts-line-curve {
+  stroke-width: var(--pnl-chart-line-stroke-width, 1);
+}
+
 .Layer__profit-and-loss-chart__bar--loading {
   fill: var(--color-base-50);
   animation: layer_chart_bar_loading_anim 2s linear infinite;

--- a/src/components/features/profitAndLoss/ProfitAndLossChart/profitAndLossChartPatternDefs.scss
+++ b/src/components/features/profitAndLoss/ProfitAndLossChart/profitAndLossChartPatternDefs.scss
@@ -1,15 +1,15 @@
 #layer-bar-stripe-pattern rect {
-  fill: var(--color-light);
+  fill: var(--bar-color-income);
 }
 
 #layer-bar-stripe-pattern line {
-  stroke: var(--color-light);
+  stroke: var(--bar-color-income);
 }
 
 #layer-bar-stripe-pattern-dark rect {
-  fill: var(--color-dark);
+  fill: var(--bar-color-expenses);
 }
 
 #layer-bar-stripe-pattern-dark line {
-  stroke: var(--color-dark);
+  stroke: var(--bar-color-expenses);
 }


### PR DESCRIPTION
## Scope

- Add optional `innerRadius` / `outerRadius` / `fallbackFillColor` to `DetailedChart`'s `stylingProps`, and `fallbackFillColor` to `DetailedTable` / `ValueIcon`. These are domain-agnostic `@blocks` shared with `TaxEstimatesSummaryCardContent`, which passes none of them.
- Move the P&L line width to `--pnl-chart-line-stroke-width`, pairing with the `--pnl-chart-line-color` variable already on that element. A CSS declaration overrides the `stroke-width` attribute recharts renders, so no JS is involved.
- Point the uncategorized bar stripe at `--bar-color-income` / `--bar-color-expenses` instead of `--color-light` / `--color-dark`. Byte-identical today since both resolve to the same HSL; going forward, overriding a bar color also recolors its stripe.
- No consumer-visible change: every added prop is optional and every default is unchanged. This is groundwork the config API in the next PR builds on.

## Verification

- `npm run typecheck`
- `npm run lint` (eslint + stylelint)
- `npm test` — 272 passing

Root: this
Base: main
Next: #1746

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional styling props and CSS variable wiring with unchanged defaults; no consumer-visible behavior change.
> 
> **Overview**
> Makes shared chart styling configurable as groundwork for a follow-up config API, with **no consumer-visible change** today.
> 
> `DetailedChart` now accepts optional `innerRadius`, `outerRadius`, and `fallbackFillColor` on `stylingProps` (defaults remain `91%` / `100%` / dotted pattern). The same `fallbackFillColor` flows through `DetailedTable` / `ValueIcon` so legend icons can match a solid fallback fill.
> 
> On the P&L chart, line width moves to `--pnl-chart-line-stroke-width` (CSS override of recharts’ attribute), and uncategorized bar stripes now follow `--bar-color-income` / `--bar-color-expenses` so overriding bar colors also recolors their stripes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a527e7d66ec10ce8e835e885f92df5bf699fd1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
