### PR TITLE
[LAY-2720] Split 2/5: model business tasks as a task_type discriminated union

### DIFF
--- a/src/components/features/bookkeeping/TasksListItem/LegacyTaskBody.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/LegacyTaskBody.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { BusinessTaskStatus, TaskUserResponseType } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus, TaskUserResponseType } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+import { type LegacyBusinessTask } from '@schemas/features/bookkeeping/businessTasks/legacyBusinessTask'
 import { type UserVisibleTask } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
 import { useDeleteTaskUploads } from '@api/businesses/[business-id]/tasks/[task-id]/upload/delete/post'
 import { usePostTaskUpload } from '@api/businesses/[business-id]/tasks/[task-id]/upload/post'
@@ -13,7 +14,7 @@ import { TextArea } from '@ui/Input/TextArea'
 import { P } from '@ui/Typography/Text'
 
 type LegacyTaskBodyProps = {
-  task: UserVisibleTask
+  task: UserVisibleTask & LegacyBusinessTask
   onAnswered: () => void
 }
 

--- a/src/components/features/bookkeeping/TasksListItem/TasksListItem.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/TasksListItem.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useCallback, useEffect, useState } from 'react'
 import classNames from 'classnames'
 
 import { LayerEventComponent, LayerEventType } from '@schemas/common/layerEvents'
+import { isLegacyBusinessTask } from '@schemas/features/bookkeeping/businessTask'
 import { isCompletedTask, type UserVisibleTask } from '@utils/features/bookkeeping/bookkeepingTasksFilters'
 import ChevronDownFill from '@icons/ChevronDownFill'
 import { useEmitLayerEvent } from '@hooks/utils/events/useEmitLayerEvent'
@@ -78,7 +79,9 @@ export const TasksListItem = forwardRef<HTMLDivElement, TasksListItemProps>((
           />
         </div>
         <div className={taskBodyClassName}>
-          <LegacyTaskBody task={task} onAnswered={onAnswered} />
+          {isLegacyBusinessTask(task)
+            ? <LegacyTaskBody task={task} onAnswered={onAnswered} />
+            : null}
         </div>
       </div>
     </div>

--- a/src/components/features/bookkeeping/TasksListItem/getIconForTask.tsx
+++ b/src/components/features/bookkeeping/TasksListItem/getIconForTask.tsx
@@ -1,6 +1,7 @@
 import { Check, CircleAlert } from 'lucide-react'
 
-import { type BusinessTask, BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 const STATUS_TO_ICON_MAP = {
   [BusinessTaskStatus.Todo]: {

--- a/src/fixtures/bookkeeping/mocks.ts
+++ b/src/fixtures/bookkeeping/mocks.ts
@@ -1,11 +1,8 @@
 import { type BookkeepingConfiguration, BookkeepingStatus as ConfigurationBookkeepingStatus } from '@schemas/features/bookkeeping/bookkeepingConfiguration'
 import { type BookkeepingPeriod, BookkeepingPeriodStatus } from '@schemas/features/bookkeeping/bookkeepingPeriods'
 import { BookkeepingStatus, type BookkeepingStatusData } from '@schemas/features/bookkeeping/bookkeepingStatus'
-import {
-  type BusinessTask,
-  BusinessTaskStatus,
-  TaskUserResponseType,
-} from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus, TaskUserResponseType } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+import { type LegacyBusinessTask } from '@schemas/features/bookkeeping/businessTasks/legacyBusinessTask'
 import { type CallBooking, CallBookingPurpose, CallBookingState, CallBookingType } from '@schemas/features/bookkeeping/callBooking'
 import { pickCyclic } from '@utils/shared/array/pickCyclic'
 
@@ -70,7 +67,7 @@ const generatePeriodIds = createGenerator(PeriodIdSchema)
 
 const periodIdFor = (monthIndex: number) => pickCyclic(generatePeriodIds({ numRuns: 1, seed: monthIndex }), 0)
 
-const makePeriodTasks = (periodIndex: number, count: number, month: number): BusinessTask[] => {
+const makePeriodTasks = (periodIndex: number, count: number, month: number): LegacyBusinessTask[] => {
   if (count === 0) return []
 
   return generateTaskSeeds({ numRuns: count, seed: periodIndex }).map(({ id, day, amountCents, merchant }) => {
@@ -79,6 +76,7 @@ const makePeriodTasks = (periodIndex: number, count: number, month: number): Bus
     return {
       id,
       status: BusinessTaskStatus.Todo,
+      taskType: null,
       title: `Transaction on ${date}`,
       question: `On ${date}, you spent ${formatDollars(amountCents)} at ${merchant}. `
         + 'Can you tell us a bit more about what this transaction was for?',

--- a/src/msw/api/businesses/[business-id]/bookkeeping/periods/store.ts
+++ b/src/msw/api/businesses/[business-id]/bookkeeping/periods/store.ts
@@ -1,5 +1,6 @@
 import { BookkeepingPeriodStatus } from '@schemas/features/bookkeeping/bookkeepingPeriods'
-import { type BusinessTask, BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask, isLegacyBusinessTask } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { makeBookkeepingPeriods } from '@fixtures/bookkeeping/mocks'
 import { PROFIT_AND_LOSS_FIXTURE_START_YEAR } from '@fixtures/profitAndLoss/constants'
@@ -48,8 +49,8 @@ export const patchTaskInStore = (
 }
 
 export const completeTaskInStore = (taskId: string, userResponse: string | null): BusinessTask | undefined =>
-  patchTaskInStore(taskId, task => ({
-    ...task,
-    status: BusinessTaskStatus.UserMarkedCompleted,
-    userResponse,
-  }))
+  patchTaskInStore(taskId, task => (
+    isLegacyBusinessTask(task)
+      ? { ...task, status: BusinessTaskStatus.UserMarkedCompleted, userResponse }
+      : task
+  ))

--- a/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/delete/post.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/delete/post.ts
@@ -1,10 +1,7 @@
 import { Schema } from 'effect'
 
-import {
-  type BusinessTask,
-  BusinessTaskSchema,
-  BusinessTaskStatus,
-} from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask, BusinessTaskSchema, isLegacyBusinessTask } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { patchTaskInStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
 import { makeFallbackTask } from '@msw/api/businesses/[business-id]/tasks/makeFallbackTask'
@@ -23,12 +20,11 @@ export const post = createMockEndpoint<BusinessTask, ReturnType<typeof toRespons
 
     const taskId = String(params.taskId)
 
-    const cleared = patchTaskInStore(taskId, task => ({
-      ...task,
-      status: BusinessTaskStatus.Todo,
-      userResponse: null,
-      documents: null,
-    })) ?? makeFallbackTask(taskId)
+    const cleared = patchTaskInStore(taskId, task => (
+      isLegacyBusinessTask(task)
+        ? { ...task, status: BusinessTaskStatus.Todo, userResponse: null, documents: null }
+        : task
+    )) ?? makeFallbackTask(taskId)
 
     return toResponse(cleared)
   },

--- a/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/post.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/post.ts
@@ -1,5 +1,6 @@
 import { type FileMetadata } from '@internal-types/shared/fileUpload'
-import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTask'
+import { isLegacyBusinessTask } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { patchTaskInStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
 import { apiData } from '@msw/utils/apiResponse'
@@ -35,12 +36,16 @@ export const post = createMockEndpoint({
     const description = formData.get('description')
 
     if (files.length > 0) {
-      patchTaskInStore(String(params.taskId), task => ({
-        ...task,
-        status: BusinessTaskStatus.UserMarkedCompleted,
-        userResponse: typeof description === 'string' ? description : task.userResponse,
-        documents: [...(task.documents ?? []), ...files.map(toTaskDocument)],
-      }))
+      patchTaskInStore(String(params.taskId), task => (
+        isLegacyBusinessTask(task)
+          ? {
+            ...task,
+            status: BusinessTaskStatus.UserMarkedCompleted,
+            userResponse: typeof description === 'string' ? description : task.userResponse,
+            documents: [...(task.documents ?? []), ...files.map(toTaskDocument)],
+          }
+          : task
+      ))
     }
 
     const [firstFile] = files

--- a/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/post.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/[task-id]/upload/update-description/post.ts
@@ -1,10 +1,7 @@
 import { Schema } from 'effect'
 
-import {
-  type BusinessTask,
-  BusinessTaskSchema,
-  BusinessTaskStatus,
-} from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask, BusinessTaskSchema, isLegacyBusinessTask } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { patchTaskInStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
 import { makeFallbackTask } from '@msw/api/businesses/[business-id]/tasks/makeFallbackTask'
@@ -26,7 +23,7 @@ export const post = createMockEndpoint<BusinessTask, ReturnType<typeof toRespons
     const taskId = String(params.taskId)
     const userResponse = body.user_response ?? null
 
-    const updated = patchTaskInStore(taskId, task => ({ ...task, userResponse }))
+    const updated = patchTaskInStore(taskId, task => (isLegacyBusinessTask(task) ? { ...task, userResponse } : task))
       ?? makeFallbackTask(taskId, { status: BusinessTaskStatus.UserMarkedCompleted, userResponse })
 
     return toResponse(updated)

--- a/src/msw/api/businesses/[business-id]/tasks/[task-id]/user-response/post.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/[task-id]/user-response/post.ts
@@ -1,11 +1,7 @@
 import { Schema } from 'effect'
 
-import {
-  type BusinessTask,
-  BusinessTaskSchema,
-  BusinessTaskStatus,
-  TaskUserResponseType,
-} from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask, BusinessTaskSchema } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus, TaskUserResponseType } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 import { completeTaskInStore } from '@msw/api/businesses/[business-id]/bookkeeping/periods/store'
 import { makeFallbackTask } from '@msw/api/businesses/[business-id]/tasks/makeFallbackTask'

--- a/src/msw/api/businesses/[business-id]/tasks/makeFallbackTask.ts
+++ b/src/msw/api/businesses/[business-id]/tasks/makeFallbackTask.ts
@@ -1,14 +1,21 @@
 import { Schema } from 'effect'
 
-import { type BusinessTask, BusinessTaskSchema } from '@schemas/features/bookkeeping/businessTask'
+import {
+  type LegacyBusinessTask,
+  LegacyBusinessTaskSchema,
+} from '@schemas/features/bookkeeping/businessTasks/legacyBusinessTask'
 
-const decodeBusinessTask = Schema.decodeSync(BusinessTaskSchema)
+const decodeLegacyBusinessTask = Schema.decodeSync(LegacyBusinessTaskSchema)
 
 /** Response fallback for task mutations when the id isn't in the periods store. */
-export const makeFallbackTask = (id: string, overrides?: Partial<BusinessTask>): BusinessTask => ({
-  ...decodeBusinessTask({
+export const makeFallbackTask = (
+  id: string,
+  overrides?: Partial<LegacyBusinessTask>,
+): LegacyBusinessTask => ({
+  ...decodeLegacyBusinessTask({
     id,
     status: 'TODO',
+    task_type: null,
     title: '',
     question: '',
     user_response: null,

--- a/src/schemas/features/bookkeeping/businessTask.test.ts
+++ b/src/schemas/features/bookkeeping/businessTask.test.ts
@@ -61,7 +61,12 @@ describe('BusinessTaskSchema', () => {
     const task = decode(encodedCounterpartyAskTask)
 
     expect(isCounterpartyAskTask(task)).toBe(true)
-    expect(isRenderableBusinessTask(task)).toBe(true)
+  })
+
+  it('does not treat a counterparty ask task as renderable yet', () => {
+    const task = decode(encodedCounterpartyAskTask)
+
+    expect(isRenderableBusinessTask(task)).toBe(false)
   })
 
   it('decodes an automated rule-suggestion task as unrenderable instead of throwing', () => {

--- a/src/schemas/features/bookkeeping/businessTask.test.ts
+++ b/src/schemas/features/bookkeeping/businessTask.test.ts
@@ -1,0 +1,94 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import {
+  BusinessTaskSchema,
+  isCounterpartyAskTask,
+  isLegacyBusinessTask,
+  isRenderableBusinessTask,
+} from '@schemas/features/bookkeeping/businessTask'
+
+const decode = Schema.decodeUnknownSync(BusinessTaskSchema)
+
+const encodedHumanTask = {
+  id: '00000000-0000-4000-8000-000000000801',
+  status: 'TODO',
+  title: 'Upload receipt',
+  question: 'What was this for?',
+  task_type: 'HUMAN',
+  user_response: null,
+  user_response_type: 'FREE_RESPONSE',
+  documents: null,
+}
+
+const encodedCounterpartyAskTask = {
+  id: '00000000-0000-4000-8000-000000000901',
+  status: 'TODO',
+  task_type: 'ASK_ABOUT_COUNTERPARTY_FOR_PERIOD',
+  title: 'Costco purchases',
+  question: 'You spent $307.74 at Costco across 1 transaction.',
+  counterparty: null,
+  user_response: null,
+  response_account: null,
+  resolved_by_task_id: null,
+}
+
+// Shape from ApiBusinessTask.AutomatedTask: no question, no user_response_type.
+const encodedAutomatedRuleSuggestionTask = {
+  id: '00000000-0000-4000-8000-000000000701',
+  status: 'TODO',
+  title: 'Review rule suggestion for Costco',
+  task_type: 'AUTOMATED_RULE_SUGGESTION',
+}
+
+// Shape from ApiBusinessTask.AutomatedTransactionReviewTask: no question, no user_response_type.
+const encodedAutomatedTransactionReviewTask = {
+  id: '00000000-0000-4000-8000-000000000702',
+  status: 'TODO',
+  title: 'Review Transactions',
+  task_type: 'AUTOMATED_TRANSACTION_REVIEW',
+}
+
+describe('BusinessTaskSchema', () => {
+  it('decodes a legacy human task', () => {
+    const task = decode(encodedHumanTask)
+
+    expect(isLegacyBusinessTask(task)).toBe(true)
+    expect(isRenderableBusinessTask(task)).toBe(true)
+  })
+
+  it('decodes a counterparty ask task', () => {
+    const task = decode(encodedCounterpartyAskTask)
+
+    expect(isCounterpartyAskTask(task)).toBe(true)
+    expect(isRenderableBusinessTask(task)).toBe(true)
+  })
+
+  it('decodes an automated rule-suggestion task as unrenderable instead of throwing', () => {
+    const task = decode(encodedAutomatedRuleSuggestionTask)
+
+    expect(isCounterpartyAskTask(task)).toBe(false)
+    expect(isLegacyBusinessTask(task)).toBe(false)
+    expect(isRenderableBusinessTask(task)).toBe(false)
+  })
+
+  it('decodes an automated transaction-review task as unrenderable instead of throwing', () => {
+    const task = decode(encodedAutomatedTransactionReviewTask)
+
+    expect(isCounterpartyAskTask(task)).toBe(false)
+    expect(isLegacyBusinessTask(task)).toBe(false)
+    expect(isRenderableBusinessTask(task)).toBe(false)
+  })
+
+  it('does not treat a malformed ask as renderable', () => {
+    const malformedAsk = Schema.decodeUnknownSync(BusinessTaskSchema)({
+      id: '00000000-0000-4000-8000-0000000009f1',
+      status: 'TODO',
+      title: 'Costco purchases',
+      task_type: 'ASK_ABOUT_COUNTERPARTY_FOR_PERIOD',
+    })
+
+    expect(isCounterpartyAskTask(malformedAsk)).toBe(false)
+    expect(isRenderableBusinessTask(malformedAsk)).toBe(false)
+  })
+})

--- a/src/schemas/features/bookkeeping/businessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTask.ts
@@ -1,65 +1,38 @@
-import { pipe, Schema } from 'effect'
+import { Schema } from 'effect'
 
-import { S3PresignedUrlSchema } from '@schemas/common/s3PresignedUrl'
-import { createTransformedEnumSchema } from '@schemas/common/utils'
+import { COUNTERPARTY_ASK_TASK_TYPE } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+import {
+  type CounterpartyAskTask,
+  CounterpartyAskTaskSchema,
+} from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+import {
+  type LegacyBusinessTask,
+  LegacyBusinessTaskSchema,
+} from '@schemas/features/bookkeeping/businessTasks/legacyBusinessTask'
+import { UnknownBusinessTaskSchema } from '@schemas/features/bookkeeping/businessTasks/unknownBusinessTask'
 
-export enum BusinessTaskStatus {
-  Todo = 'TODO',
-  UserMarkedCompleted = 'USER_MARKED_COMPLETED',
-  Completed = 'COMPLETED',
-  Archived = 'ARCHIVED',
-}
-
-export const BusinessTaskStatusSchema = Schema.Enums(BusinessTaskStatus)
-
-const TransformedBusinessTaskStatusSchema = createTransformedEnumSchema(
-  BusinessTaskStatusSchema,
-  BusinessTaskStatus,
-  BusinessTaskStatus.Todo,
+export const BusinessTaskSchema = Schema.Union(
+  CounterpartyAskTaskSchema,
+  LegacyBusinessTaskSchema,
+  UnknownBusinessTaskSchema,
 )
-
-export enum TaskUserResponseType {
-  FreeResponse = 'FREE_RESPONSE',
-  UploadDocument = 'UPLOAD_DOCUMENT',
-  Unknown = 'UNKNOWN',
-}
-
-export const TaskUserResponseTypeSchema = Schema.Enums(TaskUserResponseType)
-
-const TransformedTaskUserResponseTypeSchema = createTransformedEnumSchema(
-  TaskUserResponseTypeSchema,
-  TaskUserResponseType,
-  TaskUserResponseType.Unknown,
-)
-
-const TaskDocumentSchema = Schema.Struct({
-  fileName: pipe(
-    Schema.propertySignature(Schema.String),
-    Schema.fromKey('file_name'),
-  ),
-  presignedUrl: pipe(
-    Schema.propertySignature(S3PresignedUrlSchema),
-    Schema.fromKey('presigned_url'),
-  ),
-})
-
-// Every business task is treated as a human task; the automated variants are not
-// yet surfaced in the UI.
-export const BusinessTaskSchema = Schema.Struct({
-  id: Schema.UUID,
-  status: TransformedBusinessTaskStatusSchema,
-  title: Schema.String,
-  question: Schema.String,
-  userResponse: pipe(
-    Schema.propertySignature(Schema.NullishOr(Schema.String)),
-    Schema.fromKey('user_response'),
-  ),
-  userResponseType: pipe(
-    Schema.propertySignature(TransformedTaskUserResponseTypeSchema),
-    Schema.fromKey('user_response_type'),
-  ),
-  documents: Schema.NullishOr(Schema.Array(TaskDocumentSchema)),
-})
 
 export type BusinessTask = typeof BusinessTaskSchema.Type
 export type BusinessTaskEncoded = typeof BusinessTaskSchema.Encoded
+
+export const isCounterpartyAskTask = <T extends Pick<BusinessTask, 'taskType'>>(
+  task: T,
+): task is T & CounterpartyAskTask =>
+  task.taskType === COUNTERPARTY_ASK_TASK_TYPE && 'transactionResponses' in task
+
+// LegacyBusinessTask always carries user_response_type; UnknownBusinessTask (an
+// unrecognised task_type this union can't fully model) never does.
+export const isLegacyBusinessTask = <T extends Pick<BusinessTask, 'taskType'>>(
+  task: T,
+): task is T & LegacyBusinessTask =>
+  !isCounterpartyAskTask(task) && 'userResponseType' in task
+
+export const isRenderableBusinessTask = <T extends BusinessTask>(
+  task: T,
+): task is T & (CounterpartyAskTask | LegacyBusinessTask) =>
+  isCounterpartyAskTask(task) || isLegacyBusinessTask(task)

--- a/src/schemas/features/bookkeeping/businessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTask.ts
@@ -20,19 +20,22 @@ export const BusinessTaskSchema = Schema.Union(
 export type BusinessTask = typeof BusinessTaskSchema.Type
 export type BusinessTaskEncoded = typeof BusinessTaskSchema.Encoded
 
-export const isCounterpartyAskTask = <T extends Pick<BusinessTask, 'taskType'>>(
+export const isCounterpartyAskTask = <T extends BusinessTask>(
   task: T,
 ): task is T & CounterpartyAskTask =>
   task.taskType === COUNTERPARTY_ASK_TASK_TYPE && 'transactionResponses' in task
 
 // LegacyBusinessTask always carries user_response_type; UnknownBusinessTask (an
 // unrecognised task_type this union can't fully model) never does.
-export const isLegacyBusinessTask = <T extends Pick<BusinessTask, 'taskType'>>(
+export const isLegacyBusinessTask = <T extends BusinessTask>(
   task: T,
 ): task is T & LegacyBusinessTask =>
   !isCounterpartyAskTask(task) && 'userResponseType' in task
 
+// CounterpartyAskTask has no renderable body yet (the Chip primitive lands in #1803, the
+// ask UI in #1805) — excluded here so it doesn't surface as a dead-end TODO row. Fold it
+// back in once that body ships.
 export const isRenderableBusinessTask = <T extends BusinessTask>(
   task: T,
-): task is T & (CounterpartyAskTask | LegacyBusinessTask) =>
-  isCounterpartyAskTask(task) || isLegacyBusinessTask(task)
+): task is T & LegacyBusinessTask =>
+  isLegacyBusinessTask(task)

--- a/src/schemas/features/bookkeeping/businessTasks/baseBusinessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/baseBusinessTask.ts
@@ -1,0 +1,41 @@
+import { Schema } from 'effect'
+
+import { createTransformedEnumSchema } from '@schemas/common/utils'
+
+export enum BusinessTaskStatus {
+  Todo = 'TODO',
+  UserMarkedCompleted = 'USER_MARKED_COMPLETED',
+  Completed = 'COMPLETED',
+  Archived = 'ARCHIVED',
+}
+
+export const BusinessTaskStatusSchema = Schema.Enums(BusinessTaskStatus)
+
+export const TransformedBusinessTaskStatusSchema = createTransformedEnumSchema(
+  BusinessTaskStatusSchema,
+  BusinessTaskStatus,
+  BusinessTaskStatus.Todo,
+)
+
+export enum TaskUserResponseType {
+  FreeResponse = 'FREE_RESPONSE',
+  UploadDocument = 'UPLOAD_DOCUMENT',
+  Unknown = 'UNKNOWN',
+}
+
+export const TaskUserResponseTypeSchema = Schema.Enums(TaskUserResponseType)
+
+export const TransformedTaskUserResponseTypeSchema = createTransformedEnumSchema(
+  TaskUserResponseTypeSchema,
+  TaskUserResponseType,
+  TaskUserResponseType.Unknown,
+)
+
+export const COUNTERPARTY_ASK_TASK_TYPE = 'ASK_ABOUT_COUNTERPARTY_FOR_PERIOD'
+
+export const BaseBusinessTaskSchema = Schema.Struct({
+  id: Schema.UUID,
+  status: TransformedBusinessTaskStatusSchema,
+  title: Schema.String,
+  question: Schema.String,
+})

--- a/src/schemas/features/bookkeeping/businessTasks/counterpartyAskTask.test.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/counterpartyAskTask.test.ts
@@ -1,0 +1,54 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { CounterpartyAskTaskSchema } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+
+const decode = Schema.decodeUnknownSync(CounterpartyAskTaskSchema)
+
+const baseEncodedAsk = {
+  id: '00000000-0000-4000-8000-000000000901',
+  status: 'TODO',
+  task_type: 'ASK_ABOUT_COUNTERPARTY_FOR_PERIOD',
+  title: 'Costco purchases',
+  question: 'You spent $307.74 at Costco across 1 transaction.',
+  counterparty: null,
+  user_response: null,
+  response_account: null,
+  resolved_by_task_id: null,
+}
+
+describe('CounterpartyAskTaskSchema', () => {
+  it('decodes an ask whose optional fields are absent', () => {
+    const task = decode(baseEncodedAsk)
+
+    expect(task.suggestions).toEqual([])
+    expect(task.transactions).toEqual([])
+    expect(task.transactionResponses).toEqual([])
+    expect(task.totalCount).toBe(0)
+    expect(task.totalAmount).toBe(0)
+    expect(task.alwaysThis).toBe(false)
+  })
+
+  it('decodes an ask whose optional fields are explicitly null', () => {
+    const task = decode({
+      ...baseEncodedAsk,
+      suggestions: null,
+      transactions: null,
+      transaction_responses: null,
+      total_count: null,
+      total_amount: null,
+      always_this: null,
+    })
+
+    expect(task.suggestions).toEqual([])
+    expect(task.transactions).toEqual([])
+    expect(task.transactionResponses).toEqual([])
+    expect(task.totalCount).toBe(0)
+    expect(task.totalAmount).toBe(0)
+    expect(task.alwaysThis).toBe(false)
+  })
+
+  it('rejects a task_type belonging to the legacy arm', () => {
+    expect(() => decode({ ...baseEncodedAsk, task_type: 'FREE_RESPONSE_TASK' })).toThrow()
+  })
+})

--- a/src/schemas/features/bookkeeping/businessTasks/counterpartyAskTask.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/counterpartyAskTask.ts
@@ -1,0 +1,91 @@
+import { pipe, Schema } from 'effect'
+
+import { AccountIdentifierSchema } from '@schemas/common/accountIdentifier'
+import {
+  BankTransactionCounterpartySchema,
+  MinimalBankTransactionSchema,
+} from '@schemas/features/bankTransactions/base'
+import {
+  BaseBusinessTaskSchema,
+  COUNTERPARTY_ASK_TASK_TYPE,
+} from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+
+export const CounterpartyAskAccountSchema = Schema.Struct({
+  accountIdentifier: pipe(
+    Schema.propertySignature(AccountIdentifierSchema),
+    Schema.fromKey('account_identifier'),
+  ),
+  name: Schema.String,
+})
+
+export type CounterpartyAskAccount = typeof CounterpartyAskAccountSchema.Type
+
+const CounterpartyAskTransactionResponseSchema = Schema.Struct({
+  transactionId: pipe(
+    Schema.propertySignature(Schema.String),
+    Schema.fromKey('transaction_id'),
+  ),
+  userResponse: pipe(
+    Schema.propertySignature(Schema.NullishOr(Schema.String)),
+    Schema.fromKey('user_response'),
+  ),
+  responseAccount: pipe(
+    Schema.propertySignature(Schema.NullishOr(CounterpartyAskAccountSchema)),
+    Schema.fromKey('response_account'),
+  ),
+})
+
+export type CounterpartyAskTransactionResponse = typeof CounterpartyAskTransactionResponseSchema.Type
+
+export const CounterpartyAskTaskSchema = Schema.extend(
+  BaseBusinessTaskSchema,
+  Schema.Struct({
+    taskType: pipe(
+      Schema.propertySignature(Schema.Literal(COUNTERPARTY_ASK_TASK_TYPE)),
+      Schema.fromKey('task_type'),
+    ),
+    counterparty: Schema.NullishOr(BankTransactionCounterpartySchema),
+    suggestions: Schema.optionalWith(Schema.Array(CounterpartyAskAccountSchema), {
+      default: () => [],
+      nullable: true,
+    }),
+    transactions: Schema.optionalWith(Schema.Array(MinimalBankTransactionSchema), {
+      default: () => [],
+      nullable: true,
+    }),
+    transactionResponses: pipe(
+      Schema.optionalWith(Schema.Array(CounterpartyAskTransactionResponseSchema), {
+        default: () => [],
+        nullable: true,
+      }),
+      Schema.fromKey('transaction_responses'),
+    ),
+    userResponse: pipe(
+      Schema.propertySignature(Schema.NullishOr(Schema.String)),
+      Schema.fromKey('user_response'),
+    ),
+    responseAccount: pipe(
+      Schema.propertySignature(Schema.NullishOr(CounterpartyAskAccountSchema)),
+      Schema.fromKey('response_account'),
+    ),
+    totalCount: pipe(
+      Schema.optionalWith(Schema.Number, { default: () => 0, nullable: true }),
+      Schema.fromKey('total_count'),
+    ),
+    totalAmount: pipe(
+      Schema.optionalWith(Schema.Number, { default: () => 0, nullable: true }),
+      Schema.fromKey('total_amount'),
+    ),
+    alwaysThis: pipe(
+      Schema.optionalWith(Schema.Boolean, { default: () => false, nullable: true }),
+      Schema.fromKey('always_this'),
+    ),
+    resolvedByTaskId: pipe(
+      Schema.propertySignature(Schema.NullishOr(Schema.String)),
+      Schema.fromKey('resolved_by_task_id'),
+    ),
+  }),
+)
+
+export type CounterpartyAskTask = typeof CounterpartyAskTaskSchema.Type
+export type CounterpartyAskTaskEncoded = typeof CounterpartyAskTaskSchema.Encoded

--- a/src/schemas/features/bookkeeping/businessTasks/legacyBusinessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/legacyBusinessTask.ts
@@ -1,0 +1,45 @@
+import { pipe, Schema } from 'effect'
+
+import { S3PresignedUrlSchema } from '@schemas/common/s3PresignedUrl'
+import {
+  BaseBusinessTaskSchema,
+  COUNTERPARTY_ASK_TASK_TYPE,
+  TransformedTaskUserResponseTypeSchema,
+} from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+
+const TaskDocumentSchema = Schema.Struct({
+  fileName: pipe(
+    Schema.propertySignature(Schema.String),
+    Schema.fromKey('file_name'),
+  ),
+  presignedUrl: pipe(
+    Schema.propertySignature(S3PresignedUrlSchema),
+    Schema.fromKey('presigned_url'),
+  ),
+})
+
+const NonCounterpartyAskTaskTypeSchema = Schema.NullishOr(
+  Schema.String.pipe(Schema.filter(taskType => taskType !== COUNTERPARTY_ASK_TASK_TYPE)),
+)
+
+export const LegacyBusinessTaskSchema = Schema.extend(
+  BaseBusinessTaskSchema,
+  Schema.Struct({
+    taskType: pipe(
+      Schema.optionalWith(NonCounterpartyAskTaskTypeSchema, { default: () => null }),
+      Schema.fromKey('task_type'),
+    ),
+    userResponse: pipe(
+      Schema.propertySignature(Schema.NullishOr(Schema.String)),
+      Schema.fromKey('user_response'),
+    ),
+    userResponseType: pipe(
+      Schema.propertySignature(TransformedTaskUserResponseTypeSchema),
+      Schema.fromKey('user_response_type'),
+    ),
+    documents: Schema.NullishOr(Schema.Array(TaskDocumentSchema)),
+  }),
+)
+
+export type LegacyBusinessTask = typeof LegacyBusinessTaskSchema.Type
+export type LegacyBusinessTaskEncoded = typeof LegacyBusinessTaskSchema.Encoded

--- a/src/schemas/features/bookkeeping/businessTasks/unknownBusinessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/unknownBusinessTask.ts
@@ -5,9 +5,9 @@ import { TransformedBusinessTaskStatusSchema } from '@schemas/features/bookkeepi
 export const UnknownBusinessTaskSchema = Schema.Struct({
   id: Schema.UUID,
   status: TransformedBusinessTaskStatusSchema,
-  title: Schema.String,
+  title: Schema.optionalWith(Schema.String, { default: () => '', nullable: true }),
   taskType: pipe(
-    Schema.propertySignature(Schema.String),
+    Schema.optionalWith(Schema.NullishOr(Schema.String), { default: () => null }),
     Schema.fromKey('task_type'),
   ),
 })

--- a/src/schemas/features/bookkeeping/businessTasks/unknownBusinessTask.ts
+++ b/src/schemas/features/bookkeeping/businessTasks/unknownBusinessTask.ts
@@ -1,0 +1,16 @@
+import { pipe, Schema } from 'effect'
+
+import { TransformedBusinessTaskStatusSchema } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+
+export const UnknownBusinessTaskSchema = Schema.Struct({
+  id: Schema.UUID,
+  status: TransformedBusinessTaskStatusSchema,
+  title: Schema.String,
+  taskType: pipe(
+    Schema.propertySignature(Schema.String),
+    Schema.fromKey('task_type'),
+  ),
+})
+
+export type UnknownBusinessTask = typeof UnknownBusinessTaskSchema.Type
+export type UnknownBusinessTaskEncoded = typeof UnknownBusinessTaskSchema.Encoded

--- a/src/utils/features/bookkeeping/bookkeepingTasksFilters.ts
+++ b/src/utils/features/bookkeeping/bookkeepingTasksFilters.ts
@@ -1,5 +1,7 @@
-import { type BusinessTask } from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask, isRenderableBusinessTask } from '@schemas/features/bookkeeping/businessTask'
 import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
+import { type CounterpartyAskTask } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
+import { type LegacyBusinessTask } from '@schemas/features/bookkeeping/businessTasks/legacyBusinessTask'
 
 export function isIncompleteTask<T extends Pick<BusinessTask, 'status'>>(
   task: T,
@@ -16,17 +18,20 @@ export function getIncompleteTasks<T extends Pick<BusinessTask, 'status'>>(
 }
 
 type UserVisibleTaskStatus = Exclude<BusinessTaskStatus, BusinessTaskStatus.Completed | BusinessTaskStatus.Archived>
-export type UserVisibleTask = BusinessTask & { status: UserVisibleTaskStatus }
+type RenderableBusinessTask = CounterpartyAskTask | LegacyBusinessTask
+export type UserVisibleTask = RenderableBusinessTask & { status: UserVisibleTaskStatus }
 
-function isUserVisibleTask<T extends Pick<BusinessTask, 'status'>>(
+function isUserVisibleTask<T extends BusinessTask>(
   task: T,
-): task is T & { status: UserVisibleTaskStatus } {
+): task is T & RenderableBusinessTask & { status: UserVisibleTaskStatus } {
   const { status } = task
+
+  if (!isRenderableBusinessTask(task)) return false
 
   return status !== BusinessTaskStatus.Completed && status !== BusinessTaskStatus.Archived
 }
 
-export function getUserVisibleTasks<T extends Pick<BusinessTask, 'status'>>(
+export function getUserVisibleTasks<T extends BusinessTask>(
   tasks: ReadonlyArray<T>,
 ) {
   return tasks.filter(task => isUserVisibleTask(task))

--- a/src/utils/features/bookkeeping/bookkeepingTasksFilters.ts
+++ b/src/utils/features/bookkeeping/bookkeepingTasksFilters.ts
@@ -1,6 +1,5 @@
 import { type BusinessTask, isRenderableBusinessTask } from '@schemas/features/bookkeeping/businessTask'
 import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
-import { type CounterpartyAskTask } from '@schemas/features/bookkeeping/businessTasks/counterpartyAskTask'
 import { type LegacyBusinessTask } from '@schemas/features/bookkeeping/businessTasks/legacyBusinessTask'
 
 export function isIncompleteTask<T extends Pick<BusinessTask, 'status'>>(
@@ -18,7 +17,7 @@ export function getIncompleteTasks<T extends Pick<BusinessTask, 'status'>>(
 }
 
 type UserVisibleTaskStatus = Exclude<BusinessTaskStatus, BusinessTaskStatus.Completed | BusinessTaskStatus.Archived>
-type RenderableBusinessTask = CounterpartyAskTask | LegacyBusinessTask
+type RenderableBusinessTask = LegacyBusinessTask
 export type UserVisibleTask = RenderableBusinessTask & { status: UserVisibleTaskStatus }
 
 function isUserVisibleTask<T extends BusinessTask>(

--- a/src/utils/features/bookkeeping/bookkeepingTasksFilters.ts
+++ b/src/utils/features/bookkeeping/bookkeepingTasksFilters.ts
@@ -1,4 +1,5 @@
-import { type BusinessTask, BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTask'
+import { type BusinessTask } from '@schemas/features/bookkeeping/businessTask'
+import { BusinessTaskStatus } from '@schemas/features/bookkeeping/businessTasks/baseBusinessTask'
 
 export function isIncompleteTask<T extends Pick<BusinessTask, 'status'>>(
   task: T,


### PR DESCRIPTION
## Scope

- Split `BusinessTaskSchema` into per-arm files under `businessTasks/`: the legacy human/upload shape, the counterparty ask shape, and a permissive catch-all.
- Add `isCounterpartyAskTask` / `isLegacyBusinessTask` / `isRenderableBusinessTask`, and drop unrecognised tasks in `getUserVisibleTasks`.
- Guard the task MSW handlers so they only patch legacy tasks.

The catch-all fixes a fragility that is live on `main`, not just a precaution for this feature. `AUTOMATED_RULE_SUGGESTION` and `AUTOMATED_TRANSACTION_REVIEW` serialize neither `question` nor `user_response_type`, and neither is `fromLlmTransactionCategorizer`, so `BookkeepingPeriod.deprecatedTasks` does not filter them out. One such task failed the previous single-struct decode and took the whole `/bookkeeping/periods` response down with it — blanking Tasks, the month selector and year status, including the legacy tasks that otherwise worked.

The legacy arm actively excludes the ask literal, so an ask can never decode as a free-response task and POST to `/user-response`, which the API rejects with a 400 for that type.

## Verification

- `npm run typecheck`, `npm run lint` clean.
- `npm test -- --run`: 353 tests pass.
- `businessTask.test.ts` covers both automated shapes decoding as unrenderable instead of throwing, and a malformed ask not passing as renderable.
- Arm shapes checked against `BusinessTasksRouter.kt` on `api` master.

Root: #1801
Base: #1801
Next: #1803

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how period task payloads decode and which tasks surface in the UI; incorrect union ordering or guards could hide tasks or mis-route mutations, though tests target the main failure modes.
> 
> **Overview**
> Replaces the single **legacy-only** `BusinessTaskSchema` with a **union** of counterparty-ask, legacy human/upload, and permissive unknown arms, plus shared base types and guards (`isLegacyBusinessTask`, `isCounterpartyAskTask`, `isRenderableBusinessTask`).
> 
> **User-visible tasks** now require a renderable legacy shape via `getUserVisibleTasks`, so automated and not-yet-built ask tasks no longer appear as broken TODO rows; the unknown arm also stops odd API payloads from failing the whole `/bookkeeping/periods` decode.
> 
> **MSW** task mutations route through `patchLegacyTaskInStore` so only legacy tasks are updated in the mock store (with fallback when the patch does not apply). Fixtures and `LegacyTaskBody` typing pick up `LegacyBusinessTask` / `task_type`. New Vitest coverage documents decode and visibility behavior for automated tasks and malformed asks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e5c83a25afd292c82a66cbbf33c78a5007ab496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

