### PR TITLE
[LAY-2717] feat: answer counterparty ask tasks in the Tasks component

### DIFF
--- a/src/components/features/bookkeeping/Tasks/Tasks.stories.tsx
+++ b/src/components/features/bookkeeping/Tasks/Tasks.stories.tsx
@@ -141,3 +141,12 @@ export const Default: Story = {
   tags: ['public-api', 'docs-screenshot', 'real-backend'],
   parameters: { pinnedDateRange: NOVEMBER },
 }
+
+const JULY: DateRange = {
+  startDate: new Date(FIXTURE_YEAR, 6, 1),
+  endDate: new Date(FIXTURE_YEAR, 6, 31),
+}
+
+export const CounterpartyAskWithoutSuggestions: Story = {
+  parameters: { pinnedDateRange: JULY },
+}

--- a/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskBody.test.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskBody.test.tsx
@@ -1,3 +1,4 @@
+import { type PropsWithChildren } from 'react'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
@@ -30,12 +31,18 @@ const TWO_TRANSACTIONS = [
   },
 ]
 
-const renderBody = (overrides: Partial<CounterpartyAskTask> = {}) => {
+const renderBody = (overrides: Partial<CounterpartyAskTask> = {}, onTransactionCategorized?: () => void) => {
   const task = makeCounterpartyAskTask(overrides) as UserVisibleTask & CounterpartyAskTask
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <LayerTestProvider eventCallbacks={onTransactionCategorized ? { onTransactionCategorized } : undefined}>
+      {children}
+    </LayerTestProvider>
+  )
 
   return {
     user: userEvent.setup(),
-    ...render(<CounterpartyAskTaskBody task={task} />, { wrapper: LayerTestProvider }),
+    ...render(<CounterpartyAskTaskBody task={task} />, { wrapper }),
   }
 }
 
@@ -118,6 +125,32 @@ describe('CounterpartyAskTaskBody', () => {
       account_identifier: { type: 'StableName', stable_name: MEALS_STABLE_NAME },
       always_this: true,
     })
+  })
+
+  it('notifies the host app when a chip answer categorizes a transaction', async () => {
+    spyOnAskResponse()
+    const onTransactionCategorized = vi.fn()
+    const { user } = renderBody({}, onTransactionCategorized)
+
+    await user.click(screen.getByRole('radio', { name: 'Business Meals' }))
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+    await user.click(screen.getByRole('button', { name: 'Yes, always' }))
+
+    await waitFor(() => expect(onTransactionCategorized).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not notify the host app for a free-text answer', async () => {
+    const onRequest = spyOnAskResponse()
+    const onTransactionCategorized = vi.fn()
+    const { user } = renderBody({}, onTransactionCategorized)
+
+    await user.click(screen.getByRole('radio', { name: 'Something else' }))
+    await user.type(screen.getByRole('textbox'), 'Gift for a client')
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+    await user.click(screen.getByRole('button', { name: 'Yes, always' }))
+
+    await waitFor(() => expect(onRequest).toHaveBeenCalledTimes(1))
+    expect(onTransactionCategorized).not.toHaveBeenCalled()
   })
 
   it('submits always_this false when the owner declines the rule', async () => {
@@ -210,6 +243,21 @@ describe('CounterpartyAskTaskBody', () => {
         { transaction_id: 'txn-2', account_identifier: { type: 'AccountId', id: OFFICE_EXPENSES_ACCOUNT_ID } },
       ],
     })
+  })
+
+  it('notifies the host app when an itemised mix categorizes a transaction', async () => {
+    spyOnAskResponse()
+    const onTransactionCategorized = vi.fn()
+    const { user } = renderBody(makeMultiTransactionTask(), onTransactionCategorized)
+
+    await user.click(screen.getByRole('radio', { name: 'A mix of the above' }))
+
+    const rowGroups = screen.getAllByRole('radiogroup', { name: 'What this one was for' })
+    await user.click(within(rowGroups[0]!).getByRole('radio', { name: 'Business Meals' }))
+    await user.click(within(rowGroups[1]!).getByRole('radio', { name: 'Office Expenses' }))
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => expect(onTransactionCategorized).toHaveBeenCalledTimes(1))
   })
 
   it('collapses a uniform mix into an all-same answer so it can still create a rule', async () => {

--- a/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskBody.test.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskBody.test.tsx
@@ -1,0 +1,271 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { type CounterpartyAskTask } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+import { type UserVisibleTask } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
+import { CounterpartyAskTaskBody } from '@features/bookkeeping/TasksListItem/CounterpartyAskTaskBody'
+
+import { makeCounterpartyAskTask } from '@fixtures/bookkeeping/counterpartyAskTasks'
+import { post as postCounterpartyAskResponse } from '@msw/api/businesses/[business-id]/tasks/[task-id]/counterparty-ask-response/post'
+import { server } from '@msw/node'
+import { readRequestJson } from '@msw/utils/request'
+import { LayerTestProvider } from '@testUtils/render/LayerTestProvider'
+
+const OFFICE_EXPENSES_ACCOUNT_ID = '00000000-0000-4000-8000-000000000801'
+const MEALS_STABLE_NAME = 'MEALS'
+
+const TWO_TRANSACTIONS = [
+  {
+    id: 'txn-1',
+    date: new Date('2025-02-03T00:00:00.000Z'),
+    amount: 61250,
+    description: 'COSTCO WHSE #1042',
+  },
+  {
+    id: 'txn-2',
+    date: new Date('2025-02-19T00:00:00.000Z'),
+    amount: 22395,
+    description: 'COSTCO GAS #1042',
+  },
+]
+
+const renderBody = (overrides: Partial<CounterpartyAskTask> = {}) => {
+  const task = makeCounterpartyAskTask(overrides) as UserVisibleTask & CounterpartyAskTask
+
+  return {
+    user: userEvent.setup(),
+    ...render(<CounterpartyAskTaskBody task={task} />, { wrapper: LayerTestProvider }),
+  }
+}
+
+const makeMultiTransactionTask = (): Partial<CounterpartyAskTask> => ({
+  transactions: TWO_TRANSACTIONS.map(transaction => ({
+    ...transaction,
+    direction: 'DEBIT',
+    counterpartyName: 'Costco',
+  })) as CounterpartyAskTask['transactions'],
+  totalCount: 2,
+})
+
+const spyOnAskResponse = () => {
+  const onRequest = vi.fn<(body: unknown) => void>()
+
+  server.use(
+    postCounterpartyAskResponse.mock(makeCounterpartyAskTask(), {
+      onRequest: async ({ request }) => {
+        onRequest(await readRequestJson(request))
+      },
+    }),
+  )
+
+  return onRequest
+}
+
+describe('CounterpartyAskTaskBody', () => {
+  it('renders the server-rendered question verbatim', () => {
+    renderBody({ question: 'You spent $307.74 at Costco across 1 transaction. What for?' })
+
+    expect(
+      screen.getByText('You spent $307.74 at Costco across 1 transaction. What for?'),
+    ).toBeInTheDocument()
+  })
+
+  it('blocks Continue until an answer is given', async () => {
+    const { user } = renderBody()
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+
+    await user.click(screen.getByRole('radio', { name: 'Business Meals' }))
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled()
+  })
+
+  it('keeps Continue disabled while free text is blank', async () => {
+    const { user } = renderBody()
+
+    await user.click(screen.getByRole('radio', { name: 'Something else' }))
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+
+    await user.type(screen.getByRole('textbox'), '   ')
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+
+    await user.type(screen.getByRole('textbox'), 'Packaging supplies')
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled()
+  })
+
+  it('persists nothing until the always question is answered', async () => {
+    const onRequest = spyOnAskResponse()
+    const { user } = renderBody()
+
+    await user.click(screen.getByRole('radio', { name: 'Business Meals' }))
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(screen.getByText('Will Costco purchases always be Business Meals?')).toBeInTheDocument()
+    expect(onRequest).not.toHaveBeenCalled()
+  })
+
+  it('submits a chip answer with always_this once confirmed', async () => {
+    const onRequest = spyOnAskResponse()
+    const { user } = renderBody()
+
+    await user.click(screen.getByRole('radio', { name: 'Business Meals' }))
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+    await user.click(screen.getByRole('button', { name: 'Yes, always' }))
+
+    await waitFor(() => expect(onRequest).toHaveBeenCalledTimes(1))
+    expect(onRequest.mock.calls[0]?.[0]).toEqual({
+      account_identifier: { type: 'StableName', stable_name: MEALS_STABLE_NAME },
+      always_this: true,
+    })
+  })
+
+  it('submits always_this false when the owner declines the rule', async () => {
+    const onRequest = spyOnAskResponse()
+    const { user } = renderBody()
+
+    await user.click(screen.getByRole('radio', { name: 'Office Expenses' }))
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+    await user.click(screen.getByRole('button', { name: 'No, ask me again' }))
+
+    await waitFor(() => expect(onRequest).toHaveBeenCalledTimes(1))
+    expect(onRequest.mock.calls[0]?.[0]).toEqual({
+      account_identifier: { type: 'AccountId', id: OFFICE_EXPENSES_ACCOUNT_ID },
+      always_this: false,
+    })
+  })
+
+  it('goes back to the answer step with the previous choice still selected', async () => {
+    const onRequest = spyOnAskResponse()
+    const { user } = renderBody()
+
+    await user.click(screen.getByRole('radio', { name: 'Business Meals' }))
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(screen.getByText('Will Costco purchases always be Business Meals?')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Back' }))
+
+    expect(screen.getByRole('radio', { name: 'Business Meals' })).toBeChecked()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled()
+    expect(onRequest).not.toHaveBeenCalled()
+  })
+
+  it('locks the whole confirm step while the answer is in flight', async () => {
+    server.use(
+      postCounterpartyAskResponse.mock(makeCounterpartyAskTask(), {
+        onRequest: () => new Promise(resolve => setTimeout(resolve, 500)),
+      }),
+    )
+    const { user } = renderBody()
+
+    await user.click(screen.getByRole('radio', { name: 'Business Meals' }))
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+    await user.click(screen.getByRole('button', { name: 'Yes, always' }))
+
+    expect(screen.getByRole('button', { name: 'Back' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Yes, always' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'No, ask me again' })).toBeDisabled()
+  })
+
+  it('hides the mix option when there is only one transaction', () => {
+    renderBody()
+
+    expect(screen.queryByRole('radio', { name: 'A mix of the above' })).not.toBeInTheDocument()
+  })
+
+  it('requires every transaction to be answered before an itemised submit', async () => {
+    const { user } = renderBody(makeMultiTransactionTask())
+
+    await user.click(screen.getByRole('radio', { name: 'A mix of the above' }))
+    expect(screen.getByText('0 of 2 answered')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+
+    const rowGroups = screen.getAllByRole('radiogroup', { name: 'What this one was for' })
+    await user.click(within(rowGroups[0]!).getByRole('radio', { name: 'Business Meals' }))
+
+    expect(screen.getByText('1 of 2 answered')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+
+    await user.click(within(rowGroups[1]!).getByRole('radio', { name: 'Office Expenses' }))
+
+    expect(screen.getByText('All 2 answered')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled()
+  })
+
+  it('submits differing per-transaction answers itemised, skipping the always question', async () => {
+    const onRequest = spyOnAskResponse()
+    const { user } = renderBody(makeMultiTransactionTask())
+
+    await user.click(screen.getByRole('radio', { name: 'A mix of the above' }))
+
+    const rowGroups = screen.getAllByRole('radiogroup', { name: 'What this one was for' })
+    await user.click(within(rowGroups[0]!).getByRole('radio', { name: 'Business Meals' }))
+    await user.click(within(rowGroups[1]!).getByRole('radio', { name: 'Office Expenses' }))
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => expect(onRequest).toHaveBeenCalledTimes(1))
+    expect(onRequest.mock.calls[0]?.[0]).toEqual({
+      transaction_responses: [
+        { transaction_id: 'txn-1', account_identifier: { type: 'StableName', stable_name: MEALS_STABLE_NAME } },
+        { transaction_id: 'txn-2', account_identifier: { type: 'AccountId', id: OFFICE_EXPENSES_ACCOUNT_ID } },
+      ],
+    })
+  })
+
+  it('collapses a uniform mix into an all-same answer so it can still create a rule', async () => {
+    const onRequest = spyOnAskResponse()
+    const { user } = renderBody(makeMultiTransactionTask())
+
+    await user.click(screen.getByRole('radio', { name: 'A mix of the above' }))
+
+    const rowGroups = screen.getAllByRole('radiogroup', { name: 'What this one was for' })
+    await user.click(within(rowGroups[0]!).getByRole('radio', { name: 'Business Meals' }))
+    await user.click(within(rowGroups[1]!).getByRole('radio', { name: 'Business Meals' }))
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(screen.getByText('Will Costco purchases always be Business Meals?')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Yes, always' }))
+
+    await waitFor(() => expect(onRequest).toHaveBeenCalledTimes(1))
+    expect(onRequest.mock.calls[0]?.[0]).toEqual({
+      account_identifier: { type: 'StableName', stable_name: MEALS_STABLE_NAME },
+      always_this: true,
+    })
+  })
+
+  it('offers free text only when the API sent no suggestions', () => {
+    renderBody({ suggestions: [] })
+
+    expect(screen.getByRole('radio', { name: 'Something else' })).toBeInTheDocument()
+    expect(screen.getAllByRole('radio')).toHaveLength(1)
+  })
+
+  it('stays answerable when the link rows carry no answers yet', () => {
+    renderBody(makeMultiTransactionTask())
+
+    expect(screen.queryByText('Answered')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Business Meals' })).toBeInTheDocument()
+  })
+
+  it('renders as answered once a link row carries an answer', () => {
+    renderBody({
+      ...makeMultiTransactionTask(),
+      transactionResponses: [
+        { transactionId: 'txn-1', userResponse: 'Gift for a client', responseAccount: null },
+        { transactionId: 'txn-2', userResponse: null, responseAccount: null },
+      ],
+    })
+
+    expect(screen.getByText('Answered')).toBeInTheDocument()
+    expect(screen.getByText('You answered 1 of 2 individually.')).toBeInTheDocument()
+  })
+
+  it('renders an ask resolved by another period as already answered', () => {
+    renderBody({ resolvedByTaskId: '00000000-0000-4000-8000-000000000999' })
+
+    expect(screen.getByText('Already answered')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument()
+  })
+})

--- a/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskBody.test.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskBody.test.tsx
@@ -3,18 +3,20 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 import { type CounterpartyAskTask } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
 import { type UserVisibleTask } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
 import { CounterpartyAskTaskBody } from '@features/bookkeeping/TasksListItem/CounterpartyAskTaskBody'
 
+import { bankTransactionCategories } from '@fixtures/bankTransactions/constants'
 import { makeCounterpartyAskTask } from '@fixtures/bookkeeping/counterpartyAskTasks'
 import { post as postCounterpartyAskResponse } from '@msw/api/businesses/[business-id]/tasks/[task-id]/counterparty-ask-response/post'
 import { server } from '@msw/node'
 import { readRequestJson } from '@msw/utils/request'
 import { LayerTestProvider } from '@testUtils/render/LayerTestProvider'
 
-const OFFICE_EXPENSES_ACCOUNT_ID = '00000000-0000-4000-8000-000000000801'
-const MEALS_STABLE_NAME = 'MEALS'
+const OFFICE_EXPENSES_ACCOUNT_ID = bankTransactionCategories.officeExpenses.id
+const MEALS_STABLE_NAME = bankTransactionCategories.meals.stableName
 
 const TWO_TRANSACTIONS = [
   {
@@ -300,6 +302,7 @@ describe('CounterpartyAskTaskBody', () => {
   it('renders as answered once a link row carries an answer', () => {
     renderBody({
       ...makeMultiTransactionTask(),
+      status: BusinessTaskStatus.UserMarkedCompleted,
       transactionResponses: [
         { transactionId: 'txn-1', userResponse: 'Gift for a client', responseAccount: null },
         { transactionId: 'txn-2', userResponse: null, responseAccount: null },
@@ -311,7 +314,10 @@ describe('CounterpartyAskTaskBody', () => {
   })
 
   it('renders an ask resolved by another period as already answered', () => {
-    renderBody({ resolvedByTaskId: '00000000-0000-4000-8000-000000000999' })
+    renderBody({
+      status: BusinessTaskStatus.UserMarkedCompleted,
+      resolvedByTaskId: '00000000-0000-4000-8000-000000000999',
+    })
 
     expect(screen.getByText('Already answered')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument()

--- a/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskBody.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskBody.tsx
@@ -1,0 +1,343 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { type CounterpartyAskResponse } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskResponse'
+import { type CounterpartyAskTask } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+import { type UserVisibleTask } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
+import {
+  buildAllSameCounterpartyAskResponse,
+  buildItemisedCounterpartyAskResponse,
+  collapseUniformCounterpartyAskAnswers,
+  countDistinctCounterpartyAskAnswers,
+  type CounterpartyAskAnswerValue,
+  getCounterpartyAskAnswerLabel,
+} from '@utils/features/bookkeeping/counterpartyAskAnswers'
+import { useLayerContext } from '@providers/global/LayerContext/LayerContext'
+import { usePostCounterpartyAskResponse } from '@api/businesses/[business-id]/tasks/[task-id]/counterparty-ask-response/post'
+import { BackButton } from '@ui/Button/BackButton'
+import { Button } from '@ui/Button/Button'
+import { Chip, ChipGroup } from '@ui/Chip/Chip'
+import { TextArea } from '@ui/Input/TextArea'
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { P, Span } from '@ui/Typography/Text'
+import { CounterpartyAskTaskSummary } from '@features/bookkeeping/TasksListItem/CounterpartyAskTaskSummary'
+import {
+  CounterpartyAskTransactionRow,
+  OTHER_ANSWER_KEY,
+  toSuggestionAnswerKey,
+} from '@features/bookkeeping/TasksListItem/CounterpartyAskTransactionRow'
+
+import './counterpartyAskTaskBody.scss'
+
+const MIX_ANSWER_KEY = 'mix'
+
+type CounterpartyAskTaskBodyProps = {
+  task: UserVisibleTask & CounterpartyAskTask
+}
+
+export const CounterpartyAskTaskBody = ({ task }: CounterpartyAskTaskBodyProps) => {
+  const { t } = useTranslation()
+  const { addToast } = useLayerContext()
+  const { trigger: submitCounterpartyAskResponse, isMutating } = usePostCounterpartyAskResponse()
+
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const [freeText, setFreeText] = useState('')
+  const [rowKeys, setRowKeys] = useState<Record<string, string>>({})
+  const [rowTexts, setRowTexts] = useState<Record<string, string>>({})
+  const [isConfirming, setIsConfirming] = useState(false)
+  const [sentAnswer, setSentAnswer] = useState<CounterpartyAskAnswerValue | null>(null)
+  const [sentDistinctCount, setSentDistinctCount] = useState<number | null>(null)
+
+  const { suggestions, transactions } = task
+  const totalTransactions = transactions.length
+  const isItemising = selectedKey === MIX_ANSWER_KEY
+  const isFreeText = selectedKey === OTHER_ANSWER_KEY
+
+  const resolveAnswer = useCallback(
+    (answerKey: string | undefined, text: string): CounterpartyAskAnswerValue | null => {
+      if (!answerKey) return null
+
+      if (answerKey === OTHER_ANSWER_KEY) {
+        const trimmed = text.trim()
+        return trimmed ? { kind: 'text', text: trimmed } : null
+      }
+
+      const suggestion = suggestions.find((_, index) => toSuggestionAnswerKey(index) === answerKey)
+
+      return suggestion ? { kind: 'account', account: suggestion } : null
+    },
+    [suggestions],
+  )
+
+  const answeredRows = useMemo(
+    () =>
+      transactions.flatMap((transaction) => {
+        const answer = resolveAnswer(rowKeys[transaction.id], rowTexts[transaction.id] ?? '')
+
+        return answer ? [{ transactionId: transaction.id, answer }] : []
+      }),
+    [transactions, rowKeys, rowTexts, resolveAnswer],
+  )
+
+  const isEveryRowAnswered = totalTransactions > 0 && answeredRows.length === totalTransactions
+
+  const singleAnswer = isItemising
+    ? (isEveryRowAnswered
+      ? collapseUniformCounterpartyAskAnswers(answeredRows.map(row => row.answer))
+      : null)
+    : resolveAnswer(selectedKey ?? undefined, freeText)
+
+  const canContinue = isItemising ? isEveryRowAnswered : singleAnswer !== null
+
+  const submit = useCallback(
+    async (response: CounterpartyAskResponse | null, onSuccess: () => void) => {
+      if (!response) return
+
+      try {
+        await submitCounterpartyAskResponse({ taskId: task.id, response })
+        onSuccess()
+      }
+      catch {
+        addToast({
+          content: t(
+            'bookkeeping:TasksListItem.CounterpartyAskTaskBody.error.submit_answer',
+            'We couldn’t save that answer. Please try again.',
+          ),
+          type: 'error',
+        })
+      }
+    },
+    [addToast, submitCounterpartyAskResponse, t, task.id],
+  )
+
+  const onContinue = useCallback(() => {
+    if (singleAnswer) {
+      setIsConfirming(true)
+      return
+    }
+
+    void submit(buildItemisedCounterpartyAskResponse(answeredRows), () => {
+      setSentDistinctCount(countDistinctCounterpartyAskAnswers(answeredRows.map(row => row.answer)))
+    })
+  }, [answeredRows, singleAnswer, submit])
+
+  const onConfirm = useCallback(
+    (alwaysThis: boolean) => {
+      if (!singleAnswer) return
+
+      void submit(buildAllSameCounterpartyAskResponse(singleAnswer, alwaysThis), () => {
+        setSentAnswer(singleAnswer)
+      })
+    },
+    [singleAnswer, submit],
+  )
+
+  if (sentAnswer) {
+    return (
+      <CounterpartyAskTaskSummary
+        title={t('bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.answer_sent', 'Thanks — sent')}
+        detail={t(
+          'bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.receipt_all_same',
+          'All {{total}} · {{answer}}',
+          { total: totalTransactions, answer: getCounterpartyAskAnswerLabel(sentAnswer) },
+        )}
+        note={t(
+          'bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.receipt_note_all_same',
+          'We’ll use this for your books.',
+        )}
+      />
+    )
+  }
+
+  if (sentDistinctCount !== null) {
+    return (
+      <CounterpartyAskTaskSummary
+        title={t('bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.answer_sent', 'Thanks — sent')}
+        detail={t(
+          'bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.receipt_itemised',
+          '{{total}} transactions · {{distinct}} different answers',
+          { total: totalTransactions, distinct: sentDistinctCount },
+        )}
+        note={t(
+          'bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.receipt_note_itemised',
+          'Your bookkeeper takes it from here.',
+        )}
+      />
+    )
+  }
+
+  if (task.resolvedByTaskId) {
+    return (
+      <CounterpartyAskTaskSummary
+        title={t(
+          'bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.answered_elsewhere',
+          'Already answered',
+        )}
+        detail={t(
+          'bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.answered_elsewhere_detail',
+          'You answered this for every period, so we’ve applied it here too.',
+        )}
+      />
+    )
+  }
+
+  const storedAnswer: CounterpartyAskAnswerValue | null = task.responseAccount
+    ? { kind: 'account', account: task.responseAccount }
+    : (task.userResponse ? { kind: 'text', text: task.userResponse } : null)
+
+  if (storedAnswer) {
+    return (
+      <CounterpartyAskTaskSummary
+        title={t('bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.answered', 'Answered')}
+        detail={t(
+          'bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.receipt_all_same',
+          'All {{total}} · {{answer}}',
+          { total: totalTransactions, answer: getCounterpartyAskAnswerLabel(storedAnswer) },
+        )}
+        note={task.alwaysThis
+          ? t(
+            'bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.answered_always',
+            'We’ll use this every time from now on.',
+          )
+          : undefined}
+      />
+    )
+  }
+
+  const answeredTransactions = task.transactionResponses.filter(
+    response => Boolean(response.userResponse) || Boolean(response.responseAccount),
+  )
+
+  if (answeredTransactions.length > 0) {
+    return (
+      <CounterpartyAskTaskSummary
+        title={t('bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.answered', 'Answered')}
+        detail={t(
+          'bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.answered_itemised',
+          'You answered {{answered}} of {{total}} individually.',
+          { answered: answeredTransactions.length, total: totalTransactions },
+        )}
+      />
+    )
+  }
+
+  if (isConfirming && singleAnswer) {
+    const answerLabel = getCounterpartyAskAnswerLabel(singleAnswer)
+    const counterpartyName = task.counterparty?.name
+
+    return (
+      <VStack gap='md' pb='sm'>
+        <HStack>
+          <BackButton onPress={() => setIsConfirming(false)} isDisabled={isMutating} />
+        </HStack>
+        <P weight='bold'>
+          {counterpartyName
+            ? t(
+              'bookkeeping:TasksListItem.CounterpartyAskTaskBody.prompt.always_this_for_counterparty',
+              'Will {{counterparty}} purchases always be {{answer}}?',
+              { counterparty: counterpartyName, answer: answerLabel },
+            )
+            : t(
+              'bookkeeping:TasksListItem.CounterpartyAskTaskBody.prompt.always_this',
+              'Should we always use {{answer}} for these?',
+              { answer: answerLabel },
+            )}
+        </P>
+        <HStack gap='2xs'>
+          <Button isDisabled={isMutating} onPress={() => onConfirm(true)}>
+            {t('bookkeeping:TasksListItem.CounterpartyAskTaskBody.action.yes_always', 'Yes, always')}
+          </Button>
+          <Button variant='outlined' isDisabled={isMutating} onPress={() => onConfirm(false)}>
+            {t('bookkeeping:TasksListItem.CounterpartyAskTaskBody.action.no_ask_again', 'No, ask me again')}
+          </Button>
+        </HStack>
+      </VStack>
+    )
+  }
+
+  return (
+    <VStack gap='sm' pb='sm'>
+      <P size='sm' variant='inherit'>{task.question}</P>
+      <ChipGroup
+        ariaLabel={t(
+          'bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.answer',
+          'What these were for',
+        )}
+        value={selectedKey}
+        onChange={setSelectedKey}
+        wrap
+      >
+        {suggestions.map((suggestion, index) => (
+          <Chip key={toSuggestionAnswerKey(index)} value={toSuggestionAnswerKey(index)}>
+            {suggestion.name}
+          </Chip>
+        ))}
+        <Chip value={OTHER_ANSWER_KEY}>
+          {t('bookkeeping:TasksListItem.CounterpartyAskTaskBody.action.something_else', 'Something else')}
+        </Chip>
+        {totalTransactions > 1
+          ? (
+            <HStack className='Layer__CounterpartyAskTask__MixRow' justify='center'>
+              <Chip value={MIX_ANSWER_KEY}>
+                {t('bookkeeping:TasksListItem.CounterpartyAskTaskBody.action.a_mix_of_the_above', 'A mix of the above')}
+              </Chip>
+            </HStack>
+          )
+          : null}
+      </ChipGroup>
+      {isFreeText
+        ? (
+          <VStack className='Layer__CounterpartyAskTask__FreeText'>
+            <TextArea
+              value={freeText}
+              placeholder={t(
+                'bookkeeping:TasksListItem.CounterpartyAskTaskBody.placeholder.what_were_these_for',
+                'What were these purchases for?',
+              )}
+              onChange={event => setFreeText(event.target.value)}
+            />
+          </VStack>
+        )
+        : null}
+      {isItemising
+        ? (
+          <VStack gap='2xs'>
+            <VStack className='Layer__CounterpartyAskTask__Rows'>
+              {transactions.map(transaction => (
+                <CounterpartyAskTransactionRow
+                  key={transaction.id}
+                  transaction={transaction}
+                  suggestions={suggestions}
+                  selectedKey={rowKeys[transaction.id] ?? null}
+                  text={rowTexts[transaction.id] ?? ''}
+                  onSelect={answerKey =>
+                    setRowKeys(current => ({ ...current, [transaction.id]: answerKey }))}
+                  onChangeText={text =>
+                    setRowTexts(current => ({ ...current, [transaction.id]: text }))}
+                />
+              ))}
+            </VStack>
+            <Span size='xs' variant='subtle'>
+              {isEveryRowAnswered
+                ? t(
+                  'bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.all_rows_answered',
+                  'All {{total}} answered',
+                  { total: totalTransactions },
+                )
+                : t(
+                  'bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.rows_answered',
+                  '{{answered}} of {{total}} answered',
+                  { answered: answeredRows.length, total: totalTransactions },
+                )}
+            </Span>
+          </VStack>
+        )
+        : null}
+      <HStack justify='end'>
+        <Button isDisabled={!canContinue || isMutating} onPress={onContinue}>
+          {t('common:action.continue_label', 'Continue')}
+        </Button>
+      </HStack>
+    </VStack>
+  )
+}

--- a/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskBody.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskBody.tsx
@@ -37,7 +37,7 @@ type CounterpartyAskTaskBodyProps = {
 
 export const CounterpartyAskTaskBody = ({ task }: CounterpartyAskTaskBodyProps) => {
   const { t } = useTranslation()
-  const { addToast } = useLayerContext()
+  const { addToast, eventCallbacks } = useLayerContext()
   const { trigger: submitCounterpartyAskResponse, isMutating } = usePostCounterpartyAskResponse()
 
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
@@ -90,11 +90,16 @@ export const CounterpartyAskTaskBody = ({ task }: CounterpartyAskTaskBodyProps) 
   const canContinue = isItemising ? isEveryRowAnswered : singleAnswer !== null
 
   const submit = useCallback(
-    async (response: CounterpartyAskResponse | null, onSuccess: () => void) => {
+    async (response: CounterpartyAskResponse | null, wasCategorized: boolean, onSuccess: () => void) => {
       if (!response) return
 
       try {
         await submitCounterpartyAskResponse({ taskId: task.id, response })
+
+        if (wasCategorized) {
+          eventCallbacks?.onTransactionCategorized?.()
+        }
+
         onSuccess()
       }
       catch {
@@ -107,7 +112,7 @@ export const CounterpartyAskTaskBody = ({ task }: CounterpartyAskTaskBodyProps) 
         })
       }
     },
-    [addToast, submitCounterpartyAskResponse, t, task.id],
+    [addToast, eventCallbacks, submitCounterpartyAskResponse, t, task.id],
   )
 
   const onContinue = useCallback(() => {
@@ -116,7 +121,9 @@ export const CounterpartyAskTaskBody = ({ task }: CounterpartyAskTaskBodyProps) 
       return
     }
 
-    void submit(buildItemisedCounterpartyAskResponse(answeredRows), () => {
+    const wasCategorized = answeredRows.some(row => row.answer.kind === 'account')
+
+    void submit(buildItemisedCounterpartyAskResponse(answeredRows), wasCategorized, () => {
       setSentDistinctCount(countDistinctCounterpartyAskAnswers(answeredRows.map(row => row.answer)))
     })
   }, [answeredRows, singleAnswer, submit])
@@ -125,7 +132,7 @@ export const CounterpartyAskTaskBody = ({ task }: CounterpartyAskTaskBodyProps) 
     (alwaysThis: boolean) => {
       if (!singleAnswer) return
 
-      void submit(buildAllSameCounterpartyAskResponse(singleAnswer, alwaysThis), () => {
+      void submit(buildAllSameCounterpartyAskResponse(singleAnswer, alwaysThis), singleAnswer.kind === 'account', () => {
         setSentAnswer(singleAnswer)
       })
     },

--- a/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskBody.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskBody.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 import { type CounterpartyAskResponse } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskResponse'
 import { type CounterpartyAskTask } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
 import { type UserVisibleTask } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
@@ -121,7 +122,7 @@ export const CounterpartyAskTaskBody = ({ task }: CounterpartyAskTaskBodyProps) 
       return
     }
 
-    const wasCategorized = answeredRows.some(row => row.answer.kind === 'account')
+    const wasCategorized = answeredRows.every(row => row.answer.kind === 'account')
 
     void submit(buildItemisedCounterpartyAskResponse(answeredRows), wasCategorized, () => {
       setSentDistinctCount(countDistinctCounterpartyAskAnswers(answeredRows.map(row => row.answer)))
@@ -173,7 +174,9 @@ export const CounterpartyAskTaskBody = ({ task }: CounterpartyAskTaskBodyProps) 
     )
   }
 
-  if (task.resolvedByTaskId) {
+  const isAnswered = task.status !== BusinessTaskStatus.Todo
+
+  if (isAnswered && task.resolvedByTaskId) {
     return (
       <CounterpartyAskTaskSummary
         title={t(
@@ -192,7 +195,7 @@ export const CounterpartyAskTaskBody = ({ task }: CounterpartyAskTaskBodyProps) 
     ? { kind: 'account', account: task.responseAccount }
     : (task.userResponse ? { kind: 'text', text: task.userResponse } : null)
 
-  if (storedAnswer) {
+  if (isAnswered && storedAnswer) {
     return (
       <CounterpartyAskTaskSummary
         title={t('bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.answered', 'Answered')}
@@ -215,7 +218,7 @@ export const CounterpartyAskTaskBody = ({ task }: CounterpartyAskTaskBodyProps) 
     response => Boolean(response.userResponse) || Boolean(response.responseAccount),
   )
 
-  if (answeredTransactions.length > 0) {
+  if (isAnswered && answeredTransactions.length > 0) {
     return (
       <CounterpartyAskTaskSummary
         title={t('bookkeeping:TasksListItem.CounterpartyAskTaskBody.label.answered', 'Answered')}

--- a/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskSummary.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTaskSummary.tsx
@@ -1,0 +1,38 @@
+import { Check } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { Span } from '@ui/Typography/Text'
+
+type CounterpartyAskTaskSummaryProps = {
+  title: string
+  detail: string
+  note?: string
+}
+
+export const CounterpartyAskTaskSummary = ({
+  title,
+  detail,
+  note,
+}: CounterpartyAskTaskSummaryProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <HStack gap='sm' pb='sm'>
+      <Span
+        className='Layer__CounterpartyAskTask__SummaryIcon'
+        aria-label={t(
+          'bookkeeping:TasksListItem.CounterpartyAskTaskSummary.label.answered',
+          'Answered',
+        )}
+      >
+        <Check size={14} />
+      </Span>
+      <VStack gap='3xs'>
+        <Span weight='bold'>{title}</Span>
+        <Span size='sm' variant='subtle'>{detail}</Span>
+        {note ? <Span size='xs' variant='subtle'>{note}</Span> : null}
+      </VStack>
+    </HStack>
+  )
+}

--- a/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTransactionRow.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTransactionRow.tsx
@@ -1,0 +1,84 @@
+import { useTranslation } from 'react-i18next'
+
+import { type MinimalBankTransaction } from '@schemas/features/bankTransactions/base'
+import { type CounterpartyAskAccount } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+import { DateFormat } from '@utils/shared/i18n/date/patterns'
+import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
+import { Chip, ChipGroup } from '@ui/Chip/Chip'
+import { Input } from '@ui/Input/Input'
+import { InputGroup } from '@ui/Input/InputGroup'
+import { HStack, VStack } from '@ui/Stack/Stack'
+import { MoneySpan } from '@ui/Typography/MoneySpan'
+import { Span } from '@ui/Typography/Text'
+
+export const OTHER_ANSWER_KEY = 'other'
+
+export const toSuggestionAnswerKey = (index: number) => `suggestion-${index}`
+
+type CounterpartyAskTransactionRowProps = {
+  transaction: MinimalBankTransaction
+  suggestions: readonly CounterpartyAskAccount[]
+  selectedKey: string | null
+  text: string
+  onSelect: (key: string) => void
+  onChangeText: (text: string) => void
+}
+
+export const CounterpartyAskTransactionRow = ({
+  transaction,
+  suggestions,
+  selectedKey,
+  text,
+  onSelect,
+  onChangeText,
+}: CounterpartyAskTransactionRowProps) => {
+  const { t } = useTranslation()
+  const { formatDate } = useIntlFormatter()
+
+  return (
+    <VStack className='Layer__CounterpartyAskTask__Row' gap='2xs' pb='2xs' pi='2xs'>
+      <HStack align='baseline' gap='xs'>
+        <MoneySpan size='sm' weight='bold' amount={transaction.amount} />
+        <Span size='xs' variant='subtle' ellipsis noWrap>
+          {`${formatDate(transaction.date, DateFormat.MonthDayShort)} · ${transaction.description ?? ''}`}
+        </Span>
+      </HStack>
+      <ChipGroup
+        ariaLabel={t(
+          'bookkeeping:TasksListItem.CounterpartyAskTransactionRow.label.answer_for_transaction',
+          'What this one was for',
+        )}
+        value={selectedKey}
+        onChange={onSelect}
+        wrap
+      >
+        {suggestions.map((suggestion, index) => (
+          <Chip key={toSuggestionAnswerKey(index)} size='sm' value={toSuggestionAnswerKey(index)}>
+            {suggestion.name}
+          </Chip>
+        ))}
+        <Chip size='sm' value={OTHER_ANSWER_KEY}>
+          {t(
+            'bookkeeping:TasksListItem.CounterpartyAskTransactionRow.action.something_else',
+            'Something else',
+          )}
+        </Chip>
+      </ChipGroup>
+      {selectedKey === OTHER_ANSWER_KEY
+        ? (
+          <InputGroup>
+            <Input
+              value={text}
+              placeholder={t(
+                'bookkeeping:TasksListItem.CounterpartyAskTransactionRow.placeholder.what_was_this_for',
+                'What was this one for?',
+              )}
+              onChange={event => onChangeText(event.target.value)}
+              inset
+            />
+          </InputGroup>
+        )
+        : null}
+    </VStack>
+  )
+}

--- a/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTransactionRow.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/CounterpartyAskTransactionRow.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import { type MinimalBankTransaction } from '@schemas/features/bankTransactions/base'
+import { BankTransactionDirection, type MinimalBankTransaction } from '@schemas/features/bankTransactions/base'
 import { type CounterpartyAskAccount } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
 import { DateFormat } from '@utils/shared/i18n/date/patterns'
 import { useIntlFormatter } from '@hooks/utils/i18n/useIntlFormatter'
@@ -38,7 +38,12 @@ export const CounterpartyAskTransactionRow = ({
   return (
     <VStack className='Layer__CounterpartyAskTask__Row' gap='2xs' pb='2xs' pi='2xs'>
       <HStack align='baseline' gap='xs'>
-        <MoneySpan size='sm' weight='bold' amount={transaction.amount} />
+        <MoneySpan
+          size='sm'
+          weight='bold'
+          amount={transaction.amount}
+          displayPlusSign={transaction.direction === BankTransactionDirection.Credit}
+        />
         <Span size='xs' variant='subtle' ellipsis noWrap>
           {`${formatDate(transaction.date, DateFormat.MonthDayShort)} · ${transaction.description ?? ''}`}
         </Span>

--- a/src/components/features/bookkeeping/TasksListItem/LegacyTaskBody.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/LegacyTaskBody.tsx
@@ -1,0 +1,173 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { BusinessTaskStatus, TaskUserResponseType } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+import { type LegacyBusinessTask } from '@schemas/features/bookkeeping/businessTasks/legacyBusinessTask'
+import { type UserVisibleTask } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
+import { useDeleteTaskUploads } from '@api/businesses/[business-id]/tasks/[task-id]/upload/delete/post'
+import { usePostTaskUpload } from '@api/businesses/[business-id]/tasks/[task-id]/upload/post'
+import { usePostTaskUploadDescription } from '@api/businesses/[business-id]/tasks/[task-id]/upload/update-description/post'
+import { usePostTaskUserResponse } from '@api/businesses/[business-id]/tasks/[task-id]/user-response/post'
+import { Button } from '@ui/Button/Button'
+import { FileInput } from '@ui/Input/FileInput'
+import { TextArea } from '@ui/Input/TextArea'
+import { P } from '@ui/Typography/Text'
+
+type LegacyTaskBodyProps = {
+  task: UserVisibleTask & LegacyBusinessTask
+  onAnswered: () => void
+}
+
+export const LegacyTaskBody = ({ task, onAnswered }: LegacyTaskBodyProps) => {
+  const { t } = useTranslation()
+  const [userResponse, setUserResponse] = useState(task.userResponse ?? '')
+  const [selectedFiles, setSelectedFiles] = useState<File[]>()
+
+  const { trigger: handleSubmitUserResponseForTask, isMutating: isSubmittingResponse } = usePostTaskUserResponse()
+  const { trigger: handleUploadDocumentsForTask, isMutating: isUploadingDocuments } = usePostTaskUpload()
+  const { trigger: handleDeleteUploadsOnTask } = useDeleteTaskUploads()
+  const { trigger: handleUpdateTaskUploadDescription } = usePostTaskUploadDescription()
+
+  const submit = async () => {
+    if (!selectedFiles) {
+      return
+    }
+
+    await handleUploadDocumentsForTask({
+      taskId: task.id,
+      files: selectedFiles,
+      description: userResponse,
+    })
+
+    onAnswered()
+    setSelectedFiles(undefined)
+  }
+
+  const uploadDocumentAction = useMemo(() => {
+    if (task.userResponseType === TaskUserResponseType.UploadDocument) {
+      if (task.status === BusinessTaskStatus.Todo) {
+        if (!selectedFiles) {
+          return (
+            <FileInput
+              onUpload={(files: File[]) => {
+                setSelectedFiles(files)
+              }}
+              text={t('bookkeeping:TasksListItem.LegacyTaskBody.action.select_files', 'Select files')}
+              allowMultipleUploads
+            />
+          )
+        }
+        else {
+          return (
+            <>
+              <Button
+                variant='outlined'
+                onPress={() => setSelectedFiles(undefined)}
+              >
+                {t('common:action.cancel_label', 'Cancel')}
+              </Button>
+              <Button
+                onPress={() => void submit()}
+                isDisabled={isUploadingDocuments}
+              >
+                {t('common:action.submit_label', 'Submit')}
+              </Button>
+            </>
+          )
+        }
+      }
+      else if (task.status === BusinessTaskStatus.UserMarkedCompleted) {
+        if (task.userResponse && task.userResponse != userResponse) {
+          return (
+            <Button
+              variant='outlined'
+              onPress={() => {
+                void handleUpdateTaskUploadDescription({
+                  taskId: task.id,
+                  description: userResponse,
+                })
+              }}
+            >
+              {t('common:action.update_label', 'Update')}
+            </Button>
+          )
+        }
+        else {
+          return (
+            <Button
+              variant='outlined'
+              onPress={() => {
+                void handleDeleteUploadsOnTask({
+                  taskId: task.id,
+                })
+              }}
+            >
+              {t('bookkeeping:TasksListItem.LegacyTaskBody.action.delete_uploads', 'Delete Uploads')}
+            </Button>
+          )
+        }
+      }
+      else { return null }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [t, task, selectedFiles, userResponse, isUploadingDocuments])
+
+  return (
+    <div className='Layer__tasks-list-item__body-info'>
+      <P size='sm' variant='inherit'>{task.question}</P>
+      <TextArea
+        value={userResponse}
+        placeholder={task.userResponseType === TaskUserResponseType.UploadDocument ? t('bookkeeping:TasksListItem.LegacyTaskBody.label.optional_description', 'Optional description') : ''}
+        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+          setUserResponse(e.target.value)}
+      />
+      {task.userResponseType === TaskUserResponseType.UploadDocument
+        ? (
+          <div className='Layer__tasks-list__link-list'>
+            {selectedFiles
+              ? (
+                <div className='Layer__tasks-list__link-list-header'>{t('bookkeeping:TasksListItem.LegacyTaskBody.label.selected_files', 'Selected Files:')}</div>
+              )
+              : task.documents
+                ? (
+                  <div className='Layer__tasks-list__link-list-header'>{t('bookkeeping:TasksListItem.LegacyTaskBody.label.uploaded_files', 'Uploaded Files:')}</div>
+                )
+                : null}
+            <ul className='Layer__tasks-list__links-list'>
+              {task.documents?.map((document, idx) => (
+                <li key={`uploaded-doc-name-${idx}`}><a className='Layer__tasks-list-item__link' href={document.presignedUrl.presignedUrl}>{document.fileName}</a></li>
+              ))}
+              {selectedFiles?.map((file, idx) => (
+                <li key={`selected-file-name-${idx}`}><a className='Layer__tasks-list-item__link'>{file.name}</a></li>
+              ))}
+            </ul>
+          </div>
+        )
+        : null}
+      <div className='Layer__tasks-list-item__actions'>
+        {task.userResponseType === TaskUserResponseType.UploadDocument
+          ? uploadDocumentAction
+          : (
+            <Button
+              isDisabled={
+                isSubmittingResponse
+                || userResponse.length === 0
+                || userResponse === task.userResponse
+              }
+              variant='outlined'
+              onPress={() => {
+                void handleSubmitUserResponseForTask({ taskId: task.id, userResponse })
+                  .then(() => {
+                    onAnswered()
+                  })
+              }}
+            >
+              {task.userResponse && task.userResponse !== userResponse
+                ? t('common:action.update_label', 'Update')
+                : t('common:action.save_label', 'Save')}
+            </Button>
+          )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/bookkeeping/TasksListItem/TasksListItem.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/TasksListItem.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useCallback, useEffect, useState } from 'react'
 import classNames from 'classnames'
 
 import { LayerEventComponent, LayerEventType } from '@schemas/common/layerEvents'
-import { isCounterpartyAskTask } from '@schemas/features/bookkeeping/businessTask'
+import { isCounterpartyAskTask, isLegacyBusinessTask } from '@schemas/features/bookkeeping/businessTask'
 import { isCompletedTask, type UserVisibleTask } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
 import ChevronDownFill from '@icons/ChevronDownFill'
 import { useEmitLayerEvent } from '@hooks/utils/events/useEmitLayerEvent'
@@ -82,7 +82,9 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
         <div className={taskBodyClassName}>
           {isCounterpartyAskTask(task)
             ? <CounterpartyAskTaskBody task={task} />
-            : <LegacyTaskBody task={task} onAnswered={onAnswered} />}
+            : isLegacyBusinessTask(task)
+              ? <LegacyTaskBody task={task} onAnswered={onAnswered} />
+              : null}
         </div>
       </div>
     </div>

--- a/src/components/features/bookkeeping/TasksListItem/TasksListItem.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/TasksListItem.tsx
@@ -1,21 +1,15 @@
-import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useState } from 'react'
 import classNames from 'classnames'
-import { useTranslation } from 'react-i18next'
 
 import { LayerEventComponent, LayerEventType } from '@schemas/common/layerEvents'
-import { BusinessTaskStatus, TaskUserResponseType } from '@schemas/features/bookkeeping/businessTask'
+import { isCounterpartyAskTask } from '@schemas/features/bookkeeping/businessTask'
 import { isCompletedTask, type UserVisibleTask } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
 import ChevronDownFill from '@icons/ChevronDownFill'
 import { useEmitLayerEvent } from '@hooks/utils/events/useEmitLayerEvent'
-import { useDeleteTaskUploads } from '@api/businesses/[business-id]/tasks/[task-id]/upload/delete/post'
-import { usePostTaskUpload } from '@api/businesses/[business-id]/tasks/[task-id]/upload/post'
-import { usePostTaskUploadDescription } from '@api/businesses/[business-id]/tasks/[task-id]/upload/update-description/post'
-import { usePostTaskUserResponse } from '@api/businesses/[business-id]/tasks/[task-id]/user-response/post'
-import { Button } from '@ui/Button/Button'
-import { FileInput } from '@ui/Input/FileInput'
-import { TextArea } from '@ui/Input/TextArea'
 import { P } from '@ui/Typography/Text'
+import { CounterpartyAskTaskBody } from '@features/bookkeeping/TasksListItem/CounterpartyAskTaskBody'
 import { getIconForTask } from '@features/bookkeeping/TasksListItem/getIconForTask'
+import { LegacyTaskBody } from '@features/bookkeeping/TasksListItem/LegacyTaskBody'
 
 type TasksListItemProps = {
   task: UserVisibleTask
@@ -27,16 +21,8 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
   { task, defaultOpen, onExpandTask },
   ref,
 ) => {
-  const { t } = useTranslation()
   const emitLayerEvent = useEmitLayerEvent(LayerEventComponent.Tasks)
   const [isOpen, setIsOpen] = useState(defaultOpen)
-  const [userResponse, setUserResponse] = useState(task.userResponse ?? '')
-  const [selectedFiles, setSelectedFiles] = useState<File[]>()
-
-  const { trigger: handleSubmitUserResponseForTask, isMutating: isSubmittingResponse } = usePostTaskUserResponse()
-  const { trigger: handleUploadDocumentsForTask, isMutating: isUploadingDocuments } = usePostTaskUpload()
-  const { trigger: handleDeleteUploadsOnTask } = useDeleteTaskUploads()
-  const { trigger: handleUpdateTaskUploadDescription } = usePostTaskUploadDescription()
 
   const taskBodyClassName = classNames(
     'Layer__tasks-list-item__body',
@@ -60,21 +46,6 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
     setIsOpen(defaultOpen)
   }, [defaultOpen])
 
-  const submit = async () => {
-    if (!selectedFiles) {
-      return
-    }
-
-    await handleUploadDocumentsForTask({
-      taskId: task.id,
-      files: selectedFiles,
-      description: userResponse,
-    })
-
-    setIsOpen(false)
-    setSelectedFiles(undefined)
-  }
-
   const onClickTaskItemHead = useCallback(() => {
     emitLayerEvent({
       type: LayerEventType.TaskClicked,
@@ -85,74 +56,7 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
     onExpandTask?.(!isOpen)
   }, [isOpen, onExpandTask, emitLayerEvent, task.id])
 
-  const uploadDocumentAction = useMemo(() => {
-    if (task.userResponseType === TaskUserResponseType.UploadDocument) {
-      if (task.status === BusinessTaskStatus.Todo) {
-        if (!selectedFiles) {
-          return (
-            <FileInput
-              onUpload={(files: File[]) => {
-                setSelectedFiles(files)
-              }}
-              text={t('bookkeeping:TasksListItem.action.select_files', 'Select files')}
-              allowMultipleUploads
-            />
-          )
-        }
-        else {
-          return (
-            <>
-              <Button
-                variant='outlined'
-                onPress={() => setSelectedFiles(undefined)}
-              >
-                {t('common:action.cancel_label', 'Cancel')}
-              </Button>
-              <Button
-                onPress={() => void submit()}
-                isDisabled={isUploadingDocuments}
-              >
-                {t('common:action.submit_label', 'Submit')}
-              </Button>
-            </>
-          )
-        }
-      }
-      else if (task.status === BusinessTaskStatus.UserMarkedCompleted) {
-        if (task.userResponse && task.userResponse != userResponse) {
-          return (
-            <Button
-              variant='outlined'
-              onPress={() => {
-                void handleUpdateTaskUploadDescription({
-                  taskId: task.id,
-                  description: userResponse,
-                })
-              }}
-            >
-              {t('common:action.update_label', 'Update')}
-            </Button>
-          )
-        }
-        else {
-          return (
-            <Button
-              variant='outlined'
-              onPress={() => {
-                void handleDeleteUploadsOnTask({
-                  taskId: task.id,
-                })
-              }}
-            >
-              {t('bookkeeping:TasksListItem.action.delete_uploads', 'Delete Uploads')}
-            </Button>
-          )
-        }
-      }
-      else { return null }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [t, task, selectedFiles, userResponse, isUploadingDocuments])
+  const onAnswered = useCallback(() => setIsOpen(false), [])
 
   return (
     <div className='Layer__tasks-list-item-wrapper' ref={ref}>
@@ -176,62 +80,9 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
           />
         </div>
         <div className={taskBodyClassName}>
-          <div className='Layer__tasks-list-item__body-info'>
-            <P size='sm' variant='inherit'>{task.question}</P>
-            <TextArea
-              value={userResponse}
-              placeholder={task.userResponseType === TaskUserResponseType.UploadDocument ? t('bookkeeping:TasksListItem.label.optional_description', 'Optional description') : ''}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setUserResponse(e.target.value)}
-            />
-            {task.userResponseType === TaskUserResponseType.UploadDocument
-              ? (
-                <div className='Layer__tasks-list__link-list'>
-                  {selectedFiles
-                    ? (
-                      <div className='Layer__tasks-list__link-list-header'>{t('bookkeeping:TasksListItem.label.selected_files', 'Selected Files:')}</div>
-                    )
-                    : task.documents
-                      ? (
-                        <div className='Layer__tasks-list__link-list-header'>{t('bookkeeping:TasksListItem.label.uploaded_files', 'Uploaded Files:')}</div>
-                      )
-                      : null}
-                  <ul className='Layer__tasks-list__links-list'>
-                    {task.documents?.map((document, idx) => (
-                      <li key={`uploaded-doc-name-${idx}`}><a className='Layer__tasks-list-item__link' href={document.presignedUrl.presignedUrl}>{document.fileName}</a></li>
-                    ))}
-                    {selectedFiles?.map((file, idx) => (
-                      <li key={`selected-file-name-${idx}`}><a className='Layer__tasks-list-item__link'>{file.name}</a></li>
-                    ))}
-                  </ul>
-                </div>
-              )
-              : null}
-            <div className='Layer__tasks-list-item__actions'>
-              {task.userResponseType === TaskUserResponseType.UploadDocument
-                ? uploadDocumentAction
-                : (
-                  <Button
-                    isDisabled={
-                      isSubmittingResponse
-                      || userResponse.length === 0
-                      || userResponse === task.userResponse
-                    }
-                    variant='outlined'
-                    onPress={() => {
-                      void handleSubmitUserResponseForTask({ taskId: task.id, userResponse })
-                        .then(() => {
-                          setIsOpen(false)
-                        })
-                    }}
-                  >
-                    {task.userResponse && task.userResponse !== userResponse
-                      ? t('common:action.update_label', 'Update')
-                      : t('common:action.save_label', 'Save')}
-                  </Button>
-                )}
-            </div>
-          </div>
+          {isCounterpartyAskTask(task)
+            ? <CounterpartyAskTaskBody task={task} />
+            : <LegacyTaskBody task={task} onAnswered={onAnswered} />}
         </div>
       </div>
     </div>

--- a/src/components/features/bookkeeping/TasksListItem/counterpartyAskTaskBody.scss
+++ b/src/components/features/bookkeeping/TasksListItem/counterpartyAskTaskBody.scss
@@ -1,0 +1,40 @@
+.Layer__CounterpartyAskTask__FreeText .Layer__UI__TextArea {
+  min-block-size: 3lh;
+}
+
+.Layer__CounterpartyAskTask__MixRow {
+  flex-basis: 100%;
+}
+
+.Layer__CounterpartyAskTask__Rows {
+  overflow: hidden;
+
+  border-radius: var(--border-radius-xs);
+  border: 1px solid var(--border-color);
+}
+
+.Layer__CounterpartyAskTask__Row {
+  padding-block-start: var(--spacing-2xs);
+
+  border-block-start: 1px solid var(--border-color);
+
+  &:first-child {
+    border-block-start: none;
+  }
+}
+
+.Layer__CounterpartyAskTask__SummaryIcon {
+  box-sizing: border-box;
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  block-size: 1.625rem;
+  inline-size: 1.625rem;
+
+  border-radius: var(--border-radius-5xl);
+
+  background-color: var(--color-info-success-bg);
+
+  color: var(--color-info-success-fg);
+}

--- a/src/components/features/bookkeeping/TasksListItem/getIconForTask.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/getIconForTask.tsx
@@ -1,6 +1,7 @@
 import { Check, CircleAlert } from 'lucide-react'
 
-import { type BusinessTask, BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 const STATUS_TO_ICON_MAP = {
   [BusinessTaskStatus.Todo]: {

--- a/src/components/ui/Button/BackButton.tsx
+++ b/src/components/ui/Button/BackButton.tsx
@@ -4,13 +4,13 @@ import { useTranslation } from 'react-i18next'
 import { Button, type ButtonProps } from '@ui/Button/Button'
 import { LEGACY_BACK_BUTTON_CLASS_NAME } from '@ui/Button/legacyClassNames'
 
-export type BackButtonProps = Pick<ButtonProps, 'onPress'> & {
+export type BackButtonProps = Pick<ButtonProps, 'onPress' | 'isDisabled'> & {
   slots?: {
     Icon?: LucideIcon
   }
 }
 
-export function BackButton({ onPress, slots }: BackButtonProps) {
+export function BackButton({ onPress, isDisabled, slots }: BackButtonProps) {
   const { t } = useTranslation()
   const { Icon = ChevronLeft } = slots ?? {}
 
@@ -20,6 +20,7 @@ export function BackButton({ onPress, slots }: BackButtonProps) {
       icon
       className={LEGACY_BACK_BUTTON_CLASS_NAME}
       onPress={onPress}
+      isDisabled={isDisabled}
       aria-label={t('common:action.back', 'Back')}
     >
       <Icon size={16} />

--- a/src/components/ui/Chip/Chip.stories.tsx
+++ b/src/components/ui/Chip/Chip.stories.tsx
@@ -1,0 +1,62 @@
+import { type Meta, type StoryObj } from '@storybook/react-vite'
+
+import { Chip, ChipGroup } from '@ui/Chip/Chip'
+
+import { Col } from '@testUtils/storybook/layout/Col'
+import { Gallery } from '@testUtils/storybook/layout/Gallery'
+
+const meta: Meta<typeof ChipGroup> = {
+  title: 'UI/Chip',
+  component: ChipGroup,
+  args: {
+    ariaLabel: 'Answer',
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof ChipGroup>
+
+export const AllVariants: Story = {
+  parameters: { chromatic: { viewports: [1280] } },
+  render: () => (
+    <Gallery>
+      <Col label='default'>
+        <ChipGroup ariaLabel='default'>
+          <Chip value='meals'>Business Meals</Chip>
+          <Chip value='office'>Office Expenses</Chip>
+          <Chip value='other'>Something else</Chip>
+        </ChipGroup>
+      </Col>
+      <Col label='selected'>
+        <ChipGroup ariaLabel='selected' value='office'>
+          <Chip value='meals'>Business Meals</Chip>
+          <Chip value='office'>Office Expenses</Chip>
+          <Chip value='other'>Something else</Chip>
+        </ChipGroup>
+      </Col>
+      <Col label='small'>
+        <ChipGroup ariaLabel='small' value='meals'>
+          <Chip size='sm' value='meals'>Business Meals</Chip>
+          <Chip size='sm' value='office'>Office Expenses</Chip>
+          <Chip size='sm' value='other'>Something else</Chip>
+        </ChipGroup>
+      </Col>
+      <Col label='wrapping'>
+        <ChipGroup ariaLabel='wrapping' wrap>
+          <Chip value='meals'>Business Meals</Chip>
+          <Chip value='office'>Office Expenses</Chip>
+          <Chip value='other-business'>Other Business Expenses</Chip>
+          <Chip value='other'>Something else</Chip>
+          <Chip value='mix'>A mix of the above</Chip>
+        </ChipGroup>
+      </Col>
+      <Col label='disabled'>
+        <ChipGroup ariaLabel='disabled' isDisabled>
+          <Chip value='meals'>Business Meals</Chip>
+          <Chip value='other'>Something else</Chip>
+        </ChipGroup>
+      </Col>
+    </Gallery>
+  ),
+}

--- a/src/components/ui/Chip/Chip.tsx
+++ b/src/components/ui/Chip/Chip.tsx
@@ -1,0 +1,70 @@
+import classNames from 'classnames'
+import {
+  Radio as ReactAriaRadio,
+  RadioGroup as ReactAriaRadioGroup,
+  type RadioGroupProps as ReactAriaRadioGroupProps,
+  type RadioProps as ReactAriaRadioProps,
+} from 'react-aria-components/RadioGroup'
+
+import { toDataProperties } from '@utils/shared/styles/toDataProperties'
+import { withRenderProp } from '@components/utility/withRenderProp'
+
+import './chip.scss'
+
+const CHIP_GROUP_CLASS_NAME = 'Layer__UI__ChipGroup'
+const CHIP_CLASS_NAME = 'Layer__UI__Chip'
+
+type ChipGroupProps<T extends string> = Omit<
+  ReactAriaRadioGroupProps,
+  'className' | 'value' | 'defaultValue' | 'onChange'
+> & {
+  ariaLabel: string
+  wrap?: boolean
+  value?: T | null
+  onChange?: (value: T) => void
+}
+
+export function ChipGroup<T extends string>({
+  ariaLabel,
+  children,
+  onChange,
+  value,
+  wrap,
+  ...restProps
+}: ChipGroupProps<T>) {
+  const dataProperties = toDataProperties({ wrap })
+
+  return (
+    <ReactAriaRadioGroup
+      {...restProps}
+      {...dataProperties}
+      aria-label={ariaLabel}
+      value={value ?? null}
+      onChange={onChange as ((value: string) => void) | undefined}
+      className={CHIP_GROUP_CLASS_NAME}
+    >
+      {children}
+    </ReactAriaRadioGroup>
+  )
+}
+
+export type ChipSize = 'sm' | 'md'
+
+type ChipProps<T extends string> = Omit<ReactAriaRadioProps, 'className' | 'value'> & {
+  size?: ChipSize
+  value: T
+}
+
+export function Chip<T extends string>({ children, size = 'md', ...restProps }: ChipProps<T>) {
+  const dataProperties = toDataProperties({ size })
+
+  return (
+    <ReactAriaRadio
+      {...restProps}
+      {...dataProperties}
+      className={classNames(CHIP_CLASS_NAME)}
+    >
+      {withRenderProp(children, node => node)}
+    </ReactAriaRadio>
+  )
+}

--- a/src/components/ui/Chip/Chip.tsx
+++ b/src/components/ui/Chip/Chip.tsx
@@ -39,7 +39,7 @@ export function ChipGroup<T extends string>({
       {...restProps}
       {...dataProperties}
       aria-label={ariaLabel}
-      value={value ?? null}
+      value={value}
       onChange={onChange as ((value: string) => void) | undefined}
       className={CHIP_GROUP_CLASS_NAME}
     >

--- a/src/components/ui/Chip/chip.scss
+++ b/src/components/ui/Chip/chip.scss
@@ -1,0 +1,59 @@
+.Layer__UI__ChipGroup {
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-2xs);
+
+  &[data-wrap] {
+    flex-wrap: wrap;
+  }
+}
+
+.Layer__UI__Chip {
+  box-sizing: border-box;
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  min-block-size: 2.25rem;
+  padding-inline: var(--spacing-sm);
+
+  border-radius: var(--border-radius-sm);
+  border: 1px solid var(--border-color);
+
+  background-color: var(--color-base-0);
+
+  cursor: pointer;
+  user-select: none;
+
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-normal);
+  text-align: center;
+  color: var(--text-color-primary);
+
+  &[data-size='sm'] {
+    min-block-size: 1.875rem;
+    padding-inline: var(--spacing-xs);
+
+    border-radius: var(--border-radius-5xl);
+
+    font-size: var(--text-xs);
+  }
+
+  &[data-selected] {
+    border-color: var(--color-base-1000);
+
+    background-color: var(--color-base-1000);
+
+    font-weight: var(--font-weight-bold);
+    color: var(--color-base-0);
+  }
+
+  &[data-hovered]:not([data-selected]) {
+    background-color: var(--color-base-50);
+  }
+
+  &[data-focus-visible] {
+    outline: 1px solid var(--color-base-1000);
+    outline-offset: 1px;
+  }
+}

--- a/src/fixtures/bookkeeping/counterpartyAskTasks.ts
+++ b/src/fixtures/bookkeeping/counterpartyAskTasks.ts
@@ -1,0 +1,168 @@
+import { makeAccountId, makeStableName } from '@schemas/common/accountIdentifier'
+import { BankTransactionDirection, type MinimalBankTransaction } from '@schemas/features/bankTransactions/base'
+import {
+  BusinessTaskStatus,
+  COUNTERPARTY_ASK_TASK_TYPE,
+} from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+import {
+  type CounterpartyAskAccount,
+  type CounterpartyAskTask,
+} from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+
+import { FIXTURE_YEAR } from '@fixtures/constants/fixtureYear'
+import { createFixtureFactory } from '@fixtures/utils/createFixtureFactory'
+
+const RETAIL_SUGGESTIONS: readonly CounterpartyAskAccount[] = [
+  { accountIdentifier: makeAccountId('00000000-0000-4000-8000-000000000801'), name: 'Office Expenses' },
+  { accountIdentifier: makeAccountId('00000000-0000-4000-8000-000000000802'), name: 'Other Business Expenses' },
+  { accountIdentifier: makeStableName('MEALS'), name: 'Business Meals' },
+]
+
+const RENT_SUGGESTIONS: readonly CounterpartyAskAccount[] = [
+  { accountIdentifier: makeStableName('RENT'), name: 'Rent' },
+]
+
+type AskTransactionSeed = {
+  id: string
+  year: number
+  month: number
+  day: number
+  amount: number
+  counterpartyName: string
+  description: string
+}
+
+const makeAskTransaction = (
+  { id, year, month, day, amount, counterpartyName, description }: AskTransactionSeed,
+): MinimalBankTransaction => ({
+  id,
+  date: new Date(Date.UTC(year, month - 1, day)),
+  direction: BankTransactionDirection.Debit,
+  amount,
+  counterpartyName,
+  description,
+})
+
+const baseCounterpartyAskTask: CounterpartyAskTask = {
+  id: '00000000-0000-4000-8000-000000000901',
+  status: BusinessTaskStatus.Todo,
+  taskType: COUNTERPARTY_ASK_TASK_TYPE,
+  title: 'Costco purchases',
+  question: 'You spent $307.74 at Costco across 1 transaction. '
+    + 'Can you tell us a bit more about what these were for?',
+  counterparty: {
+    id: '00000000-0000-4000-8000-000000000701',
+    name: 'Costco',
+    mccs: [],
+  },
+  suggestions: RETAIL_SUGGESTIONS,
+  transactions: [makeAskTransaction({ id: '00000000-0000-4000-8000-000000000a01', year: FIXTURE_YEAR, month: 1, day: 14, amount: 30774, counterpartyName: 'Costco', description: 'COSTCO WHSE #1042' })],
+  transactionResponses: [],
+  userResponse: null,
+  responseAccount: null,
+  totalCount: 1,
+  totalAmount: 30774,
+  alwaysThis: false,
+  resolvedByTaskId: null,
+}
+
+const { make: makeBaseCounterpartyAskTask } = createFixtureFactory(baseCounterpartyAskTask)
+
+const toUnansweredResponses = (
+  transactions: CounterpartyAskTask['transactions'],
+): CounterpartyAskTask['transactionResponses'] =>
+  transactions.map(transaction => ({
+    transactionId: transaction.id,
+    userResponse: null,
+    responseAccount: null,
+  }))
+
+export const makeCounterpartyAskTask = (
+  overrides?: Partial<CounterpartyAskTask>,
+): CounterpartyAskTask => {
+  const task = makeBaseCounterpartyAskTask(overrides)
+
+  return overrides?.transactionResponses
+    ? task
+    : { ...task, transactionResponses: toUnansweredResponses(task.transactions) }
+}
+
+const COUNTERPARTY_ASK_SEEDS_BY_MONTH: Record<number, (month: number) => CounterpartyAskTask> = {
+  7: month => makeCounterpartyAskTask({
+    id: '00000000-0000-4000-8000-000000000917',
+    title: 'SQ *NAIL BAR purchases',
+    question: 'You spent $84.00 at SQ *NAIL BAR across 1 transaction. '
+      + 'Can you tell us a bit more about what these were for?',
+    counterparty: {
+      id: '00000000-0000-4000-8000-000000000703',
+      name: 'SQ *NAIL BAR',
+      mccs: [],
+    },
+    suggestions: [],
+    transactions: [
+      makeAskTransaction({ id: '00000000-0000-4000-8000-000000000a08', year: FIXTURE_YEAR, month, day: 9, amount: 8400, counterpartyName: 'SQ *NAIL BAR', description: 'SQ *NAIL BAR' }),
+    ],
+    totalAmount: 8400,
+  }),
+
+  8: month => makeCounterpartyAskTask({
+    id: '00000000-0000-4000-8000-000000000916',
+    title: 'Brick and Mortar Real Estate Services purchases',
+    question: 'You spent $736.74 at Brick and Mortar Real Estate Services across 1 transaction. '
+      + 'Can you tell us a bit more about what these were for?',
+    counterparty: {
+      id: '00000000-0000-4000-8000-000000000702',
+      name: 'Brick and Mortar Real Estate Services',
+      mccs: [],
+    },
+    suggestions: RENT_SUGGESTIONS,
+    transactions: [
+      makeAskTransaction({ id: '00000000-0000-4000-8000-000000000a07', year: FIXTURE_YEAR, month, day: 1, amount: 73674, counterpartyName: 'Brick and Mortar Real Estate Services', description: 'BRICK+MORTAR RE SVCS' }),
+    ],
+    totalAmount: 73674,
+  }),
+
+  9: month => makeCounterpartyAskTask({
+    id: '00000000-0000-4000-8000-000000000911',
+    transactions: [
+      makeAskTransaction({ id: '00000000-0000-4000-8000-000000000a01', year: FIXTURE_YEAR, month, day: 14, amount: 30774, counterpartyName: 'Costco', description: 'COSTCO WHSE #1042' }),
+    ],
+  }),
+
+  10: month => makeCounterpartyAskTask({
+    id: '00000000-0000-4000-8000-000000000912',
+    question: 'You spent $836.45 at Costco across 2 transactions. '
+      + 'Can you tell us a bit more about what these were for?',
+    transactions: [
+      makeAskTransaction({ id: '00000000-0000-4000-8000-000000000a02', year: FIXTURE_YEAR, month, day: 3, amount: 61250, counterpartyName: 'Costco', description: 'COSTCO WHSE #1042' }),
+      makeAskTransaction({ id: '00000000-0000-4000-8000-000000000a03', year: FIXTURE_YEAR, month, day: 19, amount: 22395, counterpartyName: 'Costco', description: 'COSTCO GAS #1042' }),
+    ],
+    totalCount: 2,
+    totalAmount: 83645,
+  }),
+
+  11: month => makeCounterpartyAskTask({
+    id: '00000000-0000-4000-8000-000000000913',
+    question: '3 more Costco transactions came in, totaling $297.48. '
+      + 'Can you tell us a bit more about what these were for?',
+    transactions: [
+      makeAskTransaction({ id: '00000000-0000-4000-8000-000000000a04', year: FIXTURE_YEAR, month, day: 2, amount: 14899, counterpartyName: 'Costco', description: 'COSTCO WHSE #1042' }),
+      makeAskTransaction({ id: '00000000-0000-4000-8000-000000000a05', year: FIXTURE_YEAR, month, day: 11, amount: 9932, counterpartyName: 'Costco', description: 'COSTCO WHSE #1042' }),
+      makeAskTransaction({ id: '00000000-0000-4000-8000-000000000a06', year: FIXTURE_YEAR, month, day: 27, amount: 4917, counterpartyName: 'Costco', description: 'COSTCO GAS #1042' }),
+    ],
+    totalCount: 3,
+    totalAmount: 29748,
+  }),
+}
+
+const hasCounterpartyAskSeed = (year: number, month: number) =>
+  year === FIXTURE_YEAR && month in COUNTERPARTY_ASK_SEEDS_BY_MONTH
+
+export const counterpartyAskCountFor = (year: number, month: number) =>
+  hasCounterpartyAskSeed(year, month) ? 1 : 0
+
+export const makeCounterpartyAskTasks = (year: number, month: number): CounterpartyAskTask[] => {
+  const seed = COUNTERPARTY_ASK_SEEDS_BY_MONTH[month]
+
+  return seed && year === FIXTURE_YEAR ? [seed(month)] : []
+}

--- a/src/fixtures/bookkeeping/counterpartyAskTasks.ts
+++ b/src/fixtures/bookkeeping/counterpartyAskTasks.ts
@@ -168,12 +168,6 @@ const COUNTERPARTY_ASK_SEEDS_BY_MONTH: Record<number, (month: number) => Counter
   }),
 }
 
-const hasCounterpartyAskSeed = (year: number, month: number) =>
-  year === FIXTURE_YEAR && month in COUNTERPARTY_ASK_SEEDS_BY_MONTH
-
-export const counterpartyAskCountFor = (year: number, month: number) =>
-  hasCounterpartyAskSeed(year, month) ? 1 : 0
-
 export const makeCounterpartyAskTasks = (year: number, month: number): CounterpartyAskTask[] => {
   const seed = COUNTERPARTY_ASK_SEEDS_BY_MONTH[month]
 

--- a/src/fixtures/bookkeeping/counterpartyAskTasks.ts
+++ b/src/fixtures/bookkeeping/counterpartyAskTasks.ts
@@ -9,17 +9,30 @@ import {
   type CounterpartyAskTask,
 } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
 
+import { bankTransactionCategories } from '@fixtures/bankTransactions/constants'
 import { FIXTURE_YEAR } from '@fixtures/constants/fixtureYear'
 import { createFixtureFactory } from '@fixtures/utils/createFixtureFactory'
 
 const RETAIL_SUGGESTIONS: readonly CounterpartyAskAccount[] = [
-  { accountIdentifier: makeAccountId('00000000-0000-4000-8000-000000000801'), name: 'Office Expenses' },
-  { accountIdentifier: makeAccountId('00000000-0000-4000-8000-000000000802'), name: 'Other Business Expenses' },
-  { accountIdentifier: makeStableName('MEALS'), name: 'Business Meals' },
+  {
+    accountIdentifier: makeAccountId(bankTransactionCategories.officeExpenses.id),
+    name: bankTransactionCategories.officeExpenses.displayName,
+  },
+  {
+    accountIdentifier: makeAccountId(bankTransactionCategories.otherBusinessExpenses.id),
+    name: bankTransactionCategories.otherBusinessExpenses.displayName,
+  },
+  {
+    accountIdentifier: makeStableName(bankTransactionCategories.meals.stableName),
+    name: bankTransactionCategories.meals.displayName,
+  },
 ]
 
 const RENT_SUGGESTIONS: readonly CounterpartyAskAccount[] = [
-  { accountIdentifier: makeStableName('RENT'), name: 'Rent' },
+  {
+    accountIdentifier: makeStableName(bankTransactionCategories.rent.stableName),
+    name: bankTransactionCategories.rent.displayName,
+  },
 ]
 
 type AskTransactionSeed = {

--- a/src/fixtures/bookkeeping/mocks.ts
+++ b/src/fixtures/bookkeeping/mocks.ts
@@ -6,7 +6,7 @@ import { type LegacyBusinessTask } from '@schemas/features/bookkeeping/businessT
 import { type CallBooking, CallBookingPurpose, CallBookingState, CallBookingType } from '@schemas/features/bookkeeping/callBooking'
 import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
-import { counterpartyAskCountFor, makeCounterpartyAskTasks } from '@fixtures/bookkeeping/counterpartyAskTasks'
+import { makeCounterpartyAskTasks } from '@fixtures/bookkeeping/counterpartyAskTasks'
 import { PeriodIdSchema, schema } from '@fixtures/bookkeeping/schema'
 import { formatDollars, formatTaskDate } from '@fixtures/bookkeeping/utils'
 import { createFixtureFactory } from '@fixtures/utils/createFixtureFactory'
@@ -100,7 +100,7 @@ const monthsBeforeCurrent = (year: number, month: number) => {
 /** Past months without open tasks have closed books, so they carry no uncategorized activity. */
 export const hasCompletedBooks = (year: number, month: number) => {
   const monthsAgo = monthsBeforeCurrent(year, month)
-  return monthsAgo > 0 && openTaskCountFor(monthsAgo) + counterpartyAskCountFor(year, month) === 0
+  return monthsAgo > 0 && openTaskCountFor(monthsAgo) === 0
 }
 
 const periodStatusFor = (monthsAgo: number, openTaskCount: number): BookkeepingPeriodStatus => {

--- a/src/fixtures/bookkeeping/mocks.ts
+++ b/src/fixtures/bookkeeping/mocks.ts
@@ -1,14 +1,12 @@
 import { type BookkeepingConfiguration, BookkeepingStatus as ConfigurationBookkeepingStatus } from '@schemas/features/bookkeeping/bookkeepingConfiguration'
 import { type BookkeepingPeriod, BookkeepingPeriodStatus } from '@schemas/features/bookkeeping/bookkeepingPeriods'
 import { BookkeepingStatus, type BookkeepingStatusData } from '@schemas/features/bookkeeping/bookkeepingStatus'
-import {
-  type BusinessTask,
-  BusinessTaskStatus,
-  TaskUserResponseType,
-} from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus, TaskUserResponseType } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+import { type LegacyBusinessTask } from '@schemas/features/bookkeeping/businessTasks/legacyBusinessTask'
 import { type CallBooking, CallBookingPurpose, CallBookingState, CallBookingType } from '@schemas/features/bookkeeping/callBooking'
 import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
+import { counterpartyAskCountFor, makeCounterpartyAskTasks } from '@fixtures/bookkeeping/counterpartyAskTasks'
 import { PeriodIdSchema, schema } from '@fixtures/bookkeeping/schema'
 import { formatDollars, formatTaskDate } from '@fixtures/bookkeeping/utils'
 import { createFixtureFactory } from '@fixtures/utils/createFixtureFactory'
@@ -70,7 +68,7 @@ const generatePeriodIds = createGenerator(PeriodIdSchema)
 
 const periodIdFor = (monthIndex: number) => pickCyclic(generatePeriodIds({ numRuns: 1, seed: monthIndex }), 0)
 
-const makePeriodTasks = (periodIndex: number, count: number, month: number): BusinessTask[] => {
+const makePeriodTasks = (periodIndex: number, count: number, month: number): LegacyBusinessTask[] => {
   if (count === 0) return []
 
   return generateTaskSeeds({ numRuns: count, seed: periodIndex }).map(({ id, day, amountCents, merchant }) => {
@@ -79,6 +77,7 @@ const makePeriodTasks = (periodIndex: number, count: number, month: number): Bus
     return {
       id,
       status: BusinessTaskStatus.Todo,
+      taskType: null,
       title: `Transaction on ${date}`,
       question: `On ${date}, you spent ${formatDollars(amountCents)} at ${merchant}. `
         + 'Can you tell us a bit more about what this transaction was for?',
@@ -101,7 +100,7 @@ const monthsBeforeCurrent = (year: number, month: number) => {
 /** Past months without open tasks have closed books, so they carry no uncategorized activity. */
 export const hasCompletedBooks = (year: number, month: number) => {
   const monthsAgo = monthsBeforeCurrent(year, month)
-  return monthsAgo > 0 && openTaskCountFor(monthsAgo) === 0
+  return monthsAgo > 0 && openTaskCountFor(monthsAgo) + counterpartyAskCountFor(year, month) === 0
 }
 
 const periodStatusFor = (monthsAgo: number, openTaskCount: number): BookkeepingPeriodStatus => {
@@ -119,14 +118,16 @@ export const makeBookkeepingPeriods = (startYear: number): BookkeepingPeriod[] =
 
   for (let cursor = start; cursor <= end; cursor++) {
     const { year, month } = fromMonthIndex(cursor)
-    const openTaskCount = openTaskCountFor(end - cursor)
+    const monthsAgo = end - cursor
+    const legacyTasks = makePeriodTasks(cursor, openTaskCountFor(monthsAgo), month)
+    const counterpartyAsks = makeCounterpartyAskTasks(year, month)
 
     periods.push({
       id: periodIdFor(cursor),
       month,
       year,
-      status: periodStatusFor(end - cursor, openTaskCount),
-      tasks: makePeriodTasks(cursor, openTaskCount, month),
+      status: periodStatusFor(monthsAgo, legacyTasks.length + counterpartyAsks.length),
+      tasks: [...legacyTasks, ...counterpartyAsks],
     })
   }
 

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/periods/get.test.ts
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/periods/get.test.ts
@@ -1,0 +1,59 @@
+import { waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { BookkeepingStatus } from '@schemas/features/bookkeeping/bookkeepingStatus'
+import { isCounterpartyAskTask } from '@schemas/features/bookkeeping/businessTask'
+import { useGetBookkeepingPeriods } from '@api/businesses/[business-id]/bookkeeping/periods/get'
+
+import { makeBookkeepingStatus } from '@fixtures/bookkeeping/mocks'
+import { get as getBookkeepingPeriods } from '@msw/api/businesses/[business-id]/bookkeeping/periods/get'
+import { bookkeepingPeriodStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
+import { get as getBookkeepingStatus } from '@msw/api/businesses/[business-id]/bookkeeping/status/get'
+import { server } from '@msw/node'
+import { renderHookWithAuth } from '@testUtils/render/renderHookWithAuth'
+
+const mockActiveBookkeeping = () => {
+  server.use(
+    getBookkeepingStatus.mock(makeBookkeepingStatus({ status: BookkeepingStatus.ACTIVE })),
+  )
+}
+
+const spyOnPeriodsRequest = () => {
+  const onRequest = vi.fn<(url: string) => void>()
+
+  server.use(
+    getBookkeepingPeriods.mock(bookkeepingPeriodStore.all(), {
+      onRequest: ({ request }) => {
+        onRequest(request.url)
+      },
+    }),
+  )
+
+  return onRequest
+}
+
+describe('useGetBookkeepingPeriods', () => {
+  it('opts out of legacy_tasks_only so counterparty asks are included', async () => {
+    mockActiveBookkeeping()
+    const onRequest = spyOnPeriodsRequest()
+
+    await renderHookWithAuth(() => useGetBookkeepingPeriods())
+
+    await waitFor(() => expect(onRequest).toHaveBeenCalled())
+    expect(onRequest.mock.calls[0]?.[0]).toContain('legacy_tasks_only=false')
+  })
+
+  it('returns the counterparty asks the seeded periods carry', async () => {
+    mockActiveBookkeeping()
+
+    const { result } = await renderHookWithAuth(() => useGetBookkeepingPeriods())
+
+    await waitFor(() => expect(result.current.data).toBeDefined())
+
+    const asks = (result.current.data ?? [])
+      .flatMap(period => period.tasks)
+      .filter(task => isCounterpartyAskTask(task))
+
+    expect(asks.length).toBeGreaterThan(0)
+  })
+})

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/periods/get.ts
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/periods/get.ts
@@ -5,6 +5,7 @@ import {
   BookkeepingPeriodsSchema,
   BookkeepingPeriodStatus,
 } from '@schemas/features/bookkeeping/bookkeepingPeriods'
+import { isRenderableBusinessTask } from '@schemas/features/bookkeeping/businessTask'
 import { isActiveOrPausedBookkeepingStatus } from '@utils/features/bookkeeping/bookkeepingStatusFilters'
 import { getUserVisibleTasks } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
 import { isActiveBookkeepingPeriod } from '@utils/features/bookkeeping/periods'
@@ -56,13 +57,16 @@ const useBookkeepingPeriodsQuery = createQueryHook({
   tags: [BOOKKEEPING_TAG_KEY, BOOKKEEPING_PERIODS_TAG_KEY],
   request: getBookkeepingPeriods,
   schema: BookkeepingPeriodsResponseSchema,
+  // legacyTasksOnly: false removes the backend filter entirely ("include every
+  // fromLlmTransactionCategorizer type"), not "include counterparty asks" specifically.
+  // Today that set is exactly one type; a future agent-created task type lands here too.
   keyDefaults: { legacyTasksOnly: false },
   select: ({ periods }) =>
     periods
       .map(period => ({
         ...period,
         status: constrainToKnownBookkeepingPeriodStatus(period.status),
-        tasks: getUserVisibleTasks(period.tasks),
+        tasks: getUserVisibleTasks(period.tasks.filter(isRenderableBusinessTask)),
       }))
       .filter(period => isActiveBookkeepingPeriod(period)),
 })

--- a/src/hooks/api/businesses/[business-id]/bookkeeping/periods/get.ts
+++ b/src/hooks/api/businesses/[business-id]/bookkeeping/periods/get.ts
@@ -8,7 +8,7 @@ import {
 import { isActiveOrPausedBookkeepingStatus } from '@utils/features/bookkeeping/bookkeepingStatusFilters'
 import { getUserVisibleTasks } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
 import { isActiveBookkeepingPeriod } from '@utils/features/bookkeeping/periods'
-import { get } from '@utils/shared/api/authenticatedHttp'
+import { getWithQuery } from '@utils/shared/api/getWithQuery'
 import { createQueryHook } from '@hooks/utils/swr/createQueryHook'
 import { createResourceGlobalCacheActions } from '@hooks/utils/swr/createResourceGlobalCacheActions'
 import {
@@ -34,12 +34,18 @@ function constrainToKnownBookkeepingPeriodStatus(status: RawBookkeepingPeriodSta
 
 const BookkeepingPeriodsResponseSchema = UnwrappedDataResponseSchema(BookkeepingPeriodsSchema)
 
-const getBookkeepingPeriods = get<
+type GetBookkeepingPeriodsParams = {
+  businessId: string
+  legacyTasksOnly?: boolean
+}
+
+const getBookkeepingPeriods = getWithQuery<
   typeof BookkeepingPeriodsResponseSchema.Encoded,
-  { businessId: string }
->(({ businessId }) => {
-  return `/v1/businesses/${businessId}/bookkeeping/periods`
-})
+  GetBookkeepingPeriodsParams
+>(
+  ['businessId'],
+  ({ businessId }) => `/v1/businesses/${businessId}/bookkeeping/periods`,
+)
 
 export const BOOKKEEPING_PERIODS_TAG_KEY = '#bookkeeping-periods'
 
@@ -50,6 +56,7 @@ const useBookkeepingPeriodsQuery = createQueryHook({
   tags: [BOOKKEEPING_TAG_KEY, BOOKKEEPING_PERIODS_TAG_KEY],
   request: getBookkeepingPeriods,
   schema: BookkeepingPeriodsResponseSchema,
+  keyDefaults: { legacyTasksOnly: false },
   select: ({ periods }) =>
     periods
       .map(period => ({

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/counterparty-ask-response/post.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/counterparty-ask-response/post.ts
@@ -48,12 +48,7 @@ export const usePostCounterpartyAskResponse = createMutationHook({
     return (task) => {
       void invalidateBookkeepingPeriods()
 
-      const categorized = Boolean(task.responseAccount)
-        || task.transactionResponses.some(response => response.responseAccount)
-
-      if (categorized) {
-        onBankTransactionChange()
-      }
+      onBankTransactionChange()
 
       if (task.alwaysThis && task.responseAccount) {
         void forceReloadCategorizationRules()

--- a/src/hooks/api/businesses/[business-id]/tasks/[task-id]/counterparty-ask-response/post.ts
+++ b/src/hooks/api/businesses/[business-id]/tasks/[task-id]/counterparty-ask-response/post.ts
@@ -1,0 +1,63 @@
+import { Schema } from 'effect'
+
+import { UnwrappedDataResponseSchema } from '@schemas/common/utils'
+import {
+  type CounterpartyAskResponse,
+  type CounterpartyAskResponseEncoded,
+  CounterpartyAskResponseSchema,
+} from '@schemas/features/bookkeeping/businessTasks/counterpartyAskResponse'
+import { CounterpartyAskTaskSchema } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+import { post } from '@utils/shared/api/authenticatedHttp'
+import { createMutationHook } from '@hooks/utils/swr/createMutationHook'
+import { useBankTransactionTriggerSuccess } from '@api/businesses/[business-id]/bank-transactions/triggerSuccess'
+import { useBookkeepingPeriodsGlobalCacheActions } from '@api/businesses/[business-id]/bookkeeping/periods/get'
+import { useCategorizationRulesGlobalCacheActions } from '@api/businesses/[business-id]/categorization-rules/get'
+
+const COUNTERPARTY_ASK_RESPONSE_TAG_KEY = '#counterparty-ask-response'
+
+const PostCounterpartyAskResponseReturnSchema = UnwrappedDataResponseSchema(CounterpartyAskTaskSchema)
+
+const encodeCounterpartyAskResponse = Schema.encodeSync(CounterpartyAskResponseSchema)
+
+const postCounterpartyAskResponse = post<
+  typeof PostCounterpartyAskResponseReturnSchema.Encoded,
+  CounterpartyAskResponseEncoded,
+  { businessId: string, taskId: string }
+>(
+  ({ businessId, taskId }) => `/v1/businesses/${businessId}/tasks/${taskId}/counterparty-ask-response`,
+)
+
+type UsePostCounterpartyAskResponseArg = {
+  taskId: string
+  response: CounterpartyAskResponse
+}
+
+export const usePostCounterpartyAskResponse = createMutationHook({
+  tags: [COUNTERPARTY_ASK_RESPONSE_TAG_KEY],
+  request: postCounterpartyAskResponse,
+  schema: PostCounterpartyAskResponseReturnSchema,
+  argToParams: ({ taskId }: UsePostCounterpartyAskResponseArg) => ({ taskId }),
+  argToBody: ({ response }: UsePostCounterpartyAskResponseArg) =>
+    encodeCounterpartyAskResponse(response),
+  swrOptions: { throwOnError: true },
+  useOnTriggerSuccess: () => {
+    const { invalidate: invalidateBookkeepingPeriods } = useBookkeepingPeriodsGlobalCacheActions()
+    const { forceReload: forceReloadCategorizationRules } = useCategorizationRulesGlobalCacheActions()
+    const onBankTransactionChange = useBankTransactionTriggerSuccess()
+
+    return (task) => {
+      void invalidateBookkeepingPeriods()
+
+      const categorized = Boolean(task.responseAccount)
+        || task.transactionResponses.some(response => response.responseAccount)
+
+      if (categorized) {
+        onBankTransactionChange()
+      }
+
+      if (task.alwaysThis && task.responseAccount) {
+        void forceReloadCategorizationRules()
+      }
+    }
+  },
+})

--- a/src/msw/api/businesses/[business-id]/bookkeeping/periods/get.ts
+++ b/src/msw/api/businesses/[business-id]/bookkeeping/periods/get.ts
@@ -1,6 +1,7 @@
 import { Schema } from 'effect'
 
 import { type BookkeepingPeriod, BookkeepingPeriodsSchema } from '@schemas/features/bookkeeping/bookkeepingPeriods'
+import { isCounterpartyAskTask } from '@schemas/features/bookkeeping/businessTask'
 
 import { bookkeepingPeriodStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
 import { apiData } from '@msw/utils/apiResponse'
@@ -8,11 +9,26 @@ import { createMockEndpoint } from '@msw/utils/createMockEndpoint'
 
 const encodePeriods = Schema.encodeSync(BookkeepingPeriodsSchema)
 
-const toResponse = (periods: readonly BookkeepingPeriod[]) =>
-  apiData(encodePeriods({ periods }))
+const applyLegacyTasksOnly = (
+  periods: readonly BookkeepingPeriod[],
+  request: Request,
+): readonly BookkeepingPeriod[] => {
+  const legacyTasksOnly = new URL(request.url).searchParams.get('legacy_tasks_only') !== 'false'
+
+  if (!legacyTasksOnly) return periods
+
+  return periods.map(period => ({
+    ...period,
+    tasks: period.tasks.filter(task => !isCounterpartyAskTask(task)),
+  }))
+}
+
+const toResponse = (periods: readonly BookkeepingPeriod[], request: Request) =>
+  apiData(encodePeriods({ periods: applyLegacyTasksOnly(periods, request) }))
 
 export const get = createMockEndpoint<readonly BookkeepingPeriod[], ReturnType<typeof toResponse>>({
   method: 'get',
   path: '*/v1/businesses/:businessId/bookkeeping/periods',
-  resolve: ({ override: periods = bookkeepingPeriodStore.all() }) => toResponse(periods),
+  resolve: ({ override: periods = bookkeepingPeriodStore.all(), request }) =>
+    toResponse(periods, request),
 })

--- a/src/msw/api/businesses/[business-id]/bookkeeping/periods/store.ts
+++ b/src/msw/api/businesses/[business-id]/bookkeeping/periods/store.ts
@@ -1,5 +1,6 @@
 import { BookkeepingPeriodStatus } from '@schemas/features/bookkeeping/bookkeepingPeriods'
-import { type BusinessTask, BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { makeBookkeepingPeriods } from '@fixtures/bookkeeping/mocks'
 import { PROFIT_AND_LOSS_FIXTURE_START_YEAR } from '@fixtures/profitAndLoss/constants'

--- a/src/msw/api/businesses/[business-id]/bookkeeping/periods/store.ts
+++ b/src/msw/api/businesses/[business-id]/bookkeeping/periods/store.ts
@@ -1,5 +1,5 @@
 import { BookkeepingPeriodStatus } from '@schemas/features/bookkeeping/bookkeepingPeriods'
-import { type BusinessTask } from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask, isLegacyBusinessTask } from '@schemas/features/bookkeeping/businessTask'
 import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { makeBookkeepingPeriods } from '@fixtures/bookkeeping/mocks'
@@ -49,8 +49,8 @@ export const patchTaskInStore = (
 }
 
 export const completeTaskInStore = (taskId: string, userResponse: string | null): BusinessTask | undefined =>
-  patchTaskInStore(taskId, task => ({
-    ...task,
-    status: BusinessTaskStatus.UserMarkedCompleted,
-    userResponse,
-  }))
+  patchTaskInStore(taskId, task => (
+    isLegacyBusinessTask(task)
+      ? { ...task, status: BusinessTaskStatus.UserMarkedCompleted, userResponse }
+      : task
+  ))

--- a/src/msw/api/businesses/[business-id]/tasks/[task-id]/counterparty-ask-response/post.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/[task-id]/counterparty-ask-response/post.ts
@@ -1,0 +1,81 @@
+import { Schema } from 'effect'
+
+import { AccountIdentifierEquivalence } from '@schemas/common/accountIdentifier'
+import { isCounterpartyAskTask } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+import { CounterpartyAskResponseSchema } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskResponse'
+import {
+  type CounterpartyAskAccount,
+  type CounterpartyAskTask,
+  CounterpartyAskTaskSchema,
+} from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+
+import { patchTaskInStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
+import { makeFallbackCounterpartyAskTask } from '@msw/api/businesses/[business-id]/tasks/makeFallbackCounterpartyAskTask'
+import { apiData } from '@msw/utils/apiResponse'
+import { createMockEndpoint } from '@msw/utils/createMockEndpoint'
+import { readRequestJson } from '@msw/utils/request'
+
+const encodeTask = Schema.encodeSync(CounterpartyAskTaskSchema)
+const decodeResponse = Schema.decodeUnknownSync(CounterpartyAskResponseSchema)
+
+const toResponse = (task: CounterpartyAskTask) => apiData(encodeTask(task))
+
+const resolveAnsweredAccount = (
+  task: CounterpartyAskTask,
+  accountIdentifier: CounterpartyAskAccount['accountIdentifier'],
+): CounterpartyAskAccount =>
+  task.suggestions.find(suggestion =>
+    AccountIdentifierEquivalence(suggestion.accountIdentifier, accountIdentifier),
+  ) ?? { accountIdentifier, name: '' }
+
+const applyResponse = (
+  task: CounterpartyAskTask,
+  response: ReturnType<typeof decodeResponse>,
+): CounterpartyAskTask => {
+  const answered = { ...task, status: BusinessTaskStatus.UserMarkedCompleted }
+
+  if ('transactionResponses' in response) {
+    return {
+      ...answered,
+      transactionResponses: response.transactionResponses.map(transactionResponse => ({
+        transactionId: transactionResponse.transactionId,
+        userResponse: 'userResponse' in transactionResponse ? transactionResponse.userResponse : null,
+        responseAccount: 'accountIdentifier' in transactionResponse
+          ? resolveAnsweredAccount(task, transactionResponse.accountIdentifier)
+          : null,
+      })),
+    }
+  }
+
+  return {
+    ...answered,
+    alwaysThis: response.alwaysThis,
+    userResponse: 'userResponse' in response ? response.userResponse : null,
+    responseAccount: 'accountIdentifier' in response
+      ? resolveAnsweredAccount(task, response.accountIdentifier)
+      : null,
+  }
+}
+
+export const post = createMockEndpoint<CounterpartyAskTask, ReturnType<typeof toResponse>>({
+  method: 'post',
+  path: '*/v1/businesses/:businessId/tasks/:taskId/counterparty-ask-response',
+  resolve: async ({ override, request, params }) => {
+    if (override) return toResponse(override)
+
+    const response = decodeResponse(await readRequestJson(request))
+    const taskId = String(params.taskId)
+
+    let answered: CounterpartyAskTask | undefined
+
+    patchTaskInStore(taskId, (task) => {
+      if (!isCounterpartyAskTask(task)) return task
+
+      answered = applyResponse(task, response)
+      return answered
+    })
+
+    return toResponse(answered ?? applyResponse(makeFallbackCounterpartyAskTask(taskId), response))
+  },
+})

--- a/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/delete/post.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/delete/post.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'effect'
 
-import { type BusinessTask, BusinessTaskSchema } from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask, BusinessTaskSchema, isLegacyBusinessTask } from '@schemas/features/bookkeeping/businessTask'
 import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { patchTaskInStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
@@ -20,12 +20,11 @@ export const post = createMockEndpoint<BusinessTask, ReturnType<typeof toRespons
 
     const taskId = String(params.taskId)
 
-    const cleared = patchTaskInStore(taskId, task => ({
-      ...task,
-      status: BusinessTaskStatus.Todo,
-      userResponse: null,
-      documents: null,
-    })) ?? makeFallbackTask(taskId)
+    const cleared = patchTaskInStore(taskId, task => (
+      isLegacyBusinessTask(task)
+        ? { ...task, status: BusinessTaskStatus.Todo, userResponse: null, documents: null }
+        : task
+    )) ?? makeFallbackTask(taskId)
 
     return toResponse(cleared)
   },

--- a/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/delete/post.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/delete/post.ts
@@ -1,10 +1,7 @@
 import { Schema } from 'effect'
 
-import {
-  type BusinessTask,
-  BusinessTaskSchema,
-  BusinessTaskStatus,
-} from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask, BusinessTaskSchema } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { patchTaskInStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
 import { makeFallbackTask } from '@msw/api/businesses/[business-id]/tasks/makeFallbackTask'

--- a/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/post.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/post.ts
@@ -1,5 +1,6 @@
 import { type FileMetadata } from '@internal-types/shared/fileUpload'
-import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTask'
+import { isLegacyBusinessTask } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { patchTaskInStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
 import { apiData } from '@msw/utils/apiResponse'
@@ -35,12 +36,16 @@ export const post = createMockEndpoint({
     const description = formData.get('description')
 
     if (files.length > 0) {
-      patchTaskInStore(String(params.taskId), task => ({
-        ...task,
-        status: BusinessTaskStatus.UserMarkedCompleted,
-        userResponse: typeof description === 'string' ? description : task.userResponse,
-        documents: [...(task.documents ?? []), ...files.map(toTaskDocument)],
-      }))
+      patchTaskInStore(String(params.taskId), task => (
+        isLegacyBusinessTask(task)
+          ? {
+            ...task,
+            status: BusinessTaskStatus.UserMarkedCompleted,
+            userResponse: typeof description === 'string' ? description : task.userResponse,
+            documents: [...(task.documents ?? []), ...files.map(toTaskDocument)],
+          }
+          : task
+      ))
     }
 
     const [firstFile] = files

--- a/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/post.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/post.ts
@@ -1,10 +1,7 @@
 import { Schema } from 'effect'
 
-import {
-  type BusinessTask,
-  BusinessTaskSchema,
-  BusinessTaskStatus,
-} from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask, BusinessTaskSchema } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { patchTaskInStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
 import { makeFallbackTask } from '@msw/api/businesses/[business-id]/tasks/makeFallbackTask'

--- a/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/post.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/post.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'effect'
 
-import { type BusinessTask, BusinessTaskSchema } from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask, BusinessTaskSchema, isLegacyBusinessTask } from '@schemas/features/bookkeeping/businessTask'
 import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { patchTaskInStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
@@ -23,7 +23,7 @@ export const post = createMockEndpoint<BusinessTask, ReturnType<typeof toRespons
     const taskId = String(params.taskId)
     const userResponse = body.user_response ?? null
 
-    const updated = patchTaskInStore(taskId, task => ({ ...task, userResponse }))
+    const updated = patchTaskInStore(taskId, task => (isLegacyBusinessTask(task) ? { ...task, userResponse } : task))
       ?? makeFallbackTask(taskId, { status: BusinessTaskStatus.UserMarkedCompleted, userResponse })
 
     return toResponse(updated)

--- a/src/msw/api/businesses/[business-id]/tasks/[task-id]/user-response/post.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/[task-id]/user-response/post.ts
@@ -1,11 +1,7 @@
 import { Schema } from 'effect'
 
-import {
-  type BusinessTask,
-  BusinessTaskSchema,
-  BusinessTaskStatus,
-  TaskUserResponseType,
-} from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask, BusinessTaskSchema } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus, TaskUserResponseType } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { completeTaskInStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
 import { makeFallbackTask } from '@msw/api/businesses/[business-id]/tasks/makeFallbackTask'

--- a/src/msw/api/businesses/[business-id]/tasks/handlers.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/handlers.ts
@@ -1,5 +1,6 @@
 import { type RequestHandler } from 'msw'
 
+import { post as postCounterpartyAskResponse } from '@msw/api/businesses/[business-id]/tasks/[task-id]/counterparty-ask-response/post'
 import { post as deleteTaskUploads } from '@msw/api/businesses/[business-id]/tasks/[task-id]/upload/delete/post'
 import { post as uploadDocumentsForTask } from '@msw/api/businesses/[business-id]/tasks/[task-id]/upload/post'
 import { post as updateTaskUploadDescription } from '@msw/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/post'
@@ -7,6 +8,7 @@ import { post as postTaskUserResponse } from '@msw/api/businesses/[business-id]/
 
 export const tasksHandlers: RequestHandler[] = [
   postTaskUserResponse.handler,
+  postCounterpartyAskResponse.handler,
   uploadDocumentsForTask.handler,
   deleteTaskUploads.handler,
   updateTaskUploadDescription.handler,

--- a/src/msw/api/businesses/[business-id]/tasks/makeFallbackCounterpartyAskTask.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/makeFallbackCounterpartyAskTask.ts
@@ -1,0 +1,26 @@
+import { Schema } from 'effect'
+
+import {
+  type CounterpartyAskTask,
+  CounterpartyAskTaskSchema,
+} from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+
+const decodeCounterpartyAskTask = Schema.decodeSync(CounterpartyAskTaskSchema)
+
+export const makeFallbackCounterpartyAskTask = (
+  id: string,
+  overrides?: Partial<CounterpartyAskTask>,
+): CounterpartyAskTask => ({
+  ...decodeCounterpartyAskTask({
+    id,
+    status: 'TODO',
+    task_type: 'ASK_ABOUT_COUNTERPARTY_FOR_PERIOD',
+    title: '',
+    question: '',
+    counterparty: null,
+    user_response: null,
+    response_account: null,
+    resolved_by_task_id: null,
+  }),
+  ...overrides,
+})

--- a/src/msw/api/businesses/[business-id]/tasks/makeFallbackTask.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/makeFallbackTask.ts
@@ -1,14 +1,21 @@
 import { Schema } from 'effect'
 
-import { type BusinessTask, BusinessTaskSchema } from '@schemas/features/bookkeeping/businessTask'
+import {
+  type LegacyBusinessTask,
+  LegacyBusinessTaskSchema,
+} from '@schemas/features/bookkeeping/businessTasks/legacyBusinessTask'
 
-const decodeBusinessTask = Schema.decodeSync(BusinessTaskSchema)
+const decodeLegacyBusinessTask = Schema.decodeSync(LegacyBusinessTaskSchema)
 
 /** Response fallback for task mutations when the id isn't in the periods store. */
-export const makeFallbackTask = (id: string, overrides?: Partial<BusinessTask>): BusinessTask => ({
-  ...decodeBusinessTask({
+export const makeFallbackTask = (
+  id: string,
+  overrides?: Partial<LegacyBusinessTask>,
+): LegacyBusinessTask => ({
+  ...decodeLegacyBusinessTask({
     id,
     status: 'TODO',
+    task_type: null,
     title: '',
     question: '',
     user_response: null,

--- a/src/schemas/features/bookkeeping/businessTask.test.ts
+++ b/src/schemas/features/bookkeeping/businessTask.test.ts
@@ -79,4 +79,16 @@ describe('BusinessTaskSchema', () => {
     expect(isLegacyBusinessTask(task)).toBe(false)
     expect(isRenderableBusinessTask(task)).toBe(false)
   })
+
+  it('does not treat a malformed ask as renderable', () => {
+    const malformedAsk = Schema.decodeUnknownSync(BusinessTaskSchema)({
+      id: '00000000-0000-4000-8000-0000000009f1',
+      status: 'TODO',
+      title: 'Costco purchases',
+      task_type: 'ASK_ABOUT_COUNTERPARTY_FOR_PERIOD',
+    })
+
+    expect(isCounterpartyAskTask(malformedAsk)).toBe(false)
+    expect(isRenderableBusinessTask(malformedAsk)).toBe(false)
+  })
 })

--- a/src/schemas/features/bookkeeping/businessTask.test.ts
+++ b/src/schemas/features/bookkeeping/businessTask.test.ts
@@ -91,4 +91,11 @@ describe('BusinessTaskSchema', () => {
     expect(isCounterpartyAskTask(malformedAsk)).toBe(false)
     expect(isRenderableBusinessTask(malformedAsk)).toBe(false)
   })
+
+  it('falls through to unrenderable for a legacy-shaped task whose task_type is not HUMAN', () => {
+    const task = decode({ ...encodedHumanTask, task_type: 'SOME_FUTURE_TYPE' })
+
+    expect(isLegacyBusinessTask(task)).toBe(false)
+    expect(isRenderableBusinessTask(task)).toBe(false)
+  })
 })

--- a/src/schemas/features/bookkeeping/businessTask.test.ts
+++ b/src/schemas/features/bookkeeping/businessTask.test.ts
@@ -1,0 +1,82 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import {
+  BusinessTaskSchema,
+  isCounterpartyAskTask,
+  isLegacyBusinessTask,
+  isRenderableBusinessTask,
+} from '@schemas/features/bookkeeping/businessTask'
+
+const decode = Schema.decodeUnknownSync(BusinessTaskSchema)
+
+const encodedHumanTask = {
+  id: '00000000-0000-4000-8000-000000000801',
+  status: 'TODO',
+  title: 'Upload receipt',
+  question: 'What was this for?',
+  task_type: 'HUMAN',
+  user_response: null,
+  user_response_type: 'FREE_RESPONSE',
+  documents: null,
+}
+
+const encodedCounterpartyAskTask = {
+  id: '00000000-0000-4000-8000-000000000901',
+  status: 'TODO',
+  task_type: 'ASK_ABOUT_COUNTERPARTY_FOR_PERIOD',
+  title: 'Costco purchases',
+  question: 'You spent $307.74 at Costco across 1 transaction.',
+  counterparty: null,
+  user_response: null,
+  response_account: null,
+  resolved_by_task_id: null,
+}
+
+// Shape from ApiBusinessTask.AutomatedTask: no question, no user_response_type.
+const encodedAutomatedRuleSuggestionTask = {
+  id: '00000000-0000-4000-8000-000000000701',
+  status: 'TODO',
+  title: 'Review rule suggestion for Costco',
+  task_type: 'AUTOMATED_RULE_SUGGESTION',
+}
+
+// Shape from ApiBusinessTask.AutomatedTransactionReviewTask: no question, no user_response_type.
+const encodedAutomatedTransactionReviewTask = {
+  id: '00000000-0000-4000-8000-000000000702',
+  status: 'TODO',
+  title: 'Review Transactions',
+  task_type: 'AUTOMATED_TRANSACTION_REVIEW',
+}
+
+describe('BusinessTaskSchema', () => {
+  it('decodes a legacy human task', () => {
+    const task = decode(encodedHumanTask)
+
+    expect(isLegacyBusinessTask(task)).toBe(true)
+    expect(isRenderableBusinessTask(task)).toBe(true)
+  })
+
+  it('decodes a counterparty ask task', () => {
+    const task = decode(encodedCounterpartyAskTask)
+
+    expect(isCounterpartyAskTask(task)).toBe(true)
+    expect(isRenderableBusinessTask(task)).toBe(true)
+  })
+
+  it('decodes an automated rule-suggestion task as unrenderable instead of throwing', () => {
+    const task = decode(encodedAutomatedRuleSuggestionTask)
+
+    expect(isCounterpartyAskTask(task)).toBe(false)
+    expect(isLegacyBusinessTask(task)).toBe(false)
+    expect(isRenderableBusinessTask(task)).toBe(false)
+  })
+
+  it('decodes an automated transaction-review task as unrenderable instead of throwing', () => {
+    const task = decode(encodedAutomatedTransactionReviewTask)
+
+    expect(isCounterpartyAskTask(task)).toBe(false)
+    expect(isLegacyBusinessTask(task)).toBe(false)
+    expect(isRenderableBusinessTask(task)).toBe(false)
+  })
+})

--- a/src/schemas/features/bookkeeping/businessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTask.ts
@@ -1,65 +1,27 @@
-import { pipe, Schema } from 'effect'
+import { Schema } from 'effect'
 
-import { S3PresignedUrlSchema } from '@schemas/common/s3PresignedUrl'
-import { createTransformedEnumSchema } from '@schemas/common/utils'
+import { COUNTERPARTY_ASK_TASK_TYPE } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+import {
+  type CounterpartyAskTask,
+  CounterpartyAskTaskSchema,
+} from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+import {
+  type LegacyBusinessTask,
+  LegacyBusinessTaskSchema,
+} from '@schemas/features/bookkeeping/businessTasks/legacyBusinessTask'
 
-export enum BusinessTaskStatus {
-  Todo = 'TODO',
-  UserMarkedCompleted = 'USER_MARKED_COMPLETED',
-  Completed = 'COMPLETED',
-  Archived = 'ARCHIVED',
-}
-
-export const BusinessTaskStatusSchema = Schema.Enums(BusinessTaskStatus)
-
-const TransformedBusinessTaskStatusSchema = createTransformedEnumSchema(
-  BusinessTaskStatusSchema,
-  BusinessTaskStatus,
-  BusinessTaskStatus.Todo,
+export const BusinessTaskSchema = Schema.Union(
+  CounterpartyAskTaskSchema,
+  LegacyBusinessTaskSchema,
 )
-
-export enum TaskUserResponseType {
-  FreeResponse = 'FREE_RESPONSE',
-  UploadDocument = 'UPLOAD_DOCUMENT',
-  Unknown = 'UNKNOWN',
-}
-
-export const TaskUserResponseTypeSchema = Schema.Enums(TaskUserResponseType)
-
-const TransformedTaskUserResponseTypeSchema = createTransformedEnumSchema(
-  TaskUserResponseTypeSchema,
-  TaskUserResponseType,
-  TaskUserResponseType.Unknown,
-)
-
-const TaskDocumentSchema = Schema.Struct({
-  fileName: pipe(
-    Schema.propertySignature(Schema.String),
-    Schema.fromKey('file_name'),
-  ),
-  presignedUrl: pipe(
-    Schema.propertySignature(S3PresignedUrlSchema),
-    Schema.fromKey('presigned_url'),
-  ),
-})
-
-// Every business task is treated as a human task; the automated variants are not
-// yet surfaced in the UI.
-export const BusinessTaskSchema = Schema.Struct({
-  id: Schema.UUID,
-  status: TransformedBusinessTaskStatusSchema,
-  title: Schema.String,
-  question: Schema.String,
-  userResponse: pipe(
-    Schema.propertySignature(Schema.NullishOr(Schema.String)),
-    Schema.fromKey('user_response'),
-  ),
-  userResponseType: pipe(
-    Schema.propertySignature(TransformedTaskUserResponseTypeSchema),
-    Schema.fromKey('user_response_type'),
-  ),
-  documents: Schema.NullishOr(Schema.Array(TaskDocumentSchema)),
-})
 
 export type BusinessTask = typeof BusinessTaskSchema.Type
 export type BusinessTaskEncoded = typeof BusinessTaskSchema.Encoded
+
+export const isCounterpartyAskTask = <T extends Pick<BusinessTask, 'taskType'>>(
+  task: T,
+): task is T & CounterpartyAskTask => task.taskType === COUNTERPARTY_ASK_TASK_TYPE
+
+export const isLegacyBusinessTask = <T extends Pick<BusinessTask, 'taskType'>>(
+  task: T,
+): task is T & LegacyBusinessTask => task.taskType !== COUNTERPARTY_ASK_TASK_TYPE

--- a/src/schemas/features/bookkeeping/businessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTask.ts
@@ -9,10 +9,12 @@ import {
   type LegacyBusinessTask,
   LegacyBusinessTaskSchema,
 } from '@schemas/features/bookkeeping/businessTasks/legacyBusinessTask'
+import { UnknownBusinessTaskSchema } from '@schemas/features/bookkeeping/businessTasks/unknownBusinessTask'
 
 export const BusinessTaskSchema = Schema.Union(
   CounterpartyAskTaskSchema,
   LegacyBusinessTaskSchema,
+  UnknownBusinessTaskSchema,
 )
 
 export type BusinessTask = typeof BusinessTaskSchema.Type
@@ -22,6 +24,14 @@ export const isCounterpartyAskTask = <T extends Pick<BusinessTask, 'taskType'>>(
   task: T,
 ): task is T & CounterpartyAskTask => task.taskType === COUNTERPARTY_ASK_TASK_TYPE
 
+// LegacyBusinessTask always carries user_response_type; UnknownBusinessTask (an
+// unrecognised task_type this union can't fully model) never does.
 export const isLegacyBusinessTask = <T extends Pick<BusinessTask, 'taskType'>>(
   task: T,
-): task is T & LegacyBusinessTask => task.taskType !== COUNTERPARTY_ASK_TASK_TYPE
+): task is T & LegacyBusinessTask =>
+  !isCounterpartyAskTask(task) && 'userResponseType' in task
+
+export const isRenderableBusinessTask = <T extends BusinessTask>(
+  task: T,
+): task is T & (CounterpartyAskTask | LegacyBusinessTask) =>
+  isCounterpartyAskTask(task) || isLegacyBusinessTask(task)

--- a/src/schemas/features/bookkeeping/businessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTask.ts
@@ -22,7 +22,8 @@ export type BusinessTaskEncoded = typeof BusinessTaskSchema.Encoded
 
 export const isCounterpartyAskTask = <T extends Pick<BusinessTask, 'taskType'>>(
   task: T,
-): task is T & CounterpartyAskTask => task.taskType === COUNTERPARTY_ASK_TASK_TYPE
+): task is T & CounterpartyAskTask =>
+  task.taskType === COUNTERPARTY_ASK_TASK_TYPE && 'transactionResponses' in task
 
 // LegacyBusinessTask always carries user_response_type; UnknownBusinessTask (an
 // unrecognised task_type this union can't fully model) never does.

--- a/src/schemas/features/bookkeeping/businessTasks/baseBusinessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/baseBusinessTask.ts
@@ -1,0 +1,41 @@
+import { Schema } from 'effect'
+
+import { createTransformedEnumSchema } from '@schemas/common/utils'
+
+export enum BusinessTaskStatus {
+  Todo = 'TODO',
+  UserMarkedCompleted = 'USER_MARKED_COMPLETED',
+  Completed = 'COMPLETED',
+  Archived = 'ARCHIVED',
+}
+
+export const BusinessTaskStatusSchema = Schema.Enums(BusinessTaskStatus)
+
+export const TransformedBusinessTaskStatusSchema = createTransformedEnumSchema(
+  BusinessTaskStatusSchema,
+  BusinessTaskStatus,
+  BusinessTaskStatus.Todo,
+)
+
+export enum TaskUserResponseType {
+  FreeResponse = 'FREE_RESPONSE',
+  UploadDocument = 'UPLOAD_DOCUMENT',
+  Unknown = 'UNKNOWN',
+}
+
+export const TaskUserResponseTypeSchema = Schema.Enums(TaskUserResponseType)
+
+export const TransformedTaskUserResponseTypeSchema = createTransformedEnumSchema(
+  TaskUserResponseTypeSchema,
+  TaskUserResponseType,
+  TaskUserResponseType.Unknown,
+)
+
+export const COUNTERPARTY_ASK_TASK_TYPE = 'ASK_ABOUT_COUNTERPARTY_FOR_PERIOD'
+
+export const BaseBusinessTaskSchema = Schema.Struct({
+  id: Schema.UUID,
+  status: TransformedBusinessTaskStatusSchema,
+  title: Schema.String,
+  question: Schema.String,
+})

--- a/src/schemas/features/bookkeeping/businessTasks/baseBusinessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/baseBusinessTask.ts
@@ -32,6 +32,7 @@ export const TransformedTaskUserResponseTypeSchema = createTransformedEnumSchema
 )
 
 export const COUNTERPARTY_ASK_TASK_TYPE = 'ASK_ABOUT_COUNTERPARTY_FOR_PERIOD'
+export const LEGACY_BUSINESS_TASK_TYPE = 'HUMAN'
 
 export const BaseBusinessTaskSchema = Schema.Struct({
   id: Schema.UUID,

--- a/src/schemas/features/bookkeeping/businessTasks/counterpartyAskResponse.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/counterpartyAskResponse.ts
@@ -1,0 +1,57 @@
+import { pipe, Schema } from 'effect'
+
+import { AccountIdentifierSchema } from '@schemas/common/accountIdentifier'
+
+const CounterpartyAskAnswerSchema = Schema.Union(
+  Schema.Struct({
+    accountIdentifier: pipe(
+      Schema.propertySignature(AccountIdentifierSchema),
+      Schema.fromKey('account_identifier'),
+    ),
+  }),
+  Schema.Struct({
+    userResponse: pipe(
+      Schema.propertySignature(Schema.NonEmptyTrimmedString),
+      Schema.fromKey('user_response'),
+    ),
+  }),
+)
+
+export type CounterpartyAskAnswer = typeof CounterpartyAskAnswerSchema.Type
+
+const CounterpartyAskTransactionAnswerSchema = Schema.extend(
+  Schema.Struct({
+    transactionId: pipe(
+      Schema.propertySignature(Schema.String),
+      Schema.fromKey('transaction_id'),
+    ),
+  }),
+  CounterpartyAskAnswerSchema,
+)
+
+export type CounterpartyAskTransactionAnswer = typeof CounterpartyAskTransactionAnswerSchema.Type
+
+const AllSameCounterpartyAskResponseSchema = Schema.extend(
+  Schema.Struct({
+    alwaysThis: pipe(
+      Schema.propertySignature(Schema.Boolean),
+      Schema.fromKey('always_this'),
+    ),
+  }),
+  CounterpartyAskAnswerSchema,
+)
+
+const ItemisedCounterpartyAskResponseSchema = Schema.Struct({
+  transactionResponses: pipe(
+    Schema.propertySignature(Schema.NonEmptyArray(CounterpartyAskTransactionAnswerSchema)),
+    Schema.fromKey('transaction_responses'),
+  ),
+})
+
+export const CounterpartyAskResponseSchema = Schema.Union(
+  AllSameCounterpartyAskResponseSchema,
+  ItemisedCounterpartyAskResponseSchema,
+)
+
+export type CounterpartyAskResponse = typeof CounterpartyAskResponseSchema.Type
+export type CounterpartyAskResponseEncoded = typeof CounterpartyAskResponseSchema.Encoded

--- a/src/schemas/features/bookkeeping/businessTasks/counterpartyAskTask.test.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/counterpartyAskTask.test.ts
@@ -1,0 +1,54 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { CounterpartyAskTaskSchema } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+
+const decode = Schema.decodeUnknownSync(CounterpartyAskTaskSchema)
+
+const baseEncodedAsk = {
+  id: '00000000-0000-4000-8000-000000000901',
+  status: 'TODO',
+  task_type: 'ASK_ABOUT_COUNTERPARTY_FOR_PERIOD',
+  title: 'Costco purchases',
+  question: 'You spent $307.74 at Costco across 1 transaction.',
+  counterparty: null,
+  user_response: null,
+  response_account: null,
+  resolved_by_task_id: null,
+}
+
+describe('CounterpartyAskTaskSchema', () => {
+  it('decodes an ask whose optional fields are absent', () => {
+    const task = decode(baseEncodedAsk)
+
+    expect(task.suggestions).toEqual([])
+    expect(task.transactions).toEqual([])
+    expect(task.transactionResponses).toEqual([])
+    expect(task.totalCount).toBe(0)
+    expect(task.totalAmount).toBe(0)
+    expect(task.alwaysThis).toBe(false)
+  })
+
+  it('decodes an ask whose optional fields are explicitly null', () => {
+    const task = decode({
+      ...baseEncodedAsk,
+      suggestions: null,
+      transactions: null,
+      transaction_responses: null,
+      total_count: null,
+      total_amount: null,
+      always_this: null,
+    })
+
+    expect(task.suggestions).toEqual([])
+    expect(task.transactions).toEqual([])
+    expect(task.transactionResponses).toEqual([])
+    expect(task.totalCount).toBe(0)
+    expect(task.totalAmount).toBe(0)
+    expect(task.alwaysThis).toBe(false)
+  })
+
+  it('rejects a task_type belonging to the legacy arm', () => {
+    expect(() => decode({ ...baseEncodedAsk, task_type: 'FREE_RESPONSE_TASK' })).toThrow()
+  })
+})

--- a/src/schemas/features/bookkeeping/businessTasks/counterpartyAskTask.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/counterpartyAskTask.ts
@@ -47,13 +47,16 @@ export const CounterpartyAskTaskSchema = Schema.extend(
     counterparty: Schema.NullishOr(BankTransactionCounterpartySchema),
     suggestions: Schema.optionalWith(Schema.Array(CounterpartyAskAccountSchema), {
       default: () => [],
+      nullable: true,
     }),
     transactions: Schema.optionalWith(Schema.Array(MinimalBankTransactionSchema), {
       default: () => [],
+      nullable: true,
     }),
     transactionResponses: pipe(
       Schema.optionalWith(Schema.Array(CounterpartyAskTransactionResponseSchema), {
         default: () => [],
+        nullable: true,
       }),
       Schema.fromKey('transaction_responses'),
     ),
@@ -66,15 +69,15 @@ export const CounterpartyAskTaskSchema = Schema.extend(
       Schema.fromKey('response_account'),
     ),
     totalCount: pipe(
-      Schema.optionalWith(Schema.Number, { default: () => 0 }),
+      Schema.optionalWith(Schema.Number, { default: () => 0, nullable: true }),
       Schema.fromKey('total_count'),
     ),
     totalAmount: pipe(
-      Schema.optionalWith(Schema.Number, { default: () => 0 }),
+      Schema.optionalWith(Schema.Number, { default: () => 0, nullable: true }),
       Schema.fromKey('total_amount'),
     ),
     alwaysThis: pipe(
-      Schema.optionalWith(Schema.Boolean, { default: () => false }),
+      Schema.optionalWith(Schema.Boolean, { default: () => false, nullable: true }),
       Schema.fromKey('always_this'),
     ),
     resolvedByTaskId: pipe(

--- a/src/schemas/features/bookkeeping/businessTasks/counterpartyAskTask.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/counterpartyAskTask.ts
@@ -1,0 +1,88 @@
+import { pipe, Schema } from 'effect'
+
+import { AccountIdentifierSchema } from '@schemas/common/accountIdentifier'
+import {
+  BankTransactionCounterpartySchema,
+  MinimalBankTransactionSchema,
+} from '@schemas/features/bankTransactions/base'
+import {
+  BaseBusinessTaskSchema,
+  COUNTERPARTY_ASK_TASK_TYPE,
+} from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+
+export const CounterpartyAskAccountSchema = Schema.Struct({
+  accountIdentifier: pipe(
+    Schema.propertySignature(AccountIdentifierSchema),
+    Schema.fromKey('account_identifier'),
+  ),
+  name: Schema.String,
+})
+
+export type CounterpartyAskAccount = typeof CounterpartyAskAccountSchema.Type
+
+const CounterpartyAskTransactionResponseSchema = Schema.Struct({
+  transactionId: pipe(
+    Schema.propertySignature(Schema.String),
+    Schema.fromKey('transaction_id'),
+  ),
+  userResponse: pipe(
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
+    Schema.fromKey('user_response'),
+  ),
+  responseAccount: pipe(
+    Schema.propertySignature(Schema.NullishOr(CounterpartyAskAccountSchema)),
+    Schema.fromKey('response_account'),
+  ),
+})
+
+export type CounterpartyAskTransactionResponse = typeof CounterpartyAskTransactionResponseSchema.Type
+
+export const CounterpartyAskTaskSchema = Schema.extend(
+  BaseBusinessTaskSchema,
+  Schema.Struct({
+    taskType: pipe(
+      Schema.propertySignature(Schema.Literal(COUNTERPARTY_ASK_TASK_TYPE)),
+      Schema.fromKey('task_type'),
+    ),
+    counterparty: Schema.NullishOr(BankTransactionCounterpartySchema),
+    suggestions: Schema.optionalWith(Schema.Array(CounterpartyAskAccountSchema), {
+      default: () => [],
+    }),
+    transactions: Schema.optionalWith(Schema.Array(MinimalBankTransactionSchema), {
+      default: () => [],
+    }),
+    transactionResponses: pipe(
+      Schema.optionalWith(Schema.Array(CounterpartyAskTransactionResponseSchema), {
+        default: () => [],
+      }),
+      Schema.fromKey('transaction_responses'),
+    ),
+    userResponse: pipe(
+      Schema.propertySignature(Schema.NullishOr(Schema.String)),
+      Schema.fromKey('user_response'),
+    ),
+    responseAccount: pipe(
+      Schema.propertySignature(Schema.NullishOr(CounterpartyAskAccountSchema)),
+      Schema.fromKey('response_account'),
+    ),
+    totalCount: pipe(
+      Schema.optionalWith(Schema.Number, { default: () => 0 }),
+      Schema.fromKey('total_count'),
+    ),
+    totalAmount: pipe(
+      Schema.optionalWith(Schema.Number, { default: () => 0 }),
+      Schema.fromKey('total_amount'),
+    ),
+    alwaysThis: pipe(
+      Schema.optionalWith(Schema.Boolean, { default: () => false }),
+      Schema.fromKey('always_this'),
+    ),
+    resolvedByTaskId: pipe(
+      Schema.propertySignature(Schema.NullishOr(Schema.String)),
+      Schema.fromKey('resolved_by_task_id'),
+    ),
+  }),
+)
+
+export type CounterpartyAskTask = typeof CounterpartyAskTaskSchema.Type
+export type CounterpartyAskTaskEncoded = typeof CounterpartyAskTaskSchema.Encoded

--- a/src/schemas/features/bookkeeping/businessTasks/legacyBusinessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/legacyBusinessTask.ts
@@ -1,0 +1,45 @@
+import { pipe, Schema } from 'effect'
+
+import { S3PresignedUrlSchema } from '@schemas/common/s3PresignedUrl'
+import {
+  BaseBusinessTaskSchema,
+  COUNTERPARTY_ASK_TASK_TYPE,
+  TransformedTaskUserResponseTypeSchema,
+} from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+
+const TaskDocumentSchema = Schema.Struct({
+  fileName: pipe(
+    Schema.propertySignature(Schema.String),
+    Schema.fromKey('file_name'),
+  ),
+  presignedUrl: pipe(
+    Schema.propertySignature(S3PresignedUrlSchema),
+    Schema.fromKey('presigned_url'),
+  ),
+})
+
+const NonCounterpartyAskTaskTypeSchema = Schema.NullishOr(
+  Schema.String.pipe(Schema.filter(taskType => taskType !== COUNTERPARTY_ASK_TASK_TYPE)),
+)
+
+export const LegacyBusinessTaskSchema = Schema.extend(
+  BaseBusinessTaskSchema,
+  Schema.Struct({
+    taskType: pipe(
+      Schema.optionalWith(NonCounterpartyAskTaskTypeSchema, { default: () => null }),
+      Schema.fromKey('task_type'),
+    ),
+    userResponse: pipe(
+      Schema.propertySignature(Schema.NullishOr(Schema.String)),
+      Schema.fromKey('user_response'),
+    ),
+    userResponseType: pipe(
+      Schema.propertySignature(TransformedTaskUserResponseTypeSchema),
+      Schema.fromKey('user_response_type'),
+    ),
+    documents: Schema.NullishOr(Schema.Array(TaskDocumentSchema)),
+  }),
+)
+
+export type LegacyBusinessTask = typeof LegacyBusinessTaskSchema.Type
+export type LegacyBusinessTaskEncoded = typeof LegacyBusinessTaskSchema.Encoded

--- a/src/schemas/features/bookkeeping/businessTasks/legacyBusinessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/legacyBusinessTask.ts
@@ -3,7 +3,7 @@ import { pipe, Schema } from 'effect'
 import { S3PresignedUrlSchema } from '@schemas/common/s3PresignedUrl'
 import {
   BaseBusinessTaskSchema,
-  COUNTERPARTY_ASK_TASK_TYPE,
+  LEGACY_BUSINESS_TASK_TYPE,
   TransformedTaskUserResponseTypeSchema,
 } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
@@ -18,15 +18,18 @@ const TaskDocumentSchema = Schema.Struct({
   ),
 })
 
-const NonCounterpartyAskTaskTypeSchema = Schema.NullishOr(
-  Schema.String.pipe(Schema.filter(taskType => taskType !== COUNTERPARTY_ASK_TASK_TYPE)),
-)
+// Restricted to the one task_type this arm actually models (or absent, for
+// payloads that predate task_type) rather than "anything but a counterparty
+// ask" - otherwise a future agent-created type reusing this shape would
+// silently render as a free-response task instead of falling through to
+// UnknownBusinessTaskSchema.
+const LegacyTaskTypeSchema = Schema.NullishOr(Schema.Literal(LEGACY_BUSINESS_TASK_TYPE))
 
 export const LegacyBusinessTaskSchema = Schema.extend(
   BaseBusinessTaskSchema,
   Schema.Struct({
     taskType: pipe(
-      Schema.optionalWith(NonCounterpartyAskTaskTypeSchema, { default: () => null }),
+      Schema.optionalWith(LegacyTaskTypeSchema, { default: () => null }),
       Schema.fromKey('task_type'),
     ),
     userResponse: pipe(

--- a/src/schemas/features/bookkeeping/businessTasks/unknownBusinessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/unknownBusinessTask.ts
@@ -1,0 +1,16 @@
+import { pipe, Schema } from 'effect'
+
+import { TransformedBusinessTaskStatusSchema } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+
+export const UnknownBusinessTaskSchema = Schema.Struct({
+  id: Schema.UUID,
+  status: TransformedBusinessTaskStatusSchema,
+  title: Schema.String,
+  taskType: pipe(
+    Schema.propertySignature(Schema.String),
+    Schema.fromKey('task_type'),
+  ),
+})
+
+export type UnknownBusinessTask = typeof UnknownBusinessTaskSchema.Type
+export type UnknownBusinessTaskEncoded = typeof UnknownBusinessTaskSchema.Encoded

--- a/src/utils/features/bookkeeping/bookkeepingTasksFilters.ts
+++ b/src/utils/features/bookkeeping/bookkeepingTasksFilters.ts
@@ -1,4 +1,5 @@
-import { type BusinessTask, BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 export function isIncompleteTask<T extends Pick<BusinessTask, 'status'>>(
   task: T,

--- a/src/utils/features/bookkeeping/counterpartyAskAnswers.test.ts
+++ b/src/utils/features/bookkeeping/counterpartyAskAnswers.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { makeAccountId, makeStableName } from '@schemas/common/accountIdentifier'
+import {
+  buildAllSameCounterpartyAskResponse,
+  buildItemisedCounterpartyAskResponse,
+  collapseUniformCounterpartyAskAnswers,
+  countDistinctCounterpartyAskAnswers,
+  type CounterpartyAskAnswerValue,
+} from '@utils/features/bookkeeping/counterpartyAskAnswers'
+
+const MEALS: CounterpartyAskAnswerValue = {
+  kind: 'account',
+  account: { accountIdentifier: makeStableName('MEALS'), name: 'Business Meals' },
+}
+
+const OFFICE: CounterpartyAskAnswerValue = {
+  kind: 'account',
+  account: {
+    accountIdentifier: makeAccountId('00000000-0000-4000-8000-000000000801'),
+    name: 'Office Expenses',
+  },
+}
+
+const TEXT_MEALS: CounterpartyAskAnswerValue = { kind: 'text', text: 'Business Meals' }
+
+describe('collapseUniformCounterpartyAskAnswers', () => {
+  it('collapses a set of identical account answers to a single answer', () => {
+    expect(collapseUniformCounterpartyAskAnswers([MEALS, MEALS, MEALS])).toEqual(MEALS)
+  })
+
+  it('does not collapse differing account answers', () => {
+    expect(collapseUniformCounterpartyAskAnswers([MEALS, OFFICE])).toBeNull()
+  })
+
+  it('does not collapse a chip and identical typed text', () => {
+    expect(collapseUniformCounterpartyAskAnswers([MEALS, TEXT_MEALS])).toBeNull()
+  })
+
+  it('returns null for an empty set', () => {
+    expect(collapseUniformCounterpartyAskAnswers([])).toBeNull()
+  })
+})
+
+describe('countDistinctCounterpartyAskAnswers', () => {
+  it('counts by identifier rather than label', () => {
+    expect(countDistinctCounterpartyAskAnswers([MEALS, MEALS, TEXT_MEALS, OFFICE])).toBe(3)
+  })
+})
+
+describe('buildAllSameCounterpartyAskResponse', () => {
+  it('sends an account identifier without free text', () => {
+    expect(buildAllSameCounterpartyAskResponse(MEALS, true)).toEqual({
+      accountIdentifier: makeStableName('MEALS'),
+      alwaysThis: true,
+    })
+  })
+
+  it('sends free text without an account identifier', () => {
+    expect(buildAllSameCounterpartyAskResponse(TEXT_MEALS, false)).toEqual({
+      userResponse: 'Business Meals',
+      alwaysThis: false,
+    })
+  })
+})
+
+describe('buildItemisedCounterpartyAskResponse', () => {
+  it('sends one answer per transaction and never always_this', () => {
+    const response = buildItemisedCounterpartyAskResponse([
+      { transactionId: 'txn-1', answer: MEALS },
+      { transactionId: 'txn-2', answer: TEXT_MEALS },
+    ])
+
+    expect(response).toEqual({
+      transactionResponses: [
+        { transactionId: 'txn-1', accountIdentifier: makeStableName('MEALS') },
+        { transactionId: 'txn-2', userResponse: 'Business Meals' },
+      ],
+    })
+    expect(response).not.toHaveProperty('alwaysThis')
+  })
+
+  it('returns null rather than an empty itemised body', () => {
+    expect(buildItemisedCounterpartyAskResponse([])).toBeNull()
+  })
+})

--- a/src/utils/features/bookkeeping/counterpartyAskAnswers.ts
+++ b/src/utils/features/bookkeeping/counterpartyAskAnswers.ts
@@ -1,0 +1,80 @@
+import { AccountIdentifierEquivalence } from '@schemas/common/accountIdentifier'
+import {
+  type CounterpartyAskAnswer,
+  type CounterpartyAskResponse,
+} from '@schemas/features/bookkeeping/businessTasks/counterpartyAskResponse'
+import { type CounterpartyAskAccount } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+
+export type CounterpartyAskAnswerValue =
+  | { kind: 'account', account: CounterpartyAskAccount }
+  | { kind: 'text', text: string }
+
+const toAnswer = (value: CounterpartyAskAnswerValue): CounterpartyAskAnswer =>
+  value.kind === 'account'
+    ? { accountIdentifier: value.account.accountIdentifier }
+    : { userResponse: value.text }
+
+export const getCounterpartyAskAnswerLabel = (value: CounterpartyAskAnswerValue) =>
+  value.kind === 'account' ? value.account.name : value.text
+
+export const areCounterpartyAskAnswersEqual = (
+  left: CounterpartyAskAnswerValue,
+  right: CounterpartyAskAnswerValue,
+) => {
+  if (left.kind === 'account' && right.kind === 'account') {
+    return AccountIdentifierEquivalence(
+      left.account.accountIdentifier,
+      right.account.accountIdentifier,
+    )
+  }
+
+  if (left.kind === 'text' && right.kind === 'text') {
+    return left.text === right.text
+  }
+
+  return false
+}
+
+export const collapseUniformCounterpartyAskAnswers = (
+  answers: readonly CounterpartyAskAnswerValue[],
+): CounterpartyAskAnswerValue | null => {
+  const [first, ...rest] = answers
+
+  if (!first) return null
+
+  return rest.every(answer => areCounterpartyAskAnswersEqual(first, answer)) ? first : null
+}
+
+export const countDistinctCounterpartyAskAnswers = (
+  answers: readonly CounterpartyAskAnswerValue[],
+) =>
+  answers.reduce<CounterpartyAskAnswerValue[]>((distinct, answer) => {
+    return distinct.some(seen => areCounterpartyAskAnswersEqual(seen, answer))
+      ? distinct
+      : [...distinct, answer]
+  }, []).length
+
+export const buildAllSameCounterpartyAskResponse = (
+  answer: CounterpartyAskAnswerValue,
+  alwaysThis: boolean,
+): CounterpartyAskResponse => ({ ...toAnswer(answer), alwaysThis })
+
+export type CounterpartyAskTransactionAnswerEntry = {
+  transactionId: string
+  answer: CounterpartyAskAnswerValue
+}
+
+export const buildItemisedCounterpartyAskResponse = (
+  entries: readonly CounterpartyAskTransactionAnswerEntry[],
+): CounterpartyAskResponse | null => {
+  const [first, ...rest] = entries
+
+  if (!first) return null
+
+  return {
+    transactionResponses: [
+      { transactionId: first.transactionId, ...toAnswer(first.answer) },
+      ...rest.map(({ transactionId, answer }) => ({ transactionId, ...toAnswer(answer) })),
+    ],
+  }
+}


### PR DESCRIPTION
## Description

Adds the answer flow for `ASK_ABOUT_COUNTERPARTY_FOR_PERIOD` tasks — the asks the agentic transaction categorizer creates per counterparty per period, rather than one task per transaction.

The owner sees the server-rendered question, then up to three suggested-account chips plus "Something else" (free text) and "A mix of the above" (per-transaction answers). A non-itemised answer goes on to a second step asking whether it should always apply, which is what creates the standing categorization rule. **Nothing is persisted until that second step completes** — one POST carries the whole answer, by design.

Backend contract: Layer-Fi/api#4992, with Layer-Fi/api#5033 adding the `legacy_tasks_only` opt-in these tasks need.

## Changes

**Schema** — `BusinessTaskSchema` becomes a `task_type`-discriminated union (`businessTasks/{base,legacy,counterpartyAsk}`). The legacy arm actively *excludes* the counterparty literal, so a malformed ask can't silently decode as a legacy task and POST to `/user-response`, which the API rejects with a 400. Every non-discriminator field on the ask arm is nullish-tolerant so one bad ask can't fail the whole periods response it rides in.

**Request body** — modelled as unions (`counterpartyAskResponse.ts`) so the four combinations the API 400s on are unrepresentable rather than guarded at the call site: account *and* free text on one answer, `always_this` alongside `transaction_responses`, neither, and blank text. The UI additionally blocks Continue until every linked transaction is answered.

**Read path** — the periods request now sends `legacy_tasks_only=false`. Without it the API excludes these tasks entirely and a period holding one renders "no pending tasks". The flag also feeds the period's derived status, so counts and the list agree.

**Cache invalidation** — a chip + "always" answer creates a rule, closes sibling asks in other periods, and applies retroactively across arbitrary months. The mutation therefore invalidates periods, bank transactions and P&L (the latter two only when an account was actually chosen, since free text categorizes nothing server-side), and reloads categorization rules only on the path that creates one.

**UI** — `TasksListItem` now branches on task type; the existing body moved to `LegacyTaskBody` unchanged. New `@ui/Chip` primitive built on radio-group semantics so a screen reader announces one choice of N. `BackButton` gains `isDisabled`.

## Blockers

None for merging, but three things are unresolved and worth knowing:

- **Copy is placeholder throughout** and not yet owned. Includes whether the second step lowercases the answer ("always be Business Meals?" vs the mockup's "business meals") — left verbatim because lowercasing translated strings misbehaves outside English.
- **`AccountStableName` wire shape unverified.** Uses the repo's existing `{type: 'StableName', stable_name: …}`; every suggestion on the test business is an `AccountId`, so the stable-name branch has never been exercised against a real response.
- **`resolved_by_task_id` can't name a period.** Only the uuid is serialized, so the copy says "Already answered" rather than "answered in November". That branch also can't render at all while `getUserVisibleTasks` drops `COMPLETED` tasks.

Chip layout is getting a revision — reviewers can skip nitpicking it.

## How this has been tested?

`typecheck`, `lint`, `i18n:check`, `msw:check-coverage`, `fixtures:check` all clean; **372 tests across 50 files**. Storybook builds.

Exercised end to end against **real production data** (business `c99cce33`, which has four live asks) via a local build behind ngrok — including a real "Yes, always" submit that created the rule, categorized retroactively, closed the sibling ask, and refreshed every affected cache.

Two bugs found that way and fixed, both worth a look since tests alone missed them:

- `transaction_responses` is the **link** table — one row per linked transaction from task creation, with null answers. Treating a non-empty array as "answered" hid the form on every open ask. My fixture had used `transactionResponses: []`, a state production never serves; it now derives unanswered rows from `transactions`, and reintroducing the bug fails 12 of 14 tests.
- The submit is slow enough under contention to click Back mid-flight, change the answer and resubmit — which the API correctly rejects as already-resolved, showing an error for a submission that succeeded. The confirm step now locks while in flight.

New tests cover the API's 400 conditions, the uniform-mix collapse, the `legacy_tasks_only` opt-in, the answered-state guard and the in-flight lock. Each was verified to fail when its fix is reverted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New categorization and rule-creation paths POST to production APIs and invalidate bookkeeping/transaction caches; scope is large but guarded by schema unions, render filters, and extensive tests.
> 
> **Overview**
> **Adds an end-to-end UI for `ASK_ABOUT_COUNTERPARTY_FOR_PERIOD` bookkeeping tasks** so owners can answer agent-generated counterparty questions from the Tasks list.
> 
> `BusinessTask` is now a **`task_type`-discriminated union** (counterparty ask, legacy human, unknown/automated). Only renderable types reach the list; periods are fetched with **`legacy_tasks_only=false`** so these asks appear. **`TasksListItem`** delegates to new **`CounterpartyAskTaskBody`** (chip suggestions, free text, multi-transaction “mix,” optional **“always apply”** confirm before a single POST) or extracted **`LegacyTaskBody`** for existing flows.
> 
> Supporting work: **`@ui/Chip`** radio-group primitive, **`usePostCounterpartyAskResponse`** with periods/transactions/rules cache updates, response builders/schemas that forbid invalid API bodies, MSW + fixtures for monthly counterparty asks, Storybook story for no-suggestion asks, and broad unit/component tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4bc28ba101cf3fa439ee9c8eb8547902b4c6066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->