### PR TITLE
[LAY-2723] Split 3/5: add the Chip primitive and BackButton isDisabled

### DIFF
--- a/src/components/ui/Button/BackButton.tsx
+++ b/src/components/ui/Button/BackButton.tsx
@@ -4,13 +4,13 @@ import { useTranslation } from 'react-i18next'
 import { Button, type ButtonProps } from '@ui/Button/Button'
 import { LEGACY_BACK_BUTTON_CLASS_NAME } from '@ui/Button/legacyClassNames'
 
-export type BackButtonProps = Pick<ButtonProps, 'onPress'> & {
+export type BackButtonProps = Pick<ButtonProps, 'onPress' | 'isDisabled'> & {
   slots?: {
     Icon?: LucideIcon
   }
 }
 
-export function BackButton({ onPress, slots }: BackButtonProps) {
+export function BackButton({ onPress, isDisabled, slots }: BackButtonProps) {
   const { t } = useTranslation()
   const { Icon = ChevronLeft } = slots ?? {}
 
@@ -20,6 +20,7 @@ export function BackButton({ onPress, slots }: BackButtonProps) {
       icon
       className={LEGACY_BACK_BUTTON_CLASS_NAME}
       onPress={onPress}
+      isDisabled={isDisabled}
       aria-label={t('common:action.back', 'Back')}
     >
       <Icon size={16} />

--- a/src/components/ui/Chip/Chip.stories.tsx
+++ b/src/components/ui/Chip/Chip.stories.tsx
@@ -1,0 +1,62 @@
+import { type Meta, type StoryObj } from '@storybook/react-vite'
+
+import { Chip, ChipGroup } from '@ui/Chip/Chip'
+
+import { Col } from '@testUtils/storybook/layout/Col'
+import { Gallery } from '@testUtils/storybook/layout/Gallery'
+
+const meta: Meta<typeof ChipGroup> = {
+  title: 'UI/Chip',
+  component: ChipGroup,
+  args: {
+    ariaLabel: 'Answer',
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof ChipGroup>
+
+export const AllVariants: Story = {
+  parameters: { chromatic: { viewports: [1280] } },
+  render: () => (
+    <Gallery>
+      <Col label='default'>
+        <ChipGroup ariaLabel='default'>
+          <Chip value='meals'>Business Meals</Chip>
+          <Chip value='office'>Office Expenses</Chip>
+          <Chip value='other'>Something else</Chip>
+        </ChipGroup>
+      </Col>
+      <Col label='selected'>
+        <ChipGroup ariaLabel='selected' value='office'>
+          <Chip value='meals'>Business Meals</Chip>
+          <Chip value='office'>Office Expenses</Chip>
+          <Chip value='other'>Something else</Chip>
+        </ChipGroup>
+      </Col>
+      <Col label='small'>
+        <ChipGroup ariaLabel='small' value='meals'>
+          <Chip size='sm' value='meals'>Business Meals</Chip>
+          <Chip size='sm' value='office'>Office Expenses</Chip>
+          <Chip size='sm' value='other'>Something else</Chip>
+        </ChipGroup>
+      </Col>
+      <Col label='wrapping'>
+        <ChipGroup ariaLabel='wrapping' wrap>
+          <Chip value='meals'>Business Meals</Chip>
+          <Chip value='office'>Office Expenses</Chip>
+          <Chip value='other-business'>Other Business Expenses</Chip>
+          <Chip value='other'>Something else</Chip>
+          <Chip value='mix'>A mix of the above</Chip>
+        </ChipGroup>
+      </Col>
+      <Col label='disabled'>
+        <ChipGroup ariaLabel='disabled' isDisabled>
+          <Chip value='meals'>Business Meals</Chip>
+          <Chip value='other'>Something else</Chip>
+        </ChipGroup>
+      </Col>
+    </Gallery>
+  ),
+}

--- a/src/components/ui/Chip/Chip.tsx
+++ b/src/components/ui/Chip/Chip.tsx
@@ -1,0 +1,70 @@
+import classNames from 'classnames'
+import {
+  Radio as ReactAriaRadio,
+  RadioGroup as ReactAriaRadioGroup,
+  type RadioGroupProps as ReactAriaRadioGroupProps,
+  type RadioProps as ReactAriaRadioProps,
+} from 'react-aria-components/RadioGroup'
+
+import { toDataProperties } from '@utils/shared/styles/toDataProperties'
+import { withRenderProp } from '@components/utility/withRenderProp'
+
+import './chip.scss'
+
+const CHIP_GROUP_CLASS_NAME = 'Layer__UI__ChipGroup'
+const CHIP_CLASS_NAME = 'Layer__UI__Chip'
+
+type ChipGroupProps<T extends string> = Omit<
+  ReactAriaRadioGroupProps,
+  'className' | 'value' | 'defaultValue' | 'onChange'
+> & {
+  ariaLabel: string
+  wrap?: boolean
+  value?: T | null
+  onChange?: (value: T) => void
+}
+
+export function ChipGroup<T extends string>({
+  ariaLabel,
+  children,
+  onChange,
+  value,
+  wrap,
+  ...restProps
+}: ChipGroupProps<T>) {
+  const dataProperties = toDataProperties({ wrap })
+
+  return (
+    <ReactAriaRadioGroup
+      {...restProps}
+      {...dataProperties}
+      aria-label={ariaLabel}
+      value={value}
+      onChange={onChange as ((value: string) => void) | undefined}
+      className={CHIP_GROUP_CLASS_NAME}
+    >
+      {children}
+    </ReactAriaRadioGroup>
+  )
+}
+
+export type ChipSize = 'sm' | 'md'
+
+type ChipProps<T extends string> = Omit<ReactAriaRadioProps, 'className' | 'value'> & {
+  size?: ChipSize
+  value: T
+}
+
+export function Chip<T extends string>({ children, size = 'md', ...restProps }: ChipProps<T>) {
+  const dataProperties = toDataProperties({ size })
+
+  return (
+    <ReactAriaRadio
+      {...restProps}
+      {...dataProperties}
+      className={classNames(CHIP_CLASS_NAME)}
+    >
+      {withRenderProp(children, node => node)}
+    </ReactAriaRadio>
+  )
+}

--- a/src/components/ui/Chip/Chip.tsx
+++ b/src/components/ui/Chip/Chip.tsx
@@ -16,7 +16,7 @@ const CHIP_CLASS_NAME = 'Layer__UI__Chip'
 
 type ChipGroupProps<T extends string> = Omit<
   ReactAriaRadioGroupProps,
-  'className' | 'value' | 'defaultValue' | 'onChange'
+  'className' | 'value' | 'defaultValue' | 'onChange' | 'isReadOnly' | 'isInvalid'
 > & {
   ariaLabel: string
   wrap?: boolean
@@ -26,7 +26,7 @@ type ChipGroupProps<T extends string> = Omit<
 }
 
 function ChipGroupWithRef<T extends string>(
-  { ariaLabel, children, onChange, wrap, ...restProps }: ChipGroupProps<T>,
+  { ariaLabel, children, onChange, wrap = true, ...restProps }: ChipGroupProps<T>,
   ref: ForwardedRef<HTMLDivElement>,
 ) {
   const dataProperties = toDataProperties({ wrap })

--- a/src/components/ui/Chip/Chip.tsx
+++ b/src/components/ui/Chip/Chip.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import { type ForwardedRef, forwardRef } from 'react'
 import {
   Radio as ReactAriaRadio,
   RadioGroup as ReactAriaRadioGroup,
@@ -21,17 +21,14 @@ type ChipGroupProps<T extends string> = Omit<
   ariaLabel: string
   wrap?: boolean
   value?: T | null
+  defaultValue?: T
   onChange?: (value: T) => void
 }
 
-export function ChipGroup<T extends string>({
-  ariaLabel,
-  children,
-  onChange,
-  value,
-  wrap,
-  ...restProps
-}: ChipGroupProps<T>) {
+function ChipGroupWithRef<T extends string>(
+  { ariaLabel, children, onChange, wrap, ...restProps }: ChipGroupProps<T>,
+  ref: ForwardedRef<HTMLDivElement>,
+) {
   const dataProperties = toDataProperties({ wrap })
 
   return (
@@ -39,14 +36,19 @@ export function ChipGroup<T extends string>({
       {...restProps}
       {...dataProperties}
       aria-label={ariaLabel}
-      value={value}
+      orientation='horizontal'
       onChange={onChange as ((value: string) => void) | undefined}
       className={CHIP_GROUP_CLASS_NAME}
+      ref={ref}
     >
       {children}
     </ReactAriaRadioGroup>
   )
 }
+
+export const ChipGroup = forwardRef(ChipGroupWithRef) as <T extends string>(
+  props: ChipGroupProps<T> & { ref?: ForwardedRef<HTMLDivElement> },
+) => React.ReactElement
 
 export type ChipSize = 'sm' | 'md'
 
@@ -55,16 +57,24 @@ type ChipProps<T extends string> = Omit<ReactAriaRadioProps, 'className' | 'valu
   value: T
 }
 
-export function Chip<T extends string>({ children, size = 'md', ...restProps }: ChipProps<T>) {
+function ChipWithRef<T extends string>(
+  { children, size = 'md', ...restProps }: ChipProps<T>,
+  ref: ForwardedRef<HTMLLabelElement>,
+) {
   const dataProperties = toDataProperties({ size })
 
   return (
     <ReactAriaRadio
       {...restProps}
       {...dataProperties}
-      className={classNames(CHIP_CLASS_NAME)}
+      className={CHIP_CLASS_NAME}
+      ref={ref}
     >
       {withRenderProp(children, node => node)}
     </ReactAriaRadio>
   )
 }
+
+export const Chip = forwardRef(ChipWithRef) as <T extends string>(
+  props: ChipProps<T> & { ref?: ForwardedRef<HTMLLabelElement> },
+) => React.ReactElement

--- a/src/components/ui/Chip/chip.scss
+++ b/src/components/ui/Chip/chip.scss
@@ -56,4 +56,22 @@
     outline: 1px solid var(--color-base-1000);
     outline-offset: 1px;
   }
+
+  &[data-disabled] {
+    border-color: var(--border-color);
+
+    background-color: var(--color-base-50);
+
+    cursor: not-allowed;
+
+    color: var(--color-base-500);
+  }
+
+  &[data-disabled][data-selected] {
+    border-color: var(--color-base-300);
+
+    background-color: var(--color-base-300);
+
+    color: var(--color-base-0);
+  }
 }

--- a/src/components/ui/Chip/chip.scss
+++ b/src/components/ui/Chip/chip.scss
@@ -1,0 +1,59 @@
+.Layer__UI__ChipGroup {
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-2xs);
+
+  &[data-wrap] {
+    flex-wrap: wrap;
+  }
+}
+
+.Layer__UI__Chip {
+  box-sizing: border-box;
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  min-block-size: 2.25rem;
+  padding-inline: var(--spacing-sm);
+
+  border-radius: var(--border-radius-sm);
+  border: 1px solid var(--border-color);
+
+  background-color: var(--color-base-0);
+
+  cursor: pointer;
+  user-select: none;
+
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-normal);
+  text-align: center;
+  color: var(--text-color-primary);
+
+  &[data-size='sm'] {
+    min-block-size: 1.875rem;
+    padding-inline: var(--spacing-xs);
+
+    border-radius: var(--border-radius-5xl);
+
+    font-size: var(--text-xs);
+  }
+
+  &[data-selected] {
+    border-color: var(--color-base-1000);
+
+    background-color: var(--color-base-1000);
+
+    font-weight: var(--font-weight-bold);
+    color: var(--color-base-0);
+  }
+
+  &[data-hovered]:not([data-selected]) {
+    background-color: var(--color-base-50);
+  }
+
+  &[data-focus-visible] {
+    outline: 1px solid var(--color-base-1000);
+    outline-offset: 1px;
+  }
+}


### PR DESCRIPTION
## Scope

- Add `@ui/Chip` (`ChipGroup` + `Chip`) with a gallery story.
- Add `isDisabled` to `BackButton`, which previously picked only `onPress` and so could not be locked.

Built on react-aria radio-group semantics rather than toggle buttons: exactly one chip is the answer, so a screen reader should announce the set as one choice of N. The selected state is the chip's own fill, which is why `@ui/RadioGroup` is not reused — its `Radio` hardcodes a dot indicator.

`undefined` means uncontrolled, so the group is not pinned to controlled mode.

## Verification

- `npm run typecheck`, `npm run lint` clean.
- `npm test -- --run`: 353 tests pass.
- Gallery story covers default, selected, small, wrapping and disabled in one Chromatic snapshot.

Root: #1801
Base: #1802
Next: #1804

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new presentational components and a small BackButton API extension with no auth, data, or routing changes.
> 
> **Overview**
> Introduces a new **`Chip` / `ChipGroup`** UI primitive for single-choice “pill” selections, implemented on **react-aria** radio-group semantics (filled chip = selected) instead of reusing `@ui/RadioGroup`, plus a Chromatic gallery story for default, selected, small, wrapping, and disabled states.
> 
> **`BackButton`** now accepts and forwards **`isDisabled`** to the underlying `Button`, so back navigation can be disabled where callers need it (e.g. via `DataTableHeader` slot props).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b3d222165fb89d32f4b91d06b27a4c27329af8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

