### PR TITLE
[LAY-2616] Chart config (3/3): document explicit component customization APIs

### DIFF
--- a/.augment/code_review_guidelines.yaml
+++ b/.augment/code_review_guidelines.yaml
@@ -147,6 +147,10 @@ areas:
       - "src/styles/**"
       - "**/*.scss"
     rules:
+      - id: "no_styling_prop_drilling"
+        description: "A component may not declare and forward a styling prop it does not use, and a view API must not grow one prop per styling knob. Use a CSS custom property when CSS can reach the value, slots or slotProps for one named element, and a config context when multiple descendants need it. A plain prop is appropriate only when the value stops at that component."
+        severity: "medium"
+
       - id: "build_on_ui_primitives"
         description: "Build on @ui before writing new markup. Reach for HStack/VStack instead of raw div, and Span/P/Label/Header instead of raw text elements. Genuinely new reusable primitives go in src/components/ui, not inside a feature."
         severity: "medium"

--- a/.augment/code_review_guidelines.yaml
+++ b/.augment/code_review_guidelines.yaml
@@ -147,8 +147,8 @@ areas:
       - "src/styles/**"
       - "**/*.scss"
     rules:
-      - id: "no_styling_prop_drilling"
-        description: "A component may not declare and forward a styling prop it does not use, and a view API must not grow one prop per styling knob. Use a CSS custom property when CSS can reach the value, slots or slotProps for one named element, and a config context when multiple descendants need it. A plain prop is appropriate only when the value stops at that component."
+      - id: "explicit_component_config"
+        description: "Flag a consumer-facing component config hidden or removed behind context, a view-level config that ambiguously controls several configurable subcomponents, or one prop added per styling knob. Components take one nested config explicitly; composed views forward targeted configs through slotProps, with separate configs when instances may differ. Use context only for genuinely implicit, subtree-stable dependency injection."
         severity: "medium"
 
       - id: "build_on_ui_primitives"

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -84,10 +84,11 @@ is this same rule set in Augment's format — keep the two in sync.
 
 ### Components and styling
 
-- A component that declares and forwards a styling prop it does not use, or a view API that grows
-  one prop per styling knob. Use a CSS custom property when CSS can reach the value, `slots` or
-  `slotProps` for one named element, and a config context when multiple descendants need it. A
-  plain prop is appropriate only when the value stops at that component.
+- A consumer-facing component config hidden or removed behind context, a view-level config that
+  ambiguously controls several configurable subcomponents, or one prop added per styling knob.
+  Components take one nested config explicitly; composed views forward targeted configs through
+  `slotProps`, with separate configs when instances may differ. Use context only for genuinely
+  implicit, subtree-stable dependency injection.
 - New markup that duplicates an existing `@ui` primitive. Reach for `HStack`/`VStack` instead of a
   raw `div`, and `Span`/`P`/`Label`/`Header` instead of raw text elements. Genuinely new reusable
   primitives go in `src/components/ui`, not inside a feature.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -84,6 +84,10 @@ is this same rule set in Augment's format — keep the two in sync.
 
 ### Components and styling
 
+- A component that declares and forwards a styling prop it does not use, or a view API that grows
+  one prop per styling knob. Use a CSS custom property when CSS can reach the value, `slots` or
+  `slotProps` for one named element, and a config context when multiple descendants need it. A
+  plain prop is appropriate only when the value stops at that component.
 - New markup that duplicates an existing `@ui` primitive. Reach for `HStack`/`VStack` instead of a
   raw `div`, and `Span`/`P`/`Label`/`Header` instead of raw text elements. Genuinely new reusable
   primitives go in `src/components/ui`, not inside a feature.

--- a/src/components/SKILL.md
+++ b/src/components/SKILL.md
@@ -168,15 +168,17 @@ Work down this list, stopping at the first that fits:
   knob adds a **field, never a prop**. Group by element, like `slotProps` keys.
 - The provider mounts at the domain root (`ProfitAndLoss`, one `chartConfig` prop), so every view
   under it gets the behaviour without being wired up.
-- Leaves read purpose-named hooks that return **resolved** values, keeping defaults and legacy
-  fallbacks in one place instead of at each call site.
+- Leaves read purpose-named hooks that return **resolved** values. The provider normalizes the
+  legacy root `chartColorsList`; public leaf components pass their retained `chartColorsList` to
+  the hook only as a per-instance override.
 - `@ui`/`@blocks` never read a feature context. A shared block keeps its `stylingProps`; the
   `@features` component reads the context and builds them — `DetailedChart` is shared by P&L and
   tax estimates for exactly this reason.
 
 Two traps: an override must not silently disable a responsive default (`barSize` needs
-`compactBarSize`, not one fixed width), and a new config supersedes an old prop by folding it in
-at the provider, not by shipping both as siblings.
+`compactBarSize`, not one fixed width), and when compatibility requires retaining an old prop,
+normalize it into the new config at the provider boundary instead of threading both
+representations through the component tree.
 
 ## Forms
 

--- a/src/components/SKILL.md
+++ b/src/components/SKILL.md
@@ -149,36 +149,42 @@ Three rules that follow:
   caller's over its own defaults: `slotProps={{ Title: { size: 'md', ...slotProps?.Title } }}`
 - **Memoize a computed `slots`/`slotProps` object**, since it's an object prop.
 
-## Customization: never drill a styling prop
+## Consumer-facing customization
 
-**No component may declare a prop it doesn't use**, and view props must not grow one-per-knob.
-Work down this list, stopping at the first that fits:
+Keep customization explicit at the component boundary. Do not hide or remove a consumer-facing
+prop behind a context merely to avoid forwarding it through a composed view. Choose the mechanism
+that matches what the consumer is configuring:
 
-1. **A CSS custom property**, if CSS can reach it — the default, and it costs zero props. Works
-   inside SVG charts too: a CSS declaration beats the presentation attribute the chart library
-   renders, which is how `--pnl-chart-line-stroke-width` sets the P&L line width.
-2. **`slots` / `slotProps`**, if it configures one named element of *one* component (above).
-3. **A config context**, as soon as a value would otherwise pass through a component that doesn't
-   use it. One nested type, a provider at the domain root, a narrow hook per leaf.
-4. **A prop**, only when the value stops at that component.
+1. **A CSS custom property**, when CSS can reach the value and the customization is naturally
+   inherited. This costs zero React props and works inside SVG charts too: a CSS declaration beats
+   the presentation attribute the chart library renders, which is how
+   `--pnl-chart-line-stroke-width` sets the P&L line width.
+2. **`slots` / `slotProps`**, when configuring a named element inside a component or view. A view
+   with several charts nests each config under the slot for the subcomponent it targets; it may
+   expose several chart configs when those chart instances can differ.
+3. **A component prop**, when the component renders or owns the configurable element. Prefer one
+   nested config object over one prop per knob. Thin composed components may forward that config
+   to the child they own so the public API remains explicit.
+4. **Context**, only for a genuinely implicit, subtree-stable dependency. Context must not erase a
+   per-instance consumer API; if two instances on one page may need different values, use props.
 
-`ProfitAndLossChartConfigContext` is the reference for (3):
+P&L chart configuration is the reference:
 
-- One nested field per chart — `{ colors, trendChart: { barSize }, donutChart: { … } }` — so a new
-  knob adds a **field, never a prop**. Group by element, like `slotProps` keys.
-- The provider mounts at the domain root (`ProfitAndLoss`, one `chartConfig` prop), so every view
-  under it gets the behaviour without being wired up.
-- Leaves read purpose-named hooks that return **resolved** values. The provider normalizes the
-  legacy root `chartColorsList`; public leaf components pass their retained `chartColorsList` to
-  the hook only as a per-instance override.
-- `@ui`/`@blocks` never read a feature context. A shared block keeps its `stylingProps`; the
-  `@features` component reads the context and builds them — `DetailedChart` is shared by P&L and
-  tax estimates for exactly this reason.
+- `ProfitAndLoss.Chart`, `ProfitAndLoss.Summaries`, and `ProfitAndLoss.DetailedCharts` each accept
+  `chartConfig` directly.
+- Accounting and bookkeeping overviews place configs under the targeted P&L summary, trend-chart,
+  revenue-detail, and expense-detail `slotProps`; Solopreneur does the same for its summaries and
+  individual summary cards.
+- The nested `ProfitAndLossChartConfig` groups related knobs without making the root
+  `ProfitAndLoss` component an ambient styling provider.
+- Existing `chartColorsList` props remain supported as compatibility fallbacks where they were
+  already consumer-facing.
+- `@ui`/`@blocks` remain domain-agnostic. A feature component converts its config into the shared
+  block's `stylingProps`; `DetailedChart` stays reusable by both P&L and tax estimates.
 
 Two traps: an override must not silently disable a responsive default (`barSize` needs
-`compactBarSize`, not one fixed width), and when compatibility requires retaining an old prop,
-normalize it into the new config at the provider boundary instead of threading both
-representations through the component tree.
+`compactBarSize`, not one fixed width), and a new config must preserve existing consumer-facing
+props unless a breaking change is intentional.
 
 ## Forms
 

--- a/src/components/SKILL.md
+++ b/src/components/SKILL.md
@@ -149,6 +149,35 @@ Three rules that follow:
   caller's over its own defaults: `slotProps={{ Title: { size: 'md', ...slotProps?.Title } }}`
 - **Memoize a computed `slots`/`slotProps` object**, since it's an object prop.
 
+## Customization: never drill a styling prop
+
+**No component may declare a prop it doesn't use**, and view props must not grow one-per-knob.
+Work down this list, stopping at the first that fits:
+
+1. **A CSS custom property**, if CSS can reach it — the default, and it costs zero props. Works
+   inside SVG charts too: a CSS declaration beats the presentation attribute the chart library
+   renders, which is how `--pnl-chart-line-stroke-width` sets the P&L line width.
+2. **`slots` / `slotProps`**, if it configures one named element of *one* component (above).
+3. **A config context**, as soon as a value would otherwise pass through a component that doesn't
+   use it. One nested type, a provider at the domain root, a narrow hook per leaf.
+4. **A prop**, only when the value stops at that component.
+
+`ProfitAndLossChartConfigContext` is the reference for (3):
+
+- One nested field per chart — `{ colors, trendChart: { barSize }, donutChart: { … } }` — so a new
+  knob adds a **field, never a prop**. Group by element, like `slotProps` keys.
+- The provider mounts at the domain root (`ProfitAndLoss`, one `chartConfig` prop), so every view
+  under it gets the behaviour without being wired up.
+- Leaves read purpose-named hooks that return **resolved** values, keeping defaults and legacy
+  fallbacks in one place instead of at each call site.
+- `@ui`/`@blocks` never read a feature context. A shared block keeps its `stylingProps`; the
+  `@features` component reads the context and builds them — `DetailedChart` is shared by P&L and
+  tax estimates for exactly this reason.
+
+Two traps: an override must not silently disable a responsive default (`barSize` needs
+`compactBarSize`, not one fixed width), and a new config supersedes an old prop by folding it in
+at the provider, not by shipping both as siblings.
+
 ## Forms
 
 Forms use TanStack Form through `useAppForm` (`@blocks/Form/useForm`) with the

--- a/src/components/SKILL.md
+++ b/src/components/SKILL.md
@@ -156,34 +156,26 @@ prop behind a context merely to avoid forwarding it through a composed view. Cho
 that matches what the consumer is configuring:
 
 1. **A CSS custom property**, when CSS can reach the value and the customization is naturally
-   inherited. This costs zero React props and works inside SVG charts too: a CSS declaration beats
-   the presentation attribute the chart library renders, which is how
-   `--pnl-chart-line-stroke-width` sets the P&L line width.
+   inherited. It costs zero React props and reaches inside SVG charts, where a CSS declaration
+   beats the chart library's presentation attribute — how `--pnl-chart-line-stroke-width` sets the
+   P&L line width.
 2. **`slots` / `slotProps`**, when configuring a named element inside a component or view. A view
-   with several charts nests each config under the slot for the subcomponent it targets; it may
-   expose several chart configs when those chart instances can differ.
+   with several charts nests each config under the slot it targets, so instances that may differ
+   get separate configs.
 3. **A component prop**, when the component renders or owns the configurable element. Prefer one
-   nested config object over one prop per knob. Thin composed components may forward that config
-   to the child they own so the public API remains explicit.
+   nested config object over one prop per knob.
 4. **Context**, only for a genuinely implicit, subtree-stable dependency. Context must not erase a
    per-instance consumer API; if two instances on one page may need different values, use props.
 
-P&L chart configuration is the reference:
+P&L chart configuration is the reference: `ProfitAndLoss.Chart`, `.Summaries`, `.DetailedCharts`,
+and `ProfitAndLossSummaryCard` each take a nested `chartConfig` directly; the overviews expose it
+under the `slotProps` of the chart it targets; and the legacy flat `chartColorsList` stays
+supported as a fallback where it was already consumer-facing. `@ui`/`@blocks` stay
+domain-agnostic — a feature component converts its config into the shared block's `stylingProps`,
+so `DetailedChart` remains reusable by both P&L and tax estimates.
 
-- `ProfitAndLoss.Chart`, `ProfitAndLoss.Summaries`, and `ProfitAndLoss.DetailedCharts` each accept
-  `chartConfig` directly.
-- Accounting and bookkeeping overviews place configs under the targeted P&L summary, trend-chart,
-  revenue-detail, and expense-detail `slotProps`; Solopreneur does the same for its summaries and
-  individual summary cards.
-- The nested `ProfitAndLossChartConfig` groups related knobs without making the root
-  `ProfitAndLoss` component an ambient styling provider.
-- Existing `chartColorsList` props remain supported as compatibility fallbacks where they were
-  already consumer-facing.
-- `@ui`/`@blocks` remain domain-agnostic. A feature component converts its config into the shared
-  block's `stylingProps`; `DetailedChart` stays reusable by both P&L and tax estimates.
-
-Two traps: an override must not silently disable a responsive default (`barSize` needs
-`compactBarSize`, not one fixed width), and a new config must preserve existing consumer-facing
+Two traps: an override must not silently disable a responsive default (`barWidth` needs
+`compactBarWidth`, not one fixed width), and a new config must preserve existing consumer-facing
 props unless a breaking change is intentional.
 
 ## Forms

--- a/src/components/SKILL.md
+++ b/src/components/SKILL.md
@@ -171,8 +171,8 @@ P&L chart configuration is the reference: `ProfitAndLoss.Chart`, `.Summaries`, `
 and `ProfitAndLossSummaryCard` each take a nested `chartConfig` directly; the overviews expose it
 under the `slotProps` of the chart it targets; and the legacy flat `chartColorsList` stays
 supported as a fallback where it was already consumer-facing. `@ui`/`@blocks` stay
-domain-agnostic — a feature component converts its config into the shared block's `stylingProps`,
-so `DetailedChart` remains reusable by both P&L and tax estimates.
+domain-agnostic — a feature component translates its domain config into whatever the child below
+it takes, so `DetailedChart` remains reusable by both P&L and tax estimates.
 
 Two traps: an override must not silently disable a responsive default (`barWidth` needs
 `compactBarWidth`, not one fixed width), and a new config must preserve existing consumer-facing

--- a/src/providers/SKILL.md
+++ b/src/providers/SKILL.md
@@ -103,15 +103,12 @@ every consumer on any change, and narrow units can be mounted independently wher
 
 ### Context does not replace component configuration
 
-Context is appropriate for an implicit value that is stable for the life of a subtree. It is not
-a reason to remove a consumer-facing, per-instance configuration prop. A component that renders or
+Context is appropriate for an implicit value that is stable for the life of a subtree. It is not a
+reason to remove a consumer-facing, per-instance configuration prop. A component that renders or
 owns a configurable element accepts the config explicitly; a composed view forwards it through
-targeted `slotProps`, with separate configs when separate instances may differ. Do not mount a
-domain provider merely to avoid that wiring.
-
-Use a config context only when the value is genuinely dependency injection rather than component
-configuration, and scope it so mounting the feature more than once does not leak values between
-instances. `src/components/SKILL.md` has the full customization decision list.
+targeted `slotProps`, with separate configs when instances may differ. Do not mount a domain
+provider merely to avoid that wiring, and never let a context erase a per-instance prop.
+`src/components/SKILL.md` has the full customization decision list.
 
 `LayerContext` is the root: API URL, auth, environment, theme, locale. Read it through
 `useLayerContext` or, better, the purpose-built hooks (`useAuth`, `useGetBusiness`,

--- a/src/providers/SKILL.md
+++ b/src/providers/SKILL.md
@@ -101,18 +101,17 @@ which is domain-agnostic and shared).
 Prefer adding a new small context over widening an existing one — a fat context re-renders
 every consumer on any change, and narrow units can be mounted independently where needed.
 
-### Config contexts replace prop drilling
+### Context does not replace component configuration
 
-A consumer-facing config (string overrides, styling, feature flags) that several components need
-is a **context**, never a prop threaded through the components in between. Mount the provider at
-the domain root (`ProfitAndLoss` takes one `chartConfig` and mounts
-`ProfitAndLossChartConfigProvider`) and have leaves read purpose-named hooks that return
-**resolved** values. `ProfitAndLossChartConfigProvider` normalizes the legacy root
-`chartColorsList` into scoped colors; public leaf components may pass their retained
-`chartColorsList` to `useProfitAndLossChartPalette` as a per-instance override.
+Context is appropriate for an implicit value that is stable for the life of a subtree. It is not
+a reason to remove a consumer-facing, per-instance configuration prop. A component that renders or
+owns a configurable element accepts the config explicitly; a composed view forwards it through
+targeted `slotProps`, with separate configs when separate instances may differ. Do not mount a
+domain provider merely to avoid that wiring.
 
-`src/components/SKILL.md` has the full decision list — CSS variable, `slotProps`, config context,
-plain prop.
+Use a config context only when the value is genuinely dependency injection rather than component
+configuration, and scope it so mounting the feature more than once does not leak values between
+instances. `src/components/SKILL.md` has the full customization decision list.
 
 `LayerContext` is the root: API URL, auth, environment, theme, locale. Read it through
 `useLayerContext` or, better, the purpose-built hooks (`useAuth`, `useGetBusiness`,

--- a/src/providers/SKILL.md
+++ b/src/providers/SKILL.md
@@ -101,6 +101,18 @@ which is domain-agnostic and shared).
 Prefer adding a new small context over widening an existing one — a fat context re-renders
 every consumer on any change, and narrow units can be mounted independently where needed.
 
+### Config contexts replace prop drilling
+
+A consumer-facing config (string overrides, styling, feature flags) that several components need
+is a **context**, never a prop threaded through the components in between. Mount the provider at
+the domain root (`ProfitAndLoss` takes one `chartConfig` and mounts
+`ProfitAndLossChartConfigProvider`) and have leaves read purpose-named hooks that return
+**resolved** values — `useProfitAndLossChartPalette(scope)` folds the legacy flat
+`chartColorsList` into the scoped `colors`, so no call site has to know both exist.
+
+`src/components/SKILL.md` has the full decision list — CSS variable, `slotProps`, config context,
+plain prop.
+
 `LayerContext` is the root: API URL, auth, environment, theme, locale. Read it through
 `useLayerContext` or, better, the purpose-built hooks (`useAuth`, `useGetBusiness`,
 `useEnvironment`) rather than `useContext` directly.

--- a/src/providers/SKILL.md
+++ b/src/providers/SKILL.md
@@ -107,8 +107,9 @@ A consumer-facing config (string overrides, styling, feature flags) that several
 is a **context**, never a prop threaded through the components in between. Mount the provider at
 the domain root (`ProfitAndLoss` takes one `chartConfig` and mounts
 `ProfitAndLossChartConfigProvider`) and have leaves read purpose-named hooks that return
-**resolved** values — `useProfitAndLossChartPalette(scope)` folds the legacy flat
-`chartColorsList` into the scoped `colors`, so no call site has to know both exist.
+**resolved** values. `ProfitAndLossChartConfigProvider` normalizes the legacy root
+`chartColorsList` into scoped colors; public leaf components may pass their retained
+`chartColorsList` to `useProfitAndLossChartPalette` as a per-instance override.
 
 `src/components/SKILL.md` has the full decision list — CSS variable, `slotProps`, config context,
 plain prop.


### PR DESCRIPTION
## Scope

Documents consumer-facing customization as an explicit component API, matching what #1746 ships.

- Adds an ordered decision list to `src/components/SKILL.md`: CSS custom property, `slotProps`, component prop, then context last.
- Records the P&L implementation as the reference — nested `chartConfig` on `ProfitAndLoss.Chart`, `.Summaries`, `.DetailedCharts`, and `ProfitAndLossSummaryCard`; overviews expose it through targeted `slotProps`; legacy `chartColorsList` stays as a fallback.
- Notes the responsive trap: `barWidth` needs `compactBarWidth`, not one fixed width.
- Adds the matching rule to `src/providers/SKILL.md`, `.cursor/BUGBOT.md`, and `.augment/code_review_guidelines.yaml`, as AGENTS.md requires.

## Verification

- `npm run typecheck`
- `npm run lint`
- Terminology cross-checked against the head of #1746 (`74acd39`): `barChart.barWidth` / `compactBarWidth`, flat `chartConfig` on `ProfitAndLossSummaryCard`, no chart-config provider or hook remaining.

Root: #1745
Base: #1746
Next: None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and review-guideline updates only; no production code paths change.
> 
> **Overview**
> **Documentation-only PR** that codifies the explicit customization pattern shipped in the chart-config work (#1746). No runtime or API changes.
> 
> Adds a **Consumer-facing customization** section to `src/components/SKILL.md` with an ordered choice list: CSS custom properties, then `slots`/`slotProps`, nested component props, and context only for implicit subtree-stable values. It points at P&L as the reference (`chartConfig` on chart/summary components, targeted `slotProps` on overviews, legacy `chartColorsList` as fallback) and calls out pitfalls (responsive `barWidth`/`compactBarWidth`, not breaking existing props).
> 
> Mirrors that guidance in `src/providers/SKILL.md` (**Context does not replace component configuration**), `.cursor/BUGBOT.md`, and `.augment/code_review_guidelines.yaml` via a new **`explicit_component_config`** medium-severity rule so humans and bots flag configs hidden behind context, ambiguous view-level knobs, or one-prop-per-styling-knob APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92eb038779c4646c0ace6d76f8db1eb001119b06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->