### PR TITLE
[LAY-2600] fix(ci): give the preview comment a repo to talk to

### DIFF
--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -36,9 +36,10 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PR: ${{ github.event.pull_request.number }}
       # `--edit-last` targets this bot's own comment, so the PR keeps one that evolves. Safe only
-      # while no other workflow comments here.
+      # while no other workflow comments here. `--repo` because this job has no checkout for `gh` to
+      # read a remote from, the same reason the statuses below go through `$GITHUB_REPOSITORY`.
       run: |
-        gh pr comment "$PR" --edit-last --create-if-none --body "**Storybook preview** — add the \`storybook-preview\` label to build one.
+        gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --edit-last --create-if-none --body "**Storybook preview** — add the \`storybook-preview\` label to build one.
 
         It renders stories against a live sandbox business instead of MSW fixtures, and rebuilds on every push while the \`storybook-preview\` label is applied."
 


### PR DESCRIPTION
## Description

The `Offer a preview` job fails on every newly-opened PR:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The job posts a comment and nothing else, so it has no `actions/checkout` — which means `gh` has no
git remote to infer the repository from, and `gh pr comment` exits 1 before posting. The PR gets a red
X and no instructions comment.

It has been failing for a while, not just on new branches: #1766 (merged) and the open
`swr/css-bem-ui` both hit it. The sibling `deploy` job is unaffected because its comment step runs
after a checkout.

Passing `--repo "$GITHUB_REPOSITORY"` gives `gh` the context explicitly. That is already the pattern
in this same workflow — `deploy` reaches the statuses API through `gh api "repos/$GITHUB_REPOSITORY/…"`
precisely because it runs before its own checkout. Adding a checkout would also work, but cloning the
repository to post one comment is the wrong trade.

## Changes

- `.github/workflows/storybook-preview.yml` — `--repo "$GITHUB_REPOSITORY"` on the `instructions`
  job's `gh pr comment`, and a note on the comment above it saying why it is needed

The `deploy` job's `gh pr comment` is deliberately left alone: it follows `actions/checkout`, so it
resolves the repository from the remote and works today.

## Blockers

None.

## How this has been tested?

- Reproduced the exact failure and confirmed the fix outside any git repository, which is the same
  condition the job runs in:

  ```
  $ cd /tmp/empty && gh pr view 1768
  failed to run git: fatal: not a git repository (or any of the parent directories): .git

  $ cd /tmp/empty && gh pr view 1768 --repo Layer-Fi/layer-react
  {"number":1768,"title":"feat(telemetry): report component prop usage on mount"}
  ```

- `actionlint .github/workflows/storybook-preview.yml` — clean.
- Verified the comment body is byte-for-byte unchanged, including the escaped backticks and the blank
  line that keeps the second paragraph separate.
- The job only triggers on `opened`/`reopened`, so this PR does not exercise it — **opening the next
  PR is the real test**, and it should post the instructions comment and go green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to one `gh` invocation; no application or security-sensitive logic.
> 
> **Overview**
> Fixes the **Offer a preview** Storybook workflow job failing on newly opened PRs because it runs without `actions/checkout`, so `gh pr comment` could not resolve the repository and exited with a “not a git repository” error.
> 
> The instructions step now passes **`--repo "$GITHUB_REPOSITORY"`**, matching how other steps in the same workflow already target the repo when there is no checkout. A short inline comment explains that requirement; the **`deploy`** job’s comment step is unchanged because it runs after checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d90ef84b33692087ac87c27698d50cda5048789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->