### PR TITLE
[LAY-2718] Split 1/5: extract LegacyTaskBody from TasksListItem

### DIFF
--- a/src/components/features/bookkeeping/TasksListItem/LegacyTaskBody.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/LegacyTaskBody.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { BusinessTaskStatus, TaskUserResponseType } from '@schemas/features/bookkeeping/businessTask'
+import { type UserVisibleTask } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
+import { useDeleteTaskUploads } from '@api/businesses/[business-id]/tasks/[task-id]/upload/delete/post'
+import { usePostTaskUpload } from '@api/businesses/[business-id]/tasks/[task-id]/upload/post'
+import { usePostTaskUploadDescription } from '@api/businesses/[business-id]/tasks/[task-id]/upload/update-description/post'
+import { usePostTaskUserResponse } from '@api/businesses/[business-id]/tasks/[task-id]/user-response/post'
+import { Button } from '@ui/Button/Button'
+import { FileInput } from '@ui/Input/FileInput'
+import { TextArea } from '@ui/Input/TextArea'
+import { P } from '@ui/Typography/Text'
+
+type LegacyTaskBodyProps = {
+  task: UserVisibleTask
+  onAnswered: () => void
+}
+
+export const LegacyTaskBody = ({ task, onAnswered }: LegacyTaskBodyProps) => {
+  const { t } = useTranslation()
+  const [userResponse, setUserResponse] = useState(task.userResponse ?? '')
+  const [selectedFiles, setSelectedFiles] = useState<File[]>()
+
+  const { trigger: handleSubmitUserResponseForTask, isMutating: isSubmittingResponse } = usePostTaskUserResponse()
+  const { trigger: handleUploadDocumentsForTask, isMutating: isUploadingDocuments } = usePostTaskUpload()
+  const { trigger: handleDeleteUploadsOnTask } = useDeleteTaskUploads()
+  const { trigger: handleUpdateTaskUploadDescription } = usePostTaskUploadDescription()
+
+  const submit = async () => {
+    if (!selectedFiles) {
+      return
+    }
+
+    await handleUploadDocumentsForTask({
+      taskId: task.id,
+      files: selectedFiles,
+      description: userResponse,
+    })
+
+    onAnswered()
+    setSelectedFiles(undefined)
+  }
+
+  const uploadDocumentAction = useMemo(() => {
+    if (task.userResponseType === TaskUserResponseType.UploadDocument) {
+      if (task.status === BusinessTaskStatus.Todo) {
+        if (!selectedFiles) {
+          return (
+            <FileInput
+              onUpload={(files: File[]) => {
+                setSelectedFiles(files)
+              }}
+              text={t('bookkeeping:TasksListItem.LegacyTaskBody.action.select_files', 'Select files')}
+              allowMultipleUploads
+            />
+          )
+        }
+        else {
+          return (
+            <>
+              <Button
+                variant='outlined'
+                onPress={() => setSelectedFiles(undefined)}
+              >
+                {t('common:action.cancel_label', 'Cancel')}
+              </Button>
+              <Button
+                onPress={() => void submit()}
+                isDisabled={isUploadingDocuments}
+              >
+                {t('common:action.submit_label', 'Submit')}
+              </Button>
+            </>
+          )
+        }
+      }
+      else if (task.status === BusinessTaskStatus.UserMarkedCompleted) {
+        if (task.userResponse && task.userResponse != userResponse) {
+          return (
+            <Button
+              variant='outlined'
+              onPress={() => {
+                void handleUpdateTaskUploadDescription({
+                  taskId: task.id,
+                  description: userResponse,
+                })
+              }}
+            >
+              {t('common:action.update_label', 'Update')}
+            </Button>
+          )
+        }
+        else {
+          return (
+            <Button
+              variant='outlined'
+              onPress={() => {
+                void handleDeleteUploadsOnTask({
+                  taskId: task.id,
+                })
+              }}
+            >
+              {t('bookkeeping:TasksListItem.LegacyTaskBody.action.delete_uploads', 'Delete Uploads')}
+            </Button>
+          )
+        }
+      }
+      else { return null }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [t, task, selectedFiles, userResponse, isUploadingDocuments])
+
+  return (
+    <div className='Layer__tasks-list-item__body-info'>
+      <P size='sm' variant='inherit'>{task.question}</P>
+      <TextArea
+        value={userResponse}
+        placeholder={task.userResponseType === TaskUserResponseType.UploadDocument ? t('bookkeeping:TasksListItem.LegacyTaskBody.label.optional_description', 'Optional description') : ''}
+        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+          setUserResponse(e.target.value)}
+      />
+      {task.userResponseType === TaskUserResponseType.UploadDocument
+        ? (
+          <div className='Layer__tasks-list__link-list'>
+            {selectedFiles
+              ? (
+                <div className='Layer__tasks-list__link-list-header'>{t('bookkeeping:TasksListItem.LegacyTaskBody.label.selected_files', 'Selected Files:')}</div>
+              )
+              : task.documents
+                ? (
+                  <div className='Layer__tasks-list__link-list-header'>{t('bookkeeping:TasksListItem.LegacyTaskBody.label.uploaded_files', 'Uploaded Files:')}</div>
+                )
+                : null}
+            <ul className='Layer__tasks-list__links-list'>
+              {task.documents?.map((document, idx) => (
+                <li key={`uploaded-doc-name-${idx}`}><a className='Layer__tasks-list-item__link' href={document.presignedUrl.presignedUrl}>{document.fileName}</a></li>
+              ))}
+              {selectedFiles?.map((file, idx) => (
+                <li key={`selected-file-name-${idx}`}><a className='Layer__tasks-list-item__link'>{file.name}</a></li>
+              ))}
+            </ul>
+          </div>
+        )
+        : null}
+      <div className='Layer__tasks-list-item__actions'>
+        {task.userResponseType === TaskUserResponseType.UploadDocument
+          ? uploadDocumentAction
+          : (
+            <Button
+              isDisabled={
+                isSubmittingResponse
+                || userResponse.length === 0
+                || userResponse === task.userResponse
+              }
+              variant='outlined'
+              onPress={() => {
+                void handleSubmitUserResponseForTask({ taskId: task.id, userResponse })
+                  .then(() => {
+                    onAnswered()
+                  })
+              }}
+            >
+              {task.userResponse && task.userResponse !== userResponse
+                ? t('common:action.update_label', 'Update')
+                : t('common:action.save_label', 'Save')}
+            </Button>
+          )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/bookkeeping/TasksListItem/TasksListItem.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/TasksListItem.tsx
@@ -1,21 +1,13 @@
-import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useState } from 'react'
 import classNames from 'classnames'
-import { useTranslation } from 'react-i18next'
 
 import { LayerEventComponent, LayerEventType } from '@schemas/common/layerEvents'
-import { BusinessTaskStatus, TaskUserResponseType } from '@schemas/features/bookkeeping/businessTask'
 import { isCompletedTask, type UserVisibleTask } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
 import ChevronDownFill from '@icons/ChevronDownFill'
 import { useEmitLayerEvent } from '@hooks/utils/events/useEmitLayerEvent'
-import { useDeleteTaskUploads } from '@api/businesses/[business-id]/tasks/[task-id]/upload/delete/post'
-import { usePostTaskUpload } from '@api/businesses/[business-id]/tasks/[task-id]/upload/post'
-import { usePostTaskUploadDescription } from '@api/businesses/[business-id]/tasks/[task-id]/upload/update-description/post'
-import { usePostTaskUserResponse } from '@api/businesses/[business-id]/tasks/[task-id]/user-response/post'
-import { Button } from '@ui/Button/Button'
-import { FileInput } from '@ui/Input/FileInput'
-import { TextArea } from '@ui/Input/TextArea'
 import { P } from '@ui/Typography/Text'
 import { getIconForTask } from '@features/bookkeeping/TasksListItem/getIconForTask'
+import { LegacyTaskBody } from '@features/bookkeeping/TasksListItem/LegacyTaskBody'
 
 type TasksListItemProps = {
   task: UserVisibleTask
@@ -27,16 +19,8 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
   { task, defaultOpen, onExpandTask },
   ref,
 ) => {
-  const { t } = useTranslation()
   const emitLayerEvent = useEmitLayerEvent(LayerEventComponent.Tasks)
   const [isOpen, setIsOpen] = useState(defaultOpen)
-  const [userResponse, setUserResponse] = useState(task.userResponse ?? '')
-  const [selectedFiles, setSelectedFiles] = useState<File[]>()
-
-  const { trigger: handleSubmitUserResponseForTask, isMutating: isSubmittingResponse } = usePostTaskUserResponse()
-  const { trigger: handleUploadDocumentsForTask, isMutating: isUploadingDocuments } = usePostTaskUpload()
-  const { trigger: handleDeleteUploadsOnTask } = useDeleteTaskUploads()
-  const { trigger: handleUpdateTaskUploadDescription } = usePostTaskUploadDescription()
 
   const taskBodyClassName = classNames(
     'Layer__tasks-list-item__body',
@@ -60,21 +44,6 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
     setIsOpen(defaultOpen)
   }, [defaultOpen])
 
-  const submit = async () => {
-    if (!selectedFiles) {
-      return
-    }
-
-    await handleUploadDocumentsForTask({
-      taskId: task.id,
-      files: selectedFiles,
-      description: userResponse,
-    })
-
-    setIsOpen(false)
-    setSelectedFiles(undefined)
-  }
-
   const onClickTaskItemHead = useCallback(() => {
     emitLayerEvent({
       type: LayerEventType.TaskClicked,
@@ -85,74 +54,7 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
     onExpandTask?.(!isOpen)
   }, [isOpen, onExpandTask, emitLayerEvent, task.id])
 
-  const uploadDocumentAction = useMemo(() => {
-    if (task.userResponseType === TaskUserResponseType.UploadDocument) {
-      if (task.status === BusinessTaskStatus.Todo) {
-        if (!selectedFiles) {
-          return (
-            <FileInput
-              onUpload={(files: File[]) => {
-                setSelectedFiles(files)
-              }}
-              text={t('bookkeeping:TasksListItem.action.select_files', 'Select files')}
-              allowMultipleUploads
-            />
-          )
-        }
-        else {
-          return (
-            <>
-              <Button
-                variant='outlined'
-                onPress={() => setSelectedFiles(undefined)}
-              >
-                {t('common:action.cancel_label', 'Cancel')}
-              </Button>
-              <Button
-                onPress={() => void submit()}
-                isDisabled={isUploadingDocuments}
-              >
-                {t('common:action.submit_label', 'Submit')}
-              </Button>
-            </>
-          )
-        }
-      }
-      else if (task.status === BusinessTaskStatus.UserMarkedCompleted) {
-        if (task.userResponse && task.userResponse != userResponse) {
-          return (
-            <Button
-              variant='outlined'
-              onPress={() => {
-                void handleUpdateTaskUploadDescription({
-                  taskId: task.id,
-                  description: userResponse,
-                })
-              }}
-            >
-              {t('common:action.update_label', 'Update')}
-            </Button>
-          )
-        }
-        else {
-          return (
-            <Button
-              variant='outlined'
-              onPress={() => {
-                void handleDeleteUploadsOnTask({
-                  taskId: task.id,
-                })
-              }}
-            >
-              {t('bookkeeping:TasksListItem.action.delete_uploads', 'Delete Uploads')}
-            </Button>
-          )
-        }
-      }
-      else { return null }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [t, task, selectedFiles, userResponse, isUploadingDocuments])
+  const onAnswered = useCallback(() => setIsOpen(false), [])
 
   return (
     <div className='Layer__tasks-list-item-wrapper' ref={ref}>
@@ -176,62 +78,7 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
           />
         </div>
         <div className={taskBodyClassName}>
-          <div className='Layer__tasks-list-item__body-info'>
-            <P size='sm' variant='inherit'>{task.question}</P>
-            <TextArea
-              value={userResponse}
-              placeholder={task.userResponseType === TaskUserResponseType.UploadDocument ? t('bookkeeping:TasksListItem.label.optional_description', 'Optional description') : ''}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setUserResponse(e.target.value)}
-            />
-            {task.userResponseType === TaskUserResponseType.UploadDocument
-              ? (
-                <div className='Layer__tasks-list__link-list'>
-                  {selectedFiles
-                    ? (
-                      <div className='Layer__tasks-list__link-list-header'>{t('bookkeeping:TasksListItem.label.selected_files', 'Selected Files:')}</div>
-                    )
-                    : task.documents
-                      ? (
-                        <div className='Layer__tasks-list__link-list-header'>{t('bookkeeping:TasksListItem.label.uploaded_files', 'Uploaded Files:')}</div>
-                      )
-                      : null}
-                  <ul className='Layer__tasks-list__links-list'>
-                    {task.documents?.map((document, idx) => (
-                      <li key={`uploaded-doc-name-${idx}`}><a className='Layer__tasks-list-item__link' href={document.presignedUrl.presignedUrl}>{document.fileName}</a></li>
-                    ))}
-                    {selectedFiles?.map((file, idx) => (
-                      <li key={`selected-file-name-${idx}`}><a className='Layer__tasks-list-item__link'>{file.name}</a></li>
-                    ))}
-                  </ul>
-                </div>
-              )
-              : null}
-            <div className='Layer__tasks-list-item__actions'>
-              {task.userResponseType === TaskUserResponseType.UploadDocument
-                ? uploadDocumentAction
-                : (
-                  <Button
-                    isDisabled={
-                      isSubmittingResponse
-                      || userResponse.length === 0
-                      || userResponse === task.userResponse
-                    }
-                    variant='outlined'
-                    onPress={() => {
-                      void handleSubmitUserResponseForTask({ taskId: task.id, userResponse })
-                        .then(() => {
-                          setIsOpen(false)
-                        })
-                    }}
-                  >
-                    {task.userResponse && task.userResponse !== userResponse
-                      ? t('common:action.update_label', 'Update')
-                      : t('common:action.save_label', 'Save')}
-                  </Button>
-                )}
-            </div>
-          </div>
+          <LegacyTaskBody task={task} onAnswered={onAnswered} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Scope

- Move the free-response and upload UI out of `TasksListItem` into `LegacyTaskBody`, unchanged.
- `TasksListItem` keeps the accordion shell, expand/collapse and the layer event.

No behaviour change. This lands first so the later PRs, which add a second body and change the task type, don't arrive as a 160-line deletion inside an unrelated diff.

## Verification

- `npm run typecheck`, `npm run lint` clean.
- `npm test -- --run`: 345 tests pass.
- Reviewable by diffing the moved block against the deleted one; nothing else changed.

Root: this
Base: main
Next: #1802

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical component extraction with the same UI and callbacks; only translation key paths change slightly.
> 
> **Overview**
> **Refactors bookkeeping task list items** by pulling the interactive task body (text responses, file uploads, and related API actions) out of `TasksListItem` into a new `LegacyTaskBody` component.
> 
> `TasksListItem` now only handles the accordion header, expand/collapse, and layer events; it passes an `onAnswered` callback so the body can still collapse the row after save/submit. i18n keys for the moved strings are namespaced under `TasksListItem.LegacyTaskBody` instead of `TasksListItem`. Intended as a no-behavior-change split to unblock follow-up work (e.g. alternate task bodies).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83750756404cdcfcb3236ce32adb3aefd5d244a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
