### PR TITLE
[LAY-2597] ci: file per-PR Linear tickets in LAY instead of FE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 ## Linear
 
-FE-NEW
-<!-- Creates and links a new Linear issue in the FE team, assigned to you. If this PR already has an
-issue, replace the line above with its identifier (FE-<number>). Every PR gets a ticket, so removing
+LAY-NEW
+<!-- Creates and links a new Linear issue in the LAY team, assigned to you. If this PR already has an
+issue, replace the line above with its identifier (LAY-<number>). Every PR gets a ticket, so removing
 this line only means a workflow adds it back on open. -->

--- a/.github/workflows/linear-pr-ticket.yml
+++ b/.github/workflows/linear-pr-ticket.yml
@@ -1,7 +1,7 @@
 name: Linear — ticket per PR
 
-# Appends FE-NEW to a PR description so Linear's GitHub integration creates and links an issue in
-# the FE team. Bots and coding agents supply their own PR body, so the template alone misses them —
+# Appends LAY-NEW to a PR description so Linear's GitHub integration creates and links an issue in
+# the LAY team. Bots and coding agents supply their own PR body, so the template alone misses them —
 # this covers those. Needs no Linear credentials: the integration does the work.
 #
 # Dependabot is excluded; dependency bumps would be one ticket per bump.
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   tag:
-    name: Add FE-NEW
+    name: Add LAY-NEW
     if: >
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       !startsWith(github.event.pull_request.head.ref, 'release/v')
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     # PR text goes through env, never into run — interpolating it is a shell injection vector.
-    - name: Append FE-NEW to the description
+    - name: Append LAY-NEW to the description
       env:
         GH_TOKEN: ${{ github.token }}
         PR: ${{ github.event.pull_request.number }}
@@ -34,10 +34,10 @@ jobs:
       run: |
         # Linear links from the title and branch too, so appending to a PR that already names an
         # issue would create a spurious second ticket.
-        if grep -qiE '\bFE-(NEW|[0-9]+)\b' <<< "$BODY $TITLE $HEAD_REF"; then
+        if grep -qiE '\bLAY-(NEW|[0-9]+)\b' <<< "$BODY $TITLE $HEAD_REF"; then
           echo "PR #$PR already references a Linear issue."
           exit 0
         fi
 
         gh api -X PATCH "repos/$GITHUB_REPOSITORY/pulls/$PR" \
-          -f body="$(printf '%s\n\nFE-NEW' "$BODY")" --silent
+          -f body="$(printf '%s\n\nLAY-NEW' "$BODY")" --silent


### PR DESCRIPTION
## Description

Layer-Fi/layer-react#1774 wired every PR to a Linear ticket via the native GitHub integration, using the `FE-NEW` magic
word. New PRs should land in the Layer **LAY** team instead, so this swaps the magic word.

## Changes

* `.github/PULL_REQUEST_TEMPLATE.md` — the `## Linear` section now carries `LAY-NEW`, and its comment
  points at `LAY-<number>` for a PR that already has an issue.
* `.github/workflows/linear-pr-ticket.yml` — appends `LAY-NEW`; workflow header, job name and step
  name follow.
* The workflow's "already has an issue" guard becomes `\bLAY-(NEW|[0-9]+)\b`. No FE-prefixed tickets
  exist, so it has nothing to keep matching.

Nothing else changes: no credentials, no `linear-release.yml` edit (it tracks releases, not per-PR
issues, and names no team), and the dependabot / `release/v*` exclusions are untouched.

## Blockers

None. `LAY-NEW` only works if LAY is a Linear *team* key rather than a project — opening this PR
answered that: the integration created and linked [LAY-2587](https://linear.app/layerfi/issue/LAY-2587/create-per-pr-linear-tickets-in-lay-team-via-ci).

## How this has been tested?

The guard regex was exercised against the cases the workflow sees:

<!-- linear:table-colwidths:400,400 -->
| Input | Result |
| -- | -- |
| `LAY-NEW` | skip |
| `LAY-7` | skip |
| `nothing here` | append |
| `swr/lay-thing` | append (word boundary — a branch name that merely contains `lay-` is not an issue reference) |

The workflow file parses and the renamed job/step resolve.

End-to-end, this PR carried `LAY-NEW` in its own description on open and Linear created **LAY-2587**
against it — so the magic word resolves to the LAY team, which is the only part the workflow could not
verify locally. The append-on-open path itself is unchanged from #1774 apart from the two strings.

## Linear

[LAY-2587](https://linear.app/layerfi/issue/LAY-2587/create-per-pr-linear-tickets-in-lay-team-via-ci)

---

> \[!NOTE\] [Cursor Bugbot](<https://cursor.com/bugbot>) is generating a summary for commit 04636258ac4ca14e5ba80c3316eafe74b91eb59b. Configure [here](<https://www.cursor.com/dashboard/bugbot>).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/template string swap only; no app, auth, or data-path changes. Duplicate tickets are possible for PRs that still cite FE issues.
> 
> **Overview**
> Routes auto-created Linear tickets for new PRs to the **LAY** team instead of **FE**.
> 
> The PR template and `linear-pr-ticket.yml` now use `LAY-NEW` (and `LAY-<number>` in comments). The skip-if-already-linked check only looks for `LAY-` identifiers, so a PR that only mentions an old `FE-*` issue can still get a second LAY ticket appended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e043179a9464dcca87a6a1f20cef363d2cb49b5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



