### PR TITLE
[LAY-2607] perf: make the ESM build tree-shakeable

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,21 +3,21 @@
     "name": "full import (ESM)",
     "path": "dist/esm/index.mjs",
     "import": "*",
-    "limit": "1300 kB",
+    "limit": "1350 kB",
     "ignore": ["react", "react-dom"]
   },
   {
     "name": "single component, small (GlobalMonthPicker)",
     "path": "dist/esm/index.mjs",
     "import": "{ GlobalMonthPicker }",
-    "limit": "600 kB",
+    "limit": "120 kB",
     "ignore": ["react", "react-dom"]
   },
   {
     "name": "single component, large (BankTransactions)",
     "path": "dist/esm/index.mjs",
     "import": "{ BankTransactions }",
-    "limit": "650 kB",
+    "limit": "500 kB",
     "ignore": ["react", "react-dom"]
   },
   {

--- a/.storybook/mocks/systemDate.ts
+++ b/.storybook/mocks/systemDate.ts
@@ -1,22 +1,27 @@
 import { FIXTURE_YEAR } from '../../src/fixtures/constants/fixtureYear'
 
-const RealDate = Date
+// A bare `import './systemDate'` is a side-effect-only import, which `sideEffects` in
+// package.json (scoped to CSS/SCSS) makes eligible for tree-shaking under `preserveModules`.
+// Calling this from `preview.tsx` keeps the mock reachable regardless of that field.
+export function installSystemDateMock() {
+  const RealDate = Date
 
-// Clock ticks normally, but "now" is shifted to the last day of the fixture year.
-const offset = new RealDate(FIXTURE_YEAR, 11, 31, 12, 0, 0).getTime() - RealDate.now()
+  // Clock ticks normally, but "now" is shifted to the last day of the fixture year.
+  const offset = new RealDate(FIXTURE_YEAR, 11, 31, 12, 0, 0).getTime() - RealDate.now()
 
-// A Proxy rather than a subclass, so instances stay real Dates: with a subclass,
-// `value instanceof Date` is false for dates built before this module ran (e.g. the
-// fixture range constants), and query-param serialization silently falls back to
-// `String(date)` instead of an ISO date.
-globalThis.Date = new Proxy(RealDate, {
-  construct: (target, args: ConstructorParameters<DateConstructor>) =>
-    args.length === 0 ? new target(RealDate.now() + offset) : new target(...args),
-  apply: () => new RealDate(RealDate.now() + offset).toString(),
-  get: (target, property, receiver) => {
-    if (property === 'now') return () => RealDate.now() + offset
+  // A Proxy rather than a subclass, so instances stay real Dates: with a subclass,
+  // `value instanceof Date` is false for dates built before this module ran (e.g. the
+  // fixture range constants), and query-param serialization silently falls back to
+  // `String(date)` instead of an ISO date.
+  globalThis.Date = new Proxy(RealDate, {
+    construct: (target, args: ConstructorParameters<DateConstructor>) =>
+      args.length === 0 ? new target(RealDate.now() + offset) : new target(...args),
+    apply: () => new RealDate(RealDate.now() + offset).toString(),
+    get: (target, property, receiver) => {
+      if (property === 'now') return () => RealDate.now() + offset
 
-    const value: unknown = Reflect.get(target, property, receiver)
-    return value
-  },
-})
+      const value: unknown = Reflect.get(target, property, receiver)
+      return value
+    },
+  })
+}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,13 +4,15 @@ import { initialize, mswLoader } from 'msw-storybook-addon'
 
 import '../src/styles/index.scss'
 
-import './mocks/systemDate'
 import { handlers } from '../src/msw/handlers'
 import { setMinimumResponseDelay } from '../src/msw/utils/createMockEndpoint'
 import { resetMockStores } from '../src/msw/utils/createMockStore'
 import { LayerTestProvider } from '../src/testUtils/render/LayerTestProvider'
 import { BREAKPOINTS } from '../src/utils/shared/size/screenSizeBreakpoints'
+import { installSystemDateMock } from './mocks/systemDate'
 import { DOCS_SCREENSHOT_TAG } from './tags'
+
+installSystemDateMock()
 
 // Responsiveness is JS-driven off window.innerWidth (see useSizeClass), so Chromatic
 // must resize the capture iframe to exercise each size class. Widths sit just below the

--- a/consumer-fixtures/README.md
+++ b/consumer-fixtures/README.md
@@ -20,6 +20,7 @@ npm run test:consumers -- --skip-build   # reuse the existing dist/
 | fixture | what it proves |
 |---|---|
 | `vite-esm` | `import` condition resolves, `@layerfi/components/index.css` resolves, the bundle builds, and the provider mounts in a real browser under `StrictMode` with no console errors |
+| `vite-esm-treeshake` | importing a single small component does **not** drag in `recharts`, `react-select`, `motion` and the other heavy dependencies it never uses — catches a regression in `sideEffects` or `preserveModules` through a real consumer bundler, which `size-limit` (esbuild) would not |
 | `cjs-require` | `require('@layerfi/components')` resolves and executes, and `dist/index.d.ts` type-checks under `moduleResolution: node16` |
 | `ssr-node` | the module graph has no top-level `window`/`document` access and renders through `react-dom/server` |
 

--- a/consumer-fixtures/vite-esm-treeshake/check-treeshake.mjs
+++ b/consumer-fixtures/vite-esm-treeshake/check-treeshake.mjs
@@ -1,0 +1,32 @@
+import fs from 'node:fs'
+
+import { FORBIDDEN_DEPS } from './forbidden-deps.mjs'
+
+const BUILT = 'dist/main.mjs'
+
+if (!fs.existsSync(BUILT)) {
+  console.error(`::error::${BUILT} was not produced; the fixture build did not run`)
+  process.exit(1)
+}
+
+const code = fs.readFileSync(BUILT, 'utf8')
+const imported = new Set(
+  [...code.matchAll(/^import\s[^'"]*['"]([^'"]+)['"]/gm)]
+    .map(([, specifier]) => specifier),
+)
+
+const leaked = FORBIDDEN_DEPS.filter(dep =>
+  [...imported].some(specifier => specifier === dep || specifier.startsWith(`${dep}/`)),
+)
+
+if (leaked.length > 0) {
+  console.error(
+    '::error::Importing { GlobalMonthPicker } pulled in dependencies it does not use:\n'
+    + leaked.map(dep => `  ${dep}`).join('\n')
+    + '\n\nThis means tree-shaking regressed. Check that package.json still declares `sideEffects`'
+    + ' and that the ESM build still emits one file per module (`preserveModules`).',
+  )
+  process.exit(1)
+}
+
+console.info(`Tree-shaking OK — none of the ${FORBIDDEN_DEPS.length} unused dependencies were pulled in.`)

--- a/consumer-fixtures/vite-esm-treeshake/forbidden-deps.d.ts
+++ b/consumer-fixtures/vite-esm-treeshake/forbidden-deps.d.ts
@@ -1,0 +1,1 @@
+export const FORBIDDEN_DEPS: string[]

--- a/consumer-fixtures/vite-esm-treeshake/forbidden-deps.mjs
+++ b/consumer-fixtures/vite-esm-treeshake/forbidden-deps.mjs
@@ -1,0 +1,15 @@
+// Dependencies that `GlobalMonthPicker` does not need. Before per-module output the package was a
+// single bundled module, so importing any export pulled in every one of these. They are shared
+// between the vite config (which externalises them, keeping the package name in the output as a
+// bare import) and the assertion below it.
+export const FORBIDDEN_DEPS = [
+  '@tanstack/react-form',
+  '@tanstack/react-table',
+  '@tanstack/react-virtual',
+  'motion',
+  'react-calendly',
+  'react-dropzone',
+  'react-plaid-link',
+  'react-select',
+  'recharts',
+]

--- a/consumer-fixtures/vite-esm-treeshake/package.json
+++ b/consumer-fixtures/vite-esm-treeshake/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "consumer-fixture-vite-esm-treeshake",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "verify": "tsc --noEmit && vite build && node check-treeshake.mjs"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.10"
+  }
+}

--- a/consumer-fixtures/vite-esm-treeshake/src/main.tsx
+++ b/consumer-fixtures/vite-esm-treeshake/src/main.tsx
@@ -1,0 +1,7 @@
+// Imports exactly one small component. The build externalises the dependencies it should not
+// need, so check-treeshake.mjs can assert none of them appear as imports in the output.
+import { GlobalMonthPicker } from '@layerfi/components'
+
+export function App() {
+  return <GlobalMonthPicker showLabel />
+}

--- a/consumer-fixtures/vite-esm-treeshake/tsconfig.json
+++ b/consumer-fixtures/vite-esm-treeshake/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022", "dom", "dom.iterable"],
+    "jsx": "react-jsx",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/consumer-fixtures/vite-esm-treeshake/vite.config.ts
+++ b/consumer-fixtures/vite-esm-treeshake/vite.config.ts
@@ -1,0 +1,26 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+// Shared with check-treeshake.mjs, which runs under plain node and so cannot import a .ts file.
+import { FORBIDDEN_DEPS } from './forbidden-deps.mjs'
+
+// Library mode rather than an app build: externalising is what makes the assertion possible, and
+// bare imports in an app bundle would be meaningless. This fixture is never loaded in a browser.
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    minify: false,
+    lib: {
+      entry: 'src/main.tsx',
+      formats: ['es'],
+      fileName: () => 'main.mjs',
+    },
+    rollupOptions: {
+      external: [
+        /^react($|\/)/,
+        /^react-dom($|\/)/,
+        ...FORBIDDEN_DEPS.map(dep => new RegExp(`^${dep.replace('/', '\\/')}($|\\/)`)),
+      ],
+    },
+  },
+})

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "types": "dist/index.d.ts",
   "style": "dist/index.css",
   "type": "commonjs",
+  "sideEffects": [
+    "**/*.css",
+    "**/*.scss"
+  ],
   "exports": {
     ".": {
       "import": {

--- a/scripts/pack-and-test-consumers.ts
+++ b/scripts/pack-and-test-consumers.ts
@@ -15,6 +15,7 @@ const READY_SELECTOR = '[data-testid="fixture-ready"]'
 // `dist` is the built output to load in a browser once `verify` passes, relative to the fixture.
 const FIXTURES = [
   { name: 'vite-esm', dist: 'dist' },
+  { name: 'vite-esm-treeshake' },
   { name: 'cjs-require' },
   { name: 'ssr-node' },
 ] as const

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,7 @@
+// Must stay the first import: global CSS has to precede component CSS in the generated
+// stylesheet so component styles win on equal specificity.
+import './styles/index.scss'
+
 /*
 ==========================================================
 ======================= Components =======================

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,3 @@
-// Must stay the first import: global CSS has to precede component CSS in the generated
-// stylesheet so component styles win on equal specificity.
 import './styles/index.scss'
 
 /*

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,19 +28,19 @@ export default defineConfig(({ mode, command }) => {
     build: {
       minify: false,
       cssMinify: false,
-      cssCodeSplit: true,
+      // Per-module output would otherwise emit a stylesheet per component; the single
+      // `dist/index.css` is the published contract.
+      cssCodeSplit: !isESM,
       lib: isESM
         ? {
-          entry: {
-            /**
-             * Important that the `styles/index.scss` entry is before `src/index.tsx` so that CSS
-             * files imported from the styles index file appear earlier in the generated CSS than
-             * the CSS for the individual components. This means individual component styles will
-             * will be prioritized over global styles.
-             */
-            styles: path.resolve(__dirname, 'src/styles/index.scss'),
-            index: path.resolve(__dirname, 'src/index.tsx'),
-          },
+          /**
+           * `styles/index.scss` used to be a second entry, ordered before this one so that global
+           * CSS was emitted ahead of component CSS. `preserveModules` cannot carry a pure-CSS
+           * entry (vite:css-post crashes resolving its reference id), so `src/index.tsx` now
+           * imports the styles index as its first import instead. Module execution order gives
+           * the same result: global styles first, so component styles win on equal specificity.
+           */
+          entry: path.resolve(__dirname, 'src/index.tsx'),
           formats: ['es'],
         }
         : {
@@ -52,9 +52,10 @@ export default defineConfig(({ mode, command }) => {
         external: externalDeps,
         output: {
           dir: path.resolve(__dirname, `${OUT_DIR}/${mode}`),
-          entryFileNames: isESM
-            ? chunk => (chunk.name === 'styles' ? 'styles.mjs' : 'index.mjs')
-            : 'index.cjs',
+          // One file per source module, so a consumer's bundler has real boundaries to prune
+          // against. `sideEffects` in package.json is what makes those boundaries actionable.
+          ...(isESM && { preserveModules: true, preserveModulesRoot: 'src' }),
+          entryFileNames: isESM ? '[name].mjs' : 'index.cjs',
           chunkFileNames: isESM ? '[name].mjs' : '[name].cjs',
           exports: isCJS ? 'named' : undefined,
         },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,11 +34,10 @@ export default defineConfig(({ mode, command }) => {
       lib: isESM
         ? {
           /**
-           * `styles/index.scss` used to be a second entry, ordered before this one so that global
-           * CSS was emitted ahead of component CSS. `preserveModules` cannot carry a pure-CSS
-           * entry (vite:css-post crashes resolving its reference id), so `src/index.tsx` now
-           * imports the styles index as its first import instead. Module execution order gives
-           * the same result: global styles first, so component styles win on equal specificity.
+           * `preserveModules` cannot carry a pure-CSS entry (vite:css-post crashes resolving its
+           * reference id), so the styles index is imported from `src/index.tsx` instead, as its
+           * first import. Module execution order then puts global styles first in the generated
+           * CSS, so component styles win on equal specificity.
            */
           entry: path.resolve(__dirname, 'src/index.tsx'),
           formats: ['es'],

--- a/vite/plugins/bundleCss.ts
+++ b/vite/plugins/bundleCss.ts
@@ -11,21 +11,22 @@ export function bundleCss(): Plugin {
     writeBundle() {
       const distDir = path.resolve(__dirname, `../../${OUT_DIR}`)
       const esmDir = path.join(distDir, 'esm')
-      const stylesCssPath = path.join(esmDir, 'styles.css')
-      const indexCssPath = path.join(esmDir, 'index.css')
       const mergedPath = path.join(distDir, 'index.css')
 
-      // Concat styles.css (global styles) before index.css (component styles)
-      // so that component-level styles win on equal specificity.
-      const parts: string[] = []
-      if (fs.existsSync(stylesCssPath)) {
-        parts.push(fs.readFileSync(stylesCssPath, 'utf8'))
-        fs.unlinkSync(stylesCssPath)
-      }
-      if (fs.existsSync(indexCssPath)) {
-        parts.push(fs.readFileSync(indexCssPath, 'utf8'))
-        fs.unlinkSync(indexCssPath)
-      }
+      // `cssCodeSplit: false` emits a single stylesheet, but its name is derived from the lib
+      // entry rather than fixed. Collect whatever landed and sort for a stable result; ordering
+      // within the file already follows module execution order, global styles first.
+      const cssFiles = fs
+        .readdirSync(esmDir)
+        .filter(file => file.endsWith('.css'))
+        .sort()
+
+      const parts = cssFiles.map((file) => {
+        const filePath = path.join(esmDir, file)
+        const contents = fs.readFileSync(filePath, 'utf8')
+        fs.unlinkSync(filePath)
+        return contents
+      })
 
       if (parts.length > 0) {
         // Concatenating leaves a part's own `@charset` partway down the file, which is invalid and


### PR DESCRIPTION
## Scope

The ESM build shipped as a single 2.85 MB module, so a consumer's bundler had no boundaries to prune against and `sideEffects` had nothing to attach to — which is why [`6a1d91852`](https://github.com/Layer-Fi/layer-react/commit/6a1d91852) found adding the field byte-identical.

Importing one small component retained **505 modules / 539 kB** against the **57 modules** it actually needs, and pulled in all 28 runtime dependencies including `recharts`, `react-select`, `motion` and all three `@tanstack` packages.

This emits one file per source module and declares `sideEffects`. Both are load-bearing — per-module output alone changes nothing for consumers, verified below.

| size-limit (minified + brotli) | before | after | |
|---|---|---|---|
| full import (ESM) | 1.24 MB | 1.26 MB | +2% |
| single component (`GlobalMonthPicker`) | 550.28 kB | **105.51 kB** | −81% |
| single component (`BankTransactions`) | 596.62 kB | **453.14 kB** | −24% |
| stylesheet | 27.60 kB | 27.58 kB | — |

The full-import figure rises ~2%. That is the cost of real module boundaries and the trade that buys the 81%.

Of the remaining 105.51 kB for `GlobalMonthPicker`, only **9.0 kB is Layer code** — the rest is the 14 of 28 dependencies it genuinely needs. The floor is now third-party, not first-party.

### Changes

- **`vite.config.ts`** — `preserveModules: true` + `preserveModulesRoot: 'src'` on the ESM build. `dist/esm/` goes from one file to 1188 modules mirroring `src/`. `target` stays `es2016`; dropping an unimported module is a graph operation and does not depend on output syntax.
- **`package.json`** — adds `"sideEffects": ["**/*.css", "**/*.scss"]`. `main`, `module`, `types`, `style` and the `exports` map are untouched.
- **`src/index.tsx`** — the global stylesheet becomes the barrel's first import. `vite:css-post` crashes on a pure-SCSS entry under `preserveModules`, so the ordering contract moves from entry order to module execution order.
- **`vite/plugins/bundleCss.ts`** — collects whatever single stylesheet `cssCodeSplit: false` emits, since its name is no longer fixed.
- **`.size-limit.json`** — budgets retuned so the win cannot silently regress.
- **`consumer-fixtures/vite-esm-treeshake/`** — new fixture asserting a single-component import excludes nine unused heavy dependencies.

No consumer source changes. Import syntax, the `exports` map, `@layerfi/components/index.css` and types are all unchanged.

## Verification

`build:check`, `lint:package` (`publint` + `attw`, green across all four resolution modes), `test:types`, `typecheck`, `vitest` (43 files / 325 tests), and all 4 consumer fixtures.

**CSS is semantically unchanged.** Diffed against a pre-change baseline build: the rule set is identical — 1830 rules both sides, none added or removed. 101 rules shifted position, but the only genuine swap is two adjacent unrelated selectors and the rest is one contiguous block moving by a constant offset. No two rules sharing both a selector and a property changed relative order, and the global/component boundary sits at the same index in both files.

**The new fixture actually fails.** Removing `sideEffects` and doing a full rebuild makes all nine dependencies leak back in and the fixture errors out, with its bundle going 849 kB → 2,991 kB. That is also what establishes that `preserveModules` alone is not sufficient.

**`sideEffects` was audited, not assumed.** Every module-scope side effect was checked before declaring the field: `errorHandler.tsx`'s singleton only sets `onErrorCallback = undefined`; `i18n/init.ts` deliberately avoids the global `i18next` singleton; and `createResourceGlobalCacheActions` is a pure factory, so the ~19 discarded top-level calls are genuinely dead. All three bare imports esbuild drops from the built output were confirmed to have no top-level effects.

## Follow-ups (not in this PR)

- **CJS gets nothing from this.** `main` is still a single 3.12 MB `index.cjs`, so `require()` consumers are unaffected. Subpath exports via entry shims — the `react-aria-components` pattern, `"./*"` plus `"./private/*": null` — are the only thing that helps them, and are the highest-value next step if `main` has real consumers.
- `partner-accounting.jpg` is a 698 kB base64 data URI, 25% of the old bundle. Now isolated to `LandingPage`, so the other 30 exports no longer pay for it. Note `assetsInlineLimit` cannot fix this: Vite inlines all assets unconditionally in lib mode.
- `i18n/init.ts` statically pulls both `en-US` and `fr-CA` (~118 kB of JSON) for every consumer.
- `packageVersion.ts` inlines the entire `package.json`, including `scripts` and `devDependencies`, into the shipped bundle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the published ESM artifact layout and bundling contract (module graph + `sideEffects`); wrong config could break tree-shaking or CSS ordering for all ESM consumers, though consumer fixtures and size-limit mitigate regression risk.
> 
> **Overview**
> **Makes the published ESM build tree-shakeable** so importing one export no longer pulls the whole library graph. The ESM build now emits **one file per `src/` module** (`preserveModules`) and **`package.json` declares `sideEffects` for CSS/SCSS only**, giving consumer bundlers real prune boundaries. Single-component budgets drop sharply (e.g. `GlobalMonthPicker` ~550 kB → ~106 kB in size-limit); full ESM import rises slightly (~2%).
> 
> **Build/CSS wiring changes** to support that shape: global styles are the **first import on the barrel** (`src/index.tsx`) instead of a separate lib entry (pure-SCSS entry breaks under `preserveModules`), ESM uses **one merged stylesheet** (`cssCodeSplit: false` + updated `bundleCss`), and **size-limit thresholds** are retuned.
> 
> **Regression coverage**: new **`vite-esm-treeshake` consumer fixture** builds a minimal Vite app importing only `GlobalMonthPicker` and fails if heavy unused deps (`recharts`, `react-select`, `motion`, etc.) appear in the bundle. Storybook’s date mock is exposed as **`installSystemDateMock()`** so it stays reachable when side-effect-only imports are shaken.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1b7dbd66ad34d3c03b984963621e3cc2383c536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->