### PR TITLE
[LAY-2603] refactor(types): enable noUncheckedIndexedAccess

### DIFF
--- a/src/components/blocks/CsvUpload/CopyTemplateHeadersButtonGroup/CopyTemplateHeadersButtonGroup.tsx
+++ b/src/components/blocks/CsvUpload/CopyTemplateHeadersButtonGroup/CopyTemplateHeadersButtonGroup.tsx
@@ -18,13 +18,13 @@ interface CopyTemplateHeadersButtonGroupProps {
 export const CopyTemplateHeadersButtonGroup = ({ headers, className }: CopyTemplateHeadersButtonGroupProps) => {
   return (
     <HStack gap='3xs' className={classNames('Layer__csv-upload__copy-template-headers-button-group', className)}>
-      {Object.keys(headers).map(key => (
+      {Object.entries(headers).map(([key, header]) => (
         <Button
           key={key}
-          onPress={() => copyTextToClipboard(headers[key])}
+          onPress={() => copyTextToClipboard(header)}
           variant='outlined'
         >
-          {headers[key]}
+          {header}
           <CopyIcon strokeWidth={1} size={12} />
         </Button>
       ))}

--- a/src/components/blocks/CsvUpload/CsvUpload/CsvUpload.tsx
+++ b/src/components/blocks/CsvUpload/CsvUpload/CsvUpload.tsx
@@ -37,7 +37,7 @@ export const CsvUpload = ({ file, onFileSelected, replaceDropTarget = false }: C
         return
       }
 
-      if (rejections.length > 0) {
+      if (rejections.length > 0 || !firstFile) {
         onFileSelected(null)
         setErrorMessage(t('upload:error.unknown_upload_error', 'Unknown upload error'))
         return

--- a/src/components/blocks/MobileSelectionDrawer/MobileSelectionDrawerList.stories.tsx
+++ b/src/components/blocks/MobileSelectionDrawer/MobileSelectionDrawerList.stories.tsx
@@ -7,7 +7,7 @@ import { Col } from '@testUtils/storybook/layout/Col'
 import { Frame } from '@testUtils/storybook/layout/Frame'
 import { Gallery } from '@testUtils/storybook/layout/Gallery'
 
-const OPTIONS: ComboBoxOption[] = [
+const OPTIONS: [ComboBoxOption, ...ComboBoxOption[]] = [
   { label: 'Profit and Loss', value: 'pnl' },
   { label: 'Balance Sheet', value: 'balance-sheet' },
   { label: 'Cash Flow', value: 'cash-flow' },

--- a/src/components/blocks/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.stories.tsx
+++ b/src/components/blocks/MobileSelectionDrawer/MobileSelectionDrawerWithTrigger.stories.tsx
@@ -8,7 +8,7 @@ import { MobileSelectionDrawerWithTrigger } from '@blocks/MobileSelectionDrawer/
 import { Col } from '@testUtils/storybook/layout/Col'
 import { Gallery } from '@testUtils/storybook/layout/Gallery'
 
-const OPTIONS: ComboBoxOption[] = [
+const OPTIONS: [ComboBoxOption, ...ComboBoxOption[]] = [
   { label: 'Profit and Loss', value: 'pnl' },
   { label: 'Balance Sheet', value: 'balance-sheet' },
   { label: 'Cash Flow', value: 'cash-flow' },

--- a/src/components/blocks/Table/SimpleDataTable/SimpleDataTable.stories.tsx
+++ b/src/components/blocks/Table/SimpleDataTable/SimpleDataTable.stories.tsx
@@ -3,6 +3,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite'
 import type { Row, RowSelectionState } from '@tanstack/react-table'
 import { userEvent, within } from 'storybook/test'
 
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 import { Button } from '@ui/Button/Button'
 import { ExpandButton } from '@ui/ExpandButton/ExpandButton'
 import type { ColumnConfig } from '@blocks/Table/DataTable/utils/column'
@@ -16,6 +17,7 @@ import {
   TABLE_STORY_SLOTS,
   TableStoryStyles,
 } from '@testUtils/storybook/data/tables'
+import { firstMatch } from '@testUtils/storybook/interactions/firstMatch'
 import { Col } from '@testUtils/storybook/layout/Col'
 import { Gallery } from '@testUtils/storybook/layout/Gallery'
 
@@ -119,7 +121,7 @@ const ExpandableRowTable = () => {
 }
 
 const ClickableRowTable = () => {
-  const [activeId, setActiveId] = useState(SHORT_LIST[2].id)
+  const [activeId, setActiveId] = useState(pickCyclic(SHORT_LIST, 2).id)
 
   const withClickableRow = useMemo(() => ({
     onRowClick: (row: Row<CustomerRow>) => setActiveId(row.original.id),
@@ -154,7 +156,7 @@ const ClickableRowTable = () => {
 export const Default: Story = {
   parameters: { chromatic: { viewports: [1280] } },
   play: async ({ canvasElement }) => {
-    await userEvent.click(within(canvasElement).getAllByRole('button', { name: 'Expand customer' })[0])
+    await userEvent.click(firstMatch(within(canvasElement).getAllByRole('button', { name: 'Expand customer' })))
   },
   render: args => (
     <Gallery gap={32}>

--- a/src/components/blocks/Table/VirtualizedDataTable/VirtualizedDataTable.tsx
+++ b/src/components/blocks/Table/VirtualizedDataTable/VirtualizedDataTable.tsx
@@ -192,6 +192,9 @@ export const VirtualizedDataTable = <TData extends { id: string }>({
         <TableBody style={{ height: totalSize }}>
           {virtualItems.map((virtualRow) => {
             const row = rows[virtualRow.index]
+
+            if (!row) return null
+
             return (
               <Row
                 key={row.id}

--- a/src/components/features/bankTransactions/BankTransactions/BankTransactions.stories.tsx
+++ b/src/components/features/bankTransactions/BankTransactions/BankTransactions.stories.tsx
@@ -3,6 +3,7 @@ import { screen, userEvent, within } from 'storybook/test'
 
 import { type BankTransactionsStringOverrides } from '@internal-types/features/bankTransactions/bankTransactionsStringOverrides'
 import { BookkeepingStatus } from '@schemas/features/bookkeeping/bookkeepingStatus'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 import { BankTransactions } from '@features/bankTransactions/BankTransactions/BankTransactions'
 
 import { makeBookkeepingStatus } from '@fixtures/bookkeeping/mocks'
@@ -245,7 +246,7 @@ export const DocsCategorization: Story = {
 
 // The rule suggestion rides back on the categorize response, so confirming any row raises it.
 const suggestRuleAfterCategorizing = putCategorizeBankTransaction.mock({
-  ...bankTransactions[0],
+  ...pickCyclic(bankTransactions, 0),
   updateCategorizationRulesSuggestion: makeCategorizationRuleSuggestion(),
 })
 

--- a/src/components/features/bankTransactions/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
+++ b/src/components/features/bankTransactions/ExpandedBankTransactionRow/ExpandedBankTransactionRow.tsx
@@ -121,7 +121,7 @@ export const ExpandedBankTransactionRow = ({
   }
 
   const changeTags = (index: number, newTags: readonly Tag[]) => {
-    const oldTags = localSplits[index].tags
+    const oldTags = localSplits[index]?.tags ?? []
     updateSplitAtIndex(index, split => ({ ...split, tags: newTags }))
 
     // Auto-save tags only when in unsplit state (single split entry)

--- a/src/components/features/bankTransactions/RecordBankTransactionModal/RecordBankTransactionModal.test.tsx
+++ b/src/components/features/bankTransactions/RecordBankTransactionModal/RecordBankTransactionModal.test.tsx
@@ -17,6 +17,7 @@ import { post as postRecordTransaction } from '@msw/api/businesses/[business-id]
 import { get as getCustomAccounts } from '@msw/api/businesses/[business-id]/custom-accounts/get'
 import { server } from '@msw/node'
 import { createFormFiller, type FillFormSpec } from '@testUtils/forms/fillForm'
+import { getCallArgs } from '@testUtils/mocks/getCallArgs'
 import { LayerTestProvider } from '@testUtils/render/LayerTestProvider'
 
 const RecordModalWrapper = ({ children }: { children: ReactNode }) => (
@@ -287,7 +288,7 @@ describe('RecordBankTransactionModal', () => {
 
     await waitFor(() => expect(updateRequest).toHaveBeenCalledTimes(1))
 
-    const { transaction } = updateRequest.mock.calls[0][0] as { transaction: Record<string, unknown> }
+    const { transaction } = getCallArgs(updateRequest)[0] as { transaction: Record<string, unknown> }
     expect(transaction).not.toHaveProperty('categorization')
     expect(transaction.amount).toBe(12550)
   })
@@ -325,7 +326,7 @@ describe('RecordBankTransactionModal', () => {
 
     await waitFor(() => expect(updateRequest).toHaveBeenCalledTimes(1))
 
-    const { transaction } = updateRequest.mock.calls[0][0] as { transaction: Record<string, unknown> }
+    const { transaction } = getCallArgs(updateRequest)[0] as { transaction: Record<string, unknown> }
     expect(transaction).toHaveProperty('categorization')
     expect(transaction.categorization).toEqual(expect.objectContaining({ type: 'Category' }))
   })

--- a/src/components/features/bookkeeping/Tasks/Tasks.stories.tsx
+++ b/src/components/features/bookkeeping/Tasks/Tasks.stories.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 import { type Meta, type StoryObj } from '@storybook/react-vite'
 
 import { BookkeepingStatus } from '@schemas/features/bookkeeping/bookkeepingStatus'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 import { type DateRange } from '@utils/shared/date/dateRange'
 import { useBankAccountsGlobalCacheActions } from '@api/businesses/[business-id]/bank-accounts/get'
 import { Tasks } from '@features/bookkeeping/Tasks/Tasks'
@@ -26,9 +27,11 @@ type TasksStoryArgs = {
 const mockAccounts = [...bankAccounts]
 
 const setSecondAccountDisconnected = (disconnected: boolean) => {
+  const secondAccount = pickCyclic(bankAccounts, 1)
+
   mockAccounts[1] = disconnected
-    ? { ...bankAccounts[1], isDisconnected: true, notifyWhenDisconnected: true }
-    : bankAccounts[1]
+    ? { ...secondAccount, isDisconnected: true, notifyWhenDisconnected: true }
+    : secondAccount
 }
 
 const SyncDisconnectedAccountMock = ({ disconnected }: { disconnected: boolean }) => {

--- a/src/components/features/categorization/CategorySelectDrawer/utils.ts
+++ b/src/components/features/categorization/CategorySelectDrawer/utils.ts
@@ -17,8 +17,10 @@ export const isGroup = (item: CategoryOption): item is CategoryGroup => {
 
 export const flattenCategories = (categories: NestedCategorization[]): Array<CategoryGroup | CategoryAsOption> =>
   groupCategoriesByParent(categories).map(({ category, label, options }) => {
-    if (options.length === 1) {
-      return options[0]
+    const onlyOption = options.length === 1 ? options[0] : undefined
+
+    if (onlyOption) {
+      return onlyOption
     }
 
     return {

--- a/src/components/features/generalLedger/ChartOfAccountsTable/utils.ts
+++ b/src/components/features/generalLedger/ChartOfAccountsTable/utils.ts
@@ -95,24 +95,24 @@ export const getMatchedTextIndices = (
   // Locate the starting index in the original text that corresponds to the beginning of the normalized match
   let positionInNormalizedText = 0, matchStartIdx = 0
   while (positionInNormalizedText < normalizedMatchStartIdx && matchStartIdx < text.length) {
-    if (!skippedChars.includes(text[matchStartIdx])) positionInNormalizedText++
+    if (!skippedChars.includes(text.charAt(matchStartIdx))) positionInNormalizedText++
     matchStartIdx++
   }
 
   // Adjust forward to skip a leading '$' or ',' if it wasn't part of the original query
-  if (skippedChars.includes(text[matchStartIdx]) && query[0] !== text[matchStartIdx]) {
+  if (skippedChars.includes(text.charAt(matchStartIdx)) && query.charAt(0) !== text.charAt(matchStartIdx)) {
     matchStartIdx++
   }
 
   // Advance through the original text to cover all characters that map to the original query
   let charsMatched = 0, matchEndIdx = matchStartIdx
   while (charsMatched < normalizedQuery.length && matchEndIdx < text.length) {
-    if (!skippedChars.includes(text[matchEndIdx])) charsMatched++
+    if (!skippedChars.includes(text.charAt(matchEndIdx))) charsMatched++
     matchEndIdx++
   }
 
   // Optionally include a trailing '$' or ',' if it was explicitly included in the query
-  if (skippedChars.includes(text[matchEndIdx]) && query[query.length - 1] === text[matchEndIdx]) {
+  if (skippedChars.includes(text.charAt(matchEndIdx)) && query.charAt(query.length - 1) === text.charAt(matchEndIdx)) {
     matchEndIdx++
   }
 

--- a/src/components/features/generalLedger/ParentAccountComboBox/useParentAccountOptions.ts
+++ b/src/components/features/generalLedger/ParentAccountComboBox/useParentAccountOptions.ts
@@ -9,12 +9,12 @@ const isAlphanumeric = (char: string) => /[\p{L}\p{N}]/u.test(char)
 const compareSpecialCharsLast = (a: string, b: string): number => {
   const length = Math.min(a.length, b.length)
   for (let i = 0; i < length; i++) {
-    const aSpecial = !isAlphanumeric(a[i])
-    const bSpecial = !isAlphanumeric(b[i])
+    const aSpecial = !isAlphanumeric(a.charAt(i))
+    const bSpecial = !isAlphanumeric(b.charAt(i))
     if (aSpecial !== bSpecial) {
       return aSpecial ? 1 : -1
     }
-    const comparison = a[i].localeCompare(b[i])
+    const comparison = a.charAt(i).localeCompare(b.charAt(i))
     if (comparison !== 0) {
       return comparison
     }

--- a/src/components/features/invoices/InvoicePaymentForm/InvoicePaymentForm.tsx
+++ b/src/components/features/invoices/InvoicePaymentForm/InvoicePaymentForm.tsx
@@ -119,7 +119,7 @@ export const InvoicePaymentForm = (props: InvoicePaymentFormProps) => {
         <form.AppField name='amount'>
           {field => <field.FormNonRecursiveBigDecimalField label={t('invoices:InvoicePaymentForm.label.amount_paid', 'Amount paid')} inline className={`${INVOICE_PAYMENT_FORM_FIELD_CSS_PREFIX}__Amount`} mode='currency' isReadOnly={isReadOnly} maxValue={convertCentsToBigDecimal(invoice.outstandingBalance)} />}
         </form.AppField>
-        <form.Subscribe selector={state => [state.values.amount]}>
+        <form.Subscribe selector={state => [state.values.amount] as const}>
           {([amount]) => (
             <HStack justify='end' className={`${INVOICE_PAYMENT_FORM_FIELD_CSS_PREFIX}__OutstandingBalance`} gap='xs' align='center'>
               <Span size='sm'>{t('invoices:InvoicePaymentForm.label.balance_due', 'Balance due')}</Span>

--- a/src/components/features/invoices/InvoiceTable/InvoiceTable.tsx
+++ b/src/components/features/invoices/InvoiceTable/InvoiceTable.tsx
@@ -152,7 +152,7 @@ export const InvoiceTable = ({
   const options = useInvoiceStatusOptions()
 
   const selectedStatusOption = useMemo(
-    () => options.find(o => o.value === selectedInvoiceStatusOption?.value) ?? options[0],
+    () => options.find(o => o.value === selectedInvoiceStatusOption?.value) ?? options[0] ?? null,
     [options, selectedInvoiceStatusOption?.value],
   )
 

--- a/src/components/features/invoices/InvoicesMobileHeader/InvoicesMobileHeader.tsx
+++ b/src/components/features/invoices/InvoicesMobileHeader/InvoicesMobileHeader.tsx
@@ -23,7 +23,7 @@ export const InvoicesMobileHeader = ({ onCreateInvoice }: InvoicesMobileHeaderPr
   const options = useInvoiceStatusOptions()
 
   const selectedStatusOption = useMemo(
-    () => options.find(o => o.value === selectedInvoiceStatusOption?.value) ?? options[0],
+    () => options.find(o => o.value === selectedInvoiceStatusOption?.value) ?? options[0] ?? null,
     [options, selectedInvoiceStatusOption?.value],
   )
 

--- a/src/components/features/taxEstimates/FullYearProjectionComboBox/FullYearProjectionComboBox.tsx
+++ b/src/components/features/taxEstimates/FullYearProjectionComboBox/FullYearProjectionComboBox.tsx
@@ -26,7 +26,7 @@ export const FullYearProjectionComboBox = () => {
     [t],
   )
 
-  const selectedValue = fullYearProjection ? options[1] : options[0]
+  const selectedValue = (fullYearProjection ? options[1] : options[0]) ?? null
 
   const handleChange = useCallback((option: ProjectionOption | null) => {
     setFullYearProjection(option?.valueBool ?? false)

--- a/src/components/features/timeTracking/TimeTrackingStats/TimeTrackingStats.tsx
+++ b/src/components/features/timeTracking/TimeTrackingStats/TimeTrackingStats.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis } from 'recharts'
 
 import { type TimeEntrySummary, type TimeEntrySummaryGroup } from '@schemas/features/timeTracking/timeEntrySummary'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 import { DEFAULT_CHART_COLORS } from '@utils/shared/styles/chartColors'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
 import { type TimeTrackingSummaryFilterParams, useGetTimeTrackingSummary } from '@api/businesses/[business-id]/time-tracking/time-entries/summary/get'
@@ -44,7 +45,7 @@ function buildServiceBreakdown(
   return [...positive]
     .sort((a, b) => b.totalMinutes - a.totalMinutes)
     .map((entry, index) => ({
-      color: DEFAULT_CHART_COLORS[index % DEFAULT_CHART_COLORS.length],
+      color: pickCyclic(DEFAULT_CHART_COLORS, index),
       key: entry.id ?? `service-${index}`,
       totalMinutes: entry.totalMinutes,
       percentage: totalMinutes > 0 ? entry.totalMinutes / totalMinutes : 0,

--- a/src/components/features/unifiedReports/UnifiedReportDetailBreadcrumb/UnifiedReportDetailBreadcrumb.tsx
+++ b/src/components/features/unifiedReports/UnifiedReportDetailBreadcrumb/UnifiedReportDetailBreadcrumb.tsx
@@ -15,10 +15,11 @@ export const UnifiedReportDetailBreadcrumb = () => {
 
   const handleBreadcrumbClick = useCallback((key: BreadcrumbKey) => {
     const index = breadcrumbItems.findIndex(item => item.key === key)
-    if (index === -1 || !detailReportConfig) return
+    const report = breadcrumbItems[index]
+    if (!report || !detailReportConfig) return
 
     openDetailReport({
-      report: breadcrumbItems[index],
+      report,
       breadcrumb: breadcrumbItems.slice(0, index + 1),
       column: detailReportConfig?.column,
     })

--- a/src/components/ui/Chart/ChartTooltip.tsx
+++ b/src/components/ui/Chart/ChartTooltip.tsx
@@ -44,15 +44,17 @@ interface ChartTooltipCursorProps {
 }
 
 export const ChartTooltipCursor = ({ width, points, height }: ChartTooltipCursorProps) => {
-  if (!points || points.length === 0 || height === undefined) return null
+  const [firstPoint] = points ?? []
+
+  if (!firstPoint || height === undefined) return null
 
   return (
     <ZIndexLayer zIndex={DefaultZIndexes.cursorRectangle}>
       <Rectangle
         fill='#F7F8FA'
         stroke='none'
-        x={points[0].x - width / 2}
-        y={points[0].y}
+        x={firstPoint.x - width / 2}
+        y={firstPoint.y}
         width={width}
         height={height + CURSOR_Y_OFFSET}
         radius={6}

--- a/src/components/ui/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ui/ComboBox/ComboBox.stories.tsx
@@ -6,9 +6,12 @@ import type { ComboBoxOption } from '@ui/ComboBox/types'
 import { Gallery } from '@testUtils/storybook/layout/Gallery'
 import { Row } from '@testUtils/storybook/layout/Row'
 
+const CHECKING_OPTION: ComboBoxOption = { label: 'Checking', value: 'checking' }
+const SAVINGS_OPTION: ComboBoxOption = { label: 'Savings', value: 'savings' }
+
 const OPTIONS: ComboBoxOption[] = [
-  { label: 'Checking', value: 'checking' },
-  { label: 'Savings', value: 'savings' },
+  CHECKING_OPTION,
+  SAVINGS_OPTION,
   { label: 'Credit card', value: 'credit' },
 ]
 
@@ -20,7 +23,7 @@ const meta: Meta<typeof ComboBox<ComboBoxOption>> = {
   args: {
     'aria-label': 'Account',
     'options': OPTIONS,
-    'selectedValue': OPTIONS[0],
+    'selectedValue': CHECKING_OPTION,
     'onSelectedValueChange': noop,
     'placeholder': 'Select an account',
   },
@@ -51,13 +54,13 @@ export const AllVariants: Story = {
         <ComboBox aria-label='Placeholder' options={OPTIONS} selectedValue={null} onSelectedValueChange={noop} placeholder='Select an account' />
       </Field>
       <Field label='selected'>
-        <ComboBox aria-label='Selected' options={OPTIONS} selectedValue={OPTIONS[0]} onSelectedValueChange={noop} />
+        <ComboBox aria-label='Selected' options={OPTIONS} selectedValue={CHECKING_OPTION} onSelectedValueChange={noop} />
       </Field>
       <Field label='clearable'>
-        <ComboBox aria-label='Clearable' options={OPTIONS} selectedValue={OPTIONS[1]} onSelectedValueChange={noop} isClearable />
+        <ComboBox aria-label='Clearable' options={OPTIONS} selectedValue={SAVINGS_OPTION} onSelectedValueChange={noop} isClearable />
       </Field>
       <Field label='disabled'>
-        <ComboBox aria-label='Disabled' options={OPTIONS} selectedValue={OPTIONS[0]} onSelectedValueChange={noop} isDisabled />
+        <ComboBox aria-label='Disabled' options={OPTIONS} selectedValue={CHECKING_OPTION} onSelectedValueChange={noop} isDisabled />
       </Field>
       <Field label='error'>
         <ComboBox aria-label='Error' options={OPTIONS} selectedValue={null} onSelectedValueChange={noop} isError slots={{ ErrorMessage: 'Required' }} />
@@ -78,7 +81,7 @@ export const MenuOpen: Story = {
         <ComboBox aria-label='Open' options={OPTIONS} selectedValue={null} onSelectedValueChange={noop} placeholder='Select an account' menuIsOpen menuPortalTarget={null} />
       </div>
       <div style={{ width: 240 }}>
-        <ComboBox aria-label='Open selected' options={OPTIONS} selectedValue={OPTIONS[0]} onSelectedValueChange={noop} menuIsOpen menuPortalTarget={null} />
+        <ComboBox aria-label='Open selected' options={OPTIONS} selectedValue={CHECKING_OPTION} onSelectedValueChange={noop} menuIsOpen menuPortalTarget={null} />
       </div>
     </Gallery>
   ),

--- a/src/components/ui/DatePickers/YearPicker/YearPicker.tsx
+++ b/src/components/ui/DatePickers/YearPicker/YearPicker.tsx
@@ -59,7 +59,7 @@ export const YearPicker = ({
   }, [formatDate, minYear, maxYear])
 
   const selectedYearOption = useMemo(() => {
-    return yearOptions.find(opt => opt.value === String(year)) ?? yearOptions[0]
+    return yearOptions.find(opt => opt.value === String(year)) ?? yearOptions[0] ?? null
   }, [yearOptions, year])
 
   const handleChange = useCallback((option: YearOption | null) => {

--- a/src/components/ui/Input/FileInput.tsx
+++ b/src/components/ui/Input/FileInput.tsx
@@ -6,7 +6,8 @@ import { Button } from '@ui/Button/Button'
 
 export interface FileInputProps {
   text?: string
-  onUpload?: (files: File[]) => void
+  // Non-empty, so consumers that only want the first file don't have to re-check for one.
+  onUpload?: (files: [File, ...File[]]) => void
   isDisabled?: boolean
   secondary?: boolean
   icon?: boolean
@@ -36,9 +37,10 @@ export const FileInput = ({
   }
 
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (event.target.files && event.target.files.length > 0 && onUpload) {
-      const filesUploaded = Array.from(event.target.files)
-      onUpload(filesUploaded)
+    const [firstFile, ...restFiles] = Array.from(event.target.files ?? [])
+
+    if (firstFile && onUpload) {
+      onUpload([firstFile, ...restFiles])
     }
     event.target.value = ''
   }

--- a/src/components/ui/Legend/Legend.stories.tsx
+++ b/src/components/ui/Legend/Legend.stories.tsx
@@ -21,7 +21,7 @@ const COLORS: Record<string, string> = {
 const total = (items: ReadonlyArray<SeriesData>) =>
   items.reduce((sum, item) => sum + item.value, 0)
 
-const colorSelector = (item: SeriesData) => ({ color: COLORS[item.name], opacity: 1 })
+const colorSelector = (item: SeriesData) => ({ color: COLORS[item.name] ?? 'var(--color-base-300)', opacity: 1 })
 const formatValue = (value: number) => `$${value.toLocaleString()}`
 
 const meta: Meta<typeof Legend<SeriesData>> = {

--- a/src/components/ui/Tabs/Tabs.tsx
+++ b/src/components/ui/Tabs/Tabs.tsx
@@ -30,7 +30,7 @@ export const Tabs = ({ name, options, selected, onChange }: TabsProps) => {
   const [isInitialized, setIsInitialized] = useState(false)
   const thumbRef = useRef<HTMLSpanElement>(null)
 
-  const selectedValue = selected || options[0].value
+  const selectedValue = selected || options[0]?.value
 
   const baseClassName = classNames(
     'Layer__tabs',

--- a/src/components/ui/Toggle/Toggle.tsx
+++ b/src/components/ui/Toggle/Toggle.tsx
@@ -47,9 +47,9 @@ export const Toggle = ({
       selectionMode='single'
       selectedKeys={selectedKeys}
       onSelectionChange={(keys) => {
-        const selectedKeysArray = Array.from(keys)
-        if (selectedKeysArray.length > 0 && onSelectionChange) {
-          onSelectionChange(selectedKeysArray[0])
+        const [firstKey] = Array.from(keys)
+        if (firstKey !== undefined && onSelectionChange) {
+          onSelectionChange(firstKey)
         }
       }}
     >

--- a/src/fixtures/bankTransactions/derive.ts
+++ b/src/fixtures/bankTransactions/derive.ts
@@ -6,6 +6,7 @@ import { BankTransactionDirection } from '@schemas/features/bankTransactions/bas
 import { MatchType } from '@schemas/features/bankTransactions/match'
 import { type MatchDetailsType } from '@schemas/features/bankTransactions/matchDetails'
 import { type AccountCategorizationSchema } from '@schemas/features/categorization/categorization'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
 import {
   type BankTransactionCategory,
@@ -52,9 +53,9 @@ const deriveTransfer = (
   transaction: BankTransaction,
   { matched, outbound, ref }: { matched: boolean, outbound: boolean, ref: number },
 ): BankTransaction => {
-  const accountName = transaction.accountName ?? bankAccounts[0].accountName
+  const accountName = transaction.accountName ?? pickCyclic(bankAccounts, 0).accountName
   const counterpartyAccounts = bankAccounts.filter(account => account.accountName !== accountName)
-  const counterpartyAccount = counterpartyAccounts[ref % counterpartyAccounts.length].accountName
+  const counterpartyAccount = pickCyclic(counterpartyAccounts, ref).accountName
   const fromAccountName = outbound ? accountName : counterpartyAccount
   const toAccountName = outbound ? counterpartyAccount : accountName
 
@@ -81,7 +82,7 @@ const deriveTransfer = (
 
   const suggestedMatches = [{ id: toSuggestedMatchId(transaction.id), details }]
 
-  const alternateCounterparty = counterpartyAccounts[(ref + 1) % counterpartyAccounts.length].accountName
+  const alternateCounterparty = pickCyclic(counterpartyAccounts, ref + 1).accountName
   if (alternateCounterparty !== counterpartyAccount) {
     const alternateFrom = outbound ? accountName : alternateCounterparty
     const alternateTo = outbound ? alternateCounterparty : accountName
@@ -138,7 +139,7 @@ const merchantMatchDetails = (
   merchant: BankTransactionMerchant,
   ref: number,
 ): MatchDetailsType => {
-  const type = merchant.matchTypes[Math.floor(ref / 2) % merchant.matchTypes.length]
+  const type = pickCyclic(merchant.matchTypes, Math.floor(ref / 2))
 
   const base = {
     id: toMatchDetailsId(transaction.id),
@@ -198,7 +199,7 @@ const pickMatchMerchant = (merchantIndex: number, ref: number): BankTransactionM
   const pool = matchable.filter(candidate =>
     candidate.matchTypes.includes('Refund_Payment_Match') === wantRefund)
 
-  return pool[merchantIndex % pool.length]
+  return pickCyclic(pool, merchantIndex)
 }
 
 const deriveMerchantMatch = (
@@ -273,7 +274,7 @@ const deriveSplit = (
       displayName: 'Split',
       entries: [
         { type: 'AccountSplitEntry', amount: primaryAmount, category: toAccountCategorization(merchant.primary), tags: [] },
-        { type: 'AccountSplitEntry', amount: alternateAmount, category: toAccountCategorization(merchant.alternates[0]), tags: [] },
+        { type: 'AccountSplitEntry', amount: alternateAmount, category: toAccountCategorization(pickCyclic(merchant.alternates, 0)), tags: [] },
       ],
     },
   }
@@ -287,7 +288,7 @@ export const deriveBankTransaction = (
 
   // Each transaction belongs to one of the pooled bank accounts, so its
   // account fields agree with what the bank-accounts mock serves.
-  const account = bankAccounts[accountIndex % bankAccounts.length]
+  const account = pickCyclic(bankAccounts, accountIndex)
   const accountTransaction: BankTransaction = {
     ...transaction,
     accountName: account.accountName,
@@ -312,7 +313,7 @@ export const deriveBankTransaction = (
     }
   }
 
-  const merchant = bankTransactionMerchants[merchantIndex % bankTransactionMerchants.length]
+  const merchant = pickCyclic(bankTransactionMerchants, merchantIndex)
   const merchantTransaction = toMerchantTransaction(merchant)
 
   // Splits need an alternate category for the second entry; merchants without

--- a/src/fixtures/bookkeeping/mocks.ts
+++ b/src/fixtures/bookkeeping/mocks.ts
@@ -7,6 +7,7 @@ import {
   TaskUserResponseType,
 } from '@schemas/features/bookkeeping/businessTask'
 import { type CallBooking, CallBookingPurpose, CallBookingState, CallBookingType } from '@schemas/features/bookkeeping/callBooking'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
 import { PeriodIdSchema, schema } from '@fixtures/bookkeeping/schema'
 import { formatDollars, formatTaskDate } from '@fixtures/bookkeeping/utils'
@@ -67,7 +68,7 @@ const generateTaskSeeds = createGenerator(schema, {
 
 const generatePeriodIds = createGenerator(PeriodIdSchema)
 
-const periodIdFor = (monthIndex: number) => generatePeriodIds({ numRuns: 1, seed: monthIndex })[0]
+const periodIdFor = (monthIndex: number) => pickCyclic(generatePeriodIds({ numRuns: 1, seed: monthIndex }), 0)
 
 const makePeriodTasks = (periodIndex: number, count: number, month: number): BusinessTask[] => {
   if (count === 0) return []

--- a/src/fixtures/invoices/generator.ts
+++ b/src/fixtures/invoices/generator.ts
@@ -1,4 +1,5 @@
 import { InvoiceStatus } from '@schemas/features/invoices/invoiceStatus'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
 import { FIXTURE_YEAR } from '@fixtures/constants/fixtureYear'
 import { invoicePaymentTermsDays } from '@fixtures/invoices/constants'
@@ -34,7 +35,7 @@ export const generator: typeof generateInvoices = (overrides) => {
         ...invoice,
         invoiceNumber: `INV-${String(1001 + index)}`,
         sentAt: isDraft ? null : issuedAt,
-        dueAt: isDraft ? null : addDays(issuedAt, invoicePaymentTermsDays[index % invoicePaymentTermsDays.length]),
+        dueAt: isDraft ? null : addDays(issuedAt, pickCyclic(invoicePaymentTermsDays, index)),
         paidAt: invoice.paidAt == null ? null : addDays(issuedAt, 7 + (index % 14)),
         voidedAt: invoice.voidedAt == null ? null : addDays(issuedAt, 5),
         importedAt: null,

--- a/src/fixtures/invoices/schema.ts
+++ b/src/fixtures/invoices/schema.ts
@@ -2,6 +2,7 @@ import { Arbitrary, Schema } from 'effect'
 
 import { InvoiceSchema } from '@schemas/features/invoices/invoice'
 import { InvoiceStatus } from '@schemas/features/invoices/invoiceStatus'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
 import { makeBusiness } from '@fixtures/business/mocks'
 import {
@@ -61,7 +62,7 @@ const applyInvoiceInvariants = (invoice: typeof base.Type): typeof base.Type => 
   const additionalSalesTaxesTotal = lineItems.reduce((sum, lineItem) => sum + lineItem.salesTaxTotal, 0)
   const totalAmount = lineItems.reduce((sum, lineItem) => sum + lineItem.totalAmount, 0)
 
-  const paidFraction = PARTIAL_PAYMENT_FRACTIONS[Math.floor(subtotal / 100) % PARTIAL_PAYMENT_FRACTIONS.length]
+  const paidFraction = pickCyclic(PARTIAL_PAYMENT_FRACTIONS, Math.floor(subtotal / 100))
 
   const outstandingBalance = (() => {
     switch (invoice.status) {

--- a/src/fixtures/ledgerEntries/arbitrary.ts
+++ b/src/fixtures/ledgerEntries/arbitrary.ts
@@ -1,6 +1,7 @@
 import { type FastCheck } from 'effect'
 
 import { LedgerEntryDirection } from '@schemas/features/generalLedger/ledgerEntryDirection'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
 import { ROOT_STABLE_NAMES } from '@fixtures/chartOfAccounts/constants'
 import { chartOfAccounts } from '@fixtures/generated/chartOfAccounts.gen'
@@ -60,9 +61,9 @@ export const ledgerEntryLineItemsArbitrary = (fc: typeof FastCheck) =>
 
     return [
       ...debitAmounts.map((amount, index) =>
-        toLineItem(ids[index], accounts[index], amount, LedgerEntryDirection.Debit, entryAt)),
+        toLineItem(pickCyclic(ids, index), pickCyclic(accounts, index), amount, LedgerEntryDirection.Debit, entryAt)),
       ...creditAmounts.map((amount, index) =>
-        toLineItem(ids[debits + index], accounts[debits + index], amount, LedgerEntryDirection.Credit, entryAt)),
+        toLineItem(pickCyclic(ids, debits + index), pickCyclic(accounts, debits + index), amount, LedgerEntryDirection.Credit, entryAt)),
     ]
   })
 

--- a/src/fixtures/ledgerEntries/generator.ts
+++ b/src/fixtures/ledgerEntries/generator.ts
@@ -1,4 +1,5 @@
 import { ClassifierAgent, EntryType } from '@schemas/features/generalLedger/ledgerEntry'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
 import { PARENT_BY_STABLE_NAME } from '@fixtures/chartOfAccounts/constants'
 import { FIXTURE_YEAR } from '@fixtures/constants/fixtureYear'
@@ -36,7 +37,7 @@ const entryAtNoonUtc = (index: number, total: number) => {
 const assignAccountsAndDates = (lineItems: FixtureEntry['lineItems'], startSlot: number, entryAt: Date) =>
   lineItems.map((lineItem, lineIndex) => ({
     ...lineItem,
-    account: postableAccounts[(startSlot + lineIndex) % postableAccounts.length],
+    account: pickCyclic(postableAccounts, startSlot + lineIndex),
     entryAt,
     createdAt: entryAt,
   }))

--- a/src/fixtures/ledgerEntries/schema.ts
+++ b/src/fixtures/ledgerEntries/schema.ts
@@ -13,6 +13,7 @@ import { makeManualEntrySource } from '@fixtures/ledgerEntries/sources'
 import { dateArbitrary } from '@fixtures/utils/arbitrary/date'
 import { FixtureIdPrefix, idArbitrary } from '@fixtures/utils/arbitrary/id'
 import { withArbitrary } from '@fixtures/utils/arbitrary/withArbitrary'
+import { sortedDatePair } from '@fixtures/utils/sortedDatePair'
 
 const BUSINESS_ID = makeBusiness().id
 const LEDGER_ID = '00000000-0000-4000-8000-0000000000ff'
@@ -46,7 +47,7 @@ const baseArbitrary = Arbitrary.make(base)
 export const LedgerEntryArbitrarySchema = base.annotations({
   arbitrary: () => () =>
     baseArbitrary.map((entry): typeof base.Type => {
-      const [date, entryAt] = [entry.date, entry.entryAt].sort((a, b) => a.getTime() - b.getTime())
+      const [date, entryAt] = sortedDatePair(entry.date, entry.entryAt)
       const lineItems = entry.lineItems.map(lineItem => ({
         ...lineItem,
         entryId: entry.id,

--- a/src/fixtures/profitAndLoss/mocks.ts
+++ b/src/fixtures/profitAndLoss/mocks.ts
@@ -1,5 +1,6 @@
 import type { ProfitAndLoss } from '@schemas/features/profitAndLoss/profitAndLoss'
 import type { ProfitAndLossSummary } from '@schemas/features/profitAndLoss/profitAndLossSummaries'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
 import { hasCompletedBooks } from '@fixtures/bookkeeping/mocks'
 import {
@@ -33,7 +34,7 @@ export const makeProfitAndLossSummary = (year: number, month: number): ProfitAnd
   // Same seed per calendar month, so every window and endpoint agrees on that month's numbers.
   // Fast-check biases its first samples toward range edges; the last of a few runs is well spread.
   const summaries = generate({ numRuns: 5, seed: year * 12 + month })
-  const summary = { ...summaries[summaries.length - 1], year, month }
+  const summary = { ...pickCyclic(summaries, summaries.length - 1), year, month }
 
   if (!hasCompletedBooks(year, month)) return summary
 

--- a/src/fixtures/profitAndLoss/utils.ts
+++ b/src/fixtures/profitAndLoss/utils.ts
@@ -35,9 +35,10 @@ export const makeLineItem = (
 const splitIntoLineItems = (total: number, split: readonly CategorySplit[]): LineItem[] => {
   const values = split.map(([, , share]) => Math.round(total * share))
   const allocated = values.reduce((sum, value) => sum + value, 0)
-  if (values.length > 0) values[0] += total - allocated
+  const [firstValue] = values
+  if (firstValue !== undefined) values[0] = firstValue + total - allocated
 
-  return split.map(([name, displayName], index) => makeLineItem(name, displayName, values[index]))
+  return split.map(([name, displayName], index) => makeLineItem(name, displayName, values[index] ?? 0))
 }
 
 export const makeSectionLineItem = (

--- a/src/fixtures/taxEstimates/scenario/derive.ts
+++ b/src/fixtures/taxEstimates/scenario/derive.ts
@@ -5,6 +5,7 @@ import { type TaxDetails, type TaxDetailsRow } from '@schemas/features/taxEstima
 import { type TaxOverviewApiData, TaxOverviewDeadlineStatus, TaxOverviewMetricType } from '@schemas/features/taxEstimates/overview'
 import { type TaxPaymentRow } from '@schemas/features/taxEstimates/payments'
 import { type TaxSummary } from '@schemas/features/taxEstimates/summary'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
 import { type TaxScenario } from '@fixtures/taxEstimates/scenario/types'
 import {
@@ -140,10 +141,10 @@ export const deriveTaxPayments = (scenario: TaxScenario): { type: 'US_Tax_Paymen
   const data = scenario.quarters.map((quarter, index): TaxPaymentRow => ({
     rowKey: `q${quarter.quarter}`,
     label: quarterLabel(quarter.quarter),
-    ...combined[index],
+    ...pickCyclic(combined, index),
     breakdown: [
-      { rowKey: `q${quarter.quarter}-federal`, label: 'Federal', ...federal[index] },
-      { rowKey: `q${quarter.quarter}-state`, label: scenario.stateLabel, ...state[index] },
+      { rowKey: `q${quarter.quarter}-federal`, label: 'Federal', ...pickCyclic(federal, index) },
+      { rowKey: `q${quarter.quarter}-state`, label: scenario.stateLabel, ...pickCyclic(state, index) },
     ],
   }))
 
@@ -159,13 +160,13 @@ export const deriveTaxBanner = (scenario: TaxScenario): TaxEstimatesBanner => {
   const nextDueIndex = scenario.quarters.findIndex(quarter => quarterDueDate(scenario.year, quarter.quarter).compare(now) >= 0)
   const currentQuarterIndex = nextDueIndex === -1 ? scenario.quarters.length - 1 : nextDueIndex
   const hasUncategorized = scenario.uncategorized.count > 0
-  const currentQuarterRange = quarterUncategorizedRange(scenario.year, scenario.quarters[currentQuarterIndex].quarter)
+  const currentQuarterRange = quarterUncategorizedRange(scenario.year, pickCyclic(scenario.quarters, currentQuarterIndex).quarter)
   const earliestAt = hasUncategorized ? currentQuarterRange.earliest : null
   const latestAt = hasUncategorized ? currentQuarterRange.latest : null
 
   const quarters = scenario.quarters.map((quarter, index): TaxEstimatesBannerQuarter => {
     const dueDate = quarterDueDate(scenario.year, quarter.quarter)
-    const { rolledOverFromPrevious, owedThisQuarter, totalPaid, remainingBalance } = combined[index]
+    const { rolledOverFromPrevious, owedThisQuarter, totalPaid, remainingBalance } = pickCyclic(combined, index)
     const isPastDue = dueDate.compare(now) < 0 && remainingBalance > 0
     const state = remainingBalance <= 0
       ? TaxOverviewDeadlineStatus.Paid

--- a/src/fixtures/taxEstimates/scenario/utils.ts
+++ b/src/fixtures/taxEstimates/scenario/utils.ts
@@ -46,7 +46,7 @@ export const runningBalances = (owed: number[], paid: number[]): QuarterBalance[
   const balances: QuarterBalance[] = []
   let carried = 0
   owed.forEach((owedThisQuarter, index) => {
-    const totalPaid = paid[index]
+    const totalPaid = paid[index] ?? 0
     const remainingBalance = carried + owedThisQuarter - totalPaid
     balances.push({ rolledOverFromPrevious: carried, owedThisQuarter, totalPaid, remainingBalance })
     carried = Math.max(remainingBalance, 0)
@@ -56,15 +56,17 @@ export const runningBalances = (owed: number[], paid: number[]): QuarterBalance[
 
 export const quarterLabel = (quarter: number) => `Q${quarter}`
 
+const FINAL_QUARTER_MONTH_SPAN: [number, number] = [8, 11]
+
 const QUARTER_MONTH_SPANS: Record<number, [number, number]> = {
   1: [0, 2],
   2: [3, 4],
   3: [5, 7],
-  4: [8, 11],
+  4: FINAL_QUARTER_MONTH_SPAN,
 }
 
 export const quarterUncategorizedRange = (year: number, quarter: number): { earliest: Date, latest: Date } => {
-  const [startMonth, endMonth] = QUARTER_MONTH_SPANS[quarter] ?? QUARTER_MONTH_SPANS[4]
+  const [startMonth, endMonth] = QUARTER_MONTH_SPANS[quarter] ?? FINAL_QUARTER_MONTH_SPAN
   return { earliest: new Date(year, startMonth, 3), latest: new Date(year, endMonth, 18) }
 }
 

--- a/src/fixtures/timeEntries/schema.ts
+++ b/src/fixtures/timeEntries/schema.ts
@@ -16,6 +16,7 @@ import { calendarDateArbitrary } from '@fixtures/utils/arbitrary/calendarDate'
 import { dateArbitrary } from '@fixtures/utils/arbitrary/date'
 import { FixtureIdPrefix, idArbitrary } from '@fixtures/utils/arbitrary/id'
 import { withArbitrary } from '@fixtures/utils/arbitrary/withArbitrary'
+import { sortedDatePair } from '@fixtures/utils/sortedDatePair'
 
 const BUSINESS_ID = makeBusiness().id
 
@@ -46,7 +47,7 @@ const baseArbitrary = Arbitrary.make(base)
 export const TimeEntryArbitrarySchema = base.annotations({
   arbitrary: () => () =>
     baseArbitrary.map((entry): typeof base.Type => {
-      const [createdAt, updatedAt] = [entry.createdAt, entry.updatedAt].sort((a, b) => a.getTime() - b.getTime())
+      const [createdAt, updatedAt] = sortedDatePair(entry.createdAt, entry.updatedAt)
 
       const status = entry.status === 'COMPLETED' ? 'COMPLETED' : 'RECORDED'
 

--- a/src/fixtures/trips/schema.ts
+++ b/src/fixtures/trips/schema.ts
@@ -1,6 +1,7 @@
 import { Arbitrary, Schema } from 'effect'
 
 import { TripSchema } from '@schemas/features/mileage/trip'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
 import { FIXTURE_YEAR } from '@fixtures/constants/fixtureYear'
 import { addresses } from '@fixtures/constants/personal/addresses'
@@ -9,6 +10,7 @@ import { calendarDateArbitrary } from '@fixtures/utils/arbitrary/calendarDate'
 import { dateArbitrary } from '@fixtures/utils/arbitrary/date'
 import { FixtureIdPrefix, idArbitrary } from '@fixtures/utils/arbitrary/id'
 import { withArbitrary } from '@fixtures/utils/arbitrary/withArbitrary'
+import { sortedDatePair } from '@fixtures/utils/sortedDatePair'
 
 const fields = TripSchema.fields
 
@@ -39,11 +41,11 @@ const baseArbitrary = Arbitrary.make(base)
 export const TripArbitrarySchema = base.annotations({
   arbitrary: () => () =>
     baseArbitrary.map((trip): typeof base.Type => {
-      const [createdAt, updatedAt] = [trip.createdAt, trip.updatedAt].sort((a, b) => a.getTime() - b.getTime())
+      const [createdAt, updatedAt] = sortedDatePair(trip.createdAt, trip.updatedAt)
 
       const addressPool: readonly string[] = addresses
       const endAddress = trip.startAddress != null && trip.startAddress === trip.endAddress
-        ? addressPool[(addressPool.indexOf(trip.startAddress) + 1) % addressPool.length]
+        ? pickCyclic(addressPool, addressPool.indexOf(trip.startAddress) + 1)
         : trip.endAddress
 
       return { ...trip, createdAt, updatedAt, endAddress }

--- a/src/fixtures/unifiedReports/deterministicAmounts.ts
+++ b/src/fixtures/unifiedReports/deterministicAmounts.ts
@@ -1,6 +1,8 @@
 import { eachMonthOfInterval, isWithinInterval } from 'date-fns'
 import { sumBy } from 'lodash-es'
 
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
+
 export type MockReportEntry = {
   date: Date
   amountCents: number
@@ -67,7 +69,7 @@ const ENTRY_NARRATION: Record<EntryFlow | 'neutral', { types: readonly string[],
   },
 }
 
-const pickFrom = (values: readonly string[], key: string) => values[hashString(key) % values.length]
+const pickFrom = (values: readonly string[], key: string) => pickCyclic(values, hashString(key))
 
 export const monthEntries = (
   stableKey: string,
@@ -83,7 +85,7 @@ export const monthEntries = (
 
   return ENTRY_DAYS.map((day, index) => {
     const isLast = index === ENTRY_DAYS.length - 1
-    const rawAmount = isLast ? remaining : Math.round(monthTotal * LEADING_ENTRY_WEIGHTS[index])
+    const rawAmount = isLast ? remaining : Math.round(monthTotal * pickCyclic(LEADING_ENTRY_WEIGHTS, index))
     remaining -= rawAmount
 
     const entryKey = `${stableKey}:${year}-${monthIndex}-${index}`

--- a/src/fixtures/utils/createGenerator.ts
+++ b/src/fixtures/utils/createGenerator.ts
@@ -45,12 +45,12 @@ export function createGenerator<A, I, R>(
       if (rows.length === config.numRuns) break
 
       const keys = uniqueBy.map(getKey => getKey(candidate))
-      const collides = keys.some((key, index) => key != null && seenByKey[index].has(key))
+      const collides = keys.some((key, index) => key != null && seenByKey[index]?.has(key) === true)
 
       if (collides) continue
 
       keys.forEach((key, index) => {
-        if (key != null) seenByKey[index].add(key)
+        if (key != null) seenByKey[index]?.add(key)
       })
       rows.push(candidate)
     }

--- a/src/fixtures/utils/createRollTable.ts
+++ b/src/fixtures/utils/createRollTable.ts
@@ -8,6 +8,12 @@ type RollCases<TCase extends string> = ReadonlyArray<readonly [TCase, number]>
  * exceeds it, and `handle` dispatches to that case's handler.
  */
 export const createRollTable = <TCase extends string>(cases: RollCases<TCase>) => {
+  const lastCase = cases.at(-1)
+
+  if (!lastCase) {
+    throw new Error('createRollTable: at least one case is required')
+  }
+
   const outOf = cases.reduce((total, [, weight]) => total + weight, 0)
 
   const resolve = (roll: number): TCase => {
@@ -18,7 +24,7 @@ export const createRollTable = <TCase extends string>(cases: RollCases<TCase>) =
       if (roll < ceiling) return name
     }
 
-    return cases[cases.length - 1][0]
+    return lastCase[0]
   }
 
   const handle = <TResult>(roll: number, handlers: Record<TCase, () => TResult>): TResult =>

--- a/src/fixtures/utils/sortedDatePair.ts
+++ b/src/fixtures/utils/sortedDatePair.ts
@@ -1,0 +1,6 @@
+/*
+ * Orders two generated dates oldest-first, as a tuple so both halves stay defined —
+ * `[a, b].sort()` widens back to `Date[]`.
+ */
+export const sortedDatePair = (a: Date, b: Date): [Date, Date] =>
+  a.getTime() <= b.getTime() ? [a, b] : [b, a]

--- a/src/fixtures/vehicles/schema.ts
+++ b/src/fixtures/vehicles/schema.ts
@@ -6,6 +6,7 @@ import { makeBusiness } from '@fixtures/business/mocks'
 import { dateArbitrary } from '@fixtures/utils/arbitrary/date'
 import { FixtureIdPrefix, idArbitrary } from '@fixtures/utils/arbitrary/id'
 import { withArbitrary } from '@fixtures/utils/arbitrary/withArbitrary'
+import { sortedDatePair } from '@fixtures/utils/sortedDatePair'
 import {
   isEligibleForDeletionArbitrary,
   licensePlateArbitrary,
@@ -41,7 +42,7 @@ const baseArbitrary = Arbitrary.make(base)
 export const VehicleArbitrarySchema = base.annotations({
   arbitrary: () => () =>
     baseArbitrary.map((vehicle): typeof base.Type => {
-      const [createdAt, updatedAt] = [vehicle.createdAt, vehicle.updatedAt].sort((a, b) => a.getTime() - b.getTime())
+      const [createdAt, updatedAt] = sortedDatePair(vehicle.createdAt, vehicle.updatedAt)
 
       return { ...vehicle, createdAt, updatedAt }
     }),

--- a/src/hooks/features/bankTransactions/useSplitsForm.ts
+++ b/src/hooks/features/bankTransactions/useSplitsForm.ts
@@ -95,7 +95,7 @@ export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions)
 
     setTransactionCategorySelection(bankTransaction.id, new SplitAsOption(splits))
 
-    const nextTaxCode = splits.length === 1 ? splits[0].taxCode : null
+    const nextTaxCode = splits.length === 1 ? splits[0]?.taxCode : null
     setTransactionTaxCodeSelection(bankTransaction.id, nextTaxCode ?? null)
 
     setSplitFormError(undefined)
@@ -143,11 +143,15 @@ export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions)
   const changeCategoryForSplitAtIndex = useCallback((index: number, newCategory: BankTransactionNonSuggestedMatchOption | null) => {
     if (newCategory === null) return
 
+    const splitAtIndex = localSplits[index]
+
+    if (!splitAtIndex) return
+
     const newLocalSplits = [...localSplits]
     newLocalSplits[index] = {
-      ...newLocalSplits[index],
+      ...splitAtIndex,
       category: newCategory,
-      taxCode: canCategoryHaveTaxCode(newCategory) ? newLocalSplits[index].taxCode : null,
+      taxCode: canCategoryHaveTaxCode(newCategory) ? splitAtIndex.taxCode : null,
     }
     setLocalSplits(newLocalSplits)
     setSplitFormError(undefined)
@@ -156,8 +160,12 @@ export const useSplitsForm = ({ bankTransaction, isOpen }: UseSplitsFormOptions)
   }, [localSplits, saveLocalSplitsToCategoryStore])
 
   const updateSplitAtIndex = useCallback((index: number, updater: (split: Split) => Split) => {
+    const splitAtIndex = localSplits[index]
+
+    if (!splitAtIndex) return
+
     const newLocalSplits = [...localSplits]
-    newLocalSplits[index] = updater(newLocalSplits[index])
+    newLocalSplits[index] = updater(splitAtIndex)
     setLocalSplits(newLocalSplits)
     setSplitFormError(undefined)
 

--- a/src/hooks/legacy/useUpdateOpeningBalanceAndDate.ts
+++ b/src/hooks/legacy/useUpdateOpeningBalanceAndDate.ts
@@ -148,10 +148,11 @@ export function useBulkSetOpeningBalanceAndDate(
       )
     )
       .then((results) => {
-        const resultsWithIds: OpeningBalanceAPIResponseResult[] = results.map((r, i) => ({
-          ...r,
-          bankAccountId: data[i].bankAccountId,
-        }))
+        const resultsWithIds: OpeningBalanceAPIResponseResult[] = results.flatMap((r, i) => {
+          const bankAccountId = data[i]?.bankAccountId
+
+          return bankAccountId === undefined ? [] : [{ ...r, bankAccountId }]
+        })
         return onSuccess?.(resultsWithIds)
       })
       .then(() => true as const),

--- a/src/hooks/utils/size/useElementSize.ts
+++ b/src/hooks/utils/size/useElementSize.ts
@@ -34,8 +34,13 @@ export const useElementSize = <T extends HTMLElement>(
     }
 
     const observer = new ResizeObserver((entries) => {
-      const width = entries[0].borderBoxSize[0].inlineSize
-      const height = entries[0].borderBoxSize[0].blockSize
+      const entry = entries[0]
+
+      if (!entry) return
+
+      const borderBoxSize = entry.borderBoxSize[0]
+      const width = borderBoxSize?.inlineSize ?? entry.contentRect.width
+      const height = borderBoxSize?.blockSize ?? entry.contentRect.height
 
       if (resizeTimeout.current) {
         clearTimeout(resizeTimeout.current)

--- a/src/hooks/utils/size/useWindowSize.ts
+++ b/src/hooks/utils/size/useWindowSize.ts
@@ -3,7 +3,7 @@ import { useLayoutEffect, useMemo, useState } from 'react'
 import { BREAKPOINTS } from '@utils/shared/size/screenSizeBreakpoints'
 
 export const useWindowSize = () => {
-  const [size, setSize] = useState([0, 0])
+  const [size, setSize] = useState<[number, number]>([0, 0])
   useLayoutEffect(() => {
     function updateSize() {
       setSize([window.innerWidth, window.innerHeight])

--- a/src/hooks/utils/swr/createInfiniteQueryGlobalCacheActions.test.tsx
+++ b/src/hooks/utils/swr/createInfiniteQueryGlobalCacheActions.test.tsx
@@ -5,6 +5,8 @@ import { type CacheKeyInfo } from '@utils/shared/swr/withSWRKeyTags'
 import { createInfiniteQueryGlobalCacheActions } from '@hooks/utils/swr/createInfiniteQueryGlobalCacheActions'
 import { useGlobalCacheActions } from '@hooks/utils/swr/useGlobalCacheActions'
 
+import { getCallArgs } from '@testUtils/mocks/getCallArgs'
+
 vi.mock('@hooks/utils/swr/useGlobalCacheActions', () => ({ useGlobalCacheActions: vi.fn() }))
 
 const mockedUseGlobalCacheActions = vi.mocked(useGlobalCacheActions)
@@ -56,15 +58,15 @@ describe('createInfiniteQueryGlobalCacheActions', () => {
     void result.current.invalidate()
     void result.current.forceReload()
 
-    expectMatchesTag(invalidate.mock.calls[0][0], 'Widgets')
-    expectMatchesTag(forceReload.mock.calls[0][0], 'Widgets')
+    expectMatchesTag(getCallArgs(invalidate)[0], 'Widgets')
+    expectMatchesTag(getCallArgs(forceReload)[0], 'Widgets')
   })
 
   it('patchByTransformation maps every item across array-of-pages', () => {
     const result = renderInfiniteActions()
     void result.current.patchByTransformation(upper)
 
-    const [predicate, transform] = patchCache.mock.calls[0]
+    const [predicate, transform] = getCallArgs(patchCache)
     expectMatchesTag(predicate, 'Widgets')
 
     const pages = [{ data: [{ id: 'w1', name: 'a' }] }, { data: [{ id: 'w2', name: 'b' }] }]
@@ -78,7 +80,7 @@ describe('createInfiniteQueryGlobalCacheActions', () => {
     const result = renderInfiniteActions()
     void result.current.patchByTransformation(upper)
 
-    const [, transform] = patchCache.mock.calls[0]
+    const [, transform] = getCallArgs(patchCache)
     expect(transform({ data: [{ id: 'w1', name: 'a' }] })).toEqual({ data: [{ id: 'w1', name: 'A' }] })
     expect(transform(null)).toBeNull()
     expect(transform(undefined)).toBeUndefined()
@@ -89,7 +91,7 @@ describe('createInfiniteQueryGlobalCacheActions', () => {
     const updated: Widget = { id: 'w2', name: 'Updated' }
     void result.current.patchByKey(updated)
 
-    const [, transform] = patchCache.mock.calls[0]
+    const [, transform] = getCallArgs(patchCache)
     const pages = [{ data: [{ id: 'w1', name: 'a' }, { id: 'w2', name: 'b' }] }]
     expect(transform(pages)).toEqual([
       { data: [{ id: 'w1', name: 'a' }, updated] },
@@ -100,7 +102,7 @@ describe('createInfiniteQueryGlobalCacheActions', () => {
     const result = renderInfiniteActions()
     void result.current.optimisticallyUpdate(upper)
 
-    const [predicate, transform] = optimisticUpdate.mock.calls[0]
+    const [predicate, transform] = getCallArgs(optimisticUpdate)
     expectMatchesTag(predicate, 'Widgets')
     expect(transform([{ data: [{ id: 'w1', name: 'a' }] }])).toEqual([{ data: [{ id: 'w1', name: 'A' }] }])
   })

--- a/src/hooks/utils/swr/createMutationHook.test.tsx
+++ b/src/hooks/utils/swr/createMutationHook.test.tsx
@@ -8,6 +8,7 @@ import { type MutationRequest } from '@utils/shared/api/getAsMutation'
 import { SupportedLocale } from '@utils/shared/i18n/supportedLocale'
 import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
 
+import { getCallArgs } from '@testUtils/mocks/getCallArgs'
 import { LayerTestProvider, TEST_LAYER_ACCESS_TOKEN, TEST_LAYER_API_URL, TEST_LAYER_BUSINESS_ID } from '@testUtils/render/LayerTestProvider'
 import { renderHookWithAuth } from '@testUtils/render/renderHookWithAuth'
 import { getRequestOptions } from '@testUtils/requests/getRequestOptions'
@@ -59,7 +60,7 @@ describe('createMutationHook', () => {
       await result.current.trigger({ name: 'New Widget' })
     })
 
-    const [url, token, options] = request.mock.calls[0]
+    const [url, token, options] = getCallArgs(request)
     expect(url).toBe(TEST_LAYER_API_URL)
     expect(token).toBe(TEST_LAYER_ACCESS_TOKEN)
     expect(options?.body).toEqual({ name: 'New Widget' })
@@ -202,7 +203,7 @@ describe('createMutationHook', () => {
       await result.current.trigger({ name: 'New Widget' })
     })
 
-    expect(onSuccess.mock.calls[0][0]).toEqual(RAW_WIDGET)
+    expect(getCallArgs(onSuccess)[0]).toEqual(RAW_WIDGET)
   })
 
   it('surfaces schema decode failures as an error', async () => {

--- a/src/hooks/utils/swr/createResourceGlobalCacheActions.test.tsx
+++ b/src/hooks/utils/swr/createResourceGlobalCacheActions.test.tsx
@@ -5,6 +5,8 @@ import { type CacheKeyInfo } from '@utils/shared/swr/withSWRKeyTags'
 import { createResourceGlobalCacheActions } from '@hooks/utils/swr/createResourceGlobalCacheActions'
 import { useGlobalCacheActions } from '@hooks/utils/swr/useGlobalCacheActions'
 
+import { getCallArgs } from '@testUtils/mocks/getCallArgs'
+
 vi.mock('@hooks/utils/swr/useGlobalCacheActions', () => ({ useGlobalCacheActions: vi.fn() }))
 
 const mockedUseGlobalCacheActions = vi.mocked(useGlobalCacheActions)
@@ -50,15 +52,15 @@ describe('createResourceGlobalCacheActions', () => {
     void result.current.invalidate({ withPrecedingOptimisticUpdate: true })
 
     expect(invalidate).toHaveBeenCalledTimes(1)
-    expectMatchesTag(invalidate.mock.calls[0][0], 'Widgets')
-    expect(invalidate.mock.calls[0][1]).toEqual({ withPrecedingOptimisticUpdate: true })
+    expectMatchesTag(getCallArgs(invalidate)[0], 'Widgets')
+    expect(getCallArgs(invalidate)[1]).toEqual({ withPrecedingOptimisticUpdate: true })
   })
 
   it('forceReload delegates with a tag predicate', () => {
     const result = renderResourceActions()
     void result.current.forceReload()
 
-    expectMatchesTag(forceReload.mock.calls[0][0], 'Widgets')
+    expectMatchesTag(getCallArgs(forceReload)[0], 'Widgets')
   })
 
   it('overwriteCache patches with a constant transform returning the new data', () => {
@@ -66,7 +68,7 @@ describe('createResourceGlobalCacheActions', () => {
     const next: Widget = { id: 'w1', name: 'New' }
     void result.current.overwriteCache(next, { withRevalidate: false })
 
-    const [predicate, transform, options] = patchCache.mock.calls[0]
+    const [predicate, transform, options] = getCallArgs(patchCache)
     expectMatchesTag(predicate, 'Widgets')
     expect(transform()).toBe(next)
     expect(options).toEqual({ withRevalidate: false })
@@ -77,7 +79,7 @@ describe('createResourceGlobalCacheActions', () => {
     const transform = (w?: Widget) => w
     void result.current.patchCache(transform)
 
-    const [predicate, forwarded] = patchCache.mock.calls[0]
+    const [predicate, forwarded] = getCallArgs(patchCache)
     expectMatchesTag(predicate, 'Widgets')
     expect(forwarded).toBe(transform)
   })

--- a/src/hooks/utils/swr/useGlobalCacheActions.test.tsx
+++ b/src/hooks/utils/swr/useGlobalCacheActions.test.tsx
@@ -1,9 +1,11 @@
 import { renderHook } from '@testing-library/react'
 import { type Cache, useSWRConfig } from 'swr'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 
 import { type CacheKeyInfo } from '@utils/shared/swr/withSWRKeyTags'
 import { useGlobalCacheActions } from '@hooks/utils/swr/useGlobalCacheActions'
+
+import { getCallArgs } from '@testUtils/mocks/getCallArgs'
 
 // The hook only consumes useSWRConfig from swr, so a minimal mock suffices.
 vi.mock('swr', () => ({ useSWRConfig: vi.fn() }))
@@ -21,7 +23,7 @@ const CACHE = {
       : { _k: { tags: ['Other'] }, data: {} },
 } as unknown as Cache<unknown>
 
-let mutate: ReturnType<typeof vi.fn>
+let mutate: Mock<(key: unknown, data?: unknown, options?: unknown) => Promise<undefined>>
 
 beforeEach(() => {
   mutate = vi.fn(() => Promise.resolve(undefined))
@@ -76,7 +78,7 @@ describe('useGlobalCacheActions', () => {
       displayed => ({ ...displayed, patched: true }),
     )
 
-    const options = mutate.mock.calls[0][2] as {
+    const options = getCallArgs(mutate)[2] as {
       optimisticData: (current: unknown, displayed?: { id: string } | null) => unknown
       populateCache: boolean
       revalidate: boolean

--- a/src/hooks/utils/swr/useSWRInfiniteResult.test.tsx
+++ b/src/hooks/utils/swr/useSWRInfiniteResult.test.tsx
@@ -6,6 +6,8 @@ import type { PaginatedResponse } from '@schemas/common/pagination'
 import { SWRInfiniteResult } from '@hooks/utils/swr/SWRResponseTypes'
 import { useSWRInfiniteResult } from '@hooks/utils/swr/useSWRInfiniteResult'
 
+import { getCallArgs } from '@testUtils/mocks/getCallArgs'
+
 type Page = PaginatedResponse<{ id: string }>
 
 const makePage = (ids: string[], cursor: string | null): Page => ({
@@ -46,7 +48,7 @@ describe('useSWRInfiniteResult', () => {
     result.current.fetchMore()
 
     expect(setSize).toHaveBeenCalledTimes(1)
-    const increment = setSize.mock.calls[0][0] as (size: number) => number
+    const increment = getCallArgs(setSize)[0] as (size: number) => number
     expect(increment(1)).toBe(2)
   })
 

--- a/src/hooks/utils/visibility/useIsVisible.ts
+++ b/src/hooks/utils/visibility/useIsVisible.ts
@@ -17,9 +17,11 @@ export const useIsVisible = (ref: React.RefObject<HTMLElement>) => {
       return
     }
 
-    const observer = new IntersectionObserver(([entry]) =>
-      setIntersecting(entry.isIntersecting),
-    )
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry) {
+        setIntersecting(entry.isIntersecting)
+      }
+    })
 
     observer.observe(ref.current)
     return () => {

--- a/src/msw/api/businesses/[business-id]/bank-transactions/applyConfirmedMatch.ts
+++ b/src/msw/api/businesses/[business-id]/bank-transactions/applyConfirmedMatch.ts
@@ -1,6 +1,7 @@
 import { type BankTransaction } from '@internal-types/features/bankTransactions/bankTransaction'
 import { CategorizationStatus } from '@schemas/features/bankTransactions/bankTransaction'
 import { type Match } from '@schemas/features/bankTransactions/match'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
 import { MATCH_TYPE_BY_DETAILS_TYPE, toMatchDetailsId } from '@fixtures/bankTransactions/derive'
 import { bankAccounts } from '@fixtures/generated/bankAccounts.gen'
@@ -11,7 +12,7 @@ export const applyConfirmedMatch = (
 ): { transaction: BankTransaction, match: Match } => {
   const suggestedMatch = transaction.suggestedMatches.find(match => match.id === suggestedMatchId)
 
-  const fromAccountName = transaction.accountName ?? bankAccounts[0].accountName
+  const fromAccountName = transaction.accountName ?? pickCyclic(bankAccounts, 0).accountName
 
   const details = suggestedMatch?.details ?? transaction.match?.details ?? {
     type: 'Transfer_Match',

--- a/src/msw/api/businesses/[business-id]/custom-accounts/[custom-account-id]/parse-csv/parseCsv.ts
+++ b/src/msw/api/businesses/[business-id]/custom-accounts/[custom-account-id]/parse-csv/parseCsv.ts
@@ -17,7 +17,7 @@ const REQUIRED_COLUMNS = ['date', 'description', 'amount'] as const
 const CSV_FIELD = /(?:^|,)("(?:[^"]|"")*"|[^,]*)/g
 
 const splitCsvLine = (line: string) =>
-  [...line.matchAll(CSV_FIELD)].map(([, field]) =>
+  [...line.matchAll(CSV_FIELD)].map(([, field = '']) =>
     (field.startsWith('"')
       ? field.slice(1, -1).replaceAll('""', '"')
       : field

--- a/src/msw/api/businesses/[business-id]/ledger/entries/[entry-id]/reverse/post.ts
+++ b/src/msw/api/businesses/[business-id]/ledger/entries/[entry-id]/reverse/post.ts
@@ -52,7 +52,7 @@ export const post = createMockEndpoint<undefined, Record<string, never>>({
       reversalId: reversal.id,
       lineItems: original.lineItems.map((lineItem, index) => ({
         ...lineItem,
-        entryReversedBy: reversal.lineItems[index].id,
+        entryReversedBy: reversal.lineItems[index]?.id ?? null,
       })),
     })
 

--- a/src/msw/api/businesses/[business-id]/reports/unified/generators/aging.ts
+++ b/src/msw/api/businesses/[business-id]/reports/unified/generators/aging.ts
@@ -39,7 +39,8 @@ const buildAgingReport = (
 
   items.forEach((item) => {
     const entity = byEntity.get(item.entityKey) ?? { entityName: item.entityName, amounts: BUCKETS.map(() => 0) }
-    entity.amounts[bucketIndexForDaysPastDue(differenceInDays(effectiveDate, item.dueAt))] += item.amountCents
+    const bucketIndex = bucketIndexForDaysPastDue(differenceInDays(effectiveDate, item.dueAt))
+    entity.amounts[bucketIndex] = (entity.amounts[bucketIndex] ?? 0) + item.amountCents
     byEntity.set(item.entityKey, entity)
   })
 
@@ -54,12 +55,12 @@ const buildAgingReport = (
     rowKey,
     cells: {
       [entityColumn]: textCell(label, { bold }),
-      ...Object.fromEntries(BUCKETS.map((bucket, index) => [bucket.key, currencyCell(amounts[index], { bold })])),
+      ...Object.fromEntries(BUCKETS.map((bucket, index) => [bucket.key, currencyCell(amounts[index] ?? 0, { bold })])),
       total: currencyCell(sum(amounts), { bold }),
     },
   })
 
-  const bucketTotals = BUCKETS.map((_, index) => sum(entities.map(([, entity]) => entity.amounts[index])))
+  const bucketTotals = BUCKETS.map((_, index) => sum(entities.map(([, entity]) => entity.amounts[index] ?? 0)))
 
   return unifiedReport(
     [

--- a/src/msw/api/businesses/[business-id]/reports/unified/generators/balanceSheet.ts
+++ b/src/msw/api/businesses/[business-id]/reports/unified/generators/balanceSheet.ts
@@ -139,7 +139,7 @@ export const generateBalanceSheet = (params: URLSearchParams): UnifiedReport => 
   }
 
   const sumOf = (items: readonly ReportLineItem[]) =>
-    sumBy(items, item => item.amounts[TOTAL_COLUMN_KEY])
+    sumBy(items, item => item.amounts[TOTAL_COLUMN_KEY] ?? 0)
 
   return lineItemTreeReport([numericColumn(TOTAL_COLUMN_KEY, format(effectiveDate, 'MMMM d, yyyy'))], [
     {
@@ -151,7 +151,7 @@ export const generateBalanceSheet = (params: URLSearchParams): UnifiedReport => 
     {
       name: syntheticRowKey('LIABILITIES_AND_EQUITY'),
       displayName: 'Liabilities and Equity',
-      amounts: { [TOTAL_COLUMN_KEY]: sumOf(liabilities) + equities.amounts[TOTAL_COLUMN_KEY] },
+      amounts: { [TOTAL_COLUMN_KEY]: sumOf(liabilities) + (equities.amounts[TOTAL_COLUMN_KEY] ?? 0) },
       childItems: [
         {
           name: syntheticRowKey('LIABILITIES'),

--- a/src/msw/api/businesses/[business-id]/reports/unified/generators/profitAndLoss.ts
+++ b/src/msw/api/businesses/[business-id]/reports/unified/generators/profitAndLoss.ts
@@ -75,21 +75,21 @@ export const generateProfitAndLoss = (params: URLSearchParams): UnifiedReport =>
   const sectionLineItem = (name: keyof typeof sections, displayName: string): ReportLineItem => {
     const forest = sections[name]
     const [root] = forest
-    const isOwnAccount = forest.length === 1 && root.account.stableName === name
+    const ownAccountRoot = forest.length === 1 && root?.account.stableName === name ? root : undefined
 
     return {
       name,
       displayName,
       amounts: periodAmounts(periods, sectionTotal(forest)),
-      ...(isOwnAccount && root.children.length === 0 && {
+      ...(ownAccountRoot && ownAccountRoot.children.length === 0 && {
         reportConfig: linesReportConfig(
           LINES_ROUTE,
-          root.account,
+          ownAccountRoot.account,
           [ReportControl.DateRange],
           reportingBasisBaseParams(params),
         ),
       }),
-      childItems: (isOwnAccount ? root.children : forest).map(node => accountLineItem(node, periods)),
+      childItems: (ownAccountRoot ? ownAccountRoot.children : forest).map(node => accountLineItem(node, periods)),
     }
   }
 

--- a/src/msw/api/businesses/[business-id]/reports/unified/generators/timeTracking.ts
+++ b/src/msw/api/businesses/[business-id]/reports/unified/generators/timeTracking.ts
@@ -2,6 +2,7 @@ import { getLocalTimeZone } from '@internationalized/date'
 
 import { type TimeEntry } from '@schemas/features/timeTracking/timeEntry'
 import { type UnifiedReport } from '@schemas/features/unifiedReports/unifiedReport'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
 import {
   type FlatGroup,
@@ -39,7 +40,7 @@ const groupsBy = <Key>(
 
 const byCustomer = (entries: readonly TimeEntry[]) =>
   groupsBy(entries, entry => entry.customer?.id ?? null, (groupEntries) => {
-    const { customer } = groupEntries[0]
+    const { customer } = pickCyclic(groupEntries, 0)
 
     return customer
       ? {
@@ -53,7 +54,7 @@ const byCustomer = (entries: readonly TimeEntry[]) =>
 
 const byService = (entries: readonly TimeEntry[]) =>
   groupsBy(entries, entry => entry.service?.id ?? null, (groupEntries) => {
-    const { service } = groupEntries[0]
+    const { service } = pickCyclic(groupEntries, 0)
 
     return service
       ? {

--- a/src/msw/api/businesses/[business-id]/reports/unified/generators/transactions.ts
+++ b/src/msw/api/businesses/[business-id]/reports/unified/generators/transactions.ts
@@ -1,5 +1,6 @@
 import { type SingleChartAccountType } from '@schemas/features/generalLedger/chartOfAccounts'
 import { type UnifiedReport, type UnifiedReportRow } from '@schemas/features/unifiedReports/unifiedReport'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
 import { hashString } from '@fixtures/unifiedReports/deterministicAmounts'
 import { customerStore } from '@msw/api/businesses/[business-id]/customers/store'
@@ -40,7 +41,7 @@ const counterpartyFor = (candidates: readonly Counterparty[], key: string): Coun
   if (candidates.length === 0) return null
   const hash = hashString(key)
 
-  return hash % 6 === 0 ? null : candidates[hash % candidates.length]
+  return hash % 6 === 0 ? null : pickCyclic(candidates, hash)
 }
 
 type LineItemOptions = {
@@ -91,8 +92,8 @@ const groupsBy = <Key>(
 
 export const byAccount = (items: readonly TransactionLineItem[]) =>
   groupsBy(items, item => item.accountId, groupItems => ({
-    rowKey: `account:${groupItems[0].accountId}`,
-    label: groupItems[0].accountName,
+    rowKey: `account:${pickCyclic(groupItems, 0).accountId}`,
+    label: pickCyclic(groupItems, 0).accountName,
     isUncategorized: false,
     items: groupItems,
   }))
@@ -102,7 +103,7 @@ export const byCounterparty = (
   unnamedLabel: string,
 ) => (items: readonly TransactionLineItem[]) =>
   groupsBy(items, item => item.counterparty?.id ?? null, (groupItems) => {
-    const { counterparty } = groupItems[0]
+    const { counterparty } = pickCyclic(groupItems, 0)
 
     return counterparty
       ? {

--- a/src/msw/utils/createListSorter.ts
+++ b/src/msw/utils/createListSorter.ts
@@ -15,5 +15,9 @@ export const createListSorter = <TItem>(keys: SortKeys<TItem>, defaultKey: keyof
     const key = keys[params.get('sort_by') ?? ''] ?? keys[defaultKey]
     const ascending = ASCENDING_SORT_ORDERS.includes(params.get('sort_order') ?? '')
 
+    if (!key) {
+      return [...items]
+    }
+
     return [...items].sort((a, b) => compare(key(a), key(b)) * (ascending ? 1 : -1))
   }

--- a/src/providers/features/bankTransactions/BankTransactions/useAugmentedBankTransactions.tsx
+++ b/src/providers/features/bankTransactions/BankTransactions/useAugmentedBankTransactions.tsx
@@ -32,7 +32,7 @@ export function bankTransactionFiltersToHookOptions(
         ? filters.categorizationStatus === DisplayState.categorized
         : undefined
       : undefined,
-    direction: filters?.direction?.length === 1
+    direction: filters?.direction?.length === 1 && filters.direction[0]
       ? decodeBankTransactionDirection(filters.direction[0]) === BankTransactionDirection.Credit
         ? 'INFLOW'
         : 'OUTFLOW'

--- a/src/providers/features/taxEstimates/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider.tsx
+++ b/src/providers/features/taxEstimates/TaxEstimatesRouteStore/TaxEstimatesRouteStoreProvider.tsx
@@ -15,7 +15,7 @@ const DEFAULT_ROUTE = TaxEstimatesRoute.Estimates
 
 type TaxEstimatesRouteStoreShape = {
   routeState: RouteState<TaxEstimatesRoute>
-  navigate: RouteNavigation
+  navigate: RouteNavigation<'toOverview' | 'toEstimates' | 'toPayments' | 'toProfile'>
   year: number
   fullYearProjection: boolean
   actions: {

--- a/src/providers/features/taxEstimates/TaxEstimatesRouteStore/types.ts
+++ b/src/providers/features/taxEstimates/TaxEstimatesRouteStore/types.ts
@@ -1,3 +1,3 @@
 export type Route = string
 export type RouteState<R extends Route> = { route: R }
-export type RouteNavigation = Record<string, () => void>
+export type RouteNavigation<TAction extends string = string> = Record<TAction, () => void>

--- a/src/testUtils/SKILL.md
+++ b/src/testUtils/SKILL.md
@@ -42,6 +42,7 @@ where they belong instead of at the root:
 render/       LayerTestProvider, renderHookWithAuth
 dates/        fakeSystemTime, fixedDates
 requests/     getRequestOptions
+mocks/        getCallArgs
 forms/        fillForm + the per-kind fillers behind it
 storybook/    layout/ · controls/ · decorators/ · data/ · interactions/
 ```
@@ -251,6 +252,8 @@ payload**. Only a vitest test moves the coverage number.
 
 - `getRequestOptions(mock, index?)` (`@testUtils/requests/getRequestOptions`) — pulls the
   `{ params, body }` options off the nth call of a mocked request function.
+- `getCallArgs(mock, index?)` (`@testUtils/mocks/getCallArgs`) — the nth call's arguments as a
+  typed tuple, ready to destructure; throws when the mock never took that call.
 - `@testUtils/storybook/layout/*` — one module per story-layout component (`Gallery`, `Section`, `Frame`, `Row`, `Col`, `Matrix`, `Label`).
 - `@testUtils/storybook/decorators/PinnedGlobalDateRange` — mounts a global date store fixed to a
   known range; `decorators/profitAndLoss` wraps it with the P&L handlers as a decorator.

--- a/src/testUtils/mocks/getCallArgs.ts
+++ b/src/testUtils/mocks/getCallArgs.ts
@@ -1,0 +1,21 @@
+/**
+ * The nth call's arguments as a tuple, so destructuring them stays typed. Throws when the mock never
+ * took that call, which reads better than the `undefined` an index access would hand back.
+ *
+ * Takes the call log structurally rather than a `Mock<T>`, so the argument tuple is inferred
+ * straight off `calls` instead of through vitest's conditional parameter type.
+ */
+export function getCallArgs<TArgs extends unknown[]>(
+  mock: { mock: { calls: TArgs[] } },
+  index = 0,
+): TArgs {
+  const args = mock.mock.calls[index]
+
+  if (!args) {
+    throw new Error(
+      `getCallArgs: no call at index ${index} — the mock was called ${mock.mock.calls.length} time(s)`,
+    )
+  }
+
+  return args
+}

--- a/src/testUtils/requests/getRequestOptions.ts
+++ b/src/testUtils/requests/getRequestOptions.ts
@@ -4,6 +4,6 @@ import type { Mock } from 'vitest'
 export function getRequestOptions<T extends (...args: never[]) => unknown>(
   request: Mock<T>,
   index = 0,
-): Parameters<T>[2] {
-  return request.mock.calls[index][2]
+): Parameters<T>[2] | undefined {
+  return request.mock.calls[index]?.[2]
 }

--- a/src/testUtils/storybook/data/tables.tsx
+++ b/src/testUtils/storybook/data/tables.tsx
@@ -1,4 +1,5 @@
 import { Alignment } from '@internal-types/utility/table'
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 import { Badge, BadgeSize, BadgeVariant } from '@ui/Badge/Badge'
 import { DataState, DataStateStatus } from '@ui/DataState/DataState'
 import { VStack } from '@ui/Stack/Stack'
@@ -15,7 +16,7 @@ export type CustomerRow = (typeof customers)[number]
  */
 export const buildCustomerRows = (count: number): CustomerRow[] =>
   Array.from({ length: count }, (_unused, index) => {
-    const base = customers[index % customers.length]
+    const base = pickCyclic(customers, index)
 
     return index < customers.length
       ? base

--- a/src/testUtils/storybook/interactions/findEntryRows.ts
+++ b/src/testUtils/storybook/interactions/findEntryRows.ts
@@ -11,10 +11,12 @@ const isEntryRow = (row: HTMLElement) => !row.querySelector(PLACEHOLDER_CELL_SEL
  * is the first entry. Both the loading skeleton and the empty state render `role="row"` nodes, so
  * a plain row count resolves before the mocked data lands and clicking hits a detached node.
  */
-export function findEntryRows(canvas: RowQueries): Promise<HTMLElement[]> {
+export function findEntryRows(
+  canvas: RowQueries,
+): Promise<[HTMLElement, HTMLElement, ...HTMLElement[]]> {
   return waitFor(async () => {
-    const rows = (await canvas.findAllByRole('row')).filter(isEntryRow)
-    if (rows.length < 2) throw new Error('table has rendered no entries yet')
-    return rows
+    const [header, firstEntry, ...rest] = (await canvas.findAllByRole('row')).filter(isEntryRow)
+    if (!header || !firstEntry) throw new Error('table has rendered no entries yet')
+    return [header, firstEntry, ...rest]
   }, { timeout: 15_000 })
 }

--- a/src/testUtils/storybook/interactions/firstMatch.ts
+++ b/src/testUtils/storybook/interactions/firstMatch.ts
@@ -1,0 +1,13 @@
+/**
+ * The first element a `getAllBy*` / `findAllBy*` query returned. Those queries already throw when
+ * nothing matches, so this only carries that guarantee through the type.
+ */
+export function firstMatch<T>(elements: readonly T[]): T {
+  const [first] = elements
+
+  if (!first) {
+    throw new Error('firstMatch: the query matched no elements')
+  }
+
+  return first
+}

--- a/src/types/features/categorization/categorizationOption.ts
+++ b/src/types/features/categorization/categorizationOption.ts
@@ -166,14 +166,14 @@ export class SplitAsOption extends BaseCategorizationOption<Split[]> {
 
   get value(): string {
     if (this.isSingleSplit) {
-      return this.internalValue[0].category?.value ?? ''
+      return this.internalValue[0]?.category?.value ?? ''
     }
     return 'split'
   }
 
   // A single-entry split is effectively one category; a multi-entry split has no single classification.
   get classification(): Classification | null {
-    return this.isSingleSplit ? this.internalValue[0].category?.classification ?? null : null
+    return this.isSingleSplit ? this.internalValue[0]?.category?.classification ?? null : null
   }
 }
 

--- a/src/utils/features/bankTransactions/shared.ts
+++ b/src/utils/features/bankTransactions/shared.ts
@@ -145,8 +145,10 @@ export const getDefaultSelectedCategoryForBankTransaction = (
     return convertApiCategorizationToCategoryOrSplitAsOption(bankTransaction.category)
   }
 
-  if (hasSuggestions(bankTransaction)) {
-    return convertApiCategorizationToCategoryOrSplitAsOption(bankTransaction.categorizationFlow!.suggestions[0])
+  const firstSuggestion = bankTransaction.categorizationFlow?.suggestions[0]
+
+  if (firstSuggestion) {
+    return convertApiCategorizationToCategoryOrSplitAsOption(firstSuggestion)
   }
 
   return null
@@ -172,11 +174,13 @@ export type BankTransactionFilters = {
 
 export const isCategorized = (bankTransaction: BankTransaction) => CategorizedCategories.includes(bankTransaction.categorizationStatus)
 export const buildCategorizeBankTransactionPayloadForSplit = (splits: Split[]): CategoryUpdate => {
-  return splits.length === 1 && splits[0].category
+  const onlySplit = splits.length === 1 ? splits[0] : undefined
+
+  return onlySplit?.category
     ? ({
       type: 'Category',
-      category: splits[0].category.classification!,
-      taxCode: splits[0].taxCode ?? null,
+      category: onlySplit.category.classification!,
+      taxCode: onlySplit.taxCode ?? null,
     })
     : ({
       type: 'Split',

--- a/src/utils/features/bankTransactions/splits.ts
+++ b/src/utils/features/bankTransactions/splits.ts
@@ -73,7 +73,10 @@ export const calculateRemoveSplit = (
     return sum + splitAmount
   }, 0)
   const remaining = totalAmount - splitTotal
-  newSplits[0].amount = remaining
+  const firstSplit = newSplits[0]
+  if (firstSplit) {
+    firstSplit.amount = remaining
+  }
 
   return newSplits
 }
@@ -90,8 +93,15 @@ export const calculateUpdatedAmounts = (
 
   const remaining = totalAmount - splitTotal
 
-  initialRowSplits[index].amount = newAmount
-  initialRowSplits[0].amount = remaining
+  const updatedSplit = initialRowSplits[index]
+  if (updatedSplit) {
+    updatedSplit.amount = newAmount
+  }
+
+  const firstSplit = initialRowSplits[0]
+  if (firstSplit) {
+    firstSplit.amount = remaining
+  }
 
   return [...initialRowSplits]
 }

--- a/src/utils/features/bankTransactions/taxCode.ts
+++ b/src/utils/features/bankTransactions/taxCode.ts
@@ -44,7 +44,7 @@ export const canCategoryHaveTaxCode = (
   if (isSuggestedMatchAsOption(category)) return false
   if (isSplitAsOption(category)) {
     if (category.isSingleSplit) {
-      const classification = category.original[0].category?.classification
+      const classification = category.original[0]?.category?.classification
       return !!classification && !isClassificationExclusion(classification)
     }
 

--- a/src/utils/shared/array/pickCyclic.ts
+++ b/src/utils/shared/array/pickCyclic.ts
@@ -1,0 +1,11 @@
+/**
+ * Picks from a pool by wrapping the index around its length. The modulo keeps the index in range,
+ * which the compiler can't see, so an empty pool throws rather than handing back `undefined`.
+ */
+export function pickCyclic<T>(pool: ReadonlyArray<T>, index: number): T {
+  if (pool.length === 0) {
+    throw new Error('pickCyclic: cannot pick from an empty pool')
+  }
+
+  return pool[((index % pool.length) + pool.length) % pool.length] as T
+}

--- a/src/utils/shared/request/toDefinedSearchParameters.ts
+++ b/src/utils/shared/request/toDefinedSearchParameters.ts
@@ -27,7 +27,7 @@ export function toDefinedSearchParameters(
   input: QueryParams,
 ) {
   const definedParameterPairs = Object.entries(input)
-    .flatMap(([key, value]) => {
+    .flatMap(([key, value]): Array<[string, string]> => {
       if (value === null || value === undefined) {
         return []
       }
@@ -47,7 +47,7 @@ export function toDefinedSearchParameters(
       return [[key, value]]
     })
     .filter(([_, value]) => value !== '')
-    .map(([key, value]) => [toSnakeCase(key), value])
+    .map(([key, value]): [string, string] => [toSnakeCase(key), value])
 
   return new URLSearchParams(definedParameterPairs)
 }

--- a/src/utils/shared/styles/chartColors.ts
+++ b/src/utils/shared/styles/chartColors.ts
@@ -1,6 +1,7 @@
 export const UNCATEGORIZED_CHART_COLOR = '#EEEEF0'
 
-export const DEFAULT_CHART_COLORS = [
+// Non-empty, so the first entry stays a usable fallback for any palette index.
+export const DEFAULT_CHART_COLORS: [string, ...string[]] = [
   '#008028',
   '#7417B3',
   '#006A80',

--- a/src/utils/shared/styles/colors.ts
+++ b/src/utils/shared/styles/colors.ts
@@ -215,15 +215,13 @@ const hexToRgb = (hex: string) => {
     .match(/.{2}/g)
     ?.map(x => parseInt(x, 16))
 
-  if (!values) {
+  const [r, g, b] = values ?? []
+
+  if (r === undefined || g === undefined || b === undefined) {
     return
   }
 
-  return {
-    r: values[0],
-    g: values[1],
-    b: values[2],
-  }
+  return { r, g, b }
 }
 
 /**

--- a/src/utils/shared/styles/legacyClassNames.ts
+++ b/src/utils/shared/styles/legacyClassNames.ts
@@ -27,9 +27,8 @@ export function createLegacyClassNames<const TMap extends LegacyClassNameMap>(ma
       .filter((name): name is keyof TMap => Boolean(name))
       .flatMap((name) => {
         const key = String(name)
-        return key.startsWith('Layer__')
-          ? [key, ...toArray(map[name])]
-          : toArray(map[name])
+        const legacyNames = toArray(map[name] ?? [])
+        return key.startsWith('Layer__') ? [key, ...legacyNames] : legacyNames
       })
       .join(' ')
 }

--- a/src/utils/shared/swr/hasMorePages.ts
+++ b/src/utils/shared/swr/hasMorePages.ts
@@ -1,9 +1,6 @@
 import type { PaginatedResponse } from '@schemas/common/pagination'
 
 export function hasMorePages(pages: ReadonlyArray<PaginatedResponse<unknown>> | undefined) {
-  if (!pages || pages.length === 0) {
-    return false
-  }
-  const pagination = pages[pages.length - 1].meta?.pagination
+  const pagination = pages?.at(-1)?.meta?.pagination
   return Boolean(pagination?.hasMore && pagination.cursor)
 }

--- a/src/views/Reports/Reports.tsx
+++ b/src/views/Reports/Reports.tsx
@@ -63,7 +63,9 @@ export interface ReportsPanelProps {
   renderInAppLink?: (source: LinkingMetadata) => ReactNode
 }
 
-const defaultEnabledReports: ReportType[] = ['profitAndLoss', 'balanceSheet', 'statementOfCashFlow']
+const FALLBACK_REPORT: ReportType = 'profitAndLoss'
+
+const defaultEnabledReports: ReportType[] = [FALLBACK_REPORT, 'balanceSheet', 'statementOfCashFlow']
 export const Reports = ({
   title,
   showTitle = true,
@@ -74,7 +76,7 @@ export const Reports = ({
   renderInAppLink,
 }: ReportsProps) => {
   const { t } = useTranslation()
-  const [activeTab, setActiveTab] = useState<ReportType>(enabledReports[0])
+  const [activeTab, setActiveTab] = useState<ReportType>(enabledReports[0] ?? FALLBACK_REPORT)
   const { view, containerRef } = useElementViewSize<HTMLDivElement>()
   const isMobileView = view === 'mobile'
 

--- a/src/views/TimeTracking/TimeTracking.stories.tsx
+++ b/src/views/TimeTracking/TimeTracking.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
 import { userEvent, within } from 'storybook/test'
 
+import { pickCyclic } from '@utils/shared/array/pickCyclic'
 import { TimeTracking, type TimeTrackingProps } from '@views/TimeTracking/TimeTracking'
 
 import { FIXTURE_YEAR, FIXTURE_YEAR_RANGE } from '@fixtures/constants/fixtureYear'
@@ -10,6 +11,7 @@ import { toTimeEntryService } from '@fixtures/timeEntries/toTimeEntryService'
 import { get as getActiveTimeTracker } from '@msw/api/businesses/[business-id]/time-tracking/tracker/active/get'
 import { handlers } from '@msw/handlers'
 import { PinnedGlobalDateRange } from '@testUtils/storybook/decorators/PinnedGlobalDateRange'
+import { firstMatch } from '@testUtils/storybook/interactions/firstMatch'
 
 type TimeTrackingStoryArgs = {
   showTitle: boolean
@@ -94,7 +96,7 @@ const runningTimer = getActiveTimeTracker.mock(
     durationMinutes: 0,
     // Has to be a service the catalog endpoint serves, or the banner's selector can't resolve it
     // and falls back to its placeholder.
-    service: toTimeEntryService(catalogServices[1]),
+    service: toTimeEntryService(pickCyclic(catalogServices, 1)),
     createdAt: new Date(FIXTURE_YEAR, 11, 31, 10, 47, 0),
   }),
 )
@@ -115,7 +117,7 @@ export const EntryDetail: Story = {
     // Drawers and popovers portal to the body, so what they open isn't inside the canvas.
     const overlay = within(canvasElement.ownerDocument.body)
 
-    const [firstEntry] = await canvas.findAllByRole('button', { name: /View Entry/ })
+    const firstEntry = firstMatch(await canvas.findAllByRole('button', { name: /View Entry/ }))
     await userEvent.click(firstEntry)
     await overlay.findByRole('button', { name: /Save Entry/ }, { timeout: 10_000 })
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,12 +10,12 @@
     "moduleDetection": "force",               /* Treat all files as modules, regardless of content. */
     "types": ["@testing-library/jest-dom/vitest"],
     "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,         /* Add 'undefined' to a type when accessed using an index. */
     "libReplacement": false,
 
     // Uncomment and resolve ASAP
     // "isolatedModules": true,               /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,          /* Do not transform or elide any imports or exports not marked as type-only. */
-    // "noUncheckedIndexedAccess": true,      /* Add 'undefined' to a type when accessed using an index. */
 
     /* Type Checking */
     "strict": true,                           /* Enable all strict type-checking options. */


### PR DESCRIPTION
## Scope

Turns on `noUncheckedIndexedAccess`, which had been parked in `tsconfig.json` under an
"Uncomment and resolve ASAP" note, and resolves the 191 errors it surfaced across 100 files.

Most sites are fixed where the index happens. A handful of root causes each cleared a whole
cluster:

| Root cause | Fix | Cleared |
| --- | --- | --- |
| `useWindowSize` inferred `number[]` from `useState([0, 0])` | annotate the tuple | every `const [width] = useWindowSize()` consumer (taxEstimates ×6, BookkeepingOverview, LandingPage) |
| `FileInput`'s `onUpload?: (files: File[]) => void`, though it only fires with ≥1 file | `(files: [File, ...File[]]) => void` | six `files[0]` callers |
| `DEFAULT_CHART_COLORS: string[]`, used as its own fallback | `[string, ...string[]]` | the palette fallbacks in P&L charts, tax summary, TimeTrackingStats |
| `RouteNavigation = Record<string, () => void>` | key it on the actions it actually has | every `navigate.toX()` call in TaxEstimates |

Four small helpers absorb the shapes that repeated too often to inline:

- `pickCyclic(pool, index)` (`@utils/shared/array`) — an in-range or wrapping pick out of a
  known-non-empty pool; throws on an empty one rather than handing back `undefined`. Replaces
  ~20 `arr[i % arr.length]` sites in fixtures and MSW generators, including the local `pickFrom`
  in `deterministicAmounts`.
- `sortedDatePair(a, b)` (`@fixtures/utils`) — the `[a, b].sort(…)` idiom four generated schemas
  used for `createdAt`/`updatedAt`, which widens back to `Date[]`.
- `getCallArgs(mock, index?)` (`@testUtils/mocks`) — a mock's nth call as a typed tuple, ready to
  destructure. Sibling to the existing `getRequestOptions`; both are in `testUtils/SKILL.md`.
- `firstMatch(elements)` (`@testUtils/storybook/interactions`) — the first element a
  `getAllBy*`/`findAllBy*` query returned, which those queries already guarantee.

`findEntryRows` now types the ≥2 rows it already enforced at runtime, so `const [, firstEntry] = …`
stays typed.

Two changes are behavioral rather than purely typed, both in the safe direction:

- `VirtualizedDataTable` skips a virtual row whose data row is gone instead of throwing on `row.id`.
- `useElementSize` falls back to `contentRect` when `borderBoxSize` is empty, and ignores an
  empty `ResizeObserver` batch.

## Verification

- `npm run typecheck` · `npm run lint` — clean
- `npm test -- --run` — 341 passed
- `npm run fixtures:check` — generated fixtures byte-identical, so the fixture rewrites are
  behavior-preserving
- `npm run i18n:check` · `npm run msw:check-coverage` — clean
- `npx tsc -p tsconfig.build.json` — declaration emit clean under the flag

`npm run build:js` was not run to completion locally: it fails in a git worktree with a symlinked
`node_modules` (rolldown resolves the entry to a relative path), on this branch and on a pristine
tree alike. It does not typecheck, so the flag can't affect it — CI covers it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad touch across bank transactions, splits, reports, and fixtures with two intentional UI observer/virtualization behavior tweaks; changes are mostly defensive null checks with fixture byte-identical verification.
> 
> **Overview**
> Turns on **`noUncheckedIndexedAccess`** in `tsconfig.json` and clears the resulting type errors across the app, fixtures, MSW generators, and tests.
> 
> Most call sites add **explicit handling** for possibly-missing index results: optional chaining, `??` fallbacks, `charAt` instead of `[]`, and **`as const`** on form subscribe selectors. Combo boxes and filters that defaulted to `options[0]` now fall back to **`null`** when nothing matches.
> 
> **Shared helpers** replace repeated patterns: **`pickCyclic`** for modulo array picks (fixtures/MSW), **`sortedDatePair`** for ordered date pairs in generated schemas, **`getCallArgs`** / **`firstMatch`** in tests and Storybook plays, and stricter types on **`FileInput.onUpload`**, **`DEFAULT_CHART_COLORS`**, **`useWindowSize`**, and **`RouteNavigation`** in tax estimates.
> 
> **Runtime hardening** (not just types): **`VirtualizedDataTable`** skips a virtual row when the backing row is missing; **`useElementSize`** tolerates empty `ResizeObserver` entries and missing `borderBoxSize`; CSV upload treats a missing first file like other rejections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfdbb15d13a7431103f67a6b67c5e00376e0385d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->