### PR TITLE
[LAY-2595] ci: apply the Linear ticket exclusions to manual runs too

### DIFF
--- a/.github/workflows/linear-pr-ticket.yml
+++ b/.github/workflows/linear-pr-ticket.yml
@@ -1,8 +1,8 @@
 name: Linear
 
-# Creates a Linear issue per PR and writes its identifier into the description.
-# Needs the LINEAR_TEAM variable and a LINEAR_API_KEY secret: a personal key (lin_api_…), not the
-# LINEAR_ACCESS_KEY pipeline key.
+# Creates a Linear issue per PR and prefixes the PR title with its identifier, which is what Linear
+# links from. Needs the LINEAR_TEAM variable and a LINEAR_API_KEY secret: a personal key (lin_api_…),
+# not the LINEAR_ACCESS_KEY pipeline key.
 
 on:
   pull_request:
@@ -25,12 +25,11 @@ concurrency:
 jobs:
   ticket:
     name: Create issue
+    # Forks never receive the secret, so the job cannot run for them at all; every other exclusion
+    # lives in the script, which workflow_dispatch also reaches.
     if: >
-      github.event_name == 'workflow_dispatch' || (
-        github.event.pull_request.user.login != 'dependabot[bot]' &&
-        !startsWith(github.event.pull_request.head.ref, 'release/v') &&
-        github.event.pull_request.head.repo.full_name == github.repository
-      )
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
@@ -42,6 +41,21 @@ jobs:
       with:
         script: |
           const { LINEAR_API_KEY: key, TEAM_KEY: teamKey, PR } = process.env;
+
+          const { data: pr } = await github.rest.pulls.get({
+            ...context.repo, pull_number: Number(PR),
+          });
+
+          // Ahead of the config check: dependabot's runs are not given the secret, so testing the
+          // key first would fail its every PR instead of skipping it.
+          const skip = pr.user.login === 'dependabot[bot]' ? 'opened by dependabot'
+            : pr.head.ref.startsWith('release/v') ? 'a release branch'
+            : (pr.state === 'closed' && !pr.merged) ? 'closed without merging'
+            : null;
+          if (skip) {
+            core.info(`PR #${PR} skipped: ${skip}.`);
+            return;
+          }
 
           const missing = [!key && 'LINEAR_API_KEY secret', !teamKey && 'LINEAR_TEAM variable']
             .filter(Boolean);
@@ -65,22 +79,6 @@ jobs:
             return data;
           };
 
-          const { data: pr } = await github.rest.pulls.get({
-            ...context.repo, pull_number: Number(PR),
-          });
-          const body = pr.body ?? '';
-
-          // Authoritative: the job-level `if` cannot see these on workflow_dispatch, which has no
-          // pull_request payload, so a manual run would otherwise bypass every exclusion.
-          const skip = pr.user.login === 'dependabot[bot]' ? 'opened by dependabot'
-            : pr.head.ref.startsWith('release/v') ? 'a release branch'
-            : (pr.state === 'closed' && !pr.merged_at) ? 'closed without merging'
-            : null;
-          if (skip) {
-            core.info(`PR #${PR} skipped: ${skip}.`);
-            return;
-          }
-
           // Body must have it alone on a line so prose is not a link; title and branch are looser.
           // Matching ignores case but the digits are recombined with the configured key: Linear's
           // linking is case-sensitive, and a lowercase branch would otherwise yield [lay-1234].
@@ -89,11 +87,10 @@ jobs:
             const match = pattern.exec(text ?? '');
             return match && `${teamKey}-${match[1]}`;
           };
-          const existing = idIn(body, new RegExp(`^[ \t]*${teamKey}-(\\d+)[ \t]*$`, 'im'))
+
+          let identifier = idIn(pr.body, new RegExp(`^[ \t]*${teamKey}-(\\d+)[ \t]*$`, 'im'))
             || idIn(pr.title, loose)
             || idIn(pr.head.ref, loose);
-
-          let identifier = existing;
           let issueUrl;
 
           if (!identifier) {

--- a/.github/workflows/linear-pr-ticket.yml
+++ b/.github/workflows/linear-pr-ticket.yml
@@ -1,7 +1,6 @@
 name: Linear
 
-# Creates a Linear issue per PR and prefixes the PR title with its identifier, which is what Linear
-# links from. Needs the LINEAR_TEAM variable and a LINEAR_API_KEY secret (a personal lin_api_… key).
+# Creates a Linear issue per PR and prefixes the PR title with it — Linear links from the title.
 
 on:
   pull_request:

--- a/.github/workflows/linear-pr-ticket.yml
+++ b/.github/workflows/linear-pr-ticket.yml
@@ -1,8 +1,7 @@
 name: Linear
 
 # Creates a Linear issue per PR and prefixes the PR title with its identifier, which is what Linear
-# links from. Needs the LINEAR_TEAM variable and a LINEAR_API_KEY secret: a personal key (lin_api_…),
-# not the LINEAR_ACCESS_KEY pipeline key.
+# links from. Needs the LINEAR_TEAM variable and a LINEAR_API_KEY secret (a personal lin_api_… key).
 
 on:
   pull_request:
@@ -25,8 +24,7 @@ concurrency:
 jobs:
   ticket:
     name: Create issue
-    # Forks never receive the secret, so the job cannot run for them at all; every other exclusion
-    # lives in the script, which workflow_dispatch also reaches.
+    # Every other exclusion is in the script, which workflow_dispatch also reaches.
     if: >
       github.event_name == 'workflow_dispatch'
       || github.event.pull_request.head.repo.full_name == github.repository
@@ -46,8 +44,8 @@ jobs:
             ...context.repo, pull_number: Number(PR),
           });
 
-          // Ahead of the config check: dependabot's runs are not given the secret, so testing the
-          // key first would fail its every PR instead of skipping it.
+          // Before the config check: dependabot's runs get no secret, so checking the key first
+          // would fail its every PR rather than skip it.
           const skip = pr.user.login === 'dependabot[bot]' ? 'opened by dependabot'
             : pr.head.ref.startsWith('release/v') ? 'a release branch'
             : (pr.state === 'closed' && !pr.merged) ? 'closed without merging'
@@ -79,9 +77,8 @@ jobs:
             return data;
           };
 
-          // Body must have it alone on a line so prose is not a link; title and branch are looser.
-          // Matching ignores case but the digits are recombined with the configured key: Linear's
-          // linking is case-sensitive, and a lowercase branch would otherwise yield [lay-1234].
+          // Alone on a line in the body so prose is not a link. Linear's linking is case-sensitive,
+          // so the digits are recombined with the configured key rather than used as matched.
           const loose = new RegExp(`\\b${teamKey}-(\\d+)\\b`, 'i');
           const idIn = (text, pattern) => {
             const match = pattern.exec(text ?? '');
@@ -120,8 +117,7 @@ jobs:
             ({ identifier, url: issueUrl } = issueCreate.issue);
           }
 
-          // Drop any prefix already there, whatever its casing, so a correction does not stack.
-          // GitHub caps titles at 256; trim the original rather than fail after creating the issue.
+          // GitHub caps titles at 256, and any existing prefix goes so corrections do not stack.
           const bare = pr.title.replace(new RegExp(`^\\s*\\[${teamKey}-\\d+\\]\\s*`, 'i'), '');
           const prefix = `[${identifier}] `;
           const room = 256 - prefix.length;

--- a/.github/workflows/linear-pr-ticket.yml
+++ b/.github/workflows/linear-pr-ticket.yml
@@ -82,19 +82,18 @@ jobs:
           }
 
           // Body must have it alone on a line so prose is not a link; title and branch are looser.
-          const inTitle = new RegExp(`\\b${teamKey}-\\d+\\b`, 'i').exec(pr.title);
-          const existing = new RegExp(`^[ \t]*${teamKey}-\\d+[ \t]*$`, 'im').exec(body)
-            ?? inTitle
-            ?? new RegExp(`\\b${teamKey}-\\d+\\b`, 'i').exec(pr.head.ref);
+          // Matching ignores case but the digits are recombined with the configured key: Linear's
+          // linking is case-sensitive, and a lowercase branch would otherwise yield [lay-1234].
+          const loose = new RegExp(`\\b${teamKey}-(\\d+)\\b`, 'i');
+          const idIn = (text, pattern) => {
+            const match = pattern.exec(text ?? '');
+            return match && `${teamKey}-${match[1]}`;
+          };
+          const existing = idIn(body, new RegExp(`^[ \t]*${teamKey}-(\\d+)[ \t]*$`, 'im'))
+            || idIn(pr.title, loose)
+            || idIn(pr.head.ref, loose);
 
-          // A PR that names its own issue still needs the identifier in the title: that is what
-          // Linear links from.
-          if (existing && inTitle) {
-            core.info(`PR #${PR} already references ${existing[0].trim()}.`);
-            return;
-          }
-
-          let identifier = existing?.[0].trim();
+          let identifier = existing;
           let issueUrl;
 
           if (!identifier) {
@@ -124,10 +123,17 @@ jobs:
             ({ identifier, url: issueUrl } = issueCreate.issue);
           }
 
+          // Drop any prefix already there, whatever its casing, so a correction does not stack.
           // GitHub caps titles at 256; trim the original rather than fail after creating the issue.
+          const bare = pr.title.replace(new RegExp(`^\\s*\\[${teamKey}-\\d+\\]\\s*`, 'i'), '');
           const prefix = `[${identifier}] `;
           const room = 256 - prefix.length;
-          const title = prefix + (pr.title.length <= room ? pr.title : `${pr.title.slice(0, room - 1)}…`);
+          const title = prefix + (bare.length <= room ? bare : `${bare.slice(0, room - 1)}…`);
+
+          if (title === pr.title) {
+            core.info(`PR #${PR} is already titled for ${identifier}.`);
+            return;
+          }
 
           await github.rest.pulls.update({ ...context.repo, pull_number: Number(PR), title });
           core.info(`PR #${PR} → ${identifier}${issueUrl ? ` (${issueUrl})` : ' (already existed)'}`);

--- a/.github/workflows/linear-pr-ticket.yml
+++ b/.github/workflows/linear-pr-ticket.yml
@@ -70,6 +70,17 @@ jobs:
           });
           const body = pr.body ?? '';
 
+          // Authoritative: the job-level `if` cannot see these on workflow_dispatch, which has no
+          // pull_request payload, so a manual run would otherwise bypass every exclusion.
+          const skip = pr.user.login === 'dependabot[bot]' ? 'opened by dependabot'
+            : pr.head.ref.startsWith('release/v') ? 'a release branch'
+            : (pr.state === 'closed' && !pr.merged_at) ? 'closed without merging'
+            : null;
+          if (skip) {
+            core.info(`PR #${PR} skipped: ${skip}.`);
+            return;
+          }
+
           // Body must have it alone on a line so prose is not a link; title and branch are looser.
           const inTitle = new RegExp(`\\b${teamKey}-\\d+\\b`, 'i').exec(pr.title);
           const existing = new RegExp(`^[ \t]*${teamKey}-\\d+[ \t]*$`, 'im').exec(body)


### PR DESCRIPTION
## Description

The job-level `if` short-circuits on `workflow_dispatch`, so a manual run bypassed every exclusion —
dependabot, `release/v*` and the fork check alike. That is only visible when backfilling: dispatching
across the 77 PRs since v0.1.144 would have ticketed 28 dependency bumps and the release PR, which is
exactly what the exclusions exist to prevent.

`workflow_dispatch` carries no `pull_request` payload, so the `if` cannot inspect the author or branch
at all on that path. The checks therefore move into the script, which fetches the PR anyway.

## Changes

- The script skips a PR opened by `dependabot[bot]`, one from a `release/v*` branch, and one that is
  closed without having merged. It logs which rule matched.
- The job-level `if` is unchanged. It stays as a fast path so dependabot's PRs do not spin up a runner
  just to no-op; the script is now the authoritative check.

Closed-unmerged is new: abandoned work should not carry a ticket, and only a manual run can reach a
closed PR since `closed` is not in the trigger list.

## Wrong-case identifier in the title

A second fix, reported on review. The existing-identifier match is case-insensitive, but the matched
text was written into the title verbatim, so a lowercase branch (`swr/lay-1234-…`) produced
`[lay-1234] …`. Linear's linking is case-sensitive, so that title did not link — and because the
match was case-insensitive, later runs read it as done and never corrected it.

- The digits are now recombined with the configured team key, so the identifier is always canonical
  regardless of where it was found.
- Any prefix already on the title is stripped first, in any casing, so a correction replaces it
  instead of stacking a second one.
- The early return is gone: the run now compares the computed title against the current one and
  updates unless they already match. That makes the step idempotent *and* self-correcting, where
  before it was idempotent on a wrong value.

## Blockers

None.

## How this has been tested?

The predicate was exercised against the five shapes it has to separate, using the real field values
from #1761 (dependabot), #1777 (release) and #1759 (closed unmerged):

| PR shape | Result |
| --- | --- |
| dependabot, merged | skipped — opened by dependabot |
| `release/v0.1.145-alpha.0` | skipped — a release branch |
| closed, `merged_at: null` | skipped — closed without merging |
| human, merged | proceeds |
| human, open | proceeds |

Not covered: nothing here runs against the live Linear API, since every case short-circuits before it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow for Linear issue linking; no product, auth, or data-path changes. Skip logic and title rewrites could mis-skip or retitle PRs if predicates are wrong.
> 
> **Overview**
> Manual `workflow_dispatch` runs of the Linear PR-ticket workflow now honor the same skip rules as automatic PR events, so backfills no longer create tickets for dependabot, `release/v*` branches, or PRs closed without merging.
> 
> Those checks move into the script (after fetching the PR) because dispatch has no `pull_request` payload. The job `if` only keeps the same-repo fast path so forks still do not start a runner.
> 
> Existing identifiers are rebuilt with the configured team key so titles always use canonical casing for Linear’s case-sensitive linking. Any existing `[TEAM-n]` prefix is stripped before rewriting, and the title is updated unless it already matches—so a wrong-case prefix is corrected instead of treated as done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c1069bc4b715cd8d9e666777650aaf79f0d1e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

